### PR TITLE
tabs/related_objects_helper: delete dead related_observations_tab

### DIFF
--- a/app/helpers/tabs/related_objects_helper.rb
+++ b/app/helpers/tabs/related_objects_helper.rb
@@ -34,12 +34,5 @@ module Tabs
         current_query: current_query, controller: controller
       )&.to_a
     end
-
-    def related_observations_tab(type, current_query)
-      ::Tab::Related::Query.for(
-        model: Observation, filter: type,
-        current_query: current_query, controller: controller
-      )&.to_a
-    end
   end
 end


### PR DESCRIPTION
Last remaining caller migrated away in #4421 (observations Tab POROs batch) when `Tab::Observation::IndexActions` started composing `Tab::Related::Query.for(model: Observation, ...)` directly. Verified 0 callers across app/, test/, lib/, config/.

The other 3 methods in the file (`related_objects_tab`, `related_images_tab`, `related_locations_tab`) still have callers and remain. The file gets deleted when those last 3 callers migrate.

## Test plan
- [x] `bin/rails test test/classes/tab/related/` — 3 tests, all green
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green