### PR TITLE
Project.admin_power? requires the obs owner to be a trusting member (#4439)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -335,17 +335,21 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     false
   end
 
-  # Check if this user is an admin for a project that includes
-  # this observation.
+  # Check if this user is an admin for a project that includes this
+  # observation AND whose owner is a member trusting that project.
+  # A non-member owner is NOT trusted, so adding their observation to a
+  # project can't hand the project's admins power over it. Mirrors the
+  # #trusted_by? membership requirement (#4439). Like Project.can_edit?,
+  # keep scanning further projects when one doesn't grant.
   def self.admin_power?(observation, user)
     return false unless user
     return false if observation.projects.empty?
 
     observation.projects.each do |project|
-      if project.is_admin?(user)
-        member = project.project_members.find_by(user: observation.user)
-        return member&.trust_level != "no_trust"
-      end
+      next unless project.is_admin?(user)
+
+      member = project.project_members.find_by(user: observation.user)
+      return true if member.present? && member.trust_level != "no_trust"
     end
     false
   end

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -154,7 +154,15 @@ class ObservationsControllerShowTest < FunctionalTestCase
     assert_select("#observation_where_gps", text: gps_re)
     assert_select("#observation_where_gps i", text: hidden_re)
 
+    # roy admins current_project (which contains this obs). Per #4439, a
+    # project admin can reveal hidden GPS only when the owner is a
+    # trusting member — not when the owner (mary) is a non-member.
     login("roy")
+    get(:show, params: { id: obs.id })
+    assert_select("#observation_where_gps", text: gps_re, count: 0)
+
+    ProjectMember.create!(project: projects(:current_project),
+                          user: obs.user, trust_level: "hidden_gps")
     get(:show, params: { id: obs.id })
     assert_select("#observation_where_gps", text: gps_re)
     assert_select("#observation_where_gps i", text: hidden_re)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -843,7 +843,53 @@ class ProjectTest < UnitTestCase
                  "Adding a prefix should claim a member's matching orphan")
   end
 
+  # --- admin_power? requires the obs owner to be a trusting member (#4439) ---
+
+  def test_admin_power_over_trusting_member_obs
+    obs, = obs_in_eol_owned_by_member # mary is an editing member of eol
+
+    assert(Project.admin_power?(obs, rolf),
+           "Admin has power over a trusting member's observation")
+  end
+
+  def test_no_admin_power_over_no_trust_member_obs
+    obs, project = obs_in_eol_owned_by_member
+    ProjectMember.find_by(project: project, user: mary).
+      update!(trust_level: "no_trust")
+
+    assert_not(Project.admin_power?(obs, rolf))
+  end
+
+  def test_no_admin_power_over_non_member_obs
+    obs, project = obs_in_eol_owned_by_member
+    ProjectMember.find_by(project: project, user: mary).destroy!
+
+    assert_not(Project.admin_power?(obs, rolf),
+               "Admin must not have power over a non-member's observation")
+  end
+
+  def test_no_admin_power_when_user_not_project_admin
+    obs, = obs_in_eol_owned_by_member # dick is not an eol admin
+
+    assert_not(Project.admin_power?(obs, dick))
+  end
+
+  def test_no_admin_power_without_user
+    obs, = obs_in_eol_owned_by_member
+
+    assert_not(Project.admin_power?(obs, nil))
+  end
+
   private
+
+  # An observation owned by an eol member (mary), added to eol_project
+  # (where rolf is an admin). Returns [observation, project].
+  def obs_in_eol_owned_by_member
+    project = projects(:eol_project)
+    obs = observations(:minimal_unknown_obs) # owner mary, editing member
+    project.add_observation(obs)
+    [obs, project]
+  end
 
   # A field slip with no project, regardless of prefix matching.
   def orphan_field_slip(code, owner)


### PR DESCRIPTION
## Summary

Fixes #4439. `Project.admin_power?(observation, user)` had the same non-member-trusted hole that #4436 (PR #4441) fixed in `Project#trusted_by?`, but on the observation path. It returned `true` when the observation's owner was **not** a member of the project (`member` nil → `nil != "no_trust"` → true), so a project admin gained power over an observation whose owner never joined the project.

`admin_power?` feeds `Observation#project_admin?`, which is used by `reveal_location?` (revealing hidden GPS) and by `ObservationLabels::Fields#coordinates_visible?` (coordinates on labels). So the hole let a project admin reveal the hidden coordinates of a non-member's observation merely because that observation had been added to their project.

## Changes

- `Project.admin_power?` now requires actual membership — `member.present? && member.trust_level != "no_trust"` — mirroring the `trusted_by?` fix. A non-member owner is not trusted.
- While there, switched the loop from an early `return` on the first admin-project to the `next unless … / return true if …` shape used by the sibling `Project.can_edit?`, so it keeps scanning when one admin-project doesn't grant (correct in the multi-project case).

## Behavior

A project admin can reveal an observation's hidden GPS / see its coordinates on labels **only** when the owner is a trusting member (`hidden_gps` or `editing`) of a project the admin runs — the same consent model as field slips. Non-member owners and `no_trust` members are protected.

## Test plan

- [x] `bin/rails test test/models/project_test.rb` — new `admin_power?` unit tests: trusting member → true; `no_trust` member → false; non-member → false; non-admin user → false; nil user → false.
- [x] `bin/rails test test/controllers/observations_controller_show_test.rb` — `test_show_observation_hidden_gps` updated: a project admin is denied the hidden GPS of a non-member's obs, and granted it once the owner becomes a trusting member.
- [x] `bin/rails test test/classes/observation_labels_test.rb test/classes/observation_labels/fields_test.rb test/classes/report_test.rb` — label/coordinate paths unaffected.
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
