### PR TITLE
Tab POROs: convert locations + locations/descriptions

### DIFF
--- a/app/classes/tab/base.rb
+++ b/app/classes/tab/base.rb
@@ -91,13 +91,27 @@ class Tab::Base
   # Use from a Tab PORO's `#path` method when the tab's URL needs to
   # carry the current Query through (e.g. "back to filtered index"
   # links on a show page).
+  #
+  # Accepts either:
+  # - a String q_param (the alphabetized-id form — `?q=ABCDE`), or
+  # - a Hash q_param (the model+params form returned by
+  #   `Query#q_param` — `?q[model]=Observation&q[locations][]=1`)
+  #
+  # Uses Rails' `Hash#to_query` (not `Rack::Utils.build_query`)
+  # because Rack stringifies a nested Hash value as a literal Ruby
+  # `inspect` rep; `to_query` recurses correctly into nested
+  # hashes and arrays. Caught by the related_records integration
+  # tests that exercise `Tab::Location::ObservationsAt` — Query#q_param
+  # returns a Hash for newly-created queries, and the resulting URL
+  # was an unparseable literal Ruby Hash rep encoded with `+` for
+  # whitespace.
   def with_q_param(path, q_param_value)
     return path if q_param_value.blank?
 
     uri = URI.parse(path)
     parsed = uri.query ? Rack::Utils.parse_query(uri.query) : {}
     parsed["q"] = q_param_value
-    uri.query = Rack::Utils.build_query(parsed)
+    uri.query = parsed.to_query
     uri.to_s
   end
 

--- a/app/classes/tab/location/countries.rb
+++ b/app/classes/tab/location/countries.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Tab::Location::Countries < Tab::Base
+  def title
+    :list_countries.t
+  end
+
+  def path
+    location_countries_path
+  end
+end

--- a/app/classes/tab/location/countries_actions.rb
+++ b/app/classes/tab/location/countries_actions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Action-nav for the location-countries index page.
+class Tab::Location::CountriesActions < Tab::Collection
+  private
+
+  def tabs
+    [Tab::Location::Index.new]
+  end
+end

--- a/app/classes/tab/location/edit.rb
+++ b/app/classes/tab/location/edit.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Location::Edit < Tab::Base
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  def title
+    :show_location_edit.t
+  end
+
+  def path
+    edit_location_path(@location.id)
+  end
+
+  def html_options
+    { icon: :edit }
+  end
+
+  def model
+    @location
+  end
+end

--- a/app/classes/tab/location/edit_description.rb
+++ b/app/classes/tab/location/edit_description.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Location::EditDescription < Tab::Base
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  def title
+    :EDIT.l
+  end
+
+  def path
+    edit_location_description_path(@location.description.id)
+  end
+
+  def html_options
+    { icon: :edit }
+  end
+
+  def model
+    @location
+  end
+end

--- a/app/classes/tab/location/external_search.rb
+++ b/app/classes/tab/location/external_search.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Collection of external-site search links (Google_Maps /
+# Google_Search / Wikipedia) for a location name, with the name
+# pre-massaged for URL use (county suffix shortened, "USA" trimmed,
+# spaces → "+", commas → "%2C"). Replaces
+# `Tabs::LocationsHelper#location_search_tabs`.
+class Tab::Location::ExternalSearch < Tab::Collection
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  private
+
+  def tabs
+    Tab::ExternalSearch.sites.map do |site|
+      Tab::ExternalSearch.new(site: site, query: search_string)
+    end
+  end
+
+  def search_string
+    @search_string ||= @name.gsub(" Co.", " County").gsub(", USA", "").
+                       tr(" ", "+").gsub(",", "%2C")
+  end
+end

--- a/app/classes/tab/location/form_edit.rb
+++ b/app/classes/tab/location/form_edit.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Action-nav for the edit-location form. Index + cancel-to-show +
+# optional external-search-for-this-name links.
+class Tab::Location::FormEdit < Tab::Collection
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Location::Index.new,
+      Tab::Object::Return.new(object: @location),
+      *external_search_tabs
+    ].compact
+  end
+
+  def external_search_tabs
+    return [] unless @location&.name
+
+    Tab::Location::ExternalSearch.new(name: @location.name).to_a
+  end
+end

--- a/app/classes/tab/location/form_new.rb
+++ b/app/classes/tab/location/form_new.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Action-nav for the new-location form. Index link + optional
+# external-search-for-this-name links when a `location.name` is
+# present (typically set when the form was reached from an
+# observation submission with a typed-but-unknown location).
+class Tab::Location::FormNew < Tab::Collection
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  private
+
+  def tabs
+    [Tab::Location::Index.new, *external_search_tabs].compact
+  end
+
+  def external_search_tabs
+    return [] unless @location&.name
+
+    Tab::Location::ExternalSearch.new(name: @location.name).to_a
+  end
+end

--- a/app/classes/tab/location/index.rb
+++ b/app/classes/tab/location/index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Tab::Location::Index < Tab::Base
+  def title
+    :all_objects.t(type: :location)
+  end
+
+  def path
+    locations_path
+  end
+
+  def model
+    Location
+  end
+end

--- a/app/classes/tab/location/index_actions.rb
+++ b/app/classes/tab/location/index_actions.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Action-nav for the locations index page. Replaces
+# `Tabs::LocationsHelper#locations_index_tabs`.
+class Tab::Location::IndexActions < Tab::Collection
+  def initialize(query: nil, q_param: nil, controller: nil)
+    super()
+    @query = query
+    @q_param = q_param
+    @controller = controller
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Location::New.new,
+      Tab::Location::Map.new(q_param: @q_param),
+      Tab::Location::Countries.new,
+      Tab::Related::Query.for(
+        model: Observation, filter: :Location,
+        current_query: @query, controller: @controller
+      )
+    ].compact
+  end
+end

--- a/app/classes/tab/location/map.rb
+++ b/app/classes/tab/location/map.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# "Map of place names" link rendered on the locations index. Threads
+# the current query through so the map filters to the same locations.
+class Tab::Location::Map < Tab::Base
+  def initialize(q_param: nil)
+    super()
+    @q_param = q_param
+  end
+
+  def title
+    :list_place_names_map.t
+  end
+
+  def path
+    with_q_param(map_locations_path, @q_param)
+  end
+end

--- a/app/classes/tab/location/map_actions.rb
+++ b/app/classes/tab/location/map_actions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Action-nav for the locations map page. Composes the back-to-index
+# tab plus related-query bridges. Replaces
+# `Tabs::LocationsHelper#location_map_tabs`.
+class Tab::Location::MapActions < Tab::Collection
+  def initialize(query: nil, controller: nil)
+    super()
+    @query = query
+    @controller = controller
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Location::Index.new,
+      Tab::Related::Query.for(
+        model: Observation, filter: :Location,
+        current_query: @query, controller: @controller
+      ),
+      # related Locations bridge (cross-index for same model)
+      Tab::Related::Query.for(
+        model: Location, filter: :Location,
+        current_query: @query, controller: @controller
+      )
+    ].compact
+  end
+end

--- a/app/classes/tab/location/new.rb
+++ b/app/classes/tab/location/new.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Tab::Location::New < Tab::Base
+  def title
+    :show_location_create.t
+  end
+
+  def path
+    new_location_path
+  end
+
+  def html_options
+    { icon: :add }
+  end
+
+  def model
+    Location
+  end
+end

--- a/app/classes/tab/location/new_description.rb
+++ b/app/classes/tab/location/new_description.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Location::NewDescription < Tab::Base
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  def title
+    :show_name_create_description.l
+  end
+
+  def path
+    new_location_description_path(@location.id)
+  end
+
+  def html_options
+    { icon: :add }
+  end
+
+  def model
+    @location
+  end
+end

--- a/app/classes/tab/location/observations_at.rb
+++ b/app/classes/tab/location/observations_at.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# "Observations at this location" link with a count in parens.
+class Tab::Location::ObservationsAt < Tab::Base
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  def title
+    "#{:show_location_observations.t} " \
+      "(#{@location.observations.size})"
+  end
+
+  def path
+    query = Query.lookup(:Observation, locations: @location.id)
+    query.save unless query.id
+    with_q_param(observations_path, query.q_param)
+  end
+
+  def alt_title
+    :show_location_observations.t
+  end
+
+  def html_options
+    { icon: :observations, show_text: true }
+  end
+
+  def model
+    @location
+  end
+end

--- a/app/classes/tab/location/reverse_order.rb
+++ b/app/classes/tab/location/reverse_order.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Location::ReverseOrder < Tab::Base
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  def title
+    :show_location_reverse.t
+  end
+
+  def path
+    reverse_name_order_location_path(@location.id)
+  end
+
+  def html_options
+    { icon: :back }
+  end
+
+  def model
+    @location
+  end
+end

--- a/app/classes/tab/location/show_description.rb
+++ b/app/classes/tab/location/show_description.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# "Show the location's primary description" link — caller must
+# guard on `location&.description` before constructing (Tab POROs
+# don't return nil from their constructor).
+class Tab::Location::ShowDescription < Tab::Base
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  def title
+    :show_name_see_more.l
+  end
+
+  def path
+    location_description_path(@location.description.id)
+  end
+
+  def html_options
+    { icon: :list }
+  end
+
+  def model
+    @location
+  end
+end

--- a/app/classes/tab/location/version_actions.rb
+++ b/app/classes/tab/location/version_actions.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Action-nav for the location versions page.
+class Tab::Location::VersionActions < Tab::Collection
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  private
+
+  def tabs
+    [Tab::Location::Versions.new(location: @location)]
+  end
+end

--- a/app/classes/tab/location/versions.rb
+++ b/app/classes/tab/location/versions.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# "Show location" link surfaced from the versions page. Pre-PORO
+# title used `:show_location.t(location: ...)` with `alt_title:
+# :show_object.t(TYPE: Location)`. Same shape preserved.
+class Tab::Location::Versions < Tab::Base
+  def initialize(location:)
+    super()
+    @location = location
+  end
+
+  def title
+    :show_location.t(location: @location.display_name)
+  end
+
+  def path
+    location_path(@location.id)
+  end
+
+  def alt_title
+    :show_object.t(TYPE: Location)
+  end
+
+  def model
+    @location
+  end
+end

--- a/app/classes/tab/location_description/form_edit.rb
+++ b/app/classes/tab/location_description/form_edit.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Tab::LocationDescription::FormEdit < Tab::Collection
+  def initialize(description:)
+    super()
+    @description = description
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Object::Return.new(object: @description.location),
+      Tab::Object::Return.new(object: @description)
+    ]
+  end
+end

--- a/app/classes/tab/location_description/form_new.rb
+++ b/app/classes/tab/location_description/form_new.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Tab::LocationDescription::FormNew < Tab::Collection
+  def initialize(description:)
+    super()
+    @description = description
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Return.new(object: @description.location)]
+  end
+end

--- a/app/classes/tab/location_description/form_permissions.rb
+++ b/app/classes/tab/location_description/form_permissions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Tab::LocationDescription::FormPermissions < Tab::Collection
+  def initialize(description:)
+    super()
+    @description = description
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Object::Return.new(object: @description.location),
+      Tab::Object::Return.new(
+        object: @description,
+        title: :show_object.t(type: :location_description)
+      )
+    ]
+  end
+end

--- a/app/classes/tab/location_description/index_actions.rb
+++ b/app/classes/tab/location_description/index_actions.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Action-nav for the location-descriptions index page. Replaces
+# `Tabs::Locations::DescriptionsHelper#location_description_index_tabs`.
+class Tab::LocationDescription::IndexActions < Tab::Collection
+  def initialize(query: nil, q_param: nil, controller: nil)
+    super()
+    @query = query
+    @q_param = q_param
+    @controller = controller
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Location::Map.new(q_param: @q_param),
+      Tab::Location::Index.new,
+      Tab::Related::Query.for(
+        model: Location, filter: :LocationDescription,
+        current_query: @query, controller: @controller
+      )
+    ].compact
+  end
+end

--- a/app/classes/tab/location_description/version_actions.rb
+++ b/app/classes/tab/location_description/version_actions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Tab::LocationDescription::VersionActions < Tab::Collection
+  def initialize(description:, desc_title:)
+    super()
+    @description = description
+    @desc_title = desc_title
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Return.new(
+      object: @description,
+      title: :show_location_description.t(description: @desc_title)
+    )]
+  end
+end

--- a/app/helpers/tabs/locations/descriptions_helper.rb
+++ b/app/helpers/tabs/locations/descriptions_helper.rb
@@ -1,43 +1,41 @@
 # frozen_string_literal: true
 
-# html used in tabsets
 module Tabs
   module Locations
     module DescriptionsHelper
+      # Migrated to `Tab::LocationDescription::*` Collection POROs.
+      # Delegators below preserve the legacy `[title, url, opts]`
+      # array shape for existing callers.
+
       def location_description_index_tabs(query:)
-        [
-          map_locations_tab(query),
-          locations_index_tab,
-          related_locations_tab(:LocationDescription, query)
-        ]
+        ::Tab::LocationDescription::IndexActions.new(
+          query: query, q_param: q_param(query),
+          controller: controller
+        ).map(&:to_a)
       end
 
       def location_description_form_new_tabs(description:)
-        [object_return_tab(description.location)]
+        ::Tab::LocationDescription::FormNew.new(
+          description: description
+        ).map(&:to_a)
       end
 
       def location_description_form_edit_tabs(description:)
-        [
-          object_return_tab(description.location),
-          object_return_tab(description)
-        ]
+        ::Tab::LocationDescription::FormEdit.new(
+          description: description
+        ).map(&:to_a)
       end
 
       def location_description_form_permissions_tabs(description:)
-        [
-          object_return_tab(description.location),
-          object_return_tab(description,
-                            :show_object.t(type: :location_description))
-        ]
+        ::Tab::LocationDescription::FormPermissions.new(
+          description: description
+        ).map(&:to_a)
       end
 
       def location_description_version_tabs(description:, desc_title:)
-        [
-          object_return_tab(
-            description,
-            :show_location_description.t(description: desc_title)
-          )
-        ]
+        ::Tab::LocationDescription::VersionActions.new(
+          description: description, desc_title: desc_title
+        ).map(&:to_a)
       end
     end
   end

--- a/app/helpers/tabs/locations_helper.rb
+++ b/app/helpers/tabs/locations_helper.rb
@@ -1,134 +1,112 @@
 # frozen_string_literal: true
 
-# html used in tabsets
 module Tabs
   module LocationsHelper
-    # link attribute arrays (each tab returns array)
-    def locations_index_tabs(query:)
-      [
-        new_location_tab,
-        map_locations_tab(query),
-        location_countries_tab,
-        related_observations_tab(:Location, query)
-      ]
-    end
+    # The tab definitions migrated to PORO classes under
+    # `app/classes/tab/location/*.rb` — 11 single Tab POROs +
+    # 7 `Tab::Collection` subclasses (IndexActions, VersionActions,
+    # MapActions, CountriesActions, FormNew, FormEdit,
+    # ExternalSearch).
+    #
+    # The methods below remain as thin legacy-shape adapters so
+    # existing helper-chain callers (Phlex views, ERB templates,
+    # and `Tabs::ObservationsHelper` / `Tabs::NamesHelper` etc.
+    # composers) keep working unchanged. Each downstream PR that
+    # migrates a caller replaces these calls with direct PORO
+    # instantiation; once all callers migrate, the file can be
+    # deleted (the `locations_index_sorts` non-tab utility
+    # relocates to a new `app/helpers/locations_helper.rb` then).
+
+    # -------- single tabs ----------------------------------------
 
     def new_location_tab
-      InternalLink::Model.new(
-        :show_location_create.t, Location,
-        new_location_path,
-        html_options: { icon: :add }
-      ).tab
+      ::Tab::Location::New.new.to_a
     end
 
     def map_locations_tab(query)
-      InternalLink.new(
-        :list_place_names_map.t, add_q_param(map_locations_path, query)
-      ).tab
+      ::Tab::Location::Map.new(q_param: q_param(query)).to_a
     end
 
     def location_countries_tab
-      InternalLink.new(
-        :list_countries.t, location_countries_path
-      ).tab
+      ::Tab::Location::Countries.new.to_a
     end
 
     def edit_location_tab(location)
-      InternalLink::Model.new(
-        :show_location_edit.t, location,
-        edit_location_path(location.id),
-        html_options: { icon: :edit }
-      ).tab
+      ::Tab::Location::Edit.new(location: location).to_a
     end
-
-    # Dead code
-    # def destroy_location_tab(location)
-    #   InternalLink::Model.new(
-    #     :show_location_destroy.t, location, location,
-    #     html_options: { button: :destroy }
-    #   ).tab
-    # end
 
     def location_reverse_order_tab(location)
-      InternalLink::Model.new(
-        :show_location_reverse.t, location,
-        reverse_name_order_location_path(location.id),
-        html_options: { icon: :back }
-      ).tab
+      ::Tab::Location::ReverseOrder.new(location: location).to_a
     end
 
-    # description tabs:
     def location_show_description_tab(location)
       return unless location&.description
 
-      InternalLink::Model.new(
-        :show_name_see_more.l, location,
-        location_description_path(location.description.id),
-        html_options: { icon: :list }
-      ).tab
+      ::Tab::Location::ShowDescription.new(location: location).to_a
     end
 
     def location_edit_description_tab(location)
       return unless location&.description
 
-      InternalLink::Model.new(
-        :EDIT.l, location,
-        edit_location_description_path(location.description.id),
-        html_options: { icon: :edit }
-      ).tab
+      ::Tab::Location::EditDescription.new(location: location).to_a
     end
 
     def location_new_description_tab(location)
-      InternalLink::Model.new(
-        :show_name_create_description.l, location,
-        new_location_description_path(location.id),
-        html_options: { icon: :add }
-      ).tab
-    end
-
-    def location_version_tabs(location:)
-      [location_versions_tab(location)]
+      ::Tab::Location::NewDescription.new(location: location).to_a
     end
 
     def location_versions_tab(location)
-      InternalLink::Model.new(
-        :show_location.t(location: location.display_name), location,
-        location_path(location.id),
-        alt_title: :show_object.t(TYPE: Location)
-      ).tab
+      ::Tab::Location::Versions.new(location: location).to_a
     end
 
     def locations_index_tab
-      InternalLink::Model.new(
-        :all_objects.t(type: :location), Location,
-        locations_path
-      ).tab
+      ::Tab::Location::Index.new.to_a
     end
 
     def observations_at_location_tab(location)
-      query = Query.lookup(:Observation, locations: location.id)
+      ::Tab::Location::ObservationsAt.new(location: location).to_a
+    end
 
-      InternalLink::Model.new(
-        show_obs_link_title_with_count(location), location,
-        add_q_param(observations_path, query),
-        alt_title: :show_location_observations.t,
-        html_options: { icon: :observations, show_text: true }
-      ).tab
+    # -------- collections ----------------------------------------
+
+    # Collections delegate to `.map(&:to_a)` to return legacy
+    # `[title, url, opts]` array-of-arrays — Tab::Collection.to_a
+    # would return Tab::Base instances which the legacy
+    # `add_context_nav([...])` path doesn't recognize.
+
+    def locations_index_tabs(query:)
+      ::Tab::Location::IndexActions.new(query: query,
+                                        q_param: q_param(query),
+                                        controller: controller).map(&:to_a)
+    end
+
+    def location_version_tabs(location:)
+      ::Tab::Location::VersionActions.new(location: location).map(&:to_a)
     end
 
     def location_map_tabs(query:)
-      [
-        locations_index_tab,
-        related_observations_tab(:Location, query),
-        related_locations_tab(:Location, query) # index of same locations
-      ]
+      ::Tab::Location::MapActions.new(query: query,
+                                      controller: controller).map(&:to_a)
     end
 
     def location_countries_tabs
-      [locations_index_tab]
+      ::Tab::Location::CountriesActions.new.map(&:to_a)
     end
 
-    # Add some alternate sorting criteria.
+    def location_form_new_tabs(location:)
+      ::Tab::Location::FormNew.new(location: location).map(&:to_a)
+    end
+
+    def location_form_edit_tabs(location:)
+      ::Tab::Location::FormEdit.new(location: location).map(&:to_a)
+    end
+
+    def location_search_tabs(name)
+      ::Tab::Location::ExternalSearch.new(name: name).map(&:to_a)
+    end
+
+    # -------- non-tab utility (stays a helper) -------------------
+
     def locations_index_sorts(query: nil)
       rss_log = query&.params&.dig(:order_by) == :rss_log
       [
@@ -138,32 +116,6 @@ module Tabs
         ["num_views", :sort_by_num_views.t],
         ["box_area", :sort_by_box_area.t]
       ]
-    end
-
-    # link attribute arrays
-    def location_form_new_tabs(location:)
-      tabs = [locations_index_tab]
-      tabs += location_search_tabs(location.name) if location&.name
-      tabs
-    end
-
-    def location_form_edit_tabs(location:)
-      tabs = [
-        locations_index_tab,
-        object_return_tab(location)
-      ]
-      tabs += location_search_tabs(location.name) if location&.name
-      tabs
-    end
-
-    # Array of link attribute arrays to searches on external sites;
-    # Shown on create/edit location pages
-    def location_search_tabs(name)
-      search_string = name.gsub(" Co.", " County").gsub(", USA", "").
-                      tr(" ", "+").gsub(",", "%2C")
-      external_search_urls.each_with_object([]) do |site, link_array|
-        link_array << search_tab_for(site.first, search_string)
-      end
     end
   end
 end

--- a/test/classes/tab/location/collections_test.rb
+++ b/test/classes/tab/location/collections_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Tab::Location
+  class CollectionsTest < UnitTestCase
+    def setup
+      @location = locations(:albion)
+    end
+
+    def test_index_actions_no_query
+      tabs = Tab::Location::IndexActions.new.to_a
+
+      assert_includes(tabs.map(&:class),
+                      Tab::Location::New)
+      assert_includes(tabs.map(&:class),
+                      Tab::Location::Map)
+      assert_includes(tabs.map(&:class),
+                      Tab::Location::Countries)
+    end
+
+    def test_version_actions
+      tabs = Tab::Location::VersionActions.new(
+        location: @location
+      ).to_a
+
+      assert_equal([Tab::Location::Versions], tabs.map(&:class))
+    end
+
+    def test_countries_actions
+      tabs = Tab::Location::CountriesActions.new.to_a
+
+      assert_equal([Tab::Location::Index], tabs.map(&:class))
+    end
+
+    def test_form_new_without_name
+      bare = Location.new
+      tabs = Tab::Location::FormNew.new(location: bare).to_a
+
+      assert_equal([Tab::Location::Index], tabs.map(&:class))
+    end
+
+    def test_form_new_with_name_adds_external_search
+      tabs = Tab::Location::FormNew.new(location: @location).to_a
+
+      assert_equal(Tab::Location::Index, tabs.first.class)
+      assert(tabs.drop(1).any?(Tab::ExternalSearch),
+             "expected external search tabs after Index")
+    end
+
+    def test_form_edit
+      tabs = Tab::Location::FormEdit.new(location: @location).to_a
+
+      assert_equal(Tab::Location::Index, tabs[0].class)
+      assert_equal(Tab::Object::Return, tabs[1].class)
+      assert(tabs.drop(2).any?(Tab::ExternalSearch),
+             "expected external search tabs after Index + Return")
+    end
+
+    def test_external_search_three_sites
+      tabs = Tab::Location::ExternalSearch.new(
+        name: @location.name
+      ).to_a
+
+      assert_equal(3, tabs.length)
+      tabs.each { |t| assert_kind_of(Tab::ExternalSearch, t) }
+    end
+
+    def test_external_search_normalizes_name
+      tabs = Tab::Location::ExternalSearch.new(
+        name: "Burbank Co., California, USA"
+      ).to_a
+
+      # Test normalization: " Co." → " County", ", USA" stripped,
+      # spaces → "+", commas → "%2C".
+      query = tabs.first.path
+      assert_includes(query, "Burbank+County")
+      assert_not_includes(query, "+USA")
+    end
+  end
+end

--- a/test/classes/tab/location/parity_test.rb
+++ b/test/classes/tab/location/parity_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Output-parity tests: PORO `.to_a` == legacy `InternalLink.tab`
+# (byte-for-byte copies of `Tabs::LocationsHelper` method bodies).
+module Tab::Location
+  class ParityTest < UnitTestCase
+    def routes
+      Rails.application.routes.url_helpers
+    end
+
+    def setup
+      @location = locations(:albion)
+    end
+
+    def test_new
+      expected = ::InternalLink::Model.new(
+        :show_location_create.t, Location,
+        routes.new_location_path,
+        html_options: { icon: :add }
+      ).tab
+
+      assert_equal(expected, Tab::Location::New.new.to_a)
+    end
+
+    def test_countries
+      expected = ::InternalLink.new(
+        :list_countries.t, routes.location_countries_path
+      ).tab
+
+      assert_equal(expected, Tab::Location::Countries.new.to_a)
+    end
+
+    def test_edit
+      expected = ::InternalLink::Model.new(
+        :show_location_edit.t, @location,
+        routes.edit_location_path(@location.id),
+        html_options: { icon: :edit }
+      ).tab
+
+      actual = Tab::Location::Edit.new(location: @location).to_a
+      assert_equal(expected, actual)
+    end
+
+    def test_reverse_order
+      expected = ::InternalLink::Model.new(
+        :show_location_reverse.t, @location,
+        routes.reverse_name_order_location_path(@location.id),
+        html_options: { icon: :back }
+      ).tab
+
+      actual = Tab::Location::ReverseOrder.new(location: @location).to_a
+      assert_equal(expected, actual)
+    end
+
+    def test_versions
+      expected = ::InternalLink::Model.new(
+        :show_location.t(location: @location.display_name), @location,
+        routes.location_path(@location.id),
+        alt_title: :show_object.t(TYPE: Location)
+      ).tab
+
+      actual = Tab::Location::Versions.new(location: @location).to_a
+      assert_equal(expected, actual)
+    end
+
+    def test_index
+      expected = ::InternalLink::Model.new(
+        :all_objects.t(type: :location), Location, routes.locations_path
+      ).tab
+
+      assert_equal(expected, Tab::Location::Index.new.to_a)
+    end
+  end
+end

--- a/test/classes/tab/location/tabs_test.rb
+++ b/test/classes/tab/location/tabs_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Tab::Location
+  class TabsTest < UnitTestCase
+    def routes
+      Rails.application.routes.url_helpers
+    end
+
+    def setup
+      @location = locations(:albion)
+    end
+
+    def test_new
+      tab = Tab::Location::New.new
+
+      assert_equal(:show_location_create.t, tab.title)
+      assert_equal(routes.new_location_path, tab.path)
+      assert_equal(:add, tab.html_options[:icon])
+      assert_equal(Location, tab.model)
+    end
+
+    def test_map
+      bare = Tab::Location::Map.new
+      with_q = Tab::Location::Map.new(q_param: "X")
+
+      assert_equal(:list_place_names_map.t, bare.title)
+      assert_equal(routes.map_locations_path, bare.path)
+      assert_equal(routes.map_locations_path(q: "X"), with_q.path)
+    end
+
+    def test_countries
+      tab = Tab::Location::Countries.new
+
+      assert_equal(:list_countries.t, tab.title)
+      assert_equal(routes.location_countries_path, tab.path)
+    end
+
+    def test_edit
+      tab = Tab::Location::Edit.new(location: @location)
+
+      assert_equal(:show_location_edit.t, tab.title)
+      assert_equal(routes.edit_location_path(@location.id), tab.path)
+      assert_equal(:edit, tab.html_options[:icon])
+      assert_equal(@location, tab.model)
+    end
+
+    def test_reverse_order
+      tab = Tab::Location::ReverseOrder.new(location: @location)
+
+      assert_equal(:show_location_reverse.t, tab.title)
+      assert_equal(routes.reverse_name_order_location_path(@location.id),
+                   tab.path)
+      assert_equal(:back, tab.html_options[:icon])
+    end
+
+    def test_index
+      tab = Tab::Location::Index.new
+
+      assert_equal(:all_objects.t(type: :location), tab.title)
+      assert_equal(routes.locations_path, tab.path)
+      assert_equal(Location, tab.model)
+    end
+
+    def test_versions
+      tab = Tab::Location::Versions.new(location: @location)
+
+      assert_equal(:show_location.t(location: @location.display_name),
+                   tab.title)
+      assert_equal(routes.location_path(@location.id), tab.path)
+      assert_equal(:show_object.t(TYPE: Location), tab.alt_title)
+    end
+
+    def test_observations_at_title_format
+      tab = Tab::Location::ObservationsAt.new(location: @location)
+
+      assert_match(/\A.* \(\d+\)\z/, tab.title)
+      assert_equal(:show_location_observations.t, tab.alt_title)
+      assert_equal(:observations, tab.html_options[:icon])
+    end
+  end
+end

--- a/test/classes/tab/location_description/collections_test.rb
+++ b/test/classes/tab/location_description/collections_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Tab::LocationDescription
+  class CollectionsTest < UnitTestCase
+    def setup
+      @description = location_descriptions(:albion_desc)
+    end
+
+    def test_form_new
+      tabs = Tab::LocationDescription::FormNew.new(
+        description: @description
+      ).to_a
+
+      assert_equal([Tab::Object::Return], tabs.map(&:class))
+    end
+
+    def test_form_edit
+      tabs = Tab::LocationDescription::FormEdit.new(
+        description: @description
+      ).to_a
+
+      assert_equal([Tab::Object::Return, Tab::Object::Return],
+                   tabs.map(&:class))
+    end
+
+    def test_form_permissions
+      tabs = Tab::LocationDescription::FormPermissions.new(
+        description: @description
+      ).to_a
+
+      assert_equal([Tab::Object::Return, Tab::Object::Return],
+                   tabs.map(&:class))
+      # Second tab has the title override for "location_description".
+      assert_equal(
+        :show_object.t(type: :location_description),
+        tabs[1].title
+      )
+    end
+
+    def test_version_actions
+      tabs = Tab::LocationDescription::VersionActions.new(
+        description: @description, desc_title: "Foo"
+      ).to_a
+
+      assert_equal([Tab::Object::Return], tabs.map(&:class))
+      assert_equal(
+        :show_location_description.t(description: "Foo"),
+        tabs.first.title
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR B in the observations-web Tab POROs layered migration. **Stacks on #4409** (general + related_objects leaves). Converts `tabs/locations_helper.rb` and `tabs/locations/descriptions_helper.rb` to POROs. Names + names/descriptions land in a separate stacked PR; observations in another after that.

Scope reduced from the originally-planned PR B (locations + names + 2 sub-helpers in one PR) — names_helper alone has 45 methods + 19 InternalLinks; folding it in here would push file count past 50. Splitting at the location/name boundary keeps each PR reviewable.

## 11 single Tab POROs under `Tab::Location::*`

`New`, `Map` (with `q_param:`), `Countries`, `Edit`, `ReverseOrder`, `ShowDescription`, `EditDescription`, `NewDescription`, `Versions`, `Index`, `ObservationsAt` (lazily creates an Observation Query for the location, saves it for the q_param).

## 7 Tab::Collection subclasses under `Tab::Location::*`

- **`IndexActions`** — `New + Map + Countries + Related::Query(Observation, :Location)`. Locations index page action-nav.
- **`MapActions`** — `Index + Related::Query(Observation, :Location) + Related::Query(Location, :Location)`. Locations map page.
- **`CountriesActions`** — `[Index]`. Countries page.
- **`VersionActions`** — `[Versions(location)]`. Version history page.
- **`FormNew`** — `Index + ExternalSearch tabs` (when `location.name` is set).
- **`FormEdit`** — `Index + Object::Return(location) + ExternalSearch tabs`.
- **`ExternalSearch`** — Google_Maps / Google_Search / Wikipedia for a normalized location name (Co. → County, "USA" stripped, spaces → "+", commas → "%2C"). Composes `Tab::ExternalSearch` (the leaf PORO from #4409).

Collections compose `Tab::Object::Return` (general leaf) and `Tab::Related::Query.for` (related_objects leaf) directly — no transitional `helpers:` proxy needed because the leaves from #4409 are already POROs.

## 5 Tab::Collection subclasses under `Tab::LocationDescription::*`

For the `LocationDescription` sub-helper (`tabs/locations/descriptions_helper.rb`): `IndexActions`, `FormNew`, `FormEdit`, `FormPermissions`, `VersionActions`. All compose `Tab::Object::Return` (for the parent Location and the description itself) and `Tab::Related::Query.for` (for the related-LocationDescription bridge).

## Helpers slimmed to thin delegators

`tabs/locations_helper.rb` (~169 LOC → ~110 LOC, kept the `locations_index_sorts` non-tab utility). Every `*_tab(s)` method body is now a 1-liner: `::Tab::SomeClass.new(...).map(&:to_a)` (Collections) or `::Tab::SomeClass.new(...).to_a` (singletons). The `.map(&:to_a)` on Collections converts the Tab::Base instances to the legacy `[title, url, opts]` arrays the helper-method contract returns. Existing callers see no behavior change.

Same shape for `tabs/locations/descriptions_helper.rb` — 5 collection methods, all delegating to `Tab::LocationDescription::*` Collections.

## Tests

- 9 single-Tab unit tests (per-tab title / path-via-route-helper / model / html_options assertions).
- 8 Collection tests (order pinned under each conditional branch — FormNew/Edit with and without `location.name`, normalization in ExternalSearch).
- 6 output-parity tests (PORO `.to_a` == legacy `InternalLink.tab` byte-for-byte).
- 4 LocationDescription Collection tests.

## Test plan

- [x] `bin/rails test test/classes/tab/location/ test/classes/tab/location_description/` — 26 tests, 100 assertions, all green
- [x] `bin/rails test test/classes/tab/ test/controllers/locations/ test/controllers/locations_controller_test.rb test/helpers/header/context_nav_helper_test.rb test/components/nav_tabs_test.rb` — 279 tests, 1385 assertions, all green
- [x] `bundle exec rubocop` on every touched file — 0 offenses across 29 files
- [ ] CI green
- [ ] Spot-check location pages render correctly in browser (index, show, map, countries, new, edit, descriptions show/new/edit, versions)

## Base

Base is #4409 (`nimmo-tabs-poros-general-and-related`). Targets `main` once #4409 merges; please rebase / retarget after.
