### PR TITLE
Coverage gaps: delete dead form/panel helpers, fix Herbarium#order_by_user

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -113,18 +113,6 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
 
   # Makes an element that looks like a bootstrap button but works as a checkbox.
   # Only works within a .btn-group wrapper. NOTE: Different from a check_box!
-  def check_button_with_label(**args)
-    args = auto_label_if_form_is_account_prefs(args)
-    opts = separate_field_options_from_args(args)
-
-    wrap_class = form_group_wrap_class(args, "btn btn-default btn-sm")
-
-    args[:form].label(args[:field], class: wrap_class) do
-      [args[:form].check_box(args[:field], opts.merge(class: "mt-0 mr-2")),
-       args[:label]].safe_join
-    end
-  end
-
   # Bootstrap radio: form, field, value, label, class, checked
   #
   # The label's `for=` matches the id Rails' `radio_button` generates for
@@ -158,18 +146,6 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
 
   # Makes an element that looks like a bootstrap button but works as a radio.
   # Only works within a .btn-group wrapper. NOTE: Different from a radio_button!
-  def radio_button_with_label(**args)
-    args = auto_label_if_form_is_account_prefs(args)
-    opts = separate_field_options_from_args(args)
-
-    wrap_class = form_group_wrap_class(args, "btn btn-default btn-sm")
-
-    args[:form].label(args[:field], class: wrap_class) do
-      [args[:form].radio_button(args[:field], opts.merge(class: "mt-0 mr-2")),
-       args[:label]].safe_join
-    end
-  end
-
   # Bootstrap text_field
   def text_field_with_label(**args)
     args = auto_label_if_form_is_account_prefs(args)
@@ -312,97 +288,6 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     { include_blank: args[:include_blank], selected: args[:selected] }
   end
 
-  # Bootstrap 3-input date helper: day select + month select + year text
-  # input. Replaces Rails' `date_select` (which emits three selects)
-  # because a fixed-range year dropdown is awkward for old-date scenarios
-  # (e.g. an observation from 30 years ago that falls outside the default
-  # 20-year range). The text-input year sidesteps that entirely.
-  #
-  # Day/month/year emit element IDs `{form_id}_3i`/`_2i`/`_1i` and names
-  # `{form_name}[{field}(3i)]`/`(2i)]`/`(1i)]` to match Rails' multi-
-  # parameter date attribute convention, so controller-side param parsing
-  # is unchanged. The wrapping div uses the bare form-field id so a
-  # `<label for="…">` click focuses the day select first.
-  # https://stackoverflow.com/a/16426122/3357635
-  def date_select_with_label(**args)
-    args = check_for_optional_or_required_note(args)
-    args = check_for_help_block(args)
-    date = date_field_selected_value(args)
-    wrap_class = form_group_wrap_class(args)
-    selects_class = "form-inline date-selects"
-    selects_class += " d-inline-block" if args[:inline] == true
-    label_opts = { class: "mr-3" }
-    label_opts[:index] = args[:index] if args[:index].present?
-    tag.div(class: wrap_class) do
-      concat(args[:form].label(args[:field], args[:label], label_opts))
-      concat(args[:between]) if args[:between].present?
-      concat(date_field_inputs_div(args, date, selects_class))
-      concat(args[:append]) if args[:append].present?
-    end
-  end
-
-  # Resolve the date to display: the explicit `selected:`, then the
-  # object's value for the field, then today.
-  def date_field_selected_value(args)
-    field = args[:field] || :when
-    obj = args[:object] || args[:form]&.object
-    return args[:selected] if args[:selected]
-    return obj.try(&field.to_sym) || Time.zone.today if obj.respond_to?(field)
-
-    Time.zone.today
-  end
-
-  def date_field_inputs_div(args, date, selects_class)
-    identifier = [args[:form]&.object_name, args[:index],
-                  args[:field]].compact_blank.join("_")
-    tag.div(class: selects_class, id: identifier) do
-      concat(date_field_day_select(args, date, identifier))
-      concat(date_field_month_select(args, date, identifier))
-      concat(date_field_year_input(args, date, identifier))
-    end
-  end
-
-  def date_field_day_select(args, date, identifier)
-    tag.select(id: "#{identifier}_3i",
-               name: date_field_param_name(args, "3i"),
-               class: "form-control mr-2") do
-      (1..31).each do |day|
-        concat(tag.option(day, value: day,
-                               selected: day == date.day))
-      end
-    end
-  end
-
-  def date_field_month_select(args, date, identifier)
-    tag.select(id: "#{identifier}_2i",
-               name: date_field_param_name(args, "2i"),
-               class: "form-control mr-2") do
-      (1..12).each do |m|
-        concat(tag.option(Date::MONTHNAMES[m], value: m,
-                                               selected: m == date.month))
-      end
-    end
-  end
-
-  def date_field_year_input(args, date, identifier)
-    tag.input(type: "text",
-              id: "#{identifier}_1i",
-              name: date_field_param_name(args, "1i"),
-              class: "form-control",
-              size: 4,
-              value: date.year)
-  end
-
-  # `{object_name}[{field}(Ni)]` — matches Rails' date_select output so
-  # multi-parameter date attribute parsing on the controller stays
-  # identical. Falls back to bare `{field}(Ni)` for object-less forms.
-  def date_field_param_name(args, suffix)
-    prefix = args[:form]&.object_name
-    return "#{args[:field]}(#{suffix})" if prefix.blank?
-
-    "#{prefix}[#{args[:field]}(#{suffix})]"
-  end
-
   # Bootstrap number_field. Uses `text_label_row` so a help-button /
   # between / label_end can ride next to the label like `text_field_with_label`.
   def number_field_with_label(**args)
@@ -463,49 +348,6 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
   # Renamed from `hidden_field_with_label` (which mis-described the
   # output — it emits a visible static-text display in addition to the
   # hidden input).
-  def read_only_field_with_label(**args)
-    opts = separate_field_options_from_args(args)
-    text = opts[:text] || opts[:value] || ""
-
-    wrap_class = form_group_wrap_class(args)
-
-    tag.div(class: wrap_class) do
-      concat(args[:form].label(args[:field], args[:label], class: "mr-3"))
-      concat(tag.p(text, class: "form-control-static"))
-      concat(args[:form].hidden_field(args[:field], opts))
-    end
-  end
-
-  # Bootstrap allows you to style static text like this:
-  def static_text_with_label(**args)
-    opts = separate_field_options_from_args(args)
-    opts[:class] = "form-control-static"
-    text = opts[:text] || opts[:value] || ""
-    opts.delete(:value)
-
-    wrap_class = form_group_wrap_class(args)
-
-    tag.div(class: wrap_class) do
-      concat(args[:form].label(args[:field], args[:label], class: "mr-3"))
-      concat(tag.p(text, **opts))
-    end
-  end
-
-  # Bootstrap url_field
-  def url_field_with_label(**args)
-    args = check_for_help_block(args)
-    opts = separate_field_options_from_args(args)
-    opts[:class] = "form-control"
-    opts[:value] ||= ""
-
-    wrap_class = form_group_wrap_class(args)
-
-    tag.div(class: wrap_class) do
-      concat(args[:form].label(args[:field], args[:label], class: "mr-3"))
-      concat(args[:form].url_field(args[:field], opts))
-    end
-  end
-
   # Bootstrap file input field with client-side size validation.
   # This could be redone as an input group with a "browse" button, in BS4.
   def file_field_with_label(**args)
@@ -631,7 +473,7 @@ module FormsHelper # rubocop:disable Metrics/ModuleLength
     end
     args[:append] = capture do
       concat(args[:append])
-      concat(collapse_help_block(nil, id:) do
+      concat(collapse_help_block(id:) do
         concat(args[:help])
       end)
     end

--- a/app/helpers/panel_helper.rb
+++ b/app/helpers/panel_helper.rb
@@ -32,34 +32,25 @@ module PanelHelper
     content_tag(element, html_options) { content }
   end
 
-  # draw a help block with an arrow
+  # draw a help block with an arrow. `direction` is "up", "down", or nil
+  # (no arrow). Production callers never pass mobile: — the arrow is
+  # always xs-hidden.
   def help_block_with_arrow(direction = nil, **args, &block)
     div_class = "well well-sm mb-3 help-block position-relative"
     div_class += " mt-3" if direction == "up"
 
     tag.div(class: div_class, id: args[:id]) do
       concat(capture(&block).to_s)
-      if direction
-        arrow_class = "arrow-#{direction}"
-        arrow_class += " hidden-xs" unless args[:mobile]
-        concat(tag.div("", class: arrow_class))
-      end
+      concat(tag.div("", class: "arrow-#{direction} hidden-xs")) if direction
     end
   end
 
-  def collapse_help_block(direction = nil, string = nil, **args, &block)
-    div_class = "well well-sm mb-3 help-block position-relative"
-    div_class += " mt-3" if direction == "up"
-    content = block ? capture(&block) : string
-
+  # Wraps a Bootstrap-collapse div around a help block. Only the
+  # block-form / no-direction shape is actually used today.
+  def collapse_help_block(**args, &block)
     tag.div(class: "collapse", id: args[:id]) do
-      tag.div(class: div_class) do
-        concat(content)
-        if direction
-          arrow_class = "arrow-#{direction}"
-          arrow_class += " hidden-xs" unless args[:mobile]
-          concat(tag.div("", class: arrow_class))
-        end
+      tag.div(class: "well well-sm mb-3 help-block position-relative") do
+        concat(capture(&block))
       end
     end
   end

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -69,17 +69,6 @@ class Herbarium < AbstractModel
   scope :order_by_default,
         -> { order_by(::Query::Herbaria.default_order) }
 
-  # AbstractModel's `order_by_user` joins on `:user`; Herbarium has
-  # `:personal_user` instead (only set for personal herbaria; nil
-  # for institutional ones). Override here so the "user" sort on
-  # the herbaria index works for the full (mixed) listing.
-  scope :order_by_user, lambda {
-    joins(:personal_user).distinct.order(
-      User[:name].when(nil).then(User[:login]).when("").then(User[:login]).
-      else(User[:name]).asc
-    )
-  }
-
   scope :nonpersonal, lambda { |bool = true|
     if bool.to_s.to_boolean == true
       where(personal_user_id: nil)
@@ -278,6 +267,23 @@ class Herbarium < AbstractModel
         includeothercatnum: 1 }
 
     "#{base_url}?#{search_params.to_query}"
+  end
+
+  # AbstractModel's `order_by_user` joins on `:user`; Herbarium has
+  # `:personal_user` (only set for personal herbaria; nil for
+  # institutional ones). Override so the "user" sort on the herbaria
+  # index works for the full (mixed) listing. Private class method
+  # because Query's `order_by(:user)` dispatcher checks
+  # `private_methods(false)` on the model.
+  class << self
+    private
+
+    def order_by_user
+      joins(:personal_user).distinct.order(
+        User[:name].when(nil).then(User[:login]).when("").then(User[:login]).
+          else(User[:name]).asc
+      )
+    end
   end
 
   private

--- a/test/classes/query/herbaria_test.rb
+++ b/test/classes/query/herbaria_test.rb
@@ -32,6 +32,16 @@ class Query::HerbariaTest < UnitTestCase
     assert_query(expects, :Herbarium, order_by: :name)
   end
 
+  # Herbarium overrides AbstractModel's `order_by_user` (which joins
+  # on `:user`) because it has `:personal_user` instead. Private
+  # class method, so `send(:order_by_user)` is the supported way to
+  # exercise it directly; Query's `order_by(:user)` dispatcher hits
+  # the same method via `private_methods(false)`.
+  def test_herbarium_order_by_user
+    expects = Herbarium.send(:order_by_user)
+    assert_query(expects, :Herbarium, order_by: :user)
+  end
+
   def test_herbarium_nonpersonal
     expects = Herbarium.nonpersonal.order_by_default
     assert_query(expects, :Herbarium, nonpersonal: true)

--- a/test/components/crud_button_test.rb
+++ b/test/components/crud_button_test.rb
@@ -371,6 +371,15 @@ class CrudButtonParityTest < ComponentTestCase
     assert_html(html, "a span.sr-only", text: "Edit it")
   end
 
+  # String/Hash targets have no recoverable type, so `default_name`
+  # falls back to the generic `:EDIT.l` instead of
+  # `:edit_object.t(type: …)`.
+  def test_edit_button_string_target_default_name
+    html = view_context.edit_button(target: "/items/42/edit")
+
+    assert_html(html, "a span.sr-only", text: :EDIT.l)
+  end
+
   # post_button: form, no `_method` field (POST is default), no
   # confirm, button body is the name verbatim.
   def test_post_button_parity


### PR DESCRIPTION
## Summary

Closes the largest non-Tab coverage regressions flagged by coveralls. Same dead-delegator pattern as #4418: most of the gap is **unreachable helper methods that lost callers without being deleted**, plus one **silently-broken `scope` override** that pretended to work but didn't.

## `forms_helper.rb` — −61 missing diff

Delete 6 public helpers with zero production callers (verified across `app/` + `test/`):

- `check_button_with_label`
- `radio_button_with_label`
- `date_select_with_label`
- `read_only_field_with_label`
- `static_text_with_label`
- `url_field_with_label`

Delete their internal-only date helpers transitively (`date_field_inputs_div` / `date_field_day_select` / `date_field_month_select` / `date_field_year_input` / `date_field_param_name` / `date_field_selected_value` — 6 more methods, only called from the deleted `date_select_with_label`).

## `panel_helper.rb` — −8 missing diff

Simplify two helpers to the shape callers actually use:

- `help_block_with_arrow`: drop the `mobile:` knob (no production caller passes it — the arrow is always xs-hidden). Branch collapsed to the two real shapes (direction + no-direction).
- `collapse_help_block`: drop direction handling and the string-argument form (only one production caller, passes block + no direction). Updated the caller in `forms_helper.rb` to match the slimmed signature.

## `Herbarium#order_by_user` — −6 missing diff, **was a silently-broken override**

The original PR (#4414) defined `scope :order_by_user, lambda { ... }`, but AbstractModel's Query dispatcher checks `model.private_methods(false).include?(:order_by_user)`. Public scopes don't match — so the override silently fell through to "all herbaria, no order" instead of joining `:personal_user`. The 6-line scope was uncovered because it was never reached.

Moved to a private class method via `class << self; private; def order_by_user; ...; end; end` (matches the pattern in `AbstractModel::OrderingScopes::ClassMethods`). Added `Query::HerbariaTest#test_herbarium_order_by_user` pinning that `Query.lookup(:Herbarium, order_by: :user)` and `Herbarium.send(:order_by_user)` produce the same result.

## `CrudButton::Edit` — −1 missing line

Added `test_edit_button_string_target_default_name` — exercises the `default_name` branch where `target.is_a?(String)` falls through to `:EDIT.l` (distinct from the previously-tested "String + explicit name" case).

## Test plan

- [x] `bin/rails test test/helpers/forms_helper_test.rb test/classes/query/herbaria_test.rb test/components/crud_button_test.rb` — green
- [x] `bin/rails test test/controllers/herbaria_controller_test.rb test/controllers/observations_controller_create_test.rb test/controllers/sequences_controller_test.rb test/controllers/herbarium_records_controller_test.rb` — 282 tests, 2292 assertions, all green
- [x] `bundle exec rubocop` on every touched file — 0 offenses
- [ ] CI green
- [ ] System tests (forms still render correctly on edit/create paths for herbarium / herbarium_record / sequence / observation / location)
- [ ] Coveralls: verify `forms_helper.rb`, `panel_helper.rb`, `herbarium.rb` per-file coverage is back to 100% (or close); verify `crud_button/edit.rb` is now 100%.

## Out of scope for this PR

Smaller 1-missing-line regressions on `string.rb`, `autocompleter_helper.rb`, `header/title_helper.rb`, `locations_helper.rb`, and `application_form/select_field.rb`, plus the new Phlex view-class gaps (`descriptions/merges/form.rb` 6, `observations/namings/form.rb` 3, `field_slips/form.rb` 2, others 1 each). These need targeted tests rather than dead-code deletion and are better tackled in follow-up PRs aligned with their respective features.
