### PR TITLE
Fix field slip editing when project prefix added after creation (#4436)

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -37,10 +37,6 @@ class FieldSlipsController < ApplicationController
 
   # GET /field_slips/1/edit
   def edit
-    # Needed so the Project dropdown lists the editing user's
-    # member-projects (FieldSlip#find_projects keys off current_user).
-    # new/create already do this; edit omitted it. See #4436.
-    @field_slip.current_user = @user
     @recent_observations = recent_edit_observations
   end
 
@@ -127,6 +123,11 @@ class FieldSlipsController < ApplicationController
 
   def set_field_slip
     @field_slip = FieldSlip.find(params[:id])
+    # Set for every edit/update/destroy flow (not just the edit action):
+    # update's validation-failure path re-renders :edit without running
+    # edit, and update_project runs on a code change during update — both
+    # need current_user for the Project dropdown / association. See #4436.
+    @field_slip.current_user = @user
   end
 
   # Gate edit/update/destroy. Site admins (admin mode) may always act,

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -37,6 +37,10 @@ class FieldSlipsController < ApplicationController
 
   # GET /field_slips/1/edit
   def edit
+    # Needed so the Project dropdown lists the editing user's
+    # member-projects (FieldSlip#find_projects keys off current_user).
+    # new/create already do this; edit omitted it. See #4436.
+    @field_slip.current_user = @user
     @recent_observations = recent_edit_observations
   end
 

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -9,6 +9,7 @@ class FieldSlipsController < ApplicationController
   # Disable cop: all these methods are defined in files included above.
   # rubocop:disable Rails/LexicallyScopedActionFilter
   before_action :set_field_slip, only: [:edit, :update, :destroy]
+  before_action :require_edit_permission, only: [:edit, :update, :destroy]
   before_action :login_required, except: [:show]
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
@@ -36,10 +37,6 @@ class FieldSlipsController < ApplicationController
 
   # GET /field_slips/1/edit
   def edit
-    unless @field_slip.can_edit?(@user)
-      return redirect_to(field_slip_url(id: @field_slip.id))
-    end
-
     @recent_observations = recent_edit_observations
   end
 
@@ -82,10 +79,6 @@ class FieldSlipsController < ApplicationController
 
   # DELETE /field_slips/1 or /field_slips/1.json
   def destroy
-    unless @field_slip.can_edit?(@user)
-      return redirect_to(field_slip_url(id: @field_slip.id))
-    end
-
     @field_slip.destroy!
     respond_to do |format|
       format.html do
@@ -130,6 +123,14 @@ class FieldSlipsController < ApplicationController
 
   def set_field_slip
     @field_slip = FieldSlip.find(params[:id])
+  end
+
+  # Gate edit/update/destroy. Site admins (admin mode) may always act,
+  # matching the edit-icon visibility rule in add_edit_icons. See #4436.
+  def require_edit_permission
+    return if in_admin_mode? || @field_slip.can_edit?(@user)
+
+    redirect_to(field_slip_url(id: @field_slip.id))
   end
 
   def html_create

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -19,6 +19,14 @@ class FieldSlip < AbstractModel
     end
   end
 
+  # The project-prefix portion of a code: everything before the trailing
+  # " 123" / "-123" sequence number. Returns nil when the code has no
+  # such suffix (so it can't belong to a prefixed project).
+  def self.prefix_for_code(code)
+    match = code.to_s.match(/(^.+)[ -]\d+$/)
+    match && match[1]
+  end
+
   # Find an existing field slip by code, or create a new one.
   # Returns nil if the code is invalid (fails validation).
   def self.find_or_create_by_code(code, user)
@@ -65,6 +73,14 @@ class FieldSlip < AbstractModel
   scope :projects, lambda { |projects|
     project_ids = Lookup::Projects.new(projects).ids
     where(project: project_ids).distinct
+  }
+
+  # Orphaned (no project) slips whose code begins with the given prefix.
+  # A SQL pre-filter — callers must still confirm an exact prefix match
+  # via prefix_for_code (LIKE "FOO%" also matches "FOOBAR-1").
+  scope :orphaned_with_code_prefix, lambda { |prefix|
+    where(project_id: nil).
+      where("code LIKE ?", "#{sanitize_sql_like(prefix.to_s.upcase)}%")
   }
 
   def current_user=(a_user)
@@ -123,11 +139,11 @@ class FieldSlip < AbstractModel
   end
 
   def update_project
-    prefix_match = code.match(/(^.+)[ -]\d+$/)
-    return unless prefix_match
+    prefix = self.class.prefix_for_code(code)
+    return unless prefix
 
     # Needs to get updated when Projects can share a field_slip_prefix
-    candidate = Project.find_by(field_slip_prefix: prefix_match[1])
+    candidate = Project.find_by(field_slip_prefix: prefix)
     self.project = candidate if candidate&.can_add_field_slip?(@current_user)
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -100,6 +100,11 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   has_many :aliases, class_name: "ProjectAlias", dependent: :destroy
 
   before_destroy :orphan_drafts
+  # Adding/changing a prefix retroactively claims previously-orphaned
+  # field slips whose code matches — but only member-owned ones. See
+  # #adopt_matching_field_slips and #4436.
+  after_save :adopt_matching_field_slips,
+             if: :saved_change_to_field_slip_prefix?
   validates :field_slip_prefix, uniqueness: true, allow_blank: true
   validates :field_slip_prefix,
             allow_blank: true,
@@ -230,9 +235,14 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
   alias admin? is_admin?
 
+  # A user trusts this project (allowing project admins to edit their
+  # content) only when they are an actual member whose trust_level is
+  # not "no_trust". A non-member is NOT trusted — otherwise merely
+  # associating their content with a project would hand its admins edit
+  # rights without consent. See #4436.
   def trusted_by?(user)
     member = project_members.find_by(user: user)
-    member&.trust_level != "no_trust"
+    member.present? && member.trust_level != "no_trust"
   end
 
   def can_edit?(user)
@@ -1011,6 +1021,23 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
   def can_add_field_slip?(user)
     member?(user) || can_join?(user)
+  end
+
+  # Associate previously-orphaned field slips (no project) whose code
+  # matches this project's prefix, restricted to slips whose owner is
+  # already a member — so adding a prefix can't silently claim a
+  # non-member's field slips and hand admins edit rights over them.
+  # Returns the slips actually adopted. Idempotent. See #4436.
+  def adopt_matching_field_slips
+    prefix = field_slip_prefix
+    return [] if prefix.blank?
+
+    FieldSlip.orphaned_with_code_prefix(prefix).select do |slip|
+      next false unless FieldSlip.prefix_for_code(slip.code) == prefix
+      next false unless member?(slip.user)
+
+      slip.update_column(:project_id, id)
+    end
   end
 
   def alias_data(target)

--- a/script/adopt_orphaned_field_slips.rb
+++ b/script/adopt_orphaned_field_slips.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Associate previously-orphaned field slips (project_id nil) with the
+# project whose field_slip_prefix matches their code — but only when the
+# slip's owner is already a member of that project. Run once to clean up
+# slips created before their project's prefix was set (e.g. FS 3930 in
+# issue #4436), where the on-prefix-change hook never fired.
+#
+#   bin/rails runner script/adopt_orphaned_field_slips.rb
+#
+# Idempotent and safe to re-run: it reuses Project#adopt_matching_field_slips,
+# which skips non-member-owned slips, so it never grants a project's admins
+# edit rights over a non-member's field slips. See app/models/project.rb.
+
+class OrphanedFieldSlipAdopter
+  def run
+    prefixed_projects = Project.where.not(field_slip_prefix: [nil, ""])
+    puts("Scanning #{prefixed_projects.count} projects with a prefix...")
+
+    total = 0
+    prefixed_projects.find_each do |project|
+      adopted = project.adopt_matching_field_slips
+      next if adopted.empty?
+
+      total += adopted.size
+      adopted.each do |slip|
+        puts("  FS #{slip.id} (#{slip.code}) -> project #{project.id} " \
+             "(#{project.title})")
+      end
+    end
+
+    puts("Done. Adopted #{total} orphaned field slips.")
+  end
+end
+
+OrphanedFieldSlipAdopter.new.run

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -430,6 +430,23 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_redirected_to(field_slip_url(id: slip.id))
   end
 
+  # The Project dropdown must list the editing user's member-projects,
+  # not just the slip's own project. Regression: edit omitted setting
+  # current_user, so find_projects ran against a nil user. See #4436.
+  def test_edit_project_dropdown_lists_editor_member_projects
+    slip = field_slips(:field_slip_one) # owner mary, project eol_project
+    bolete = projects(:bolete_project)  # mary is a member, not the slip's proj
+    login(slip.user.login)
+
+    get(:edit, params: { id: slip.id })
+
+    assert_response(:success)
+    assert_select(
+      "select[name=?] option[value=?]",
+      "field_slip[project_id]", bolete.id.to_s
+    )
+  end
+
   def test_should_show_field_slip_and_allow_owner_to_change
     field_slip = field_slips(:field_slip_no_trust)
     login(field_slip.user.login)

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -447,6 +447,24 @@ class FieldSlipsControllerTest < FunctionalTestCase
     )
   end
 
+  # update re-renders :edit on validation failure without running edit,
+  # so current_user must be set in the before_action, not the edit action,
+  # for the Project dropdown to still list member-projects. See #4436.
+  def test_update_validation_failure_rerenders_with_member_projects
+    slip = field_slips(:field_slip_one) # owner mary
+    bolete = projects(:bolete_project)  # mary is a member
+    login(slip.user.login)
+
+    # code with only digits/dots/dashes fails the format validation
+    patch(:update, params: { id: slip.id, field_slip: { code: "123" } })
+
+    assert_response(:unprocessable_content)
+    assert_select(
+      "select[name=?] option[value=?]",
+      "field_slip[project_id]", bolete.id.to_s
+    )
+  end
+
   def test_should_show_field_slip_and_allow_owner_to_change
     field_slip = field_slips(:field_slip_no_trust)
     login(field_slip.user.login)

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -410,6 +410,26 @@ class FieldSlipsControllerTest < FunctionalTestCase
     # assert_redirected_to edit_field_slip_url(id: @field_slip.id)
   end
 
+  # Site admin (admin mode) can edit a slip they couldn't otherwise edit,
+  # matching the edit-icon visibility rule. See #4436.
+  def test_admin_mode_allows_edit
+    slip = field_slips(:field_slip_no_trust) # owner katrina (no_trust)
+    make_admin("rolf")
+
+    get(:edit, params: { id: slip.id })
+
+    assert_response(:success)
+  end
+
+  def test_edit_redirects_when_not_permitted
+    slip = field_slips(:field_slip_no_trust)
+    login("dick") # not owner, not project admin, not site admin
+
+    get(:edit, params: { id: slip.id })
+
+    assert_redirected_to(field_slip_url(id: slip.id))
+  end
+
   def test_should_show_field_slip_and_allow_owner_to_change
     field_slip = field_slips(:field_slip_no_trust)
     login(field_slip.user.login)
@@ -598,7 +618,9 @@ class FieldSlipsControllerTest < FunctionalTestCase
   end
 
   def test_check_name_handles_textile_formats
-    login
+    # Admin mode: this test edits slips across projects/owners (incl. a
+    # non-member's), exercising name formatting, not the permission gate.
+    make_admin
 
     # Test "_name Xxx yyy_" format - should create naming with correct name
     fs1 = field_slips(:field_slip_one)

--- a/test/models/field_slip_test.rb
+++ b/test/models/field_slip_test.rb
@@ -2,8 +2,39 @@
 
 require("test_helper")
 
-class FieldSlipTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+class FieldSlipTest < UnitTestCase
+  def test_prefix_for_code
+    assert_equal("EOL", FieldSlip.prefix_for_code("EOL-1"))
+    assert_equal("EOL", FieldSlip.prefix_for_code("EOL 1"))
+    assert_equal("2026-NAMABC", FieldSlip.prefix_for_code("2026-NAMABC-001"))
+    assert_nil(FieldSlip.prefix_for_code("EOL"), "No sequence number -> nil")
+    assert_nil(FieldSlip.prefix_for_code(""))
+  end
+
+  # eol_project: admins rolf + mary; members rolf, mary (editing),
+  # katrina (no_trust); dick is not a member. See #4436.
+  def test_admin_can_edit_trusting_members_slip
+    slip = field_slips(:field_slip_one) # eol_project, owner mary (editing)
+
+    assert(slip.can_edit?(rolf),
+           "eol admin should edit a trusting member's field slip")
+  end
+
+  def test_admin_cannot_edit_no_trust_members_slip
+    slip = field_slips(:field_slip_no_trust) # owner katrina (no_trust)
+
+    assert_not(slip.can_edit?(rolf))
+  end
+
+  def test_admin_cannot_edit_non_members_slip
+    # A slip associated with a project but owned by a non-member must not
+    # be editable by the project's admins (privilege-escalation guard).
+    eol = projects(:eol_project)
+    assert_not(eol.member?(dick))
+    slip = FieldSlip.create!(code: "EOL-7001", user: dick)
+    slip.update_column(:project_id, eol.id)
+
+    assert_not(slip.can_edit?(rolf),
+               "Project admin must not edit a non-member's field slip")
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -786,7 +786,71 @@ class ProjectTest < UnitTestCase
                         "Excluded obs should not surface as a violation")
   end
 
+  # --- trusted_by? requires membership (#4436) ---
+
+  def test_trusted_by_trusting_member
+    assert(projects(:eol_project).trusted_by?(mary)) # editing member
+  end
+
+  def test_trusted_by_no_trust_member_is_false
+    assert_not(projects(:eol_project).trusted_by?(katrina)) # no_trust member
+  end
+
+  def test_trusted_by_non_member_is_false
+    project = projects(:eol_project)
+    assert_not(project.member?(dick))
+    assert_not(project.trusted_by?(dick),
+               "A non-member must not be trusted (escalation guard)")
+  end
+
+  # --- adopt_matching_field_slips (#4436) ---
+
+  def test_adopt_matching_field_slips_member_owned
+    project = projects(:eol_project) # prefix EOL, mary is editing member
+    slip = orphan_field_slip("EOL-9001", mary)
+
+    adopted = project.adopt_matching_field_slips
+
+    assert_equal([slip], adopted)
+    assert_equal(project.id, slip.reload.project_id)
+  end
+
+  def test_adopt_skips_non_member_owned
+    project = projects(:eol_project)
+    assert_not(project.member?(dick))
+    slip = orphan_field_slip("EOL-9002", dick)
+
+    assert_empty(project.adopt_matching_field_slips)
+    assert_nil(slip.reload.project_id)
+  end
+
+  def test_adopt_skips_non_matching_prefix
+    project = projects(:eol_project)
+    slip = orphan_field_slip("XYZ-9003", mary)
+
+    project.adopt_matching_field_slips
+
+    assert_nil(slip.reload.project_id)
+  end
+
+  def test_setting_prefix_adopts_member_orphans
+    project = projects(:bolete_project) # mary is editing member
+    slip = orphan_field_slip("BOLNEW-1", mary)
+
+    project.update!(field_slip_prefix: "BOLNEW")
+
+    assert_equal(project.id, slip.reload.project_id,
+                 "Adding a prefix should claim a member's matching orphan")
+  end
+
   private
+
+  # A field slip with no project, regardless of prefix matching.
+  def orphan_field_slip(code, owner)
+    slip = FieldSlip.create!(code: code, user: owner)
+    slip.update_column(:project_id, nil)
+    slip
+  end
 
   def build_target_location_project
     Project.create!(


### PR DESCRIPTION
## Summary

Fixes #4436. A field slip created before its project had a `field_slip_prefix` kept a `nil` `project_id`, so the project's admins couldn't edit it even after the prefix was added — and in Admin Mode the edit icon redirected straight back to the show page. Investigating surfaced a permission hole and a second editing bug, fixed here together.

## What was wrong

1. **Stale `project_id`.** `FieldSlip#update_project` only runs from the `code=` setter, so a slip created before the prefix existed never got associated, and adding the prefix later didn't retroactively link it.
2. **`Project#trusted_by?` trusted non-members.** `member&.trust_level != "no_trust"` returns `true` when `member` is `nil`, so merely associating a slip with a project handed its admins edit rights over the owner — without the owner ever joining or consenting.
3. **Admin-mode edit icon did nothing.** The icon shows when `in_admin_mode? || can_edit?` (icon helper), but `edit`/`update`/`destroy` gated on `can_edit?` only, so a site admin's click redirected back. `update` had no permission check at all.
4. **Edit Project dropdown listed the wrong projects.** `edit` never set `@field_slip.current_user` (only `new`/`create` did), so `find_projects` ran its membership query against a `nil` user — which, via the `includes` LEFT JOIN, degenerated to "projects with no members" and never listed the editing user's actual member-projects.

## Changes

- `Project#trusted_by?` now requires real membership: `member.present? && member.trust_level != "no_trust"`. A non-member is not trusted. Its only caller is `FieldSlip#can_edit?`.
- `Project#adopt_matching_field_slips` links orphaned (project-less) slips whose code matches the prefix, **only when the slip's owner is already a member** — so adding a prefix claims a member's matching slips (the foray happy path) but never a non-member's. Runs via an `after_save` hook when `field_slip_prefix` is added or changed.
- `FieldSlip.prefix_for_code` extracts a code's project prefix (`update_project` refactored to share it); `orphaned_with_code_prefix` scope.
- `script/adopt_orphaned_field_slips.rb` — idempotent runner to claim slips orphaned before this change, since the on-change hook doesn't fire for prefixes already set.
- `FieldSlipsController` gates `edit`/`update`/`destroy` through a `require_edit_permission` before_action honoring `in_admin_mode? || can_edit?`, and `edit` now sets `@field_slip.current_user = @user` so the Project dropdown lists the editing user's member-projects.

## Security note

The `trusted_by?` fix closes a privilege-escalation vector: previously a project admin could edit any field slip associated with their project whose owner was a non-member. The owner-membership gate on adoption is belt-and-suspenders on top of that. Verified on a production snapshot: the adoption script claimed only member-owned matching orphans (FS 3930 → project 402) and correctly left a non-member-owned matching orphan unassociated.

## Out of scope (follow-up)

`Project.admin_power?` has the same non-member-trusted hole for **observation** editing by project admins — tracked separately in #4439 since it governs observation permissions and has a wider blast radius.

## Test plan

- [x] `bin/rails test test/models/project_test.rb test/models/field_slip_test.rb test/controllers/field_slips_controller_test.rb`
- [x] `bin/rails test test/controllers/projects/members_controller_test.rb test/controllers/projects_controller_test.rb test/models/observation_test.rb`
- [x] RuboCop clean on all changed files
- [x] Manual: ran the adoption script on a prod snapshot; FS 3930 became editable by the project admin and assignable to project 402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
