### PR TITLE
Move AccountPreferencesForm into Account::Preferences::Form namespace

### DIFF
--- a/app/views/controllers/account/preferences/edit.rb
+++ b/app/views/controllers/account/preferences/edit.rb
@@ -14,7 +14,7 @@ module Views::Controllers::Account::Preferences
       add_page_title(:prefs_title.t)
       add_context_nav(Tab::Account::PreferencesEditActions.new)
 
-      render(Components::AccountPreferencesForm.new(@user, licenses: @licenses))
+      render(Form.new(@user, licenses: @licenses))
     end
   end
 end

--- a/app/views/controllers/account/preferences/form.rb
+++ b/app/views/controllers/account/preferences/form.rb
@@ -16,7 +16,8 @@
 # than a direct model attribute. The controller's
 # `update_content_filter` private method writes them back to the
 # hash.
-class Components::AccountPreferencesForm < Components::ApplicationForm
+class Views::Controllers::Account::Preferences::Form <
+  Components::ApplicationForm
   # Email-section logic (EMAIL_GROUPS constant + two render methods)
   # lives in its own concern to keep this class under the
   # `Metrics/ClassLength` limit.

--- a/app/views/controllers/account/preferences/form/email_section.rb
+++ b/app/views/controllers/account/preferences/form/email_section.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 # Email-prefs subsection of the account preferences form. Extracted
-# from `Components::AccountPreferencesForm` (which is `include`d
-# back) so the main form class stays under the
+# from `Views::Controllers::Account::Preferences::Form` (which is
+# `include`d back) so the main form class stays under the
 # `Metrics/ClassLength` limit and the email-specific data /
 # rendering lives next to its `EMAIL_GROUPS` constant.
-module Components::AccountPreferencesForm::EmailSection
+module Views::Controllers::Account::Preferences::Form::EmailSection
   # Five `[group_heading_key, [field_syms...]]` pairs. Each entry
   # renders a "Group Name: (please notify)" heading row followed by
   # one checkbox per field. Order matches the pre-Phlex partial.

--- a/test/views/controllers/account/preferences/form_test.rb
+++ b/test/views/controllers/account/preferences/form_test.rb
@@ -2,7 +2,8 @@
 
 require("test_helper")
 
-class AccountPreferencesFormTest < ComponentTestCase
+class Views::Controllers::Account::Preferences::FormTest <
+  ComponentTestCase
   def setup
     super
     @user = users(:rolf)
@@ -213,7 +214,7 @@ class AccountPreferencesFormTest < ComponentTestCase
     # Defensive guard: an unrecognized `filter.type` would silently
     # produce no field. The form raises to surface the bug instead.
     fake = Struct.new(:type, :sym).new(:not_a_real_type, :bogus)
-    form = Components::AccountPreferencesForm.new(
+    form = Views::Controllers::Account::Preferences::Form.new(
       @user, licenses: License.available_names_and_ids(@user&.license)
     )
     assert_raises(RuntimeError) do
@@ -331,7 +332,9 @@ class AccountPreferencesFormTest < ComponentTestCase
 
   def render_form
     licenses = License.available_names_and_ids(@user&.license)
-    render(Components::AccountPreferencesForm.new(@user, licenses: licenses))
+    render(Views::Controllers::Account::Preferences::Form.new(
+             @user, licenses: licenses
+           ))
   end
 
   def prefs_path


### PR DESCRIPTION
## Summary

Move `Components::AccountPreferencesForm` into `Views::Controllers::Account::Preferences::Form` to match the phlex-conversions placement rule: single-use views live next to their only caller, not in `app/components/` where they imply reusable-primitive intent.

## Renames

| Before | After |
| --- | --- |
| `Components::AccountPreferencesForm` | `Views::Controllers::Account::Preferences::Form` |
| `Components::AccountPreferencesForm::EmailSection` | `Views::Controllers::Account::Preferences::Form::EmailSection` |
| `app/components/account_preferences_form.rb` | `app/views/controllers/account/preferences/form.rb` |
| `app/components/account_preferences_form/email_section.rb` | `app/views/controllers/account/preferences/form/email_section.rb` |
| `test/components/account_preferences_form_test.rb` | `test/views/controllers/account/preferences/form_test.rb` |

`Edit#view_template` shortens its render call to `Form.new(...)` since the action class and form are siblings in the same namespace.

Integration tests target the `#account_preferences_form` DOM id (unchanged) so they ride along without touching.

## Test plan

- [x] `bin/rails test test/views/controllers/account/preferences/form_test.rb` — 21 tests / 118 assertions pass
- [x] `bin/rails test test/controllers/account/preferences_controller_test.rb` — touched controller suite green
- [x] `bundle exec rubocop` clean on touched files
