### PR TITLE
test/components: routes proxy + render components directly (drop view_context.helper layer)

### DIFF
--- a/test/component_test_case.rb
+++ b/test/component_test_case.rb
@@ -18,6 +18,15 @@ class ComponentTestCase < UnitTestCase
   # Get the Rails view context needed for components to access helpers
   delegate :view_context, to: :controller
 
+  # Route helpers — `routes.foo_path(...)` rather than the longer
+  # `view_context.foo_path(...)`. NOT a module include because
+  # `include Rails.application.routes.url_helpers` makes MiniTest
+  # treat any helper named `test_*_path` / `test_*_url` (e.g. for a
+  # `/test` resource) as a test method, causing spurious runs.
+  def routes
+    Rails.application.routes.url_helpers
+  end
+
   def setup
     super
     controller.request = ActionDispatch::TestRequest.create

--- a/test/components/context_nav/sidebar_test.rb
+++ b/test/components/context_nav/sidebar_test.rb
@@ -42,7 +42,7 @@ module Components::ContextNav
       links = [[nil, @article, { button: :destroy }]]
       html = render_sidebar(links)
 
-      assert_html(html, "form[action='#{view_context.article_path(@article)}']")
+      assert_html(html, "form[action='#{routes.article_path(@article)}']")
       assert_html(html, "input[name='_method'][value='delete']")
     end
 

--- a/test/components/context_nav/top_bar_test.rb
+++ b/test/components/context_nav/top_bar_test.rb
@@ -58,7 +58,7 @@ module Components::ContextNav
       links = [[nil, @article, { button: :destroy }]]
       html = render_top_bar(links)
 
-      assert_html(html, "form[action='#{view_context.article_path(@article)}']")
+      assert_html(html, "form[action='#{routes.article_path(@article)}']")
       assert_html(html, "input[name='_method'][value='delete']")
       assert_no_html(html, ".glyphicon-remove-circle")
       assert_no_html(html, ".btn.btn-outline-default")

--- a/test/components/crud_button_test.rb
+++ b/test/components/crud_button_test.rb
@@ -160,12 +160,18 @@ class CrudButtonTest < ComponentTestCase
   end
 end
 
-class LinkHelperButtonTest < ComponentTestCase
-  # Test the helper wrappers that delegate to the component
-
-  def test_destroy_button_helper
+# `Components::CrudButton` subclasses (`Delete`, `Edit`, `Download`,
+# `Post`, `Put`, `Patch`) — verify each subclass's destroy / edit /
+# fetch defaults stack correctly on top of the base `CrudButton`
+# rendering. These were previously routed through the
+# `LinkHelper#destroy_button` / `#edit_button` / etc. ERB helper
+# wrappers (now thin one-liners that just `render(...)` the same
+# component subclasses); the helpers stay in `link_helper.rb` for
+# ERB callers but the tests render the components directly.
+class CrudButtonSubclassesTest < ComponentTestCase
+  def test_delete_with_model_target
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.destroy_button(target: herbarium)
+    html = render(Components::CrudButton::Delete.new(target: herbarium))
 
     assert_html(html,
                 "form[action='#{routes.herbarium_path(herbarium)}']")
@@ -175,18 +181,20 @@ class LinkHelperButtonTest < ComponentTestCase
     assert_html(html, "[data-turbo-confirm]")
   end
 
-  def test_destroy_button_with_custom_name
+  def test_delete_with_custom_name
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.destroy_button(target: herbarium, name: "Delete it")
+    html = render(
+      Components::CrudButton::Delete.new(target: herbarium, name: "Delete it")
+    )
 
     assert_html(html, "button", text: "Delete it")
   end
 
-  # Default icon. `CrudButton::Delete` auto-applies `icon: :delete`,
-  # which renders the remove-circle glyphicon + sr-only label wrapper.
-  def test_destroy_button_default_icon
+  # Default icon. `Delete` auto-applies `icon: :delete`, which
+  # renders the remove-circle glyphicon + sr-only label wrapper.
+  def test_delete_default_icon
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.destroy_button(target: herbarium)
+    html = render(Components::CrudButton::Delete.new(target: herbarium))
 
     assert_html(html, "button span.glyphicon-remove-circle")
     assert_html(html, "button span.sr-only")
@@ -194,40 +202,45 @@ class LinkHelperButtonTest < ComponentTestCase
 
   # Opt out of the default icon by passing `icon: nil`. Used by the
   # context-nav `[ DESTROY ]` text-link rendering path.
-  def test_destroy_button_icon_nil_opts_out
+  def test_delete_icon_nil_opts_out
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.destroy_button(target: herbarium, icon: nil)
+    html = render(
+      Components::CrudButton::Delete.new(target: herbarium, icon: nil)
+    )
 
     assert_no_html(html, "button span.glyphicon")
     assert_no_html(html, "button span.sr-only")
-    # button still renders the destroy machinery
     assert_html(html, "input[name='_method'][value='delete']")
     assert_html(html, ".text-danger")
   end
 
   # Explicit icon override (e.g. `:remove`) wins over the default.
-  def test_destroy_button_icon_override
+  def test_delete_icon_override
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.destroy_button(target: herbarium, icon: :remove)
+    html = render(
+      Components::CrudButton::Delete.new(target: herbarium, icon: :remove)
+    )
 
     assert_html(html, "button span.glyphicon-remove-circle")
   end
 
-  # Default btn frame. `CrudButton::Delete` auto-applies
+  # Default btn frame. `Delete` auto-applies
   # `btn: "btn btn-outline-default"` for a consistent outline frame
   # across destroy buttons.
-  def test_destroy_button_default_btn_frame
+  def test_delete_default_btn_frame
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.destroy_button(target: herbarium)
+    html = render(Components::CrudButton::Delete.new(target: herbarium))
 
     assert_html(html, "button.btn.btn-outline-default")
   end
 
   # Opt out of the btn frame via `btn: nil` — icon-only inline
   # destroys in dense table cells / list rows.
-  def test_destroy_button_btn_nil_opts_out_of_frame
+  def test_delete_btn_nil_opts_out_of_frame
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.destroy_button(target: herbarium, btn: nil)
+    html = render(
+      Components::CrudButton::Delete.new(target: herbarium, btn: nil)
+    )
 
     assert_no_html(html, "button.btn-outline-default")
     assert_no_html(html, "button.btn")
@@ -238,31 +251,52 @@ class LinkHelperButtonTest < ComponentTestCase
 
   # Caller `class:` layers on top of the `btn:` default — e.g.
   # `btn-sm` combines with the outline frame.
-  def test_destroy_button_class_layered_on_btn_default
+  def test_delete_class_layered_on_btn_default
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.destroy_button(target: herbarium, class: "btn-sm")
+    html = render(
+      Components::CrudButton::Delete.new(target: herbarium, class: "btn-sm")
+    )
 
     assert_html(html, "button.btn.btn-outline-default.btn-sm")
   end
 
-  # Edit-button default: GET + edit_<type>_path + icon :edit.
-  def test_edit_button_helper_defaults
+  # Delete with a String target: caller controls the path entirely,
+  # no identifier class is built, but delete-action defaults
+  # (text-danger, confirm, icon) still apply. `default_name` falls
+  # back to `:DESTROY.l` since there's no type to interpolate.
+  def test_delete_with_string_target
+    html = render(
+      Components::CrudButton::Delete.new(target: "/items/42", name: "Destroy")
+    )
+
+    assert_html(html, "form[action='/items/42']")
+    assert_html(html, "input[name='_method'][value='delete']")
+    assert_html(html, ".text-danger")
+    assert_no_html(html, ".destroy_link_")
+    assert_html(html, "button span.glyphicon-remove-circle")
+  end
+
+  # Edit default: GET + `edit_<type>_path` + icon `:edit`.
+  def test_edit_with_model_target
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.edit_button(target: herbarium)
+    html = render(Components::CrudButton::Edit.new(target: herbarium))
 
     assert_html(html,
                 "a[href='#{routes.edit_herbarium_path(herbarium)}']")
     assert_no_html(html, "form")
     assert_html(html, ".edit_herbarium_link_#{herbarium.id}")
     assert_html(html, "a span.glyphicon-edit")
-    assert_html(html, "a span.sr-only")
+    assert_html(html, "a span.sr-only",
+                text: :edit_object.t(type: :herbarium))
     assert_html(html, "a[data-toggle='tooltip']")
   end
 
   # `icon: nil` opt-out for text-only edit links.
-  def test_edit_button_icon_nil_opts_out
+  def test_edit_icon_nil_opts_out
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.edit_button(target: herbarium, icon: nil)
+    html = render(
+      Components::CrudButton::Edit.new(target: herbarium, icon: nil)
+    )
 
     path = routes.edit_herbarium_path(herbarium)
     assert_html(html, "a[href='#{path}']",
@@ -273,117 +307,72 @@ class LinkHelperButtonTest < ComponentTestCase
   end
 
   # Edit shares Delete's btn-frame default (`btn btn-outline-default`).
-  def test_edit_button_default_btn_frame
+  def test_edit_default_btn_frame
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.edit_button(target: herbarium)
+    html = render(Components::CrudButton::Edit.new(target: herbarium))
 
     assert_html(html, "a.btn.btn-outline-default")
   end
 
   # `btn: nil` opt-out — icon-only inline edits in dense table rows.
-  def test_edit_button_btn_nil_opts_out_of_frame
+  def test_edit_btn_nil_opts_out_of_frame
     herbarium = herbaria(:nybg_herbarium)
-    html = view_context.edit_button(target: herbarium, btn: nil)
+    html = render(
+      Components::CrudButton::Edit.new(target: herbarium, btn: nil)
+    )
 
     assert_no_html(html, "a.btn-outline-default")
     assert_no_html(html, "a.btn")
     assert_html(html, "a span.glyphicon-edit")
   end
 
-  # Download-button default: GET + explicit path + icon :download.
-  def test_download_button_helper_defaults
-    species_list = species_lists(:first_species_list)
-    html = view_context.download_button(target: species_list)
-
-    path = routes.new_download_species_list_path(id: species_list.id)
-    assert_html(html, "a[href='#{path}']")
-    assert_no_html(html, "form")
-    assert_html(html, "a span.glyphicon-download-alt")
-    assert_html(html, "a span.sr-only")
-  end
-end
-
-# Parity spot checks: verify the new component subclass output
-# matches the contract LinkHelper used to produce. Each test renders
-# through `view_context.<helper>` and asserts the structural pieces
-# (path, method, identifier class, body content) that downstream
-# templates / styles / Stimulus controllers depend on.
-class CrudButtonParityTest < ComponentTestCase
-  # destroy_button with a model target: form action is bare
-  # `<resource>_path` (no `destroy_` prefix), `_method=delete`, the
-  # identifier class is `destroy_<type>_link_<id>`, text-danger is
-  # applied, the default delete icon renders.
-  def test_destroy_button_model_target_parity
-    herbarium = herbaria(:nybg_herbarium)
-    html = view_context.destroy_button(
-      target: herbarium, name: "Destroy"
-    )
-
-    assert_html(html,
-                "form[action='#{routes.herbarium_path(herbarium)}']")
-    assert_html(html, "input[name='_method'][value='delete']")
-    assert_html(html, ".destroy_herbarium_link_#{herbarium.id}")
-    assert_html(html, ".text-danger")
-    assert_html(html, "[data-turbo-confirm]")
-    assert_html(html, "button span.glyphicon-remove-circle")
-    assert_html(html, "button span.sr-only", text: "Destroy")
-  end
-
-  # destroy_button with a String target: caller controls the path
-  # entirely, no identifier class is built, but delete-action defaults
-  # (text-danger, confirm, icon) still apply.
-  def test_destroy_button_string_target_parity
-    html = view_context.destroy_button(
-      target: "/items/42", name: "Destroy"
-    )
-
-    assert_html(html, "form[action='/items/42']")
-    assert_html(html, "input[name='_method'][value='delete']")
-    assert_html(html, ".text-danger")
-    assert_no_html(html, ".destroy_link_")
-    assert_html(html, "button span.glyphicon-remove-circle")
-  end
-
-  # edit_button with model target: link to `edit_<resource>_path`,
-  # identifier class `edit_<type>_link_<id>`, edit-icon glyph + sr-only
-  # label, tooltip data attrs.
-  def test_edit_button_model_target_parity
-    herbarium = herbaria(:nybg_herbarium)
-    html = view_context.edit_button(target: herbarium)
-
-    assert_html(html,
-                "a[href='#{routes.edit_herbarium_path(herbarium)}']")
-    assert_no_html(html, "form")
-    assert_html(html, ".edit_herbarium_link_#{herbarium.id}")
-    assert_html(html, "a span.glyphicon-edit")
-    assert_html(html, "a span.sr-only",
-                text: :edit_object.t(type: :herbarium))
-  end
-
-  # edit_button with String target + explicit `class:` override.
-  def test_edit_button_string_target_with_class_parity
-    html = view_context.edit_button(
-      target: "/items/42/edit", name: "Edit it", class: "btn btn-link"
-    )
+  # Edit with String target + explicit `class:` override.
+  def test_edit_with_string_target_and_class
+    html = render(Components::CrudButton::Edit.new(
+                    target: "/items/42/edit", name: "Edit it",
+                    class: "btn btn-link"
+                  ))
 
     assert_html(html, "a.btn.btn-link[href='/items/42/edit']")
     assert_html(html, "a span.glyphicon-edit")
     assert_html(html, "a span.sr-only", text: "Edit it")
   end
 
-  # String/Hash targets have no recoverable type, so `default_name`
+  # String / Hash targets have no recoverable type, so `default_name`
   # falls back to the generic `:EDIT.l` instead of
   # `:edit_object.t(type: …)`.
-  def test_edit_button_string_target_default_name
-    html = view_context.edit_button(target: "/items/42/edit")
+  def test_edit_with_string_target_default_name
+    html = render(
+      Components::CrudButton::Edit.new(target: "/items/42/edit")
+    )
 
     assert_html(html, "a span.sr-only", text: :EDIT.l)
   end
 
-  # post_button: form, no `_method` field (POST is default), no
-  # confirm, button body is the name verbatim.
-  def test_post_button_parity
-    html = view_context.post_button(name: "Create", path: "/items")
+  # Download: GET + explicit path + icon `:download`. The species
+  # list controller's named route is `new_download_species_list_path`,
+  # which doesn't match the standard `download_<resource>_path`
+  # shape that `target: model` would auto-resolve to — callers
+  # therefore pass an explicit path String. (The
+  # `LinkHelper#download_button` helper does the path-resolution
+  # for ERB callers; Phlex callers go through this path directly.)
+  def test_download_with_explicit_path
+    species_list = species_lists(:first_species_list)
+    path = routes.new_download_species_list_path(id: species_list.id)
+    html = render(Components::CrudButton::Download.new(target: path))
+
+    assert_html(html, "a[href='#{path}']")
+    assert_no_html(html, "form")
+    assert_html(html, "a span.glyphicon-download-alt")
+    assert_html(html, "a span.sr-only")
+  end
+
+  # Post: form, no `_method` field (POST is default), no confirm,
+  # button body is the name verbatim.
+  def test_post
+    html = render(
+      Components::CrudButton::Post.new(name: "Create", target: "/items")
+    )
 
     assert_html(html, "form[action='/items'][data-turbo='true']")
     assert_no_html(html, "input[name='_method']")
@@ -391,12 +380,12 @@ class CrudButtonParityTest < ComponentTestCase
     assert_html(html, "button", text: "Create")
   end
 
-  # put_button + confirm: form action, _method=put, turbo-confirm
-  # title and button data, body text.
-  def test_put_button_with_confirm_parity
-    html = view_context.put_button(
-      name: "Replace", path: "/items/1", confirm: "Sure?"
-    )
+  # Put + confirm: form action, `_method=put`, turbo-confirm title
+  # and button data, body text.
+  def test_put_with_confirm
+    html = render(Components::CrudButton::Put.new(
+                    name: "Replace", target: "/items/1", confirm: "Sure?"
+                  ))
 
     assert_html(html, "form[action='/items/1']")
     assert_html(html, "input[name='_method'][value='put']")
@@ -406,12 +395,13 @@ class CrudButtonParityTest < ComponentTestCase
     assert_html(html, "button", text: "Replace")
   end
 
-  # patch_button with custom class: form, _method=patch, class
-  # applied to the button.
-  def test_patch_button_with_class_parity
-    html = view_context.patch_button(
-      name: "Update", path: "/items/1", class: "btn btn-primary"
-    )
+  # Patch with custom class: form, `_method=patch`, class applied to
+  # the button.
+  def test_patch_with_class
+    html = render(Components::CrudButton::Patch.new(
+                    name: "Update", target: "/items/1",
+                    class: "btn btn-primary"
+                  ))
 
     assert_html(html, "form[action='/items/1']")
     assert_html(html, "input[name='_method'][value='patch']")

--- a/test/components/crud_button_test.rb
+++ b/test/components/crud_button_test.rb
@@ -41,7 +41,7 @@ class CrudButtonTest < ComponentTestCase
 
     # Should build path from model
     assert_html(html,
-                "form[action='#{view_context.herbarium_path(herbarium)}']")
+                "form[action='#{routes.herbarium_path(herbarium)}']")
     assert_html(html, "input[name='_method'][value='delete']")
     # Should build identifier class from action and model
     assert_html(html, ".destroy_herbarium_link_#{herbarium.id}")
@@ -83,7 +83,7 @@ class CrudButtonTest < ComponentTestCase
 
     # Should build path: herbarium_path(herbarium.id) - method is separate
     assert_html(html,
-                "form[action='#{view_context.herbarium_path(herbarium)}']")
+                "form[action='#{routes.herbarium_path(herbarium)}']")
     # Should build identifier from method: patch_herbarium_link_123
     assert_html(html, ".patch_herbarium_link_#{herbarium.id}")
   end
@@ -168,7 +168,7 @@ class LinkHelperButtonTest < ComponentTestCase
     html = view_context.destroy_button(target: herbarium)
 
     assert_html(html,
-                "form[action='#{view_context.herbarium_path(herbarium)}']")
+                "form[action='#{routes.herbarium_path(herbarium)}']")
     assert_html(html, "input[name='_method'][value='delete']")
     assert_html(html, ".destroy_herbarium_link_#{herbarium.id}")
     assert_html(html, ".text-danger")
@@ -251,7 +251,7 @@ class LinkHelperButtonTest < ComponentTestCase
     html = view_context.edit_button(target: herbarium)
 
     assert_html(html,
-                "a[href='#{view_context.edit_herbarium_path(herbarium)}']")
+                "a[href='#{routes.edit_herbarium_path(herbarium)}']")
     assert_no_html(html, "form")
     assert_html(html, ".edit_herbarium_link_#{herbarium.id}")
     assert_html(html, "a span.glyphicon-edit")
@@ -264,7 +264,7 @@ class LinkHelperButtonTest < ComponentTestCase
     herbarium = herbaria(:nybg_herbarium)
     html = view_context.edit_button(target: herbarium, icon: nil)
 
-    path = view_context.edit_herbarium_path(herbarium)
+    path = routes.edit_herbarium_path(herbarium)
     assert_html(html, "a[href='#{path}']",
                 text: :edit_object.t(type: :herbarium))
     assert_no_html(html, "a span.glyphicon")
@@ -295,7 +295,7 @@ class LinkHelperButtonTest < ComponentTestCase
     species_list = species_lists(:first_species_list)
     html = view_context.download_button(target: species_list)
 
-    path = view_context.new_download_species_list_path(id: species_list.id)
+    path = routes.new_download_species_list_path(id: species_list.id)
     assert_html(html, "a[href='#{path}']")
     assert_no_html(html, "form")
     assert_html(html, "a span.glyphicon-download-alt")
@@ -320,7 +320,7 @@ class CrudButtonParityTest < ComponentTestCase
     )
 
     assert_html(html,
-                "form[action='#{view_context.herbarium_path(herbarium)}']")
+                "form[action='#{routes.herbarium_path(herbarium)}']")
     assert_html(html, "input[name='_method'][value='delete']")
     assert_html(html, ".destroy_herbarium_link_#{herbarium.id}")
     assert_html(html, ".text-danger")
@@ -352,7 +352,7 @@ class CrudButtonParityTest < ComponentTestCase
     html = view_context.edit_button(target: herbarium)
 
     assert_html(html,
-                "a[href='#{view_context.edit_herbarium_path(herbarium)}']")
+                "a[href='#{routes.edit_herbarium_path(herbarium)}']")
     assert_no_html(html, "form")
     assert_html(html, ".edit_herbarium_link_#{herbarium.id}")
     assert_html(html, "a span.glyphicon-edit")

--- a/test/views/controllers/observations/namings/form_test.rb
+++ b/test/views/controllers/observations/namings/form_test.rb
@@ -135,7 +135,7 @@ module Views::Controllers::Observations::Namings
       html = render_form(model: naming, vote: vote)
 
       assert_html(html,
-                  "a[href='#{view_context.occurrence_path(occurrence)}']",
+                  "a[href='#{routes.occurrence_path(occurrence)}']",
                   text: :naming_see_matching_observations_reasons.l)
     end
 

--- a/test/views/controllers/species_lists/details_test.rb
+++ b/test/views/controllers/species_lists/details_test.rb
@@ -41,7 +41,7 @@ module Views::Controllers::SpeciesLists
     def test_renders_download_button_with_correct_path
       html = render_details
 
-      path = view_context.new_download_species_list_path(
+      path = routes.new_download_species_list_path(
         id: @species_list.id
       )
       assert_html(html, "a[href='#{path}']")
@@ -58,7 +58,7 @@ module Views::Controllers::SpeciesLists
       assert_includes(html, "#{:PROJECTS.t}:")
       # And each project shows up as a link_to_object.
       assert_html(html,
-                  "a[href='#{view_context.project_path(project.id)}']")
+                  "a[href='#{routes.project_path(project.id)}']")
     end
 
     def test_does_not_render_projects_when_empty

--- a/test/views/controllers/species_lists/listing_test.rb
+++ b/test/views/controllers/species_lists/listing_test.rb
@@ -39,7 +39,7 @@ module Views::Controllers::SpeciesLists
       html = render_listing(observation: @observation, remove: true)
 
       assert_html(html, ".list_manage form")
-      remove_path = view_context.observation_species_list_path(
+      remove_path = routes.observation_species_list_path(
         id: @observation.id,
         species_list_id: @species_list.id,
         commit: "remove"
@@ -55,7 +55,7 @@ module Views::Controllers::SpeciesLists
       html = render_listing(observation: @observation, add: true)
 
       assert_html(html, ".list_manage form")
-      add_path = view_context.observation_species_list_path(
+      add_path = routes.observation_species_list_path(
         id: @observation.id,
         species_list_id: @species_list.id,
         commit: "add"

--- a/test/views/controllers/species_lists/observation_test.rb
+++ b/test/views/controllers/species_lists/observation_test.rb
@@ -18,11 +18,11 @@ module Views::Controllers::SpeciesLists
       html = render_row
 
       assert_html(html, ".list-group-item .row")
-      obs_path = view_context.observation_path(id: @observation.id)
+      obs_path = routes.observation_path(id: @observation.id)
       assert_html(html, "a[href='#{obs_path}']")
       # Always renders the who+when line.
       assert_html(html,
-                  "a[href='#{view_context.user_path(@observation.user.id)}']")
+                  "a[href='#{routes.user_path(@observation.user.id)}']")
     end
 
     # When `image: true` the row is two-column (image + details);
@@ -50,7 +50,7 @@ module Views::Controllers::SpeciesLists
       html = render_row(remove: true)
 
       assert_html(html, ".manage_observation")
-      remove_path = view_context.observation_species_list_path(
+      remove_path = routes.observation_species_list_path(
         id: @observation.id,
         species_list_id: @species_list.id,
         commit: "remove"


### PR DESCRIPTION
## Summary

Two related sweeps under `test/components/` and `test/views/controllers/`:

**1. `routes` proxy on `ComponentTestCase`.** Adds a method that returns `Rails.application.routes.url_helpers` so tests can write `routes.foo_path(...)` instead of the longer `view_context.foo_path(...)`. Sweeps every existing `view_context.<route>_path` / `view_context.<route>_url` callsite to use the new proxy.

**2. Component tests render components directly, not via helper wrappers.** `crud_button_test.rb` had two classes (`LinkHelperButtonTest`, `CrudButtonParityTest`) routing every assertion through `view_context.destroy_button` / `view_context.edit_button` / etc. — `LinkHelper` wrappers that themselves are one-liners calling `render(Components::CrudButton::Delete.new(...))` (etc). The layer of indirection wasn't testing anything the component-level tests weren't. Merged the two classes into `CrudButtonSubclassesTest` and rewired every assertion to `render(...)` the subclass directly:

```ruby
# Before
html = view_context.destroy_button(target: herbarium)

# After
html = render(Components::CrudButton::Delete.new(target: herbarium))
```

The helpers themselves stay in `app/helpers/link_helper.rb` — ERB views still call them — but their tests are now component-level.

## Why not `include Rails.application.routes.url_helpers`

The obvious "make path helpers directly available" move would be `include Rails.application.routes.url_helpers`. MO's `.claude/rules/testing.md` already documents why we don't do that:

> Use a `routes` proxy method, not `include Rails.application.routes.url_helpers`. Including the module makes MiniTest pick up any route helper whose name happens to start with `test_` (e.g. `test_index_url` for `/test`) as a test method on the class, causing spurious failures.

The `routes` proxy gives you the same `foo_path(...)` ergonomics without polluting the test class's method table.

## Why `view_context` doesn't go away entirely

`view_context` is still needed for non-route, non-component helper calls — `view_context.link_to(...)` (Rails primitive used to build test data in `panel_test.rb` / `table_test.rb`), `view_context.list_descriptions(...)` (the `descriptions/list_test.rb` parity check explicitly calls the deprecated helper to compute the expected count). These cases need ActionView's render context; `routes` only gives you path/url helpers and there's no Components equivalent to drop in. They keep `view_context`.

## Files changed

- `test/component_test_case.rb` — adds `routes` proxy
- `test/components/crud_button_test.rb` — merges `LinkHelperButtonTest` + `CrudButtonParityTest` into `CrudButtonSubclassesTest`, swaps `view_context.<helper>` → `render(Components::CrudButton::<Subclass>.new(...))` (22 callsites)
- `test/components/context_nav/{sidebar,top_bar}_test.rb` — 2 `view_context.foo_path` → `routes.foo_path`
- `test/views/controllers/species_lists/{observation,details,listing}_test.rb` — 7 substitutions
- `test/views/controllers/observations/namings/form_test.rb` — 1

## Test plan

- [x] `bin/rails test test/components/ test/views/controllers/` — 1129 tests, 5635 assertions, all green.
- [x] `bundle exec rubocop` on every touched file — 0 offenses.
- [x] CI green.
