### PR TITLE
Tab POROs: convert observations (15 single Tabs + 12 Collections)

### DIFF
--- a/app/classes/tab/observation/add_to_list.rb
+++ b/app/classes/tab/observation/add_to_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Tab::Observation::AddToList < Tab::Base
+  def initialize(q_param: nil)
+    super()
+    @q_param = q_param
+  end
+
+  def title
+    :list_observations_add_to_list.l
+  end
+
+  def path
+    with_q_param(species_lists_edit_observations_path, @q_param)
+  end
+end

--- a/app/classes/tab/observation/assign_undefined_location.rb
+++ b/app/classes/tab/observation/assign_undefined_location.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Tab::Observation::AssignUndefinedLocation < Tab::Base
+  def initialize(where:, q_param: nil)
+    super()
+    @where = where
+    @q_param = q_param
+  end
+
+  def title
+    :list_observations_location_merge.l
+  end
+
+  def path
+    with_q_param(
+      matching_locations_for_observations_path(where: @where), @q_param
+    )
+  end
+end

--- a/app/classes/tab/observation/at_where_actions.rb
+++ b/app/classes/tab/observation/at_where_actions.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Extra action-nav links shown on the observations index when the
+# user landed via a typed-but-unknown location string (`?where=...`).
+# Caller passes `where:` (resolved from `params[:where]` or
+# `query.params[:search_where]`) and `q_param:`. Replaces
+# `Tabs::ObservationsHelper#observations_at_where_tabs`.
+class Tab::Observation::AtWhereActions < Tab::Collection
+  def initialize(where:, q_param: nil)
+    super()
+    @where = where
+    @q_param = q_param
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Observation::DefineLocation.new(where: @where,
+                                           q_param: @q_param),
+      Tab::Observation::AssignUndefinedLocation.new(where: @where,
+                                                    q_param: @q_param),
+      Tab::Location::Index.new
+    ]
+  end
+end

--- a/app/classes/tab/observation/define_location.rb
+++ b/app/classes/tab/observation/define_location.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# "Define location" link shown on observations-at-where pages, when
+# the user reached the page via a typed-but-unknown location string.
+# Caller resolves `where:` (typically from `params[:where]` or
+# `query.params[:search_where]`).
+class Tab::Observation::DefineLocation < Tab::Base
+  def initialize(where:, q_param: nil)
+    super()
+    @where = where
+    @q_param = q_param
+  end
+
+  def title
+    :list_observations_location_define.l
+  end
+
+  def path
+    with_q_param(new_location_path(where: @where), @q_param)
+  end
+end

--- a/app/classes/tab/observation/download_csv.rb
+++ b/app/classes/tab/observation/download_csv.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Tab::Observation::DownloadCSV < Tab::Base
+  def initialize(q_param: nil)
+    super()
+    @q_param = q_param
+  end
+
+  def title
+    :list_observations_download_as_csv.l
+  end
+
+  def path
+    with_q_param(new_observations_download_path, @q_param)
+  end
+end

--- a/app/classes/tab/observation/edit.rb
+++ b/app/classes/tab/observation/edit.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Observation::Edit < Tab::Base
+  def initialize(observation:)
+    super()
+    @observation = observation
+  end
+
+  def title
+    :edit_object.t(type: Observation)
+  end
+
+  def path
+    edit_observation_path(@observation.id)
+  end
+
+  def html_options
+    { icon: :edit }
+  end
+
+  def model
+    @observation
+  end
+end

--- a/app/classes/tab/observation/form_edit.rb
+++ b/app/classes/tab/observation/form_edit.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Tab::Observation::FormEdit < Tab::Collection
+  def initialize(observation:)
+    super()
+    @observation = observation
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Return.new(object: @observation)]
+  end
+end

--- a/app/classes/tab/observation/form_new.rb
+++ b/app/classes/tab/observation/form_new.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Tab::Observation::FormNew < Tab::Collection
+  def initialize(q_param: nil)
+    super()
+    @q_param = q_param
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Observation::InatImport.new(q_param: @q_param),
+      Tab::Observation::Index.new(q_param: @q_param)
+    ]
+  end
+end

--- a/app/classes/tab/observation/hide_thumbnail_map.rb
+++ b/app/classes/tab/observation/hide_thumbnail_map.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Observation::HideThumbnailMap < Tab::Base
+  def initialize(observation:)
+    super()
+    @observation = observation
+  end
+
+  def title
+    :show_observation_hide_map.l
+  end
+
+  def path
+    javascript_hide_thumbnail_map_path(id: @observation.id)
+  end
+
+  def html_options
+    { icon: :hide }
+  end
+
+  def model
+    @observation
+  end
+end

--- a/app/classes/tab/observation/images_edit.rb
+++ b/app/classes/tab/observation/images_edit.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Tab::Observation::ImagesEdit < Tab::Collection
+  def initialize(image:)
+    super()
+    @image = image
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Return.new(object: @image)]
+  end
+end

--- a/app/classes/tab/observation/images_reuse.rb
+++ b/app/classes/tab/observation/images_reuse.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Tab::Observation::ImagesReuse < Tab::Collection
+  def initialize(observation:)
+    super()
+    @observation = observation
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Object::Return.new(object: @observation),
+      Tab::Observation::Edit.new(observation: @observation)
+    ]
+  end
+end

--- a/app/classes/tab/observation/inat_import.rb
+++ b/app/classes/tab/observation/inat_import.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Link to the iNaturalist import flow. Lives in the Observation
+# namespace because that's where it surfaces (observation index +
+# new observation form action-nav).
+class Tab::Observation::InatImport < Tab::Base
+  def initialize(q_param: nil)
+    super()
+    @q_param = q_param
+  end
+
+  def title
+    :create_observation_inat_import_link.l
+  end
+
+  def path
+    with_q_param(new_inat_import_path, @q_param)
+  end
+end

--- a/app/classes/tab/observation/index.rb
+++ b/app/classes/tab/observation/index.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# "Cancel to observations index" action-nav link.
+class Tab::Observation::Index < Tab::Base
+  def initialize(q_param: nil)
+    super()
+    @q_param = q_param
+  end
+
+  def title
+    :cancel_to_index.t(type: :OBSERVATION)
+  end
+
+  def path
+    with_q_param(observations_path, @q_param)
+  end
+end

--- a/app/classes/tab/observation/index_actions.rb
+++ b/app/classes/tab/observation/index_actions.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Action-nav for the observations index page. When the user landed
+# via `?where=...`, the AtWhereActions tabs prepend; the rest are
+# always shown.
+class Tab::Observation::IndexActions < Tab::Collection
+  def initialize(query: nil, where: nil, q_param: nil, controller: nil)
+    super()
+    @query = query
+    @where = where
+    @q_param = q_param
+    @controller = controller
+  end
+
+  private
+
+  def tabs
+    [
+      *at_where_tabs,
+      Tab::Observation::Map.new(q_param: @q_param),
+      *related_query_tabs,
+      Tab::Observation::AddToList.new(q_param: @q_param),
+      Tab::Observation::DownloadCSV.new(q_param: @q_param),
+      Tab::Observation::InatImport.new
+    ].compact
+  end
+
+  def at_where_tabs
+    return [] if @where.blank?
+
+    Tab::Observation::AtWhereActions.new(where: @where,
+                                         q_param: @q_param).to_a
+  end
+
+  def related_query_tabs
+    Tab::Observation::RelatedQueryActions.new(query: @query,
+                                              controller: @controller).to_a
+  end
+end

--- a/app/classes/tab/observation/list_actions.rb
+++ b/app/classes/tab/observation/list_actions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Action-nav for the species-lists-of-observation page — a single
+# cancel-to-obs link. Replaces `observation_list_tabs`.
+class Tab::Observation::ListActions < Tab::Collection
+  def initialize(observation:)
+    super()
+    @observation = observation
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Return.new(object: @observation)]
+  end
+end

--- a/app/classes/tab/observation/manage_lists.rb
+++ b/app/classes/tab/observation/manage_lists.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# "Manage species lists for this observation" link. Caller must
+# guard on `user&.species_list_ids&.any?` — the helper used to do
+# this internally but Tab POROs are conditional-free.
+class Tab::Observation::ManageLists < Tab::Base
+  def initialize(observation:, q_param: nil)
+    super()
+    @observation = observation
+    @q_param = q_param
+  end
+
+  def title
+    :show_observation_manage_species_lists.l
+  end
+
+  def path
+    with_q_param(edit_observation_species_lists_path(@observation.id),
+                 @q_param)
+  end
+
+  def html_options
+    { icon: :manage_lists }
+  end
+
+  def model
+    @observation
+  end
+end

--- a/app/classes/tab/observation/map.rb
+++ b/app/classes/tab/observation/map.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# "Map" link on the observations index. The link has a
+# `links#disable` Stimulus data-action so clicking it disables the
+# button while the map page loads (long async work — gives
+# feedback to the user).
+class Tab::Observation::Map < Tab::Base
+  def initialize(q_param: nil)
+    super()
+    @q_param = q_param
+  end
+
+  def title
+    :show_object.t(type: :map)
+  end
+
+  def path
+    map_observations_path(q: @q_param)
+  end
+
+  def html_options
+    { data: { action: "links#disable" } }
+  end
+end

--- a/app/classes/tab/observation/maps_actions.rb
+++ b/app/classes/tab/observation/maps_actions.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Action-nav for the observations-map page. Two related-index
+# bridges that branch off the current Observation query: back to
+# the obs index, and to the locations index.
+class Tab::Observation::MapsActions < Tab::Collection
+  def initialize(query: nil, controller: nil)
+    super()
+    @query = query
+    @controller = controller
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Related::Query.for(model: Observation, filter: :Observation,
+                              current_query: @query,
+                              controller: @controller),
+      Tab::Related::Query.for(model: Location, filter: :Observation,
+                              current_query: @query,
+                              controller: @controller)
+    ].compact
+  end
+end

--- a/app/classes/tab/observation/naming_form.rb
+++ b/app/classes/tab/observation/naming_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Action-nav for the naming new/edit forms — single cancel-to-obs
+# link. Replaces `naming_form_new_tabs` / `naming_form_edit_tabs`.
+class Tab::Observation::NamingForm < Tab::Collection
+  def initialize(observation:)
+    super()
+    @observation = observation
+  end
+
+  private
+
+  def tabs
+    [Tab::Object::Return.new(object: @observation)]
+  end
+end

--- a/app/classes/tab/observation/of_look_alikes.rb
+++ b/app/classes/tab/observation/of_look_alikes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Tab::Observation::OfLookAlikes < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_observation_look_alikes.l
+  end
+
+  def path
+    observations_path(name: @name.id, look_alikes: "1")
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/observation/of_name.rb
+++ b/app/classes/tab/observation/of_name.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Tab::Observation::OfName < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_observation_more_like_this.l
+  end
+
+  def path
+    observations_path(name: @name.id)
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/observation/of_related_taxa.rb
+++ b/app/classes/tab/observation/of_related_taxa.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Tab::Observation::OfRelatedTaxa < Tab::Base
+  def initialize(name:)
+    super()
+    @name = name
+  end
+
+  def title
+    :show_observation_related_taxa.l
+  end
+
+  def path
+    observations_path(name: @name.id, related_taxa: "1")
+  end
+
+  def model
+    @name
+  end
+end

--- a/app/classes/tab/observation/related_name_tabs.rb
+++ b/app/classes/tab/observation/related_name_tabs.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Action-nav links shown on an observation's name panel — points
+# at the name itself plus three "observations matching this name's
+# related taxa" filtered indexes. Replaces
+# `Tabs::ObservationsHelper#obs_related_name_tabs`.
+class Tab::Observation::RelatedNameTabs < Tab::Collection
+  def initialize(user:, name:)
+    super()
+    @user = user
+    @name = name
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Object::Show.new(
+        object: @name,
+        title: :show_name.t(name: @name.display_name_brief_authors(@user))
+      ),
+      Tab::Observation::OfName.new(name: @name),
+      Tab::Observation::OfLookAlikes.new(name: @name),
+      Tab::Observation::OfRelatedTaxa.new(name: @name)
+    ]
+  end
+end

--- a/app/classes/tab/observation/related_query_actions.rb
+++ b/app/classes/tab/observation/related_query_actions.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# 3 related-index bridges (Locations / Names / Images) for the
+# observations index when filtered by a Query. Replaces
+# `Tabs::ObservationsHelper#observations_related_query_tabs`.
+class Tab::Observation::RelatedQueryActions < Tab::Collection
+  def initialize(query: nil, controller: nil)
+    super()
+    @query = query
+    @controller = controller
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Related::Query.for(model: Location, filter: :Observation,
+                              current_query: @query,
+                              controller: @controller),
+      Tab::Related::Query.for(model: Name, filter: :Observation,
+                              current_query: @query,
+                              controller: @controller),
+      Tab::Related::Query.for(model: Image, filter: :Observation,
+                              current_query: @query,
+                              controller: @controller)
+    ].compact
+  end
+end

--- a/app/classes/tab/observation/reuse_images.rb
+++ b/app/classes/tab/observation/reuse_images.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Observation::ReuseImages < Tab::Base
+  def initialize(observation:)
+    super()
+    @observation = observation
+  end
+
+  def title
+    :show_observation_reuse_image.l
+  end
+
+  def path
+    reuse_images_for_observation_path(@observation.id)
+  end
+
+  def html_options
+    { icon: :reuse }
+  end
+
+  def model
+    @observation
+  end
+end

--- a/app/classes/tab/observation/send_question.rb
+++ b/app/classes/tab/observation/send_question.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Tab::Observation::SendQuestion < Tab::Base
+  def initialize(observation:)
+    super()
+    @observation = observation
+  end
+
+  def title
+    :show_observation_send_question.l
+  end
+
+  def path
+    new_question_for_observation_path(@observation.id)
+  end
+
+  def html_options
+    { icon: :email }
+  end
+
+  def model
+    @observation
+  end
+end

--- a/app/classes/tab/observation/web_name_tabs.rb
+++ b/app/classes/tab/observation/web_name_tabs.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Cross-domain composer: external "web search for this name" links
+# rendered in the observation name panel. Each entry is a name
+# external Tab PORO (Mycoportal, MycobankSearch, UserGoogleImages).
+# Replaces `Tabs::ObservationsHelper#user_observation_web_name_tabs`.
+class Tab::Observation::WebNameTabs < Tab::Collection
+  def initialize(user:, name:)
+    super()
+    @user = user
+    @name = name
+  end
+
+  private
+
+  def tabs
+    [
+      Tab::Name::Mycoportal.new(name: @name),
+      Tab::Name::MycobankSearch.new(name: @name),
+      Tab::Name::UserGoogleImages.new(user: @user, name: @name)
+    ]
+  end
+end

--- a/app/helpers/tabs/observations_helper.rb
+++ b/app/helpers/tabs/observations_helper.rb
@@ -1,37 +1,145 @@
 # frozen_string_literal: true
 
-# html used in tabsets
 module Tabs
   module ObservationsHelper
-    ########################################################################
-    # LINKS FOR PANELS
+    # The single Tab + Collection definitions migrated to PORO
+    # classes under `app/classes/tab/observation/*.rb` (15 single
+    # Tabs + 12 Collections). The methods below remain as thin
+    # legacy-shape adapters so existing helper-chain callers
+    # (mostly ERB views + the `*_helper.rb` modules that compose
+    # this one) keep working unchanged.
     #
-    # Used in the observation panel
+    # Two HTML composers (`name_links_on_mo`, `user_name_links_web`)
+    # remain at the helper layer because they pre-render their
+    # constituent tabs to HTML strings via `context_nav_links`. They
+    # call the new PORO Collections internally. Same for
+    # `obs_name_description_tabs` which composes
+    # `app/helpers/descriptions_helper.rb#list_descriptions`
+    # (returns pre-rendered HTML strings) and stays as helper until
+    # descriptions_helper itself migrates.
+
+    # -------- single tabs ----------------------------------------
 
     def send_observer_question_tab(obs)
-      InternalLink::Model.new(
-        :show_observation_send_question.l, obs,
-        new_question_for_observation_path(obs.id),
-        html_options: { icon: :email }
-      ).tab
+      ::Tab::Observation::SendQuestion.new(observation: obs).to_a
     end
 
-    # Used in the lists panel
-    # N+1: this looks up User.current.species_lists. Mercifully quick.
     def observation_manage_lists_tab(obs, user)
       return unless user&.species_list_ids&.any?
 
-      InternalLink::Model.new(
-        :show_observation_manage_species_lists.l, obs,
-        add_q_param(edit_observation_species_lists_path(obs.id)),
-        html_options: { icon: :manage_lists }
-      ).tab
+      ::Tab::Observation::ManageLists.new(observation: obs,
+                                          q_param: q_param).to_a
     end
 
-    # Name panel -- generates HTML
+    def observations_of_name_tab(name)
+      ::Tab::Observation::OfName.new(name: name).to_a
+    end
 
-    # uses context_nav_links with extra_args { class: "d-block" }
-    # the hiccup here is that list_descriptions is already HTML, an inline list
+    def observations_of_look_alikes_tab(name)
+      ::Tab::Observation::OfLookAlikes.new(name: name).to_a
+    end
+
+    def observations_of_related_taxa_tab(name)
+      ::Tab::Observation::OfRelatedTaxa.new(name: name).to_a
+    end
+
+    def observation_hide_thumbnail_map_tab(obs)
+      ::Tab::Observation::HideThumbnailMap.new(observation: obs).to_a
+    end
+
+    def reuse_images_for_observation_tab(obs)
+      ::Tab::Observation::ReuseImages.new(observation: obs).to_a
+    end
+
+    def map_observations_tab(query)
+      ::Tab::Observation::Map.new(q_param: q_param(query)).to_a
+    end
+
+    def observations_add_to_list_tab(query)
+      ::Tab::Observation::AddToList.new(q_param: q_param(query)).to_a
+    end
+
+    def observations_download_as_csv_tab(query)
+      ::Tab::Observation::DownloadCSV.new(q_param: q_param(query)).to_a
+    end
+
+    def observations_index_tab
+      ::Tab::Observation::Index.new(q_param: q_param).to_a
+    end
+
+    def edit_observation_tab(obs)
+      ::Tab::Observation::Edit.new(observation: obs).to_a
+    end
+
+    def new_inat_import_tab(query: nil)
+      ::Tab::Observation::InatImport.new(q_param: q_param(query)).to_a
+    end
+
+    # -------- collections ----------------------------------------
+
+    def obs_related_name_tabs(user, name)
+      ::Tab::Observation::RelatedNameTabs.new(user: user,
+                                              name: name).map(&:to_a)
+    end
+
+    def user_observation_web_name_tabs(user, name)
+      ::Tab::Observation::WebNameTabs.new(user: user,
+                                          name: name).map(&:to_a)
+    end
+
+    def observations_index_tabs(query:)
+      ::Tab::Observation::IndexActions.new(
+        query: query, where: params[:where],
+        q_param: q_param(query), controller: controller
+      ).map(&:to_a)
+    end
+
+    def observations_related_query_tabs(query)
+      ::Tab::Observation::RelatedQueryActions.new(
+        query: query, controller: controller
+      ).map(&:to_a)
+    end
+
+    def observation_form_new_tabs
+      ::Tab::Observation::FormNew.new(q_param: q_param).map(&:to_a)
+    end
+
+    def observation_form_edit_tabs(obs:)
+      ::Tab::Observation::FormEdit.new(observation: obs).map(&:to_a)
+    end
+
+    def observation_maps_tabs(query:)
+      ::Tab::Observation::MapsActions.new(
+        query: query, controller: controller
+      ).map(&:to_a)
+    end
+
+    def naming_form_new_tabs(obs:)
+      ::Tab::Observation::NamingForm.new(observation: obs).map(&:to_a)
+    end
+
+    def naming_form_edit_tabs(obs:)
+      ::Tab::Observation::NamingForm.new(observation: obs).map(&:to_a)
+    end
+
+    def naming_suggestion_tabs(obs:)
+      ::Tab::Observation::NamingForm.new(observation: obs).map(&:to_a)
+    end
+
+    def observation_list_tabs(obs:)
+      ::Tab::Observation::ListActions.new(observation: obs).map(&:to_a)
+    end
+
+    def observation_images_edit_tabs(image:)
+      ::Tab::Observation::ImagesEdit.new(image: image).map(&:to_a)
+    end
+
+    def observation_images_reuse_tabs(obs:)
+      ::Tab::Observation::ImagesReuse.new(observation: obs).map(&:to_a)
+    end
+
+    # -------- HTML composers (stay at helper layer) --------------
+
     def name_links_on_mo(user:, name:)
       tabs = context_nav_links(obs_related_name_tabs(user, name),
                                { class: "d-block" })
@@ -41,59 +149,13 @@ module Tabs
       tabs.reject(&:empty?)
     end
 
-    def obs_related_name_tabs(user, name)
-      [
-        show_object_tab(
-          name, :show_name.t(name: name.display_name_brief_authors(user))
-        ),
-        observations_of_name_tab(name),
-        observations_of_look_alikes_tab(name),
-        observations_of_related_taxa_tab(name)
-      ]
-    end
-
-    def observations_of_name_tab(name)
-      InternalLink::Model.new(
-        :show_observation_more_like_this.l, name,
-        observations_path(name: name.id)
-      ).tab
-    end
-
-    def observations_of_look_alikes_tab(name)
-      InternalLink::Model.new(
-        :show_observation_look_alikes.l, name,
-        observations_path(name: name.id, look_alikes: "1")
-      ).tab
-    end
-
-    def observations_of_related_taxa_tab(name)
-      InternalLink::Model.new(
-        :show_observation_related_taxa.l, name,
-        observations_path(name: name.id, related_taxa: "1")
-      ).tab
-    end
-
-    # from descriptions_helper
+    # composes `list_descriptions` from descriptions_helper.rb (HTML).
+    # Migrates when descriptions_helper itself migrates.
     def obs_name_description_tabs(user, name)
       list_descriptions(user: user, object: name, type: :name)&.map do |link|
         tag.div(link)
       end
     end
-
-    # This appears to be dead code
-    # def observation_map_tab(mappable)
-    #   return unless mappable
-
-    #   InternalLink.new(
-    #     :MAP.t, add_q_param(map_observation_path)
-    #   ).tab
-    # end
-
-    # def name_links_web(name:)
-    #   tabs = context_nav_links(observation_web_name_tabs(name),
-    #                            { class: "d-block" })
-    #   tabs.reject(&:empty?)
-    # end
 
     def user_name_links_web(user, name:)
       tabs = context_nav_links(user_observation_web_name_tabs(user, name),
@@ -101,97 +163,20 @@ module Tabs
       tabs.reject(&:empty?)
     end
 
-    # def observation_web_name_tabs(name)
-    #   [mycoportal_name_tab(name),
-    #    mycobank_name_search_tab(name),
-    #    google_images_for_name_tab(name)]
-    # end
+    # -------- non-tab title + utility (stay at helper layer) -----
 
-    def user_observation_web_name_tabs(user, name)
-      [mycoportal_name_tab(name),
-       mycobank_name_search_tab(name),
-       user_google_images_for_name_tab(user, name)]
+    def naming_form_new_title(obs:)
+      :create_naming_title.t(id: obs.id)
     end
 
-    def observation_hide_thumbnail_map_tab(obs)
-      InternalLink::Model.new(
-        :show_observation_hide_map.l, obs,
-        javascript_hide_thumbnail_map_path(id: obs.id),
-        html_options: { icon: :hide }
-      ).tab
-    end
-
-    def reuse_images_for_observation_tab(obs)
-      InternalLink::Model.new(
-        :show_observation_reuse_image.l, obs,
-        reuse_images_for_observation_path(obs.id),
-        html_options: { icon: :reuse }
-      ).tab
-    end
-
-    ############################################
-    # INDEX
-
-    def observations_index_tabs(query:)
-      links = [
-        *observations_at_where_tabs(query), # maybe multiple links
-        map_observations_tab(query),
-        *observations_related_query_tabs(query), # multiple links
-        observations_add_to_list_tab(query),
-        observations_download_as_csv_tab(query),
-        new_inat_import_tab
-      ]
-      links.reject(&:empty?)
-    end
-
-    # for debugging
-    # def dummy_disable_tab
-    #   InternalLink.new(
-    #     "Dummy link",
-    #     "https://google.com",
-    #     html_options: { data: { action: "links#disable" } }
-    #   ).tab
-    # end
-
-    def observations_at_where_tabs(query)
-      # Add some extra links to the index user is sent to if they click on an
-      # undefined location.
-      return [] if params[:where].blank?
-
-      [define_location_tab(query),
-       assign_undefined_location_tab(query),
-       locations_index_tab]
-    end
-
-    # these are from the observations form
-    def define_location_tab(query)
-      InternalLink.new(
-        :list_observations_location_define.l,
-        add_q_param(new_location_path(where: where_param(query.params)))
-      ).tab
-    end
-
-    # Hack to use the :locations param if it's present and the :search_where
-    # param is missing.
-    def where_param(query_params)
-      query_params[:search_where] || params[:where]
-    end
-
-    def assign_undefined_location_tab(query)
-      InternalLink.new(
-        :list_observations_location_merge.l,
-        add_q_param(matching_locations_for_observations_path(
-                      where: where_param(query.params)
-                    ))
-      ).tab
+    def naming_form_edit_title(obs:)
+      :edit_naming_title.t(id: obs.id)
     end
 
     def observations_index_sorts
       [["rss_log", :sort_by_activity.l],
        ["date", :sort_by_date.l],
        ["created_at", :sort_by_posted.l],
-       # kind of redundant to sort by rss_logs, though not strictly ===
-       # ["updated_at", :sort_by_updated_at.l],
        ["name", :sort_by_name.l],
        ["user", :sort_by_user.l],
        ["confidence", :sort_by_confidence.l],
@@ -199,119 +184,10 @@ module Tabs
        ["num_views", :sort_by_num_views.l]].freeze
     end
 
-    def map_observations_tab(query)
-      InternalLink.new(
-        :show_object.t(type: :map),
-        map_observations_path(q: q_param(query)),
-        html_options: { data: { action: "links#disable" } }
-      ).tab
-    end
-
-    # NOTE: each tab returns an array
-    def observations_related_query_tabs(query)
-      [related_locations_tab(:Observation, query),
-       related_names_tab(:Observation, query),
-       related_images_tab(:Observation, query)]
-    end
-
-    def observations_add_to_list_tab(query)
-      InternalLink.new(
-        :list_observations_add_to_list.l,
-        add_q_param(species_lists_edit_observations_path, query)
-      ).tab
-    end
-
-    def observations_download_as_csv_tab(query)
-      InternalLink.new(
-        :list_observations_download_as_csv.l,
-        add_q_param(new_observations_download_path, query)
-      ).tab
-    end
-
-    ############################################
-    # FORMS
-
-    def observation_form_new_tabs
-      [new_inat_import_tab, observations_index_tab]
-    end
-
-    def observation_form_edit_tabs(obs:)
-      [object_return_tab(obs)]
-    end
-
-    def observation_maps_tabs(query:)
-      [related_observations_tab(:Observation, query), # index of the same obs
-       related_locations_tab(:Observation, query)]
-    end
-
-    def new_inat_import_tab(query: nil)
-      InternalLink.new(
-        :create_observation_inat_import_link.l,
-        add_q_param(new_inat_import_path, query)
-      ).tab
-    end
-
-    def naming_form_new_title(obs:)
-      :create_naming_title.t(id: obs.id)
-    end
-
-    def naming_form_new_tabs(obs:)
-      [object_return_tab(obs)]
-    end
-
-    def naming_form_edit_title(obs:)
-      :edit_naming_title.t(id: obs.id)
-    end
-
-    def naming_form_edit_tabs(obs:)
-      [object_return_tab(obs)]
-    end
-
-    def naming_suggestion_tabs(obs:)
-      [object_return_tab(obs)]
-    end
-
-    def observation_list_tabs(obs:)
-      [object_return_tab(obs)]
-    end
-
-    def observation_images_edit_tabs(image:)
-      [object_return_tab(image)]
-    end
-
-    def observation_images_reuse_tabs(obs:)
-      [object_return_tab(obs),
-       edit_observation_tab(obs)]
-    end
-
-    def observations_index_tab
-      InternalLink.new(
-        :cancel_to_index.t(type: :OBSERVATION),
-        add_q_param(observations_path)
-      ).tab
-    end
-
     def obs_details_links(obs)
       print_labels_button(obs)
     end
 
-    def edit_observation_tab(obs)
-      InternalLink::Model.new(
-        :edit_object.t(type: Observation), obs,
-        edit_observation_path(obs.id),
-        html_options: { icon: :edit }
-      ).tab
-    end
-
-    # def destroy_observation_tab(obs)
-    #   InternalLink::Model.new(
-    #     :destroy_object.t(TYPE: Observation),
-    #     obs, objs,
-    #     html_options: { button: :destroy }
-    #   ).tab
-    # end
-
-    # for show_obs - query is for a single obs label
     def print_labels_button(obs)
       name = :download_observations_print_labels.l
       query = Query.lookup(Observation, id_in_set: [obs.id])

--- a/test/classes/tab/observation/collections_test.rb
+++ b/test/classes/tab/observation/collections_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Tab::Observation
+  class CollectionsTest < UnitTestCase
+    def setup
+      @obs = observations(:minimal_unknown_obs)
+      @name = names(:agaricus_campestris)
+      @user = users(:rolf)
+    end
+
+    def test_related_name_tabs
+      tabs = Tab::Observation::RelatedNameTabs.new(
+        user: @user, name: @name
+      ).to_a
+
+      assert_equal(
+        [Tab::Object::Show,
+         Tab::Observation::OfName,
+         Tab::Observation::OfLookAlikes,
+         Tab::Observation::OfRelatedTaxa],
+        tabs.map(&:class)
+      )
+    end
+
+    def test_web_name_tabs
+      tabs = Tab::Observation::WebNameTabs.new(
+        user: @user, name: @name
+      ).to_a
+
+      assert_equal(
+        [Tab::Name::Mycoportal,
+         Tab::Name::MycobankSearch,
+         Tab::Name::UserGoogleImages],
+        tabs.map(&:class)
+      )
+    end
+
+    def test_at_where_actions
+      tabs = Tab::Observation::AtWhereActions.new(where: "Foo").to_a
+
+      assert_equal(
+        [Tab::Observation::DefineLocation,
+         Tab::Observation::AssignUndefinedLocation,
+         Tab::Location::Index],
+        tabs.map(&:class)
+      )
+    end
+
+    def test_index_actions_no_where
+      stub_no_bridge = ->(*) { false }
+      ::Query.stub(:related?, stub_no_bridge) do
+        tabs = Tab::Observation::IndexActions.new.to_a
+
+        # No where param → AtWhereActions tabs skipped.
+        # No related-query bridges either (stubbed). Just Map +
+        # AddToList + DownloadCSV + InatImport.
+        assert_equal(
+          [Tab::Observation::Map,
+           Tab::Observation::AddToList,
+           Tab::Observation::DownloadCSV,
+           Tab::Observation::InatImport],
+          tabs.map(&:class)
+        )
+      end
+    end
+
+    def test_index_actions_with_where_param
+      stub_no_bridge = ->(*) { false }
+      ::Query.stub(:related?, stub_no_bridge) do
+        tabs = Tab::Observation::IndexActions.new(where: "Foo").to_a
+
+        # AtWhereActions tabs prepend.
+        assert_equal(Tab::Observation::DefineLocation, tabs.first.class)
+        assert_includes(tabs.map(&:class),
+                        Tab::Observation::AssignUndefinedLocation)
+        assert_includes(tabs.map(&:class), Tab::Location::Index)
+      end
+    end
+
+    def test_form_new
+      tabs = Tab::Observation::FormNew.new.to_a
+
+      assert_equal(
+        [Tab::Observation::InatImport, Tab::Observation::Index],
+        tabs.map(&:class)
+      )
+    end
+
+    def test_form_edit
+      tabs = Tab::Observation::FormEdit.new(observation: @obs).to_a
+
+      assert_equal([Tab::Object::Return], tabs.map(&:class))
+    end
+
+    def test_naming_form
+      tabs = Tab::Observation::NamingForm.new(observation: @obs).to_a
+
+      assert_equal([Tab::Object::Return], tabs.map(&:class))
+    end
+
+    def test_list_actions
+      tabs = Tab::Observation::ListActions.new(observation: @obs).to_a
+
+      assert_equal([Tab::Object::Return], tabs.map(&:class))
+    end
+
+    def test_images_edit
+      image = images(:in_situ_image)
+      tabs = Tab::Observation::ImagesEdit.new(image: image).to_a
+
+      assert_equal([Tab::Object::Return], tabs.map(&:class))
+    end
+
+    def test_images_reuse
+      tabs = Tab::Observation::ImagesReuse.new(observation: @obs).to_a
+
+      assert_equal([Tab::Object::Return, Tab::Observation::Edit],
+                   tabs.map(&:class))
+    end
+  end
+end

--- a/test/classes/tab/observation/tabs_test.rb
+++ b/test/classes/tab/observation/tabs_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Tab::Observation
+  class TabsTest < UnitTestCase
+    def routes
+      Rails.application.routes.url_helpers
+    end
+
+    def setup
+      @obs = observations(:minimal_unknown_obs)
+      @name = names(:agaricus_campestris)
+      @user = users(:rolf)
+    end
+
+    def test_send_question
+      tab = Tab::Observation::SendQuestion.new(observation: @obs)
+
+      assert_equal(:show_observation_send_question.l, tab.title)
+      assert_equal(routes.new_question_for_observation_path(@obs.id),
+                   tab.path)
+      assert_equal(:email, tab.html_options[:icon])
+    end
+
+    def test_manage_lists
+      tab = Tab::Observation::ManageLists.new(observation: @obs)
+
+      assert_equal(:show_observation_manage_species_lists.l, tab.title)
+      assert_equal(routes.edit_observation_species_lists_path(@obs.id),
+                   tab.path)
+    end
+
+    def test_of_name
+      tab = Tab::Observation::OfName.new(name: @name)
+
+      assert_equal(:show_observation_more_like_this.l, tab.title)
+      assert_equal(routes.observations_path(name: @name.id), tab.path)
+    end
+
+    def test_of_look_alikes
+      tab = Tab::Observation::OfLookAlikes.new(name: @name)
+
+      assert_equal(routes.observations_path(name: @name.id,
+                                            look_alikes: "1"),
+                   tab.path)
+    end
+
+    def test_of_related_taxa
+      tab = Tab::Observation::OfRelatedTaxa.new(name: @name)
+
+      assert_equal(routes.observations_path(name: @name.id,
+                                            related_taxa: "1"),
+                   tab.path)
+    end
+
+    def test_hide_thumbnail_map
+      tab = Tab::Observation::HideThumbnailMap.new(observation: @obs)
+
+      assert_equal(:show_observation_hide_map.l, tab.title)
+      assert_equal(routes.javascript_hide_thumbnail_map_path(id: @obs.id),
+                   tab.path)
+      assert_equal(:hide, tab.html_options[:icon])
+    end
+
+    def test_reuse_images
+      tab = Tab::Observation::ReuseImages.new(observation: @obs)
+
+      assert_equal(:show_observation_reuse_image.l, tab.title)
+      assert_equal(routes.reuse_images_for_observation_path(@obs.id),
+                   tab.path)
+    end
+
+    def test_define_location
+      tab = Tab::Observation::DefineLocation.new(where: "Foo")
+
+      assert_equal(:list_observations_location_define.l, tab.title)
+      assert_equal(routes.new_location_path(where: "Foo"), tab.path)
+    end
+
+    def test_assign_undefined_location
+      tab = Tab::Observation::AssignUndefinedLocation.new(where: "Bar")
+
+      assert_equal(:list_observations_location_merge.l, tab.title)
+      assert_includes(tab.path, "Bar")
+    end
+
+    def test_map
+      tab = Tab::Observation::Map.new(q_param: "abc")
+
+      assert_equal(:show_object.t(type: :map), tab.title)
+      assert_equal(routes.map_observations_path(q: "abc"), tab.path)
+      assert_equal("links#disable", tab.html_options[:data][:action])
+    end
+
+    def test_add_to_list
+      tab = Tab::Observation::AddToList.new
+
+      assert_equal(:list_observations_add_to_list.l, tab.title)
+      assert_equal(routes.species_lists_edit_observations_path, tab.path)
+    end
+
+    def test_download_csv
+      tab = Tab::Observation::DownloadCSV.new
+
+      assert_equal(:list_observations_download_as_csv.l, tab.title)
+      assert_equal(routes.new_observations_download_path, tab.path)
+    end
+
+    def test_index
+      tab = Tab::Observation::Index.new
+
+      assert_equal(:cancel_to_index.t(type: :OBSERVATION), tab.title)
+      assert_equal(routes.observations_path, tab.path)
+    end
+
+    def test_edit
+      tab = Tab::Observation::Edit.new(observation: @obs)
+
+      assert_equal(:edit_object.t(type: Observation), tab.title)
+      assert_equal(routes.edit_observation_path(@obs.id), tab.path)
+    end
+
+    def test_inat_import
+      tab = Tab::Observation::InatImport.new
+
+      assert_equal(:create_observation_inat_import_link.l, tab.title)
+      assert_equal(routes.new_inat_import_path, tab.path)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Final layer of the observations dependency web (after #4409 leaves, #4411 names, #4412 locations all merged). Converts `tabs/observations_helper.rb`'s 15 single Tab definitions + 12 Collection-shape methods to POROs. The cross-domain composers (`Tab::Observation::WebNameTabs`) directly instantiate `Tab::Name::Mycoportal` / `Tab::Name::MycobankSearch` / `Tab::Name::UserGoogleImages` from the merged names PR — clean PORO composition across domains, no transitional `helpers:` proxy needed.

## 15 single Tab POROs under `Tab::Observation::*`

`SendQuestion`, `ManageLists`, `OfName`, `OfLookAlikes`, `OfRelatedTaxa`, `HideThumbnailMap`, `ReuseImages`, `DefineLocation`, `AssignUndefinedLocation`, `Map`, `AddToList`, `DownloadCSV`, `Index`, `Edit`, `InatImport`.

## 12 Tab::Collection subclasses under `Tab::Observation::*`

- **`RelatedNameTabs`** — `Object::Show(name, custom_title) + OfName + OfLookAlikes + OfRelatedTaxa`. Observation's name panel.
- **`WebNameTabs`** — cross-domain composer — `Name::Mycoportal + Name::MycobankSearch + Name::UserGoogleImages`.
- **`AtWhereActions`** — `DefineLocation + AssignUndefinedLocation + Location::Index`. Shown on the observations index when `params[:where]` is set.
- **`RelatedQueryActions`** — `Related::Query.for(Location/Name/Image, :Observation, ...)`. The 3 related-index bridges.
- **`IndexActions`** — observations index action-nav. Composes `AtWhereActions` (when where present) + `Map` + `RelatedQueryActions` + `AddToList` + `DownloadCSV` + `InatImport`.
- **`FormNew`** — `InatImport + Index`.
- **`FormEdit`** — `[Object::Return(obs)]`.
- **`MapsActions`** — `Related::Query.for(Observation/Location, :Observation)`. Observations-map page.
- **`NamingForm`** — `[Object::Return(obs)]`. Naming new / edit / suggestions form action-nav (3 helper methods all delegate to this).
- **`ListActions`** — `[Object::Return(obs)]`. Species-lists-of-observation page.
- **`ImagesEdit`** — `[Object::Return(image)]`.
- **`ImagesReuse`** — `[Object::Return(obs), Observation::Edit]`.

## Helper slimmed

`tabs/observations_helper.rb` (~325 LOC → ~190 LOC). The thin tab-method delegators (`send_observer_question_tab(obs)` → `Tab::Observation::SendQuestion.new(observation: obs).to_a`) remain as the public API for ERB callers during the migration window; they get deleted when the ERB callers convert to Phlex views (which will consume the POROs directly).

Removed entirely: `observations_at_where_tabs` (its tabs land via `Tab::Observation::AtWhereActions` inside `IndexActions`; no separate helper needed) and the internal `where_param` utility (`AtWhereActions` accepts `where:` directly). Non-tab helpers (HTML composers, sort options, title utilities) untouched.

## Tests

- 15 single-Tab tests (per-tab title / path via route helpers / html_options).
- 11 Collection tests (compositions pinned; cross-domain composition verified — `WebNameTabs` returns the 3 `Tab::Name::*` classes).

## Test plan

- [x] `bin/rails test test/classes/tab/observation/` — 26 tests, 73 assertions, all green
- [x] `bin/rails test test/integration/` — 164 tests, 1634 assertions, all green
- [x] `bundle exec rubocop` on every touched file — 0 offenses across 30 files
- [x] CI green
- [ ] Browser-verify: observations index (with and without `?where=...`); observation show name panel; new + edit observation forms; observations map pages; naming new / edit / suggestions pages; species_lists/edit; images/edit + reuse; observation thumbnail map hide link.
