### PR TITLE
Description#put_together_name: fix source_type ||= local-shadow bug

### DIFF
--- a/app/models/description.rb
+++ b/app/models/description.rb
@@ -535,8 +535,11 @@ class Description < AbstractModel
   # include the title of the parent object), in plain text.  [I'm not sure
   # I like this here.  It might violate MVC a bit too flagrantly... -JPH]
   def put_together_name(full_or_part)
-    source_type ||= :public
-    tag = :"description_#{full_or_part}_title_#{source_type}"
+    # NOT `source_type ||= :public` — Ruby would treat the LHS as a
+    # new local that shadows the AR reader for the rest of the
+    # method, flattening every description to the public title format.
+    type = source_type.presence || :public
+    tag = :"description_#{full_or_part}_title_#{type}"
     user_name = begin
                   user.legal_name
                 rescue StandardError

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1018,6 +1018,9 @@
   # descriptions in the show_name page.
   description_part_title_public: Public [:DESCRIPTION]
   description_part_title_user: "[USER]'s [:DESCRIPTION]"
+  description_part_title_project: "[USER]'s Draft"
+  description_part_title_source: "[:DESCRIPTION]"
+  description_part_title_foreign: "[:DESCRIPTION]"
 
   # Name/location description types. These are used when listing the available
   # descriptions in the show_name page, but this time the optional text field was

--- a/test/models/description_test.rb
+++ b/test/models/description_test.rb
@@ -204,9 +204,114 @@ class DescriptionTest < UnitTestCase
     desc = name_descriptions(:peltigera_user_desc)
     desc.update(user_id: nil)
 
-    assert(desc.text_name.start_with?("Public"),
-           "text_name of user sourced Description with unknown user should " \
-           "start_with Public ")
+    # User-source description with unknown user: the user-source
+    # title format still applies (the description's
+    # `source_type` is "user" regardless of whether the user
+    # record exists), but the `[USER]` placeholder falls back to
+    # the "?" sentinel from `put_together_name`'s rescue branch.
+    # Prior to the source_type-shadow bug fix this asserted
+    # "Public" because the buggy local-variable shadow made every
+    # description render with the public-source title format.
+    assert(desc.text_name.start_with?("?'s"),
+           "text_name of user-sourced description with unknown user " \
+           "should start with the user-source format and an `?` " \
+           "placeholder — got #{desc.text_name.inspect}")
+  end
+
+  # ---- source_type-specific title formats ------------------------
+  #
+  # Each `Description` source_type maps to its own i18n key — see
+  # `description_{full,part}_title_<type>` in `en.txt`. The
+  # `put_together_name` shadow bug masked these differences for
+  # years (every description rendered with the `_public` format
+  # regardless of its actual `source_type`); pin each format
+  # explicitly so regressions don't silently re-flatten everything
+  # back to "Public" again.
+
+  # `description_part_title_public_with_text: "[TEXT]"`. A public
+  # description with a `source_name` just renders the source_name
+  # verbatim.
+  def test_partial_text_name_public_source_with_text
+    desc = name_descriptions(:peltigera_alt_desc) # source_type :public
+    desc.update(source_name: "Wikipedia")
+    assert_equal("public", desc.source_type)
+
+    assert_equal("Wikipedia", desc.partial_text_name)
+  end
+
+  # `description_part_title_user_with_text: "[TEXT] by [USER]"`.
+  def test_partial_text_name_user_source_with_text
+    desc = name_descriptions(:peltigera_user_desc) # user mary
+    desc.update(source_name: "Mary's Take")
+
+    assert_equal("user", desc.source_type)
+    assert_equal("Mary's Take by Mary Newbie", desc.partial_text_name)
+  end
+
+  # `description_part_title_user: "[USER]'s [:DESCRIPTION]"` (no
+  # text variant).
+  def test_partial_text_name_user_source_without_text
+    desc = name_descriptions(:peltigera_user_desc)
+    desc.update(source_name: nil)
+
+    assert_equal("Mary Newbie's Description", desc.partial_text_name)
+  end
+
+  # `description_part_title_project_with_text: Draft for [TEXT] by [USER]`.
+  def test_partial_text_name_project_source_with_text
+    desc = name_descriptions(:draft_coprinus_comatus) # project draft
+    assert_equal("project", desc.source_type)
+    assert(desc.source_name.present?)
+
+    assert_equal("Draft for #{desc.source_name} by #{desc.user.legal_name}",
+                 desc.partial_text_name)
+  end
+
+  # `description_part_title_source_with_text: "[:DESCRIPTION] From [TEXT]"`.
+  def test_partial_text_name_source_source_with_text
+    desc = name_descriptions(:peltigera_source_desc)
+    assert_equal("source", desc.source_type)
+    assert(desc.source_name.present?)
+
+    assert_equal("Description From #{desc.source_name}",
+                 desc.partial_text_name)
+  end
+
+  # `description_full_title_public: Public [:DESCRIPTION] of [object]`
+  # — the no-text public format, used in `text_name`.
+  def test_text_name_public_source_no_text
+    desc = name_descriptions(:suillus_desc)
+    desc.update(source_name: nil)
+
+    assert(desc.text_name.start_with?("Public Description of "),
+           "Expected public-no-text format, got #{desc.text_name.inspect}")
+  end
+
+  # `description_full_title_project: Draft of [object] for [text] by [user]`.
+  def test_text_name_project_source
+    desc = name_descriptions(:draft_coprinus_comatus)
+    expected_prefix = "Draft of "
+
+    assert(desc.text_name.start_with?(expected_prefix),
+           "Expected project full title prefix, got " \
+           "#{desc.text_name.inspect}")
+    assert_includes(desc.text_name, desc.source_name)
+    assert_includes(desc.text_name, desc.user.legal_name)
+  end
+
+  # When `source_type` is nil (legacy / direct-attribute write),
+  # `put_together_name` falls back to `:public`. Re-pins the
+  # explicit fallback path so a future refactor doesn't drop it.
+  def test_nil_source_type_falls_back_to_public_format
+    desc = name_descriptions(:suillus_desc)
+    # Bypass the AR enum validation so we can set the raw nil.
+    desc.update_columns(source_type: nil)
+    desc.reload
+
+    assert_nil(desc.source_type)
+    assert(desc.text_name.start_with?("Public Description of "),
+           "Nil source_type should default to public format — got " \
+           "#{desc.text_name.inspect}")
   end
 
   def test_source_object


### PR DESCRIPTION
## Summary

`Description#put_together_name` had a Ruby parser quirk that quietly flattened every description's title to the public-source format, regardless of the record's actual `source_type`.

The line was `source_type ||= :public`. Ruby parses `||=` as `source_type = source_type || :public`. On the left-hand side, the parser sees an assignment target and declares a fresh local variable named `source_type` — which shadows the AR `source_type` reader for the rest of the method. The RHS then reads that newly-declared local (always `nil`), `||` picks `:public`, and the local is bound to `:public` from there on.

The net effect: the method computed `tag = :"description_part_title_public"` (or `_with_text` if `source_name` was present) every single time. A project-source description rendered as "Draft for Project Name by Mary Newbie" only because `source_name` was set; a project-source description with no `source_name`, or any user-source description with no `source_name`, rendered as "Public Description". User-source descriptions where the user got nil'd out rendered as "Public Description of …" instead of "?'s Description of …".

The fix assigns to a differently-named local (`type`) so the RHS stays an actual method call on the record:

```ruby
type = source_type.presence || :public
tag = :"description_#{full_or_part}_title_#{type}"
```

`.presence` keeps the original "fall back to public when the attribute is nil" intent that motivated the original (buggy) commit.

## Locale tags

With the fix in place, partial-title rendering now uses the per-source-type tag instead of always landing on `public`. Three tags were missing — pre-fix they were unreachable, so no one ever noticed:

- `description_part_title_project: "[USER]'s Draft"`
- `description_part_title_source: "[:DESCRIPTION]"`
- `description_part_title_foreign: "[:DESCRIPTION]"`

These are the no-text variants for descriptions where `source_type` is set but `source_name` is blank. Fixtures cover this: `bolete_project_private_location_desc` is `source_type: :project` with no `source_name`, and was rendering as "Public Description" before the fix.

## Tests

- `test_user_sourced_description_with_unknown_user` was previously reinforcing the bug — it asserted the buggy "Public Description of …" output for a user-source description with `user_id: nil`. Updated to assert the correct `?'s …` user-source format.
- `test_partial_text_name_public_source_with_text` updates `peltigera_alt_desc.source_name` and asserts the source_name renders verbatim.
- New tests cover each `source_type`'s partial / full title shape (public / user / project / source — with and without `source_name`).
- New test `test_nil_source_type_falls_back_to_public_format` calls `update_columns(source_type: nil)` and asserts the public-format fallback still kicks in.

## Test plan

- [x] `bin/rails test test/models/description_test.rb`
- [x] `bin/rails test test/models/ test/controllers/names/descriptions/ test/controllers/locations/descriptions/ test/integration/capybara/name_descriptions_integration_test.rb` (859 tests, 0 failures)
- [x] `bundle exec rubocop app/models/description.rb test/models/description_test.rb`
