### PR TITLE
Tab POROs: convert names + names/descriptions (action tabs + 3 cross-domain externals)

### DIFF
--- a/app/classes/tab/base.rb
+++ b/app/classes/tab/base.rb
@@ -91,13 +91,27 @@ class Tab::Base
   # Use from a Tab PORO's `#path` method when the tab's URL needs to
   # carry the current Query through (e.g. "back to filtered index"
   # links on a show page).
+  #
+  # Accepts either:
+  # - a String q_param (the alphabetized-id form — `?q=ABCDE`), or
+  # - a Hash q_param (the model+params form returned by
+  #   `Query#q_param` — `?q[model]=Observation&q[locations][]=1`)
+  #
+  # Uses Rails' `Hash#to_query` (not `Rack::Utils.build_query`)
+  # because Rack stringifies a nested Hash value as a literal Ruby
+  # `inspect` rep; `to_query` recurses correctly into nested
+  # hashes and arrays. Caught by the related_records integration
+  # tests that exercise `Tab::Location::ObservationsAt` — Query#q_param
+  # returns a Hash for newly-created queries, and the resulting URL
+  # was an unparseable literal Ruby Hash rep encoded with `+` for
+  # whitespace.
   def with_q_param(path, q_param_value)
     return path if q_param_value.blank?
 
     uri = URI.parse(path)
     parsed = uri.query ? Rack::Utils.parse_query(uri.query) : {}
     parsed["q"] = q_param_value
-    uri.query = Rack::Utils.build_query(parsed)
+    uri.query = parsed.to_query
     uri.to_s
   end
 

--- a/app/classes/tab/name/all.rb
+++ b/app/classes/tab/name/all.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# "All names" link surfaced on the names index page when the
+# current query is filtered to `has_observations`. Lets the user
+# unfilter by going to the full names index.
+class Tab::Name::All < Tab::Base
+  def title
+    :all_objects.t(type: :name)
+  end
+
+  def path
+    names_path
+  end
+end

--- a/app/classes/tab/name/approve.rb
+++ b/app/classes/tab/name/approve.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# "Approve" link — appears on deprecated names. Icon is the
+# "deprecated" exclamation to signal at-a-glance that this name is
+# currently deprecated and the action will approve it.
+class Tab::Name::Approve < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :APPROVE.l
+  end
+
+  def path
+    form_to_approve_synonym_of_name_path(@name.id)
+  end
+
+  def html_options
+    { icon: :approve }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/deprecate.rb
+++ b/app/classes/tab/name/deprecate.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# "Deprecate" link — appears on approved names, with the "approved"
+# icon (a check) to signal at-a-glance that this name is approved
+# and the action will deprecate it.
+class Tab::Name::Deprecate < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :DEPRECATE.l
+  end
+
+  def path
+    form_to_deprecate_synonym_of_name_path(@name.id)
+  end
+
+  def html_options
+    { icon: :deprecate }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/edit.rb
+++ b/app/classes/tab/name/edit.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Name::Edit < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_name_edit_name.l
+  end
+
+  def path
+    edit_name_path(@name.id)
+  end
+
+  def html_options
+    { icon: :edit }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/edit_classification.rb
+++ b/app/classes/tab/name/edit_classification.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Name::EditClassification < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :EDIT.l
+  end
+
+  def path
+    edit_classification_of_name_path(@name.id)
+  end
+
+  def html_options
+    { icon: :edit }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/edit_description.rb
+++ b/app/classes/tab/name/edit_description.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Edit-description link for the name's primary description. Caller
+# must guard on `name&.description && permission?(description)`
+# before constructing (Tab POROs are request-agnostic; the helper
+# delegator does this check).
+class Tab::Name::EditDescription < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :EDIT.l
+  end
+
+  def path
+    edit_name_description_path(@name.description.id)
+  end
+
+  def html_options
+    { icon: :edit }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/edit_lifeform.rb
+++ b/app/classes/tab/name/edit_lifeform.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Name::EditLifeform < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :EDIT.l
+  end
+
+  def path
+    edit_lifeform_of_name_path(@name.id)
+  end
+
+  def html_options
+    { icon: :edit }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/edit_synonym.rb
+++ b/app/classes/tab/name/edit_synonym.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Name::EditSynonym < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_name_change_synonyms.l
+  end
+
+  def path
+    edit_synonyms_of_name_path(@name.id)
+  end
+
+  def html_options
+    { icon: :synonyms }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/edit_tracker.rb
+++ b/app/classes/tab/name/edit_tracker.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Name::EditTracker < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_name_email_tracking.t
+  end
+
+  def path
+    edit_tracker_of_name_path(@name.id)
+  end
+
+  def html_options
+    { icon: :tracking }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/external_base.rb
+++ b/app/classes/tab/name/external_base.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Base class for external-site links for a Name (MyCoPortal, GBIF,
+# EOL, etc.). Carries the shared `target=_blank` / `rel=noopener`
+# attrs and model = the Name. Subclasses implement `#title` and
+# `#path` (the external URL). `#alt_title` is optional.
+class Tab::Name::ExternalBase < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def html_options
+    { target: :_blank, rel: :noopener }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/form_edit.rb
+++ b/app/classes/tab/name/form_edit.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Tab::Name::FormEdit < Tab::Collection
+  def initialize(name:, q_param: nil)
+    super()
+    @name = name
+    @q_param = q_param
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Object::Return.new(object: @name),
+      Tab::Object::Index.new(object: @name, q_param: @q_param)
+    ]
+  end
+end

--- a/app/classes/tab/name/form_new.rb
+++ b/app/classes/tab/name/form_new.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Tab::Name::FormNew < Tab::Collection
+  private
+
+  def tabs
+    [Tab::Name::Index.new]
+  end
+end

--- a/app/classes/tab/name/forms_return.rb
+++ b/app/classes/tab/name/forms_return.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Action-nav for various name forms — just a cancel-to-show link.
+class Tab::Name::FormsReturn < Tab::Collection
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Return.new(object: @name)]
+  end
+end

--- a/app/classes/tab/name/index.rb
+++ b/app/classes/tab/name/index.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# "All names" index link. Plain InternalLink (no model variant) —
+# the original `names_index_tab` matched this shape exactly.
+class Tab::Name::Index < Tab::Base
+  def title
+    :all_objects.t(type: :name)
+  end
+
+  def path
+    names_path
+  end
+end

--- a/app/classes/tab/name/index_actions.rb
+++ b/app/classes/tab/name/index_actions.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Action-nav for the names index page. New + (All — when the
+# current query is filtered to `has_observations`) +
+# Related::Query(Observation, :Name).
+class Tab::Name::IndexActions < Tab::Collection
+  def initialize(query: nil, controller: nil)
+    super()
+    @query = query
+    @controller = controller
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Name::New.new,
+      all_tab,
+      Tab::Related::Query.for(model: Observation, filter: :Name,
+                              current_query: @query,
+                              controller: @controller)
+    ].compact
+  end
+
+  def all_tab
+    return unless @query&.params&.dig(:has_observations)
+
+    Tab::Name::All.new
+  end
+end

--- a/app/classes/tab/name/map_actions.rb
+++ b/app/classes/tab/name/map_actions.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Action-nav for the name map page. A name-map query is, under the
+# hood, an Observations-of-name query; "related records" therefore
+# branch off the Observation query, not the Name.
+class Tab::Name::MapActions < Tab::Collection
+  def initialize(name:, query:, controller: nil)
+    super()
+    @name = name
+    @query = query
+    @controller = controller
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Object::Show.new(object: @name,
+                            title: :name_map_about.t(
+                              name: @name.display_name
+                            )),
+      Tab::Related::Query.for(model: Location, filter: :Observation,
+                              current_query: @query,
+                              controller: @controller),
+      Tab::Related::Query.for(model: Observation, filter: :Observation,
+                              current_query: @query,
+                              controller: @controller)
+    ].compact
+  end
+end

--- a/app/classes/tab/name/mycobank_search.rb
+++ b/app/classes/tab/name/mycobank_search.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# "MycoBank search" external-site link for a Name. Composed by
+# observations name-links panel. Mirrors
+# `Tabs::NamesHelper#mycobank_name_search_tab`.
+class Tab::Name::MycobankSearch < Tab::Name::ExternalBase
+  MYCOBANK_HOST = "https://www.mycobank.org/"
+  MYCOBANK_BASIC_SEARCH_PATH = "page/Basic%20names%20search"
+
+  def title
+    :mycobank_search.l
+  end
+
+  def path
+    "#{MYCOBANK_HOST}#{MYCOBANK_BASIC_SEARCH_PATH}" \
+      "/field/Taxon%20name/#{@name.sensu_stricto.gsub(" ", "%20")}"
+  end
+end

--- a/app/classes/tab/name/mycoportal.rb
+++ b/app/classes/tab/name/mycoportal.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# "MyCoPortal" external-site link for a Name. Composed by
+# observations name-links panel (via `Tab::Observation::*` once
+# that migrates). Mirrors `Tabs::NamesHelper#mycoportal_name_tab`.
+class Tab::Name::Mycoportal < Tab::Name::ExternalBase
+  def title
+    "MyCoPortal"
+  end
+
+  def path
+    "http://mycoportal.org/portal/taxa/index.php?taxauthid=1&taxon=" \
+      "#{@name.sensu_stricto}"
+  end
+end

--- a/app/classes/tab/name/new.rb
+++ b/app/classes/tab/name/new.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Tab::Name::New < Tab::Base
+  def title
+    :show_name_add_name.l
+  end
+
+  def path
+    new_name_path
+  end
+
+  def html_options
+    { icon: :add }
+  end
+
+  def model
+    Name
+  end
+end

--- a/app/classes/tab/name/new_description.rb
+++ b/app/classes/tab/name/new_description.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Name::NewDescription < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_name_create_description.l
+  end
+
+  def path
+    new_name_description_path(@name.id)
+  end
+
+  def html_options
+    { icon: :add }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/new_tracker.rb
+++ b/app/classes/tab/name/new_tracker.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Name::NewTracker < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_name_email_tracking.t
+  end
+
+  def path
+    new_tracker_of_name_path(@name.id)
+  end
+
+  def html_options
+    { icon: :tracking }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/occurrence_map.rb
+++ b/app/classes/tab/name/occurrence_map.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Distribution-map link for a name. Intentionally does NOT thread a
+# q_param through — issue #4139 surfaced that an inherited
+# `in_box` filter from a prior map popup's Show-All / Map-All click
+# would silently restrict this map to that bbox. The link always
+# lands on the full distribution map.
+class Tab::Name::OccurrenceMap < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_name_distribution_map.t
+  end
+
+  def path
+    map_name_path(id: @name.id)
+  end
+
+  def html_options
+    { data: { action: "links#disable" } }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/show_description.rb
+++ b/app/classes/tab/name/show_description.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# "See more" link to the name's primary description. Caller must
+# guard on `name&.description` before constructing.
+class Tab::Name::ShowDescription < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_name_see_more.l
+  end
+
+  def path
+    name_description_path(@name.description.id)
+  end
+
+  def html_options
+    { icon: :list }
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/name/user_google_images.rb
+++ b/app/classes/tab/name/user_google_images.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# "Google Images" external-site link for a Name. Composes the
+# query string from `name.user_real_text_name(user)` — different
+# users may see different real_text_name strings depending on
+# preferences (synonyms / sub-taxa expansion).
+class Tab::Name::UserGoogleImages < Tab::Name::ExternalBase
+  def initialize(name:, user:)
+    super(name: name)
+    @user = user
+  end
+
+  def title
+    :google_images.t
+  end
+
+  def path
+    format("https://images.google.com/images?q=%s",
+           @name.user_real_text_name(@user))
+  end
+end

--- a/app/classes/tab/name/version_actions.rb
+++ b/app/classes/tab/name/version_actions.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Tab::Name::VersionActions < Tab::Collection
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Show.new(
+      object: @name,
+      title: :show_name.t(name: @name.display_name)
+    )]
+  end
+end

--- a/app/classes/tab/name_description/form_edit.rb
+++ b/app/classes/tab/name_description/form_edit.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Form-edit action-nav for NameDescription. Does NOT include the
+# "adjust permissions" tab (which depends on `description.is_admin?
+# (user)` AND the unconverted `descriptions_helper`
+# adjust_description_permissions_tab). The helper-method delegator
+# composes that tab onto the end if applicable.
+class Tab::NameDescription::FormEdit < Tab::Collection
+  def initialize(description:)
+    super()
+    @description = description
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Object::Return.new(object: @description.name,
+                              title: :show_object.t(type: :name)),
+      Tab::Object::Return.new(object: @description)
+    ]
+  end
+end

--- a/app/classes/tab/name_description/form_new.rb
+++ b/app/classes/tab/name_description/form_new.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Tab::NameDescription::FormNew < Tab::Collection
+  def initialize(description:)
+    super()
+    @description = description
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Return.new(object: @description.name)]
+  end
+end

--- a/app/classes/tab/name_description/form_permissions.rb
+++ b/app/classes/tab/name_description/form_permissions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Tab::NameDescription::FormPermissions < Tab::Collection
+  def initialize(description:)
+    super()
+    @description = description
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Object::Return.new(object: @description.name),
+      Tab::Object::Return.new(
+        object: @description,
+        title: :show_object.t(type: :name_description)
+      )
+    ]
+  end
+end

--- a/app/classes/tab/name_description/index_actions.rb
+++ b/app/classes/tab/name_description/index_actions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Tab::NameDescription::IndexActions < Tab::Collection
+  def initialize(query: nil, controller: nil)
+    super()
+    @query = query
+    @controller = controller
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Related::Query.for(model: Name, filter: :NameDescription,
+                              current_query: @query,
+                              controller: @controller)
+    ].compact
+  end
+end

--- a/app/classes/tab/name_description/version_actions.rb
+++ b/app/classes/tab/name_description/version_actions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Tab::NameDescription::VersionActions < Tab::Collection
+  def initialize(description:, desc_title:)
+    super()
+    @description = description
+    @desc_title = desc_title
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Return.new(
+      object: @description,
+      title: :show_name_description.t(description: @desc_title)
+    )]
+  end
+end

--- a/app/helpers/tabs/names/descriptions_helper.rb
+++ b/app/helpers/tabs/names/descriptions_helper.rb
@@ -1,39 +1,45 @@
 # frozen_string_literal: true
 
-# html used in tabsets
 module Tabs
   module Names
     module DescriptionsHelper
+      # Migrated to `Tab::NameDescription::*` Collection POROs.
+      # `form_edit` retains a delegator append for the "adjust
+      # permissions" tab, which still comes from the unconverted
+      # `descriptions_helper.rb`.
+
       def name_description_index_tabs(query:)
-        [related_names_tab(:NameDescription, query)]
+        ::Tab::NameDescription::IndexActions.new(
+          query: query, controller: controller
+        ).map(&:to_a)
       end
 
       def name_description_form_new_tabs(description:)
-        [object_return_tab(description.name)]
+        ::Tab::NameDescription::FormNew.new(
+          description: description
+        ).map(&:to_a)
       end
 
       def name_description_form_edit_tabs(description:, user:)
-        links = [
-          object_return_tab(description.name, :show_object.t(type: :name)),
-          object_return_tab(description)
-        ]
+        tabs = ::Tab::NameDescription::FormEdit.new(
+          description: description
+        ).map(&:to_a)
         if description.is_admin?(user) || in_admin_mode?
-          links << adjust_description_permissions_tab(description, :name, true)
+          tabs << adjust_description_permissions_tab(description, :name, true)
         end
-        links
+        tabs
       end
 
       def name_description_form_permissions_tabs(description:)
-        [
-          object_return_tab(description.name),
-          object_return_tab(description,
-                            :show_object.t(type: :name_description))
-        ]
+        ::Tab::NameDescription::FormPermissions.new(
+          description: description
+        ).map(&:to_a)
       end
 
       def name_description_version_tabs(description:, desc_title:)
-        [object_return_tab(description,
-                           :show_name_description.t(description: desc_title))]
+        ::Tab::NameDescription::VersionActions.new(
+          description: description, desc_title: desc_title
+        ).map(&:to_a)
       end
     end
   end

--- a/app/helpers/tabs/names_helper.rb
+++ b/app/helpers/tabs/names_helper.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
-# html used in tabsets
 module Tabs
   module NamesHelper
+    # The action tabs + 3 observation-needed external links migrated
+    # to PORO classes under `app/classes/tab/name/*.rb`. The
+    # remaining external link tabs (eol, gbif, ncbi, ascomycete.org,
+    # mushroomexpert, wikipedia, index_fungorum, etc.) stay as
+    # helper methods using the `external_name_tab` utility below
+    # — they migrate in a follow-up PR or together with
+    # `app/helpers/object_link_helper.rb`'s URL builders.
+
+    # -------- action tabs ----------------------------------------
+
     def edit_name_tab(name)
-      InternalLink::Model.new(
-        :show_name_edit_name.l, name,
-        edit_name_path(name.id),
-        html_options: { icon: :edit }
-      ).tab
+      ::Tab::Name::Edit.new(name: name).to_a
     end
 
     def new_name_tab
-      InternalLink::Model.new(
-        :show_name_add_name.l, Name,
-        new_name_path,
-        html_options: { icon: :add }
-      ).tab
+      ::Tab::Name::New.new.to_a
     end
 
     def edit_synonym_form_tab(name)
@@ -25,7 +26,6 @@ module Tabs
       edit_name_synonym_tab(name)
     end
 
-    # Can't approve a misspelling
     def approve_synonym_form_tab(name)
       return unless name.deprecated && name&.correct_spelling_id.nil? &&
                     (in_admin_mode? || !name.locked)
@@ -40,47 +40,117 @@ module Tabs
     end
 
     def edit_name_synonym_tab(name)
-      InternalLink::Model.new(
-        :show_name_change_synonyms.l, name,
-        edit_synonyms_of_name_path(name.id),
-        html_options: { icon: :synonyms }
-      ).tab
+      ::Tab::Name::EditSynonym.new(name: name).to_a
     end
 
-    # Note that the "deprecate" icon appears on approved names, so it's a
-    # "check" to indicate at a glance that they're approved.
     def deprecate_name_tab(name)
-      InternalLink::Model.new(
-        :DEPRECATE.l, name,
-        form_to_deprecate_synonym_of_name_path(name.id),
-        html_options: { icon: :deprecate }
-      ).tab
+      ::Tab::Name::Deprecate.new(name: name).to_a
     end
 
-    # Likewise, the "approve" icon appears on deprecated names, so it's a "!"
     def approve_name_synonym_tab(name)
-      InternalLink::Model.new(
-        :APPROVE.l, name,
-        form_to_approve_synonym_of_name_path(name.id),
-        html_options: { icon: :approve }
-      ).tab
+      ::Tab::Name::Approve.new(name: name).to_a
     end
 
-    # Show name panels:
-    # Nomenclature tabs
-    def index_fungorum_search_page_tab
-      InternalLink.new(
-        :index_fungorum_search.l,
-        index_fungorum_search_page_url,
-        html_options: { target: :_blank, rel: :noopener }
-      ).tab
+    def edit_name_lifeform_tab(name)
+      ::Tab::Name::EditLifeform.new(name: name).to_a
     end
 
-    def index_fungorum_record_tab(name)
-      external_name_tab("[##{name.icn_id}]", name,
-                        index_fungorum_record_url(name.icn_id),
-                        alt_title: "index_fungorum_record")
+    def name_show_description_tab(name)
+      return unless name&.description
+
+      ::Tab::Name::ShowDescription.new(name: name).to_a
     end
+
+    def name_edit_description_tab(name)
+      description = name&.description
+      return unless description && permission?(description)
+
+      ::Tab::Name::EditDescription.new(name: name).to_a
+    end
+
+    def name_new_description_tab(name)
+      ::Tab::Name::NewDescription.new(name: name).to_a
+    end
+
+    def name_edit_classification_tab(name)
+      ::Tab::Name::EditClassification.new(name: name).to_a
+    end
+
+    def occurrence_map_for_name_tab(name)
+      ::Tab::Name::OccurrenceMap.new(name: name).to_a
+    end
+
+    def name_tracker_form_tab(name, user)
+      existing = NameTracker.find_by(name_id: name.id, user_id: user.id)
+      existing ? edit_name_tracker_tab(name) : new_name_tracker_tab(name)
+    end
+
+    def edit_name_tracker_tab(name)
+      ::Tab::Name::EditTracker.new(name: name).to_a
+    end
+
+    def new_name_tracker_tab(name)
+      ::Tab::Name::NewTracker.new(name: name).to_a
+    end
+
+    def names_index_tab
+      ::Tab::Name::Index.new.to_a
+    end
+
+    def all_names_tab(query)
+      return unless query&.params&.dig(:has_observations)
+
+      ::Tab::Name::All.new.to_a
+    end
+
+    # -------- 3 external tabs that observations composers use ----
+
+    def mycoportal_name_tab(name)
+      ::Tab::Name::Mycoportal.new(name: name).to_a
+    end
+
+    def mycobank_name_search_tab(name)
+      ::Tab::Name::MycobankSearch.new(name: name).to_a
+    end
+
+    def user_google_images_for_name_tab(user, name)
+      ::Tab::Name::UserGoogleImages.new(name: name, user: user).to_a
+    end
+
+    # -------- collections ----------------------------------------
+
+    def name_map_tabs(name:, query:)
+      ::Tab::Name::MapActions.new(name: name, query: query,
+                                  controller: controller).map(&:to_a)
+    end
+
+    def all_names_index_tabs(query:)
+      ::Tab::Name::IndexActions.new(query: query,
+                                    controller: controller).map(&:to_a)
+    end
+
+    def name_form_new_tabs
+      ::Tab::Name::FormNew.new.map(&:to_a)
+    end
+
+    def name_form_edit_tabs(name:)
+      ::Tab::Name::FormEdit.new(name: name,
+                                q_param: q_param).map(&:to_a)
+    end
+
+    def name_version_tabs(name:)
+      ::Tab::Name::VersionActions.new(name: name).map(&:to_a)
+    end
+
+    def name_forms_return_tabs(name:)
+      ::Tab::Name::FormsReturn.new(name: name).map(&:to_a)
+    end
+
+    # -------- unconverted external link tabs ---------------------
+    # These stay as helper methods until a follow-up PR migrates
+    # them alongside `object_link_helper.rb`'s URL builders.
+    # Used from the name show page's name-links panel, not from
+    # cross-domain composers.
 
     def external_name_tab(title, name, url, alt_title: nil)
       InternalLink::Model.new(
@@ -90,7 +160,18 @@ module Tabs
       ).tab
     end
 
-    ## In Progress
+    def index_fungorum_search_page_tab
+      InternalLink.new(
+        :index_fungorum_search.l, index_fungorum_search_page_url,
+        html_options: { target: :_blank, rel: :noopener }
+      ).tab
+    end
+
+    def index_fungorum_record_tab(name)
+      external_name_tab("[##{name.icn_id}]", name,
+                        index_fungorum_record_url(name.icn_id),
+                        alt_title: "index_fungorum_record")
+    end
 
     def mycobank_record_tab(name)
       external_name_tab("[##{name.icn_id}]", name,
@@ -108,81 +189,15 @@ module Tabs
                         species_fungorum_sf_synonymy(name.icn_id))
     end
 
-    def mycobank_name_search_tab(name)
-      external_name_tab(:mycobank_search.l, name,
-                        mycobank_name_search_url(name))
-    end
-
     def mycobank_basic_search_tab
       InternalLink.new(
-        :mycobank_search.l,
-        mycobank_basic_search_url,
+        :mycobank_search.l, mycobank_basic_search_url,
         html_options: { target: :_blank, rel: :noopener }
-      ).tab
-    end
-
-    # lifeform tabs:
-    def edit_name_lifeform_tab(name)
-      InternalLink::Model.new(
-        :EDIT.l, name,
-        edit_lifeform_of_name_path(name.id),
-        html_options: { icon: :edit }
-      ).tab
-    end
-
-    # description tabs:
-    def name_show_description_tab(name)
-      return unless name&.description
-
-      InternalLink::Model.new(
-        :show_name_see_more.l, name,
-        name_description_path(name.description.id),
-        html_options: { icon: :list }
-      ).tab
-    end
-
-    def name_edit_description_tab(name)
-      description = name&.description
-      return unless description && permission?(description)
-
-      InternalLink::Model.new(
-        :EDIT.l, name,
-        edit_name_description_path(description.id),
-        html_options: { icon: :edit }
-      ).tab
-    end
-
-    def name_new_description_tab(name)
-      InternalLink::Model.new(
-        :show_name_create_description.l, name,
-        new_name_description_path(name.id),
-        html_options: { icon: :add }
-      ).tab
-    end
-
-    # classification tabs:
-    def name_edit_classification_tab(name)
-      InternalLink::Model.new(
-        :EDIT.l, name,
-        edit_classification_of_name_path(name.id),
-        html_options: { icon: :edit }
       ).tab
     end
 
     def eol_name_tab(name)
       external_name_tab("EOL", name, name.eol_url)
-    end
-
-    # def google_images_for_name_tab(name)
-    #   url = format("https://images.google.com/images?q=%s",
-    #                name.real_text_name)
-    #   external_name_tab(:google_images.t, name, url)
-    # end
-
-    def user_google_images_for_name_tab(user, name)
-      url = format("https://images.google.com/images?q=%s",
-                   name.user_real_text_name(user))
-      external_name_tab(:google_images.t, name, url)
     end
 
     def ascomycete_org_name_tab(name)
@@ -217,111 +232,11 @@ module Tabs
                         mushroomexpert_name_web_search_url(name))
     end
 
-    def mycoportal_name_tab(name)
-      external_name_tab("MyCoPortal", name, mycoportal_url(name))
-    end
-
     def wikipedia_term_tab(name)
       external_name_tab("Wikipedia", name, wikipedia_term_search_url(name))
     end
 
-    # Drop `add_q_param` here so the link always lands on the full
-    # distribution map for the name. Carrying the current query
-    # context inherits whatever filters happen to be in scope —
-    # notably an `in_box` filter from a prior map popup's
-    # Show All / Map All click — which silently restricts the map
-    # to that bbox (issue #4139).
-    def occurrence_map_for_name_tab(name)
-      InternalLink::Model.new(
-        :show_name_distribution_map.t, name,
-        map_name_path(id: name.id),
-        html_options: { data: { action: "links#disable" } }
-      ).tab
-    end
-
-    # Others
-    def name_tracker_form_tab(name, user)
-      existing_name_tracker = NameTracker.find_by(name_id: name.id,
-                                                  user_id: user.id)
-      if existing_name_tracker
-        edit_name_tracker_tab(name)
-      else
-        new_name_tracker_tab(name)
-      end
-    end
-
-    # Note that a name map query is an observations (of name) query.
-    # "Related records" are going to be related to the observations.
-    def name_map_tabs(name:, query:)
-      [
-        show_object_tab(name, :name_map_about.t(name: name.display_name)),
-        related_locations_tab(:Observation, query),
-        related_observations_tab(:Observation, query)
-      ]
-    end
-
-    def edit_name_tracker_tab(name)
-      InternalLink::Model.new(
-        :show_name_email_tracking.t, name,
-        edit_tracker_of_name_path(name.id),
-        html_options: { icon: :tracking }
-      ).tab
-    end
-
-    def new_name_tracker_tab(name)
-      InternalLink::Model.new(
-        :show_name_email_tracking.t, name,
-        new_tracker_of_name_path(name.id),
-        html_options: { icon: :tracking }
-      ).tab
-    end
-
-    ##########################################################################
-    #
-    #    Index:
-
-    # Dead code?
-    # def names_index_tabs(query:)
-    #   [
-    #     new_name_tab,
-    #     names_with_observations_tab(query),
-    #     related_observations_tab(:Name, query),
-    #     related_descriptions_tab(query)
-    #   ].reject(&:empty?)
-    # end
-
-    # def names_with_observations_tab(query)
-    #   return unless query&.params&.dig(:has_observations)
-
-    #   InternalLink.new(
-    #     :all_objects.t(type: :name), names_path(has_observations: true)
-    #   ).tab
-    # end
-
-    # def related_descriptions_tab(names_query)
-    #   # return unless query&.coercable?(:NameDescription)
-
-    #   desc_query = Query.lookup(:NameDescription, name_query: names_query)
-    #   [:show_objects.t(type: :description),
-    #    add_q_param(name_descriptions_index_path, desc_query),
-    #    { class: tab_id(__method__.to_s) }]
-    # end
-
-    def all_names_index_tabs(query:)
-      [
-        new_name_tab,
-        all_names_tab(query),
-        related_observations_tab(:Name, query)
-      ].reject(&:empty?)
-    end
-
-    def all_names_tab(query)
-      return unless query&.params&.dig(:has_observations)
-
-      InternalLink.new(
-        :all_objects.t(type: :name), names_path
-      ).tab
-    end
+    # -------- non-tab utility ------------------------------------
 
     def names_index_sorts(query: nil)
       rss_log = query&.params&.dig(:order_by) == :rss_log
@@ -331,30 +246,6 @@ module Tabs
         [(rss_log ? "rss_log" : "updated_at"), :sort_by_updated_at.t],
         ["num_views", :sort_by_num_views.t]
       ]
-    end
-
-    ### Forms
-    def name_form_new_tabs
-      [names_index_tab]
-    end
-
-    def names_index_tab
-      InternalLink.new(
-        :all_objects.t(type: :name), names_path
-      ).tab
-    end
-
-    def name_form_edit_tabs(name:)
-      [object_return_tab(name),
-       object_index_tab(name)]
-    end
-
-    def name_version_tabs(name:)
-      [show_object_tab(name, :show_name.t(name: name.display_name))]
-    end
-
-    def name_forms_return_tabs(name:)
-      [object_return_tab(name)]
     end
   end
 end

--- a/test/classes/tab/name/collections_test.rb
+++ b/test/classes/tab/name/collections_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Tab::Name
+  class CollectionsTest < UnitTestCase
+    def setup
+      @name = names(:agaricus_campestris)
+    end
+
+    def test_form_new
+      tabs = Tab::Name::FormNew.new.to_a
+
+      assert_equal([Tab::Name::Index], tabs.map(&:class))
+    end
+
+    def test_form_edit
+      tabs = Tab::Name::FormEdit.new(name: @name).to_a
+
+      assert_equal([Tab::Object::Return, Tab::Object::Index],
+                   tabs.map(&:class))
+    end
+
+    def test_version_actions
+      tabs = Tab::Name::VersionActions.new(name: @name).to_a
+
+      assert_equal([Tab::Object::Show], tabs.map(&:class))
+      assert_equal(:show_name.t(name: @name.display_name),
+                   tabs.first.title)
+    end
+
+    def test_forms_return
+      tabs = Tab::Name::FormsReturn.new(name: @name).to_a
+
+      assert_equal([Tab::Object::Return], tabs.map(&:class))
+    end
+
+    def test_index_actions_no_query
+      tabs = Tab::Name::IndexActions.new.to_a
+
+      # Just `New` when no has_observations filter (the
+      # Related::Query bridge is also nil when current_query is nil).
+      assert_includes(tabs.map(&:class), Tab::Name::New)
+      assert_not_includes(tabs.map(&:class), Tab::Name::All)
+    end
+
+    def test_index_actions_with_has_observations_query
+      query = ::Query.lookup(:Name, has_observations: true)
+
+      stub_for_related = ->(*) { false }
+      ::Query.stub(:related?, stub_for_related) do
+        tabs = Tab::Name::IndexActions.new(query: query,
+                                           controller: nil).to_a
+
+        assert_includes(tabs.map(&:class), Tab::Name::New)
+        assert_includes(tabs.map(&:class), Tab::Name::All)
+      end
+    end
+
+    def test_map_actions
+      query = ::Query.lookup(:Observation)
+
+      stub_for_related = ->(*) { false }
+      ::Query.stub(:related?, stub_for_related) do
+        tabs = Tab::Name::MapActions.new(name: @name, query: query,
+                                         controller: nil).to_a
+
+        # Just Object::Show when the related bridges are nil.
+        assert_equal([Tab::Object::Show], tabs.map(&:class))
+        assert_equal(
+          :name_map_about.t(name: @name.display_name),
+          tabs.first.title
+        )
+      end
+    end
+  end
+end

--- a/test/classes/tab/name/tabs_test.rb
+++ b/test/classes/tab/name/tabs_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Tab::Name
+  class TabsTest < UnitTestCase
+    def routes
+      Rails.application.routes.url_helpers
+    end
+
+    def setup
+      @name = names(:agaricus_campestris)
+      @user = users(:rolf)
+    end
+
+    def test_edit
+      tab = Tab::Name::Edit.new(name: @name)
+
+      assert_equal(:show_name_edit_name.l, tab.title)
+      assert_equal(routes.edit_name_path(@name.id), tab.path)
+      assert_equal(:edit, tab.html_options[:icon])
+      assert_equal(@name, tab.model)
+    end
+
+    def test_new
+      tab = Tab::Name::New.new
+
+      assert_equal(:show_name_add_name.l, tab.title)
+      assert_equal(routes.new_name_path, tab.path)
+      assert_equal(:add, tab.html_options[:icon])
+      assert_equal(Name, tab.model)
+    end
+
+    def test_edit_synonym
+      tab = Tab::Name::EditSynonym.new(name: @name)
+
+      assert_equal(:show_name_change_synonyms.l, tab.title)
+      assert_equal(routes.edit_synonyms_of_name_path(@name.id), tab.path)
+      assert_equal(:synonyms, tab.html_options[:icon])
+    end
+
+    def test_deprecate
+      tab = Tab::Name::Deprecate.new(name: @name)
+
+      assert_equal(:DEPRECATE.l, tab.title)
+      assert_equal(routes.form_to_deprecate_synonym_of_name_path(@name.id),
+                   tab.path)
+    end
+
+    def test_approve
+      tab = Tab::Name::Approve.new(name: @name)
+
+      assert_equal(:APPROVE.l, tab.title)
+      assert_equal(routes.form_to_approve_synonym_of_name_path(@name.id),
+                   tab.path)
+    end
+
+    def test_edit_lifeform
+      tab = Tab::Name::EditLifeform.new(name: @name)
+
+      assert_equal(:EDIT.l, tab.title)
+      assert_equal(routes.edit_lifeform_of_name_path(@name.id), tab.path)
+    end
+
+    def test_new_description
+      tab = Tab::Name::NewDescription.new(name: @name)
+
+      assert_equal(:show_name_create_description.l, tab.title)
+      assert_equal(routes.new_name_description_path(@name.id), tab.path)
+      assert_equal(:add, tab.html_options[:icon])
+    end
+
+    def test_edit_classification
+      tab = Tab::Name::EditClassification.new(name: @name)
+
+      assert_equal(:EDIT.l, tab.title)
+      assert_equal(routes.edit_classification_of_name_path(@name.id),
+                   tab.path)
+    end
+
+    def test_occurrence_map_no_q_param
+      tab = Tab::Name::OccurrenceMap.new(name: @name)
+
+      assert_equal(:show_name_distribution_map.t, tab.title)
+      assert_equal(routes.map_name_path(id: @name.id), tab.path)
+      assert_equal("links#disable", tab.html_options[:data][:action])
+    end
+
+    def test_edit_tracker
+      tab = Tab::Name::EditTracker.new(name: @name)
+
+      assert_equal(:show_name_email_tracking.t, tab.title)
+      assert_equal(routes.edit_tracker_of_name_path(@name.id), tab.path)
+    end
+
+    def test_new_tracker
+      tab = Tab::Name::NewTracker.new(name: @name)
+
+      assert_equal(:show_name_email_tracking.t, tab.title)
+      assert_equal(routes.new_tracker_of_name_path(@name.id), tab.path)
+    end
+
+    def test_index
+      tab = Tab::Name::Index.new
+
+      assert_equal(:all_objects.t(type: :name), tab.title)
+      assert_equal(routes.names_path, tab.path)
+    end
+
+    def test_all
+      tab = Tab::Name::All.new
+
+      assert_equal(:all_objects.t(type: :name), tab.title)
+      assert_equal(routes.names_path, tab.path)
+    end
+
+    def test_mycoportal_external_link
+      tab = Tab::Name::Mycoportal.new(name: @name)
+
+      assert_equal("MyCoPortal", tab.title)
+      assert_includes(tab.path, "mycoportal.org")
+      assert_equal(:_blank, tab.html_options[:target])
+      assert_equal(:noopener, tab.html_options[:rel])
+      assert_equal(@name, tab.model)
+    end
+
+    def test_mycobank_search_external_link
+      tab = Tab::Name::MycobankSearch.new(name: @name)
+
+      assert_equal(:mycobank_search.l, tab.title)
+      assert_includes(tab.path, "mycobank.org")
+    end
+
+    def test_user_google_images_external_link
+      tab = Tab::Name::UserGoogleImages.new(name: @name, user: @user)
+
+      assert_equal(:google_images.t, tab.title)
+      assert_includes(tab.path, "images.google.com")
+    end
+  end
+end

--- a/test/classes/tab/name_description/collections_test.rb
+++ b/test/classes/tab/name_description/collections_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Tab::NameDescription
+  class CollectionsTest < UnitTestCase
+    def setup
+      @description = name_descriptions(:agaricus_campestras_desc)
+    end
+
+    def test_form_new
+      tabs = Tab::NameDescription::FormNew.new(
+        description: @description
+      ).to_a
+
+      assert_equal([Tab::Object::Return], tabs.map(&:class))
+    end
+
+    def test_form_edit
+      tabs = Tab::NameDescription::FormEdit.new(
+        description: @description
+      ).to_a
+
+      # 2 Object::Return tabs: name + the description itself.
+      # The "adjust permissions" tab is appended by the helper
+      # delegator (still depends on the unconverted
+      # descriptions_helper#adjust_description_permissions_tab).
+      assert_equal([Tab::Object::Return, Tab::Object::Return],
+                   tabs.map(&:class))
+      assert_equal(:show_object.t(type: :name), tabs[0].title)
+    end
+
+    def test_form_permissions
+      tabs = Tab::NameDescription::FormPermissions.new(
+        description: @description
+      ).to_a
+
+      assert_equal([Tab::Object::Return, Tab::Object::Return],
+                   tabs.map(&:class))
+      assert_equal(:show_object.t(type: :name_description), tabs[1].title)
+    end
+
+    def test_version_actions
+      tabs = Tab::NameDescription::VersionActions.new(
+        description: @description, desc_title: "Foo"
+      ).to_a
+
+      assert_equal([Tab::Object::Return], tabs.map(&:class))
+      assert_equal(
+        :show_name_description.t(description: "Foo"),
+        tabs.first.title
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR C in the observations-web Tab POROs layered migration. **Stacks on #4410** (which itself stacks on #4409). Converts the action tabs in `tabs/names_helper.rb` plus the 3 external-link tabs that `tabs/observations_helper.rb` depends on; leaves the other ~15 external link tabs (eol, gbif, ncbi, ascomycete.org, mushroomexpert, wikipedia, etc.) as helper-method delegators using the preserved `external_name_tab` utility — those migrate together with `app/helpers/object_link_helper.rb`'s URL builders in a follow-up.

Scope-limiting the externals lets this PR focus on what's needed to unblock observations (PR D) without bringing the ~15-site URL-builder cleanup into scope.

## 16 single Tab POROs under `Tab::Name::*`

**Action tabs**: `Edit`, `New`, `EditSynonym`, `Deprecate`, `Approve`, `EditLifeform`, `ShowDescription`, `EditDescription`, `NewDescription`, `EditClassification`, `OccurrenceMap`, `EditTracker`, `NewTracker`, `Index`, `All`.

`OccurrenceMap` intentionally drops `q_param` (issue #4139 — an inherited `in_box` filter from a prior map popup's Show-All / Map-All click would silently restrict the distribution map to that bbox).

**External link tabs needed by observations composers**: `Mycoportal`, `MycobankSearch`, `UserGoogleImages` — each subclasses `Tab::Name::ExternalBase` which carries the shared `target=_blank` / `rel=noopener` html_options + `model = @name`.

## 6 Tab::Collection subclasses under `Tab::Name::*`

- **`IndexActions`** — `New + (All when query[:has_observations]) + Related::Query(Observation, :Name)`.
- **`MapActions`** — `Object::Show(name, custom_title) + Related::Query(Location, :Observation) + Related::Query(Observation, :Observation)`. A name-map query is, under the hood, an Observations-of-name query; "related records" therefore branch off the Observation query, not the Name.
- **`FormNew`** — `[Index]`.
- **`FormEdit`** — `[Object::Return(name), Object::Index(name)]` with `q_param`.
- **`VersionActions`** — `[Object::Show(name, custom_title)]`.
- **`FormsReturn`** — `[Object::Return(name)]`.

## 5 Tab::Collection subclasses under `Tab::NameDescription::*`

- **`IndexActions`** — `[Related::Query(Name, :NameDescription)]`.
- **`FormNew`** — `[Object::Return(name)]`.
- **`FormEdit`** — `[Object::Return(name, custom_title), Object::Return(description)]`. The "adjust permissions" tab is conditionally appended by the helper-method delegator (still depends on the unconverted `descriptions_helper#adjust_description_permissions_tab`).
- **`FormPermissions`** — `[Object::Return(name), Object::Return(description, custom_title)]`.
- **`VersionActions`** — `[Object::Return(description, custom_title)]`.

## Helpers slimmed

`tabs/names_helper.rb` (~360 LOC → ~250 LOC). Action tabs + 3 cross-domain externals delegate to POROs; 15 remaining external tabs keep using `external_name_tab` utility + helper-context URL builders from `object_link_helper.rb`. Same shape for `tabs/names/descriptions_helper.rb`.

## Tests

- 16 single-Tab tests (per-tab title / path / html_options assertions, route helpers throughout).
- 7 Collection tests (order pinned under each conditional branch — IndexActions with/without `has_observations` query, MapActions with no related bridges).
- 4 NameDescription Collection tests.

## Test plan

- [x] `bin/rails test test/classes/tab/name/ test/classes/tab/name_description/` — 27 tests, 94 assertions, all green
- [x] `bin/rails test test/classes/tab/ test/controllers/names_controller_show_test.rb test/controllers/names_controller_index_test.rb test/controllers/names_controller_update_test.rb` — 239 tests, 1193 assertions, all green
- [x] `bundle exec rubocop` on every touched file — 0 offenses across 32 files
- [x] CI green
- [ ] Browser-verify: name show / edit / new / synonyms / classification / lifeform / tracker pages. Name index page action-nav with and without `?has_observations=true`.

## Base

Stacks on #4410. Retarget to `main` once both #4409 and #4410 merge.
