### PR TITLE
Fix Use assert_nil if expecting nil

### DIFF
--- a/test/classes/tab/image/tabs_test.rb
+++ b/test/classes/tab/image/tabs_test.rb
@@ -30,11 +30,15 @@ module Tab::Image
     end
 
     def test_eol
+      eol_url = "https://eol.org/pages/12345"
+      Triple.create!(subject: @image.show_url,
+                     predicate: @image.eol_predicate,
+                     object: eol_url)
       tab = Tab::Image::Eol.new(image: @image)
 
-      assert_equal("EOL", tab.title)
-      assert_equal(@image.eol_url, tab.path)
-      assert_equal("_blank", tab.html_options[:target])
+      assert_equal("EOL", tab.title, "EOL tab title")
+      assert_equal(eol_url, tab.path, "EOL tab path delegates to eol_url")
+      assert_equal("_blank", tab.html_options[:target], "EOL tab opens in new tab")
     end
 
     def test_commercial_inquiry

--- a/test/classes/tab/image/tabs_test.rb
+++ b/test/classes/tab/image/tabs_test.rb
@@ -38,7 +38,8 @@ module Tab::Image
 
       assert_equal("EOL", tab.title, "EOL tab title")
       assert_equal(eol_url, tab.path, "EOL tab path delegates to eol_url")
-      assert_equal("_blank", tab.html_options[:target], "EOL tab opens in new tab")
+      assert_equal("_blank", tab.html_options[:target],
+                   "EOL tab opens in new tab")
     end
 
     def test_commercial_inquiry

--- a/test/classes/tab/name/tabs_test.rb
+++ b/test/classes/tab/name/tabs_test.rb
@@ -139,11 +139,16 @@ module Tab::Name
     end
 
     def test_eol_external_link
+      eol_url = "https://eol.org/pages/67890"
+      Triple.create!(subject: @name.show_url,
+                     predicate: @name.eol_predicate,
+                     object: eol_url)
       tab = Tab::Name::Eol.new(name: @name)
 
-      assert_equal("EOL", tab.title)
-      assert_equal(@name.eol_url, tab.path)
-      assert_equal(:_blank, tab.html_options[:target])
+      assert_equal("EOL", tab.title, "EOL tab title")
+      assert_equal(eol_url, tab.path, "EOL tab path delegates to eol_url")
+      assert_equal(:_blank, tab.html_options[:target],
+                   "EOL tab opens in new tab")
     end
 
     def test_gbif_external_link


### PR DESCRIPTION
Fixes new deprecation warnings:

```
DEPRECATED: Use assert_nil if expecting nil. This will fail in Minitest 6.
```