### PR TITLE
Descriptions::List: inline list_descriptions, drop helper registration

### DIFF
--- a/.claude/rules/phlex_conversions.md
+++ b/.claude/rules/phlex_conversions.md
@@ -48,6 +48,59 @@ the work. If you find yourself opening a follow-up PR purely to
 inline helpers from a conversion you just shipped, the conversion
 was incomplete.
 
+## `register_value_helper` is a code smell — ask before you reach for it
+
+The conversion goal is to **eliminate** the helper, not paper it
+over with a thin Phlex wrapper that still depends on it. Every
+`register_value_helper :foo` line says "this view depends on
+`foo` as a contract" and gives future readers a reason to leave
+`foo` alone. That defeats the refactor.
+
+**Hard rule:** before adding a `register_value_helper` line, **stop
+and ask the user**. Lead the ask with the reminder that this
+refactor is about refactoring helpers, not just views, and
+explain why you think this specific helper can't be inlined.
+Default to inlining the helper's logic as private methods on the
+new view (per the move-vs-register heuristic above). The user has
+to explicitly approve the registration — the default answer is
+"no."
+
+The carve-outs above ("Body composes other helpers → leave
+registered for now") still exist, but treat them as the exception
+that needs justification, not the easy path. The kinds of helpers
+that may be OK to register (when nothing else works):
+
+- **Stable request-context predicates** that all controllers expose
+  and that no refactor will ever delete — `in_admin_mode?`,
+  `reviewer?`, `permission?`, `controller`, `params`,
+  `add_page_title`. These are already registered in
+  `Components::Base` / `Views::Base` / `Components::ApplicationForm`;
+  if a new view needs one of those that isn't yet registered on the
+  base class, registering it on the appropriate base (so the whole
+  class hierarchy benefits) is the right move. Ask first to confirm
+  the scope (base class vs single view).
+- **Helpers whose body itself composes 5+ other helpers** AND none
+  of those helpers are domain helpers the user is trying to delete.
+  Rare in this codebase.
+
+**Domain helpers the user is actively trying to delete**
+(`list_descriptions`, every `tabs/*_helper.rb` method,
+`add_list_of_projects`, etc.) **never** belong in
+`register_value_helper`. Inline the logic into the new view as
+private methods, even if it makes the view 100+ lines. The Phlex
+view owning its own render chain is the whole point.
+
+**Never call `helpers.foo` from inside a Phlex view.** It's not a
+substitute for registering — it's worse (silent runtime
+dispatch into ActionView, brittle across Phlex versions). If
+`foo` needs to be reachable from the view, either inline it or go
+through the proper registration channels.
+
+This rule was added after a conversion shipped a
+`register_value_helper :list_descriptions` in
+`Views::Controllers::Descriptions::List` — the helper that PR was
+nominally trying to deprecate. Don't repeat that mistake.
+
 ## Decide first: reusable or single-use?
 
 The first decision when converting an ERB helper / partial / template to

--- a/app/views/base.rb
+++ b/app/views/base.rb
@@ -38,4 +38,11 @@ class Views::Base < Components::Base
   # → Locations / Images links). ERB views have it for free; Phlex
   # views need it registered.
   register_value_helper :controller
+
+  # Stable request-context predicate exposed to all Phlex views.
+  # Reads `session[:admin]` via `ApplicationController::Authentication`
+  # (`base.helper_method(:permission?, :reviewer?, :in_admin_mode?)`),
+  # so ERB views see it for free. Phlex needs the explicit register.
+  # Matches `register_value_helper :permission?` in `Components::Base`.
+  register_value_helper :in_admin_mode?
 end

--- a/app/views/controllers/descriptions/list.rb
+++ b/app/views/controllers/descriptions/list.rb
@@ -1,18 +1,25 @@
 # frozen_string_literal: true
 
 # Renders the alt-descriptions list for a Name or Location show page:
-# each visible description as a `<div>` (Names) or joined with `<br>`
-# (Locations), containing a link to the description + its mod-controls.
-# Wraps the existing `DescriptionsHelper#list_descriptions` helper
-# rather than re-implementing the filter / sort / link / mod-link
-# chain inline — that chain composes 5+ helper methods (`reviewer?`,
-# `in_admin_mode?`, `sort_description_list`, `make_list_links`,
-# `DescriptionIconsHelper#description_mod_links`, etc.); per
-# `.claude/rules/phlex_conversions.md`, helpers that themselves compose
-# other helpers stay registered for now.
+# each visible description as a `<div>` containing a link to the
+# description + its mod-controls (Edit / Destroy when the user has
+# the appropriate permission).
+#
+# Owns the full filter / sort / link / mod-link chain that the
+# pre-Phlex `DescriptionsHelper#list_descriptions` +
+# `#sort_description_list` + `#make_list_links` + `#description_link`
+# + `#description_title` + `DescriptionIconsHelper#description_mod_links`
+# composed. The helper still exists for one remaining caller in
+# `tabs/observations_helper.rb#obs_name_description_tabs`; once the
+# `_name_info.erb` partial migrates to Phlex (which will inline that
+# composer too), the helper chain can be deleted entirely.
 module Views::Controllers::Descriptions
   class List < Views::Base
-    register_value_helper :list_descriptions
+    # `reviewer?` is description-domain only — it gates visibility
+    # of restricted descriptions for users in the "reviewers" group.
+    # Register here rather than on `Views::Base` so the helper stays
+    # scoped to its actual consumer.
+    register_value_helper :reviewer?
 
     prop :user, _Nilable(::User), default: nil
     prop :object, _Any
@@ -21,17 +28,13 @@ module Views::Controllers::Descriptions
     # When the object has no visible descriptions, emit this text
     # instead. Callers pass the type-specific i18n message
     # (`:show_name_no_descriptions.t`, etc.) — pre-translated so the
-    # view stays type-agnostic. Pass an html_safe string (or
-    # `SafeBuffer`) to embed inline markup like an `indent` span.
+    # view stays type-agnostic. Pass an html_safe string to embed
+    # inline markup like an `indent` span.
     prop :empty_text, _Nilable(String), default: nil
-    # `:div` (Names): wrap each item in its own `<div>`. `:br`
-    # (Locations): join items with `<br/>` separators (preserves the
-    # pre-Phlex `safe_join(safe_br)` shape of the locations partial).
-    prop :separator, Symbol, default: :div
 
     def view_template
-      if items.any?
-        render_items
+      if visible_descriptions.any?
+        visible_descriptions.each { |desc| div { render_item(desc) } }
       elsif @empty_text
         trusted_html(@empty_text.to_s)
       end
@@ -39,21 +42,108 @@ module Views::Controllers::Descriptions
 
     private
 
-    def items
-      list_descriptions(user: @user, object: @object,
-                        type: @type, current: @current) || []
+    def visible_descriptions
+      @visible_descriptions ||=
+        sort_descriptions(
+          @object.descriptions.includes(:user).select { |d| visible?(d) }
+        )
     end
 
-    def render_items
-      case @separator
-      when :br
-        items.each_with_index do |item, idx|
-          br if idx.positive?
-          trusted_html(item)
-        end
-      else
-        items.each { |item| div { trusted_html(item) } }
+    def visible?(desc)
+      desc.notes? || (desc.user == @user) || reviewer? ||
+        (desc.source_type == :public) || in_admin_mode?
+    end
+
+    def sort_descriptions(list)
+      type_order = ::Description::ALL_SOURCE_TYPES
+      list.sort_by do |desc|
+        [
+          (desc.id == @object.description_id ? 0 : 1),
+          type_order.index(desc.source_type),
+          -desc.note_status[0],
+          -desc.note_status[1],
+          description_title(desc),
+          desc.id
+        ]
       end
+    end
+
+    def render_item(desc)
+      if desc == @current
+        trusted_html(description_title(desc))
+      else
+        render_link(desc)
+        render_mod_links(desc)
+      end
+    end
+
+    def render_link(desc)
+      # The pre-Phlex `description_link` helper had an
+      # `return result if result.match?("(#{:private.t})$")` guard
+      # meant to skip the link when the title ended in "(private)",
+      # but Ruby's `String#match?` treats the bare `(` as a regex
+      # group rather than a literal — the guard never fired in
+      # practice. Don't reintroduce the (buggy) early return; always
+      # render the link so behavior matches the pre-conversion view.
+      a(href: url_for(desc.show_link_args),
+        class: "description_link_#{desc.id}") do
+        trusted_html(description_title(desc))
+      end
+    end
+
+    def render_mod_links(desc)
+      writer = writer?(desc)
+      admin = admin?(desc)
+      return unless writer || admin
+
+      span(class: "ml-3") do
+        plain("[ ")
+        render_edit_link(desc) if writer
+        plain(" | ") if writer && admin
+        render_destroy_button(desc) if admin
+        plain(" ]")
+      end
+    end
+
+    def render_edit_link(desc)
+      content, path, opts = ::Tab::Description::Edit.new(
+        description: desc
+      ).to_a
+      render(Components::IconLink.new(content, path, **opts))
+    end
+
+    def render_destroy_button(desc)
+      render(Components::CrudButton::Delete.new(target: desc, btn: nil))
+    end
+
+    # Wraps `Description#partial_format_name` with a rough-permissions
+    # suffix ("(public)", "(restricted)", "(private)"). Returns a
+    # `.t`-translated SafeBuffer so callers can `trusted_html` it.
+    def description_title(desc)
+      result = desc.partial_format_name
+      permit = title_permission_label(desc)
+      result += " (#{permit})" unless /(^| )#{permit}( |$)/i.match?(result)
+      result.t
+    end
+
+    def title_permission_label(desc)
+      if desc.parent.description_id == desc.id
+        :default.l
+      elsif desc.public
+        :public.l
+      elsif desc.is_reader?(@user)
+        :restricted.l
+      else
+        :private.l
+      end
+    end
+
+    def writer?(desc)
+      desc.writer?(@user) || in_admin_mode?
+    end
+
+    def admin?(desc)
+      desc.is_admin?(@user) || in_admin_mode?
     end
   end
 end

--- a/app/views/controllers/descriptions/list.rb
+++ b/app/views/controllers/descriptions/list.rb
@@ -78,13 +78,13 @@ module Views::Controllers::Descriptions
     end
 
     def render_link(desc)
-      # The pre-Phlex `description_link` helper had an
-      # `return result if result.match?("(#{:private.t})$")` guard
-      # meant to skip the link when the title ended in "(private)",
-      # but Ruby's `String#match?` treats the bare `(` as a regex
-      # group rather than a literal — the guard never fired in
-      # practice. Don't reintroduce the (buggy) early return; always
-      # render the link so behavior matches the pre-conversion view.
+      # The pre-Phlex `description_link` helper had a guard meant to
+      # skip the `<a>` when the title ended in "(private)" — but
+      # `description_title` was wrapping its return in a Rails
+      # `translation_missing` span (see `description_title` below),
+      # so the title never literally ended in "(private)" and the
+      # guard never fired in practice. Don't reintroduce the dead
+      # branch; always render the link.
       a(href: url_for(desc.show_link_args),
         class: "description_link_#{desc.id}") do
         trusted_html(description_title(desc))
@@ -118,7 +118,17 @@ module Views::Controllers::Descriptions
 
     # Wraps `Description#partial_format_name` with a rough-permissions
     # suffix ("(public)", "(restricted)", "(private)"). Returns a
-    # `.t`-translated SafeBuffer so callers can `trusted_html` it.
+    # textile-processed SafeBuffer so callers can `trusted_html` it.
+    #
+    # Pre-Phlex this method called Rails' helper `t(result)` on a
+    # free-text string, which always hit `I18n.t` as a missing
+    # translation and wrapped the title in
+    # `<span class="translation_missing">…</span>` with title-cased
+    # fallback ("Eol Project (Restricted)"). That span shipped to
+    # every show-name / show-location page with an alt description.
+    # `String#t` (textile, MO's `app/extensions/string.rb#t`) is what
+    # this method was always meant to call — it does textile
+    # processing without the missing-translation wrapper.
     def description_title(desc)
       result = desc.partial_format_name
       permit = title_permission_label(desc)
@@ -131,11 +141,19 @@ module Views::Controllers::Descriptions
         :default.l
       elsif desc.public
         :public.l
-      elsif desc.is_reader?(@user)
+      elsif reader?(desc)
         :restricted.l
       else
         :private.l
       end
+    end
+
+    # `reader?` / `writer?` / `admin?` all fall back to `in_admin_mode?`
+    # so admins see drafts as "restricted" (not "private"), can hit Edit,
+    # and can hit Destroy. Matches the pre-Phlex `user_reader?` /
+    # `user_writer?` / `user_is_admin?` helpers.
+    def reader?(desc)
+      desc.is_reader?(@user) || in_admin_mode?
     end
 
     def writer?(desc)

--- a/app/views/controllers/descriptions/list.rb
+++ b/app/views/controllers/descriptions/list.rb
@@ -69,7 +69,19 @@ module Views::Controllers::Descriptions
     end
 
     def render_item(desc)
-      if desc == @current
+      if desc == @current || !reader?(desc)
+        # Render plain text (no `<a>`) when:
+        # - We're already on `desc`'s show page (no self-link).
+        # - The user isn't a reader of `desc` — they'd just bounce
+        #   off the show controller's read check with a flash
+        #   error, so don't offer a misleading clickable link.
+        #   The pre-Phlex `description_link` helper *tried* to do
+        #   the non-reader half with
+        #   `result.match?("(#{:private.t})$")`, but the title
+        #   was always wrapped in a `translation_missing` span
+        #   (see `description_title`) so the literal "(private)"
+        #   suffix never matched and the guard never fired. We're
+        #   honoring the original intent here.
         trusted_html(description_title(desc))
       else
         render_link(desc)
@@ -78,13 +90,6 @@ module Views::Controllers::Descriptions
     end
 
     def render_link(desc)
-      # The pre-Phlex `description_link` helper had a guard meant to
-      # skip the `<a>` when the title ended in "(private)" — but
-      # `description_title` was wrapping its return in a Rails
-      # `translation_missing` span (see `description_title` below),
-      # so the title never literally ended in "(private)" and the
-      # guard never fired in practice. Don't reintroduce the dead
-      # branch; always render the link.
       a(href: url_for(desc.show_link_args),
         class: "description_link_#{desc.id}") do
         trusted_html(description_title(desc))

--- a/app/views/controllers/locations/show/alt_descriptions_panel.rb
+++ b/app/views/controllers/locations/show/alt_descriptions_panel.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 # "Descriptions" panel on the Location show page. Renders the
-# `Views::Controllers::Descriptions::List` (with `<br>` separators —
-# matches the pre-Phlex `safe_join(safe_br)` shape) inside a
+# `Views::Controllers::Descriptions::List` inside a
 # `Components::Panel`; the panel heading carries a "create new
 # description" icon-link. When the caller passes a `projects:`
 # array, appends a "create draft for project" row at the bottom.
 # Replaces `_alt_descriptions_panel.html.erb`.
+#
+# The pre-Phlex partial used `safe_join(safe_br)` to vertically
+# separate descriptions while the names panel used `<div>` wrapping.
+# The visual result is identical; standardize on `<div>` to match
+# the names panel and keep `Descriptions::List` shape-agnostic.
 module Views::Controllers::Locations::Show
   class AltDescriptionsPanel < Views::Base
     prop :user, _Nilable(::User), default: nil
@@ -22,8 +26,6 @@ module Views::Controllers::Locations::Show
       end
     end
 
-    INDENT = '<span class="ml-3">&nbsp;</span>'.html_safe
-
     private
 
     def heading_links
@@ -34,14 +36,10 @@ module Views::Controllers::Locations::Show
     def render_body
       render(Views::Controllers::Descriptions::List.new(
                user: @user, object: @object, type: @object.type_tag,
-               current: @current, separator: :br,
-               empty_text: empty_text
+               current: @current,
+               empty_text: :"show_#{@object.type_tag}_no_descriptions".t
              ))
       render_projects_list if @projects.present?
-    end
-
-    def empty_text
-      INDENT + :"show_#{@object.type_tag}_no_descriptions".t
     end
 
     def render_projects_list
@@ -49,11 +47,12 @@ module Views::Controllers::Locations::Show
         plain("#{:show_name_create_draft.l}: ")
         @projects.each do |project|
           br
-          trusted_html(INDENT)
           tab = Tab::Description::NewForProject.new(
             parent: @object, project: project
           ).to_a
-          a(href: tab[1], **tab[2].except(:icon)) { plain(tab[0]) }
+          a(href: tab[1], class: class_names("ml-3", tab[2][:class])) do
+            plain(tab[0])
+          end
         end
       end
     end

--- a/test/integration/capybara/name_descriptions_integration_test.rb
+++ b/test/integration/capybara/name_descriptions_integration_test.rb
@@ -163,11 +163,24 @@ class NameDescriptionsIntegrationTest < CapybaraIntegrationTestCase
     )
   end
 
-  # Knows it exists but can't even view it.
+  # Knows it exists but can't even view it. The draft's title is
+  # surfaced as plain text (so the user knows it exists), NOT as a
+  # link — clicking would just hit the show controller's read
+  # check and flash an error. Verify the controller still enforces
+  # that, just via a direct visit instead of a click.
   def check_another_user(url, draft:, session:)
     session.visit(url)
-    assert(session.has_link?(href: name_description_path(draft.id)))
-    session.first(:link, href: name_description_path(draft.id)).click
+    # Non-readers see the draft's title as plain text (so they
+    # know it exists), NOT as a clickable link — clicking would
+    # just bounce off the show controller's read check with a
+    # flash error.
+    session.assert_no_selector(
+      "a[href='#{name_description_path(draft.id)}']"
+    )
+    session.assert_text(draft.source_name)
+    # Verify the show controller still enforces read perms when
+    # they paste the URL directly.
+    session.visit(name_description_path(draft.id))
     assert_flash_error(session: session)
   end
 

--- a/test/integration/capybara/name_descriptions_integration_test.rb
+++ b/test/integration/capybara/name_descriptions_integration_test.rb
@@ -125,7 +125,7 @@ class NameDescriptionsIntegrationTest < CapybaraIntegrationTestCase
     session.visit(url)
     # show n.d link should be restricted
     assert(session.has_link?(href: name_description_path(draft.id),
-                             text: /Restricted/))
+                             text: /restricted/i))
     assert(session.has_link?(href: edit_name_description_path(draft.id)))
     session.assert_no_text(/#{draft.gen_desc}/)
     assert(session.has_link?(

--- a/test/views/controllers/descriptions/list_test.rb
+++ b/test/views/controllers/descriptions/list_test.rb
@@ -2,11 +2,11 @@
 
 require("test_helper")
 
-# Component-level smoke tests for `Views::Controllers::Descriptions::List`. The
-# component is a thin wrapper around `DescriptionsHelper#list_descriptions`
-# (registered as a value-helper); these tests cover the wrapper's two
-# observable behaviors: each description gets wrapped in its own `<div>`,
-# and an object with no descriptions renders nothing.
+# Component-level smoke tests for `Views::Controllers::Descriptions::List`.
+# Covers: each visible description gets its own `<div>`, readable ones
+# render as `<a class="description_link_#{id}">`, non-readable ones
+# render as plain text (no `<a>`), and an object with no descriptions
+# renders nothing (or the `empty_text` fallback).
 class Views::Controllers::Descriptions::ListTest < ComponentTestCase
   def setup
     super
@@ -28,15 +28,23 @@ class Views::Controllers::Descriptions::ListTest < ComponentTestCase
                  doc.children.count { |c| c.name == "div" })
   end
 
-  def test_each_div_contains_a_description_link
+  def test_readable_descriptions_render_as_links
     name = names_with_descriptions
 
     html = render(Views::Controllers::Descriptions::List.new(
                     user: @user, object: name, type: :name
                   ))
 
-    name.descriptions.each do |desc|
+    readable, unreadable = name.descriptions.partition do |desc|
+      desc.is_reader?(@user)
+    end
+    assert(readable.any?, "Need at least one description rolf can read")
+
+    readable.each do |desc|
       assert_html(html, "a.description_link_#{desc.id}")
+    end
+    unreadable.each do |desc|
+      assert_no_html(html, "a.description_link_#{desc.id}")
     end
   end
 

--- a/test/views/controllers/descriptions/list_test.rb
+++ b/test/views/controllers/descriptions/list_test.rb
@@ -63,20 +63,6 @@ class Views::Controllers::Descriptions::ListTest < ComponentTestCase
     assert_includes(html, "No descriptions here.")
   end
 
-  def test_br_separator_joins_descriptions_with_br
-    name = names_with_descriptions
-    html = render(Views::Controllers::Descriptions::List.new(
-                    user: @user, object: name, type: :name, separator: :br
-                  ))
-    doc = Nokogiri::HTML.fragment(html)
-
-    assert_operator(doc.css("br").count, :>=, 1,
-                    "Multiple descriptions should be `<br>`-separated")
-    top_divs = doc.children.count { |c| c.name == "div" }
-    assert_equal(0, top_divs,
-                 "br separator should not wrap items in `<div>`")
-  end
-
   private
 
   def names_with_descriptions


### PR DESCRIPTION
## Summary

#4437 introduced `Views::Controllers::Descriptions::List` as a thin wrapper around the `list_descriptions` helper via `register_value_helper :list_descriptions`. That defeated the refactor's premise — helpers are what we're eliminating, not perpetuating. This PR inlines the full helper chain into the view, lays down a hard rule against the pattern, and along the way fixes two pre-existing user-visible bugs that the refactor surfaced.

## Refactor: inline the `list_descriptions` chain

`sort_description_list` + `make_list_links` + `description_link` + `description_title` + `description_mod_links` all become private methods on the view. The view now owns the full filter / sort / link / mod-link rendering chain. The `list_descriptions` helper still exists in `descriptions_helper.rb` for its one remaining caller (`tabs/observations_helper.rb#obs_name_description_tabs`); once `_name_info.erb` migrates to Phlex, the entire helper chain can be deleted.

**Drop the `separator:` prop** — the locations panel previously passed `:br` to match the pre-Phlex `safe_join(safe_br)` shape. The visual outcome of `<div>`-wrapped vs `<br>`-joined items is identical, so standardize on `<div>` (names panel's existing shape). One fewer knob.

**Drop the `INDENT = '<span class="ml-3">&nbsp;</span>'.html_safe` pattern** — was used to insert visual left-margin via a filler `<nbsp>` in a `<span class="ml-3">`. Wrap the actual content in `<span class="ml-3">` directly — class-based margin on the content, not a filler span.

**Helper-access plumbing:**

- `register_value_helper :in_admin_mode?` on `Views::Base` — stable request-context predicate; matches `register_value_helper :permission?` on `Components::Base`. All `Views::Controllers::*` views get it without per-view registration.
- `register_value_helper :reviewer?` only on `Views::Controllers::Descriptions::List` — description-domain predicate (gates visibility of restricted descriptions for reviewers-group users), so it stays scoped to its consumer.

## Bug fixes surfaced by the refactor

**1. `description_title`'s `translation_missing` wrapper.** The pre-Phlex helper called Rails' helper `t(result)` on a free-text string ("EOL Project (restricted)"). The i18n lookup always missed and Rails wrapped the title in `<span class="translation_missing" title="…">Eol Project (Restricted)</span>` with title-cased fallback. That span shipped to every show-name / show-location page with an alt description. The new code calls `result.t` — MO's `String#t` (textile, `app/extensions/string.rb`) — which is what the helper was clearly meant to call all along. Output is the literal title without the translation_missing wrapper and without the incidental title-casing. `NameDescriptionsIntegrationTest#test_creating_drafts` was pinning the title-cased fallback (`text: /Restricted/`); loosen it to `text: /restricted/i`.

**2. `description_link`'s dead guard against linking private descriptions.** The pre-Phlex helper had `return result if result.match?("(#{:private.t})$")` — meant to render plain text (no `<a>`) when the user wasn't a reader of the description. The guard never fired in practice because `description_title` was wrapping its return in the `translation_missing` span (see bug #1), so the title literally ended in `</span>`, not "(private)". Restore the *intent* using a direct `reader?(desc)` check: non-readers see the draft's title as plain text (so they know it exists), but the misleading clickable-link-to-flash-error UX is gone. The show controller's `user_has_permission_to_see_description?` is still the source of truth — `check_another_user` now verifies that protection via a direct URL visit instead of a click.

## `.claude/rules/phlex_conversions.md`

New hard rule section: `register_value_helper` is a code smell that needs explicit user approval before being added. Default is "no" — inline the helper logic instead. Domain helpers the user is actively trying to delete (`list_descriptions`, every `tabs/*_helper.rb` method, etc.) **never** belong in `register_value_helper`. `helpers.foo` calls inside Phlex views are explicitly banned. The carve-outs (stable request-context predicates like `in_admin_mode?` / `reviewer?` / `permission?`) are still allowed when registered on the appropriate base class.

## Test plan

- [x] `bin/rails test test/views/controllers/descriptions/list_test.rb test/integration/capybara/name_descriptions_integration_test.rb test/controllers/observations_controller_show_test.rb test/controllers/names_controller_show_test.rb test/controllers/locations_controller_test.rb` — all green.
- [x] `bundle exec rubocop` on every touched file — 0 offenses.
- [x] CI green.
- [x] Per-file 100% coverage verified.
