### PR TITLE
Drop cross-form vestigial logic in description merge/move forms; close namings form coverage gap

### DIFF
--- a/app/views/controllers/descriptions/merges/form.rb
+++ b/app/views/controllers/descriptions/merges/form.rb
@@ -42,7 +42,8 @@ module Views::Controllers::Descriptions::Merges
     end
 
     def default_target_id
-      merges.first&.id
+      # default_checked? guarantees merges.length == 1, so .first is safe.
+      merges.first.id
     end
 
     def render_delete_checkbox
@@ -57,19 +58,8 @@ module Views::Controllers::Descriptions::Merges
       @merges ||= @description.parent.descriptions - [@description]
     end
 
-    def moves
-      return @moves ||= [] unless name_description?
-
-      @moves ||= begin
-                   result = @description.parent.synonyms -
-                            [@description.parent]
-                   result.reject!(&:is_misspelling?)
-                   result
-                 end
-    end
-
     def default_checked?
-      merges.length == 1 && moves.empty?
+      merges.length == 1
     end
 
     def description_title(user, desc)

--- a/app/views/controllers/descriptions/moves/form.rb
+++ b/app/views/controllers/descriptions/moves/form.rb
@@ -36,7 +36,8 @@ module Views::Controllers::Descriptions::Moves
     end
 
     def default_target_id
-      sorted_moves.first&.id
+      # default_checked? guarantees moves.length == 1, so .first is safe.
+      sorted_moves.first.id
     end
 
     def render_delete_checkbox
@@ -45,10 +46,6 @@ module Views::Controllers::Descriptions::Moves
 
     def render_submit
       submit(:SUBMIT.l, center: true)
-    end
-
-    def merges
-      @merges ||= @description.parent.descriptions - [@description]
     end
 
     def moves
@@ -69,7 +66,7 @@ module Views::Controllers::Descriptions::Moves
     end
 
     def default_checked?
-      merges.empty? && moves.length == 1
+      moves.length == 1
     end
 
     def name_description?

--- a/test/views/controllers/descriptions/merges/form_test.rb
+++ b/test/views/controllers/descriptions/merges/form_test.rb
@@ -79,6 +79,26 @@ module Views::Controllers::Descriptions::Merges
       assert_html(html, "form[action*='/merges']")
     end
 
+    # When the parent has exactly one other description, default_checked?
+    # is true and default_target_id pre-selects that lone radio button.
+    def test_single_merge_target_auto_selects
+      # coprinus_comatus has 2 descriptions: coprinus_comatus_desc and
+      # draft_coprinus_comatus. Rendering the form FOR coprinus_comatus_desc
+      # leaves draft_coprinus_comatus as the sole merge target.
+      desc = name_descriptions(:coprinus_comatus_desc)
+      target = name_descriptions(:draft_coprinus_comatus)
+
+      html = render_form(desc)
+
+      # Exactly one merge target rendered, and it is auto-checked.
+      assert_html(html, "input[type='radio']" \
+                        "[name='description_move_or_merge[target]']",
+                  count: 1)
+      assert_html(html, "input[type='radio']" \
+                        "[name='description_move_or_merge[target]']" \
+                        "[value='#{target.id}'][checked]")
+    end
+
     private
 
     # Sibling reference within the namespace — `Form` resolves to

--- a/test/views/controllers/descriptions/moves/form_test.rb
+++ b/test/views/controllers/descriptions/moves/form_test.rb
@@ -61,6 +61,28 @@ module Views::Controllers::Descriptions::Moves
       assert_no_html(html, "input[type='submit']")
     end
 
+    # When the parent has exactly one non-misspelling synonym,
+    # default_checked? is true and default_target_id pre-selects that
+    # lone move target. No fixture matches this shape, so we create a
+    # NameDescription on lactifluus_alpinus (paired with the deprecated
+    # but non-misspelling lactifluus_subalpinus).
+    def test_single_move_target_auto_selects
+      parent = names(:lactifluus_alpinus)
+      target = names(:lactifluus_subalpinus)
+      desc = NameDescription.create!(name: parent, user: @user,
+                                     source_type: "public")
+
+      html = render_form(desc)
+
+      # Exactly one move target rendered, and it is auto-checked.
+      assert_html(html, "input[type='radio']" \
+                        "[name='description_move_or_merge[target]']",
+                  count: 1)
+      assert_html(html, "input[type='radio']" \
+                        "[name='description_move_or_merge[target]']" \
+                        "[value='#{target.id}'][checked]")
+    end
+
     # MoveForm only makes sense for NameDescriptions since Locations
     # don't have synonyms. No location test.
 

--- a/test/views/controllers/observations/namings/form_test.rb
+++ b/test/views/controllers/observations/namings/form_test.rb
@@ -102,6 +102,43 @@ module Views::Controllers::Observations::Namings
       assert_no_html(html, "form[data-turbo]")
     end
 
+    # The "see matching observations reasons" link in
+    # `render_sibling_reasons_note` requires three conditions: edit mode,
+    # the observation belongs to an Occurrence, and at least one other
+    # observation in that Occurrence has a Naming for the same name_id.
+    # No existing fixture combo satisfies all three (every occurrence
+    # fixture is a singleton over its observations), so we build the
+    # scenario on the fly — per `test/fixtures/observations.yml`'s own
+    # guidance to prefer in-test creation over one-off fixtures.
+    def test_sibling_observation_link_renders_in_edit_mode
+      user = users(:rolf)
+      name = names(:coprinus_comatus)
+
+      # Put the edit-target observation into a fresh Occurrence.
+      occurrence = Occurrence.create!(
+        user: user, primary_observation: @observation
+      )
+      @observation.update!(occurrence: occurrence)
+
+      # A sibling observation in the same Occurrence, with a Naming for
+      # the same Name as the one being edited — this satisfies the
+      # `has_sibling_reasons` guard.
+      sibling = Observation.create!(
+        user: user, when: Time.zone.today, where: "Sibling Site, Earth",
+        text_name: "Coprinus comatus", name: name
+      )
+      sibling.update!(occurrence: occurrence)
+      Naming.create!(observation: sibling, user: user, name: name)
+
+      naming = namings(:coprinus_comatus_naming)
+      vote = votes(:coprinus_comatus_owner_vote)
+      html = render_form(model: naming, vote: vote)
+
+      assert_html(html,
+                  "a[href='#{view_context.occurrence_path(occurrence)}']",
+                  text: :naming_see_matching_observations_reasons.l)
+    end
+
     private
 
     # rubocop:disable Metrics/ParameterLists


### PR DESCRIPTION
## Summary

Two coverage-driven cleanups. The Phlex change is mostly mechanical, but it does shift one UX detail: the merge/move forms now pre-select a single same-page candidate even when the other flow also has candidates available — previously each page suppressed its default selection if the other had work to do too. See the "behavior change" callout below for the precise before/after.

**1. `Views::Controllers::Descriptions::Merges::Form` and `::Moves::Form`: drop cross-form vestigial logic.**

When the description merge/move pages were converted from ERB to Phlex in PR #4368, each form transcribed both `merges` and `moves` from the combined-page ERB partial. With the two flows now on separate pages, the cross-form awareness only feeds `default_checked?` and has no UX purpose — by the time the form renders, the user has already chosen merge or move by navigating to the respective page.

- `merges/form.rb` — delete the `moves` method (10 lines); simplify `default_checked?` from `merges.length == 1 && moves.empty?` to `merges.length == 1`; drop the redundant `&.` in `default_target_id` (`default_checked?` guarantees `merges.length == 1` at the call site).
- `moves/form.rb` (mirror) — delete the `merges` method; simplify `default_checked?` from `merges.empty? && moves.length == 1` to `moves.length == 1`; drop the redundant `&.` in `default_target_id`.

Two new tests exercise the single-candidate auto-select path that the deletion exposed and that the original tests didn't cover:

- `merges/form_test.rb#test_single_merge_target_auto_selects` uses `name_descriptions(:coprinus_comatus_desc)` (parent has exactly two descriptions) and asserts the lone merge target's radio is `[checked]`.
- `moves/form_test.rb#test_single_move_target_auto_selects` creates a `NameDescription` on `names(:lactifluus_alpinus)` (whose only non-misspelling synonym is `lactifluus_subalpinus`) and asserts the lone move target's radio is `[checked]`. No existing fixture matches the "exactly one valid synonym" shape, so the description is built in-test rather than added as a fixture.

Both forms now report 100% line coverage (were 89.83% and 97.96%).

**2. `Views::Controllers::Observations::Namings::Form`: cover the sibling-observation link.**

`render_sibling_reasons_note` emits a "see matching observations reasons" link only when all three of: the form is in edit mode, the observation belongs to an `Occurrence`, and at least one other observation in that `Occurrence` has a `Naming` for the same `name_id`. No existing fixture combo satisfies the third condition — every occurrence fixture is a singleton over its observations. The new test `test_sibling_observation_link_renders_in_edit_mode` builds the scenario in-test (per `test/fixtures/observations.yml`'s own guidance to prefer on-the-fly creation over one-off fixtures): puts the `coprinus_comatus_obs` fixture into a freshly-created `Occurrence`, adds a sibling `Observation` + `Naming` on the same `Name`, then renders the edit form and asserts the link is present at `view_context.occurrence_path(occurrence)`.

Closes lines 109–111 of `app/views/controllers/observations/namings/form.rb`; brings the file to 100% line coverage.

## Behavior change to call out

`default_checked?` in each form previously had a cross-page guard: the merge form required `moves.empty?` and the move form required `merges.empty?` before auto-pre-selecting a single same-page candidate. With the merge and move flows now on separate pages, those guards were holdovers from the combined-page ERB partial they were transcribed from in PR #4368. Removing them changes one narrow case:

| scenario | before | after |
| --- | --- | --- |
| 1 merge candidate, 0 move candidates | merge radio pre-selected | unchanged |
| 0 merge candidates, 1 move candidate | move radio pre-selected | unchanged |
| 1 merge candidate AND ≥1 move candidate | **no pre-selection** on either page | **same-page candidate pre-selected** |
| 1 move candidate AND ≥1 merge candidate | same as above | same as above |

The new tests pin this auto-selection. If the old "suppress default when the other page also has work" behavior was intentional rather than a transcription artifact, this PR should not land as-is — please flag.

## Coverage impact

| file | before | after |
| --- | --- | --- |
| `app/views/controllers/descriptions/merges/form.rb` | 89.83% (6 missed / 59 relevant) | 100.00% (53 / 53) |
| `app/views/controllers/descriptions/moves/form.rb` | 97.96% (1 missed / 49 relevant) | 100.00% (45 / 45) |
| `app/views/controllers/observations/namings/form.rb` | 93.88% (3 missed / 49 relevant) | 100.00% |

The relevant-line counts shift downward on the merge/move forms because the deleted `moves` / `merges` methods were themselves contributing executable lines.

## Test plan

- [x] `bin/rails test test/views/controllers/descriptions/merges/form_test.rb test/views/controllers/descriptions/moves/form_test.rb test/views/controllers/observations/namings/form_test.rb` — 14 tests, 90 assertions, 0 failures
- [x] `bundle exec rubocop` on all four touched files — no offenses
- [x] SimpleCov locally confirms all three files at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
