### PR TITLE
Add Field Slips sub-tab to project Admin tab (#4442)

### DIFF
--- a/app/classes/tab/project/admin_field_slips.rb
+++ b/app/classes/tab/project/admin_field_slips.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Admin sub-tab linking to the project's field slips index
+# (/field_slips?project=ID), which hosts the "Create Field Slips for
+# the Project" link. Gives admins a way to reach field-slip creation
+# even when the project has no observations yet. See #4442.
+class Tab::Project::AdminFieldSlips < Tab::Base
+  def initialize(project:)
+    super()
+    @project = project
+  end
+
+  def title
+    "#{@project.field_slips.count} #{:FIELD_SLIPS.l}"
+  end
+
+  def path
+    field_slips_path(project: @project.id)
+  end
+
+  def alt_title
+    "field_slips"
+  end
+end

--- a/app/classes/tab/project/admin_subtabs.rb
+++ b/app/classes/tab/project/admin_subtabs.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 # The sub-tab strip rendered under the project Admin tab (Details /
-# Members / Aliases). Always all three; no conditional inclusion.
+# Members / Aliases / Field Slips). Always all four; no conditional
+# inclusion.
 class Tab::Project::AdminSubtabs < Tab::Collection
   def initialize(project:)
     super()
@@ -14,7 +15,8 @@ class Tab::Project::AdminSubtabs < Tab::Collection
     [
       Tab::Project::AdminDetails.new(project: @project),
       Tab::Project::AdminMembers.new(project: @project),
-      Tab::Project::AdminAliases.new(project: @project)
+      Tab::Project::AdminAliases.new(project: @project),
+      Tab::Project::AdminFieldSlips.new(project: @project)
     ]
   end
 end

--- a/app/views/controllers/field_slips/index.html.erb
+++ b/app/views/controllers/field_slips/index.html.erb
@@ -20,6 +20,13 @@ project_title = @query&.params_cache&.dig(:project)&.title || ""
                       { class: "btn btn-default" }) %>
         <% end %>
       </div>
+    <% elsif @project.is_admin?(@user) %>
+      <div class="alert alert-info mt-3" id="field_slip_no_prefix_nudge">
+        <%= :show_project_field_slip_no_prefix.t %>
+        <%= link_to(:show_project_field_slip_set_prefix.t,
+                    project_admin_path(project_id: @project.id),
+                    { class: "alert-link" }) %>
+      </div>
     <% end %>
   <% else %>
     <%= render(Components::InlineFilterForm.new(

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3660,7 +3660,9 @@
   show_project_drafts: Drafts
   show_project_edit: Edit Project
   show_project_field_slip_create: Create Field Slip PDF
+  show_project_field_slip_no_prefix: This project has no field slip prefix yet, which is required before field slips can be created.
   show_project_field_slip_prefix: Field Slip Prefix
+  show_project_field_slip_set_prefix: Set a field slip prefix
   show_project_join: Join Project
   show_project_location: Location
   show_project_leave: Leave Project

--- a/test/classes/tab/project/collections_test.rb
+++ b/test/classes/tab/project/collections_test.rb
@@ -117,7 +117,7 @@ module Tab::Project
       collection.each { |t| assert_kind_of(Tab::Base, t) }
     end
 
-    # AdminSubtabs: always Details, Members, Aliases in that order.
+    # AdminSubtabs: always Details, Members, Aliases, Field Slips.
     def test_admin_subtabs_order
       bolete = projects(:bolete_project)
       tabs = Tab::Project::AdminSubtabs.new(project: bolete).to_a
@@ -125,9 +125,20 @@ module Tab::Project
       assert_equal(
         [Tab::Project::AdminDetails,
          Tab::Project::AdminMembers,
-         Tab::Project::AdminAliases],
+         Tab::Project::AdminAliases,
+         Tab::Project::AdminFieldSlips],
         tabs.map(&:class)
       )
+    end
+
+    def test_admin_field_slips_tab
+      bolete = projects(:bolete_project)
+      tab = Tab::Project::AdminFieldSlips.new(project: bolete)
+
+      assert_equal("#{bolete.field_slips.count} #{:FIELD_SLIPS.l}", tab.title)
+      assert_equal(routes.field_slips_path(project: bolete.id), tab.path)
+      assert_equal("field_slips", tab.alt_title)
+      assert_equal("field_slips", tab.nav_key)
     end
 
     # IndexNav: the "Add Project" action-nav collection for the
@@ -179,6 +190,12 @@ module Tab::Project
       ).to_a
 
       assert_empty(tabs)
+    end
+
+    private
+
+    def routes
+      Rails.application.routes.url_helpers
     end
   end
 end

--- a/test/components/nav_tabs_test.rb
+++ b/test/components/nav_tabs_test.rb
@@ -111,11 +111,12 @@ class NavTabsTest < ComponentTestCase
                     current: "members", tabs: collection
                   ))
 
-    # Collection contributed 3 tabs; the one keyed "members" is active.
-    assert_html(html, "ul.nav-tabs > li.nav-item", count: 3)
+    # Collection contributed 4 tabs; the one keyed "members" is active.
+    assert_html(html, "ul.nav-tabs > li.nav-item", count: 4)
     assert_html(html, "a.nav-link.active.members_link")
     assert_html(html, "a.nav-link.details_link")
     assert_html(html, "a.nav-link.aliases_link")
+    assert_html(html, "a.nav-link.field_slips_link")
   end
 
   def test_accepts_raw_internal_link_with_html_options
@@ -140,11 +141,12 @@ class NavTabsTest < ComponentTestCase
       tabs.tab("Extra", "/extra", key: "extra")
     end
 
-    # Collection's 3 tabs + 1 ad-hoc = 4 total, in declaration order.
-    assert_html(html, "ul.nav-tabs > li.nav-item", count: 4)
+    # Collection's 4 tabs + 1 ad-hoc = 5 total, in declaration order.
+    assert_html(html, "ul.nav-tabs > li.nav-item", count: 5)
     assert_html(html, "a.nav-link.details_link")
     assert_html(html, "a.nav-link.members_link")
     assert_html(html, "a.nav-link.aliases_link")
+    assert_html(html, "a.nav-link.field_slips_link")
     assert_html(html, "a.nav-link[href='/extra']", text: "Extra")
   end
 

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -28,6 +28,45 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_response(:success)
   end
 
+  # eol_project: admins rolf + mary; katrina is a member but not admin.
+  def test_index_nudges_admin_to_set_missing_prefix
+    project = projects(:eol_project)
+    project.update!(field_slip_prefix: nil)
+    login(users(:rolf).login)
+
+    get(:index, params: { project: project.id })
+
+    assert_response(:success)
+    assert_select(
+      "#field_slip_no_prefix_nudge a[href=?]",
+      project_admin_path(project_id: project.id), true,
+      "Admin should be nudged to the Admin Details page to set a prefix"
+    )
+  end
+
+  def test_index_prefix_nudge_hidden_from_non_admin
+    project = projects(:eol_project)
+    project.update!(field_slip_prefix: nil)
+    login(users(:katrina).login)
+
+    get(:index, params: { project: project.id })
+
+    assert_response(:success)
+    assert_select("#field_slip_no_prefix_nudge", false,
+                  "Non-admin should not see the set-prefix nudge")
+  end
+
+  def test_index_no_nudge_when_prefix_present
+    project = projects(:eol_project) # has prefix EOL
+    login(users(:rolf).login)
+
+    get(:index, params: { project: project.id })
+
+    assert_response(:success)
+    assert_select("#field_slip_no_prefix_nudge", false,
+                  "No nudge when the project already has a prefix")
+  end
+
   def test_should_get_new
     requires_login(:new)
     assert_response(:success)

--- a/test/controllers/projects/admin_controller_test.rb
+++ b/test/controllers/projects/admin_controller_test.rb
@@ -29,6 +29,9 @@ module Projects
       assert_select("a[href=?]",
                     project_aliases_path(project_id: @project.id),
                     true, "Aliases sub-tab should link to aliases page")
+      assert_select("a[href=?]",
+                    field_slips_path(project: @project.id),
+                    true, "Field Slips sub-tab should link to field slips")
       # Danger Zone with Delete Project
       assert_select("#project_danger_zone", true,
                     "Danger Zone section should be present")

--- a/test/views/controllers/projects/admin_subtabs_test.rb
+++ b/test/views/controllers/projects/admin_subtabs_test.rb
@@ -5,7 +5,7 @@ require("test_helper")
 module Views::Controllers::Projects
   # Tests for the project Admin sub-tabs component (issue #4148).
   class Views::Controllers::Projects::AdminSubtabsTest < ComponentTestCase
-    def test_renders_three_subtabs
+    def test_renders_four_subtabs
       project = projects(:eol_project)
       html = render_subtabs(project: project, current_subtab: "details")
 
@@ -17,6 +17,8 @@ module Views::Controllers::Projects
                   text: :show_project_admin_details_tab.l)
       assert_html(html, "a[href='/projects/#{project.id}/members']")
       assert_html(html, "a[href='/projects/#{project.id}/aliases']")
+      assert_html(html, "a[href='/field_slips?project=#{project.id}']",
+                  text: "#{project.field_slips.count} #{:FIELD_SLIPS.l}")
     end
 
     def test_details_active_when_current


### PR DESCRIPTION
## Summary

Fixes #4442. When a new project is created there's no way through the website to reach its field-slip creation page (e.g. `/projects/403/field_slips/new`). The only link to it lives on the Observations tab, which is hidden until the project has an associated observation — so a brand-new project is stuck.

This adds a **Field Slips** sub-tab to the project Admin sub-tab strip (now Details / Members / Aliases / Field Slips), linking to `/field_slips?project=ID`. That index page already hosts the "Create Field Slips for the Project" link (shown when the project has a prefix and the viewer is a member), so admins can reach field-slip creation regardless of whether the project has any observations yet.

It also adds a prefix nudge: the "Create Field Slips" link only appears once the project has a `field_slip_prefix`. So when an admin lands on the project field-slips index for a project with no prefix, they now see an info alert linking back to the **Admin Details** sub-tab (`project_admin_path`) where the prefix is set. The nudge is shown only to project admins (the people who can set it) and disappears once a prefix exists. This completes the new-project flow: Admin → Details (set prefix) → Field Slips → create.

## Changes

- New `Tab::Project::AdminFieldSlips` PORO — title `"N Field Slips"` (count, consistent with the Members/Aliases sub-tabs), path `field_slips_path(project: id)`, `alt_title`/`nav_key` `"field_slips"`. Added to the `Tab::Project::AdminSubtabs` collection.
- Field-slips index (`field_slips/index.html.erb`): info-alert nudge with a link to the Admin Details page when `@project` has no prefix and the viewer is an admin. Two new i18n strings.

## Test plan

- [x] `bin/rails test test/classes/tab/project/collections_test.rb test/views/controllers/projects/admin_subtabs_test.rb test/components/nav_tabs_test.rb test/helpers/header/context_nav_helper_test.rb`
- [x] `bin/rails test test/controllers/projects/admin_controller_test.rb test/controllers/projects/members_controller_test.rb test/controllers/projects/aliases_controller_test.rb`
- [x] `bin/rails test test/controllers/field_slips_controller_test.rb`
- [x] RuboCop clean
- Coverage: PORO unit test; component renders four sub-tabs incl. the Field Slips link; NavTabs collection counts; admin show page renders the Field Slips sub-tab; and the nudge shows for admins / hides for non-admins / hides when a prefix is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
