### PR TITLE
Accept whitespace-delimited iNat ID lists and ignore header rows

### DIFF
--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -190,7 +190,16 @@ class InatImportsController < ApplicationController
     params[:all] ||= new_form[:all]
   end
 
+  # For display on form reload: strip dangerous chars, preserve structure
+  # so the user can see and correct what they pasted.
   def sanitize_inat_ids(ids)
+    return nil if ids.nil?
+
+    ids.gsub(/[^\w\s,]/, "").strip.chomp(",").strip
+  end
+
+  # For storage: extract only digit tokens and join with commas.
+  def normalize_inat_ids(ids)
     return nil if ids.nil?
 
     ids.split(/[\s,]+/).grep(/\A\d+\z/).join(",")
@@ -257,7 +266,7 @@ class InatImportsController < ApplicationController
   end
 
   def clean_inat_ids
-    inat_ids = sanitize_inat_ids(params[:inat_ids])
+    inat_ids = normalize_inat_ids(params[:inat_ids])
     previous_imports = previously_imported_observations
     return inat_ids if previous_imports.none?
 

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -152,7 +152,7 @@ class InatImportsController < ApplicationController
   def reload_form
     render_new_form(
       username: params[:inat_username],
-      inat_ids: sanitize_inat_ids(params[:inat_ids]),
+      inat_ids: params[:inat_ids],
       all: params[:all],
       consent: params[:consent],
       import_others: params[:import_others]
@@ -190,14 +190,6 @@ class InatImportsController < ApplicationController
     merge_form_param(new_form, :consent)
     merge_form_param(new_form, :import_others)
     params[:all] ||= new_form[:all]
-  end
-
-  # For display on form reload: strip dangerous chars, preserve structure
-  # so the user can see and correct what they pasted.
-  def sanitize_inat_ids(ids)
-    return nil if ids.nil?
-
-    ids.gsub(/[^\w\s,]/, "").strip.chomp(",").strip
   end
 
   # For storage: extract only digit tokens and join with commas.

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -152,7 +152,7 @@ class InatImportsController < ApplicationController
   def reload_form
     render_new_form(
       username: params[:inat_username],
-      inat_ids: params[:inat_ids],
+      inat_ids: sanitize_inat_ids(params[:inat_ids]),
       all: params[:all],
       consent: params[:consent],
       import_others: params[:import_others]
@@ -190,6 +190,14 @@ class InatImportsController < ApplicationController
     merge_form_param(new_form, :consent)
     merge_form_param(new_form, :import_others)
     params[:all] ||= new_form[:all]
+  end
+
+  # For display on form reload: strip dangerous chars, preserve structure
+  # so the user can see and correct what they pasted.
+  def sanitize_inat_ids(ids)
+    return nil if ids.nil?
+
+    ids.gsub(/[^\w\s,]/, "").strip.chomp(",").strip
   end
 
   # For storage: extract only digit tokens and join with commas.

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -190,11 +190,10 @@ class InatImportsController < ApplicationController
     params[:all] ||= new_form[:all]
   end
 
-  # Sanitize to only digits, commas, and whitespace, then trim
   def sanitize_inat_ids(ids)
     return nil if ids.nil?
 
-    ids.gsub(/[^\d,\s]/, "").strip.chomp(",").strip
+    ids.split(/[\s,]+/).grep(/\A\d+\z/).join(",")
   end
 
   # Were any listed iNat IDs previously imported?
@@ -246,7 +245,7 @@ class InatImportsController < ApplicationController
   def importables_count
     return nil if importing_all?
 
-    params[:inat_ids].split(",").length
+    inat_id_list.length
   end
 
   # Returns whether this import covers other users' observations.

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -88,6 +88,8 @@ class InatImportsController < ApplicationController
   def create
     return reload_form if params[:go_back] == "1"
     return reload_form unless params_valid?
+
+    normalize_inat_ids_param!
     return confirm_import unless params[:confirmed] == "1"
 
     warn_about_listed_previous_imports
@@ -203,6 +205,15 @@ class InatImportsController < ApplicationController
     return nil if ids.nil?
 
     ids.split(/[\s,]+/).grep(/\A\d+\z/).join(",")
+  end
+
+  # Normalize params[:inat_ids] in-place once after validation so all
+  # downstream readers (estimators, confirm form, init_ivars) see a
+  # clean comma-separated digit-only string.
+  def normalize_inat_ids_param!
+    return unless listing_ids?
+
+    params[:inat_ids] = normalize_inat_ids(params[:inat_ids])
   end
 
   # Were any listed iNat IDs previously imported?

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -61,7 +61,7 @@ module InatImportsController::Validators
   end
 
   def contains_illegal_characters?
-    /[^\d ,]/.match?(params[:inat_ids])
+    /[^\w\s,]/.match?(params[:inat_ids])
   end
 
   def list_within_size_limits?
@@ -75,7 +75,9 @@ module InatImportsController::Validators
   def inat_id_list
     return [] unless listing_ids?
 
-    params[:inat_ids].delete(" ").split(",").map(&:to_i)
+    params[:inat_ids].split(/[\s,]+/).
+      grep(/\A\d+\z/).
+      map(&:to_i)
   end
 
   # Block superimporter from importing **all** another user's iNat observations

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -54,7 +54,9 @@ module InatImportsController::Validators
   end
 
   def valid_inat_ids_param?
-    return true unless contains_illegal_characters?
+    return true unless contains_illegal_characters? ||
+                       contains_malformed_id_tokens? ||
+                       (listing_ids? && inat_id_list.none?)
 
     flash_warning(:runtime_illegal_inat_id.l)
     false
@@ -62,6 +64,14 @@ module InatImportsController::Validators
 
   def contains_illegal_characters?
     /[^\w\s,]/.match?(params[:inat_ids])
+  end
+
+  def contains_malformed_id_tokens?
+    return false unless params[:inat_ids]
+
+    params[:inat_ids].split(/[\s,]+/).any? do |token|
+      token.match?(/\d/) && token.match?(/[a-zA-Z]/)
+    end
   end
 
   def list_within_size_limits?

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3243,13 +3243,13 @@
   # observation/inat_imports
   inat_import_create_title: Import from iNat
   inat_choose_observations: "Inat Observations to Import:"
-  inat_import_list: "Comma separated list of up to about 384 observation #s"
+  inat_import_list: "List of up to about 384 observation #s (comma- or whitespace-separated; a header row like \"id\" is ignored)"
   inat_import_all: Import all my iNat observations instead of a list
   inat_import_others: Import other users' observations
   inat_import_consent: "(Required) I consent to importing my iNaturalist observations into Mushroom Observer, including any unlicensed observations and images, with my default MO license applied to any unlicensed images."
   inat_consent_required: Your consent is required to import iNat observations. Please check the checkbox to give your consent.
   inat_username: iNat Username (mandatory)
-  runtime_illegal_inat_id: iNat observation number can contain only numbers, commas, and spaces
+  runtime_illegal_inat_id: iNat observation IDs can contain only numbers, letters, commas, and whitespace
   inat_missing_username: Missing your iNat Username
   inat_no_imports_designated: You must list the iNat observation(s) to be imported
   inat_list_xor_all: "Either (a) list the iNat observation(s), or (b) check \"Import all ...\" (not both)"

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -207,18 +207,26 @@ class InatImportsControllerTest < FunctionalTestCase
                  "Failed to save inat_ids at maximum length")
   end
 
-  def test_illegal_chars_preserved_in_reloaded_form
-    login
-    post(:create,
-         params: { inat_ids: "123*", inat_username: "anything", consent: 1 })
+  def test_strips_trailing_commas_and_space_chars_from_id_list
+    inat_import = inat_imports(:rolf_inat_import)
+    user = inat_import.user
+    assert_equal("Unstarted", inat_import.state,
+                 "Need a Unstarted inat_import fixture")
+    id_list = "123,456,789, \n"
+    expected_saved_id_list = "123,456,789"
 
-    assert_flash_text(:runtime_illegal_inat_id.l,
-                      "Should warn about illegal characters")
+    login(user.login)
+
+    post(:create,
+         params: { inat_ids: id_list,
+                   inat_username: "", # omit this to force form reload
+                   consent: 1 })
+
+    assert_form_action(action: :create)
     assert_select(
       "textarea#inat_import_inat_ids",
-      { text: "123*", count: 1 },
-      "Reloaded form should show raw input so user can identify " \
-      "the illegal character"
+      { text: expected_saved_id_list, count: 1 },
+      "inat_ids textarea should have trailing commas and whitespace stripped"
     )
   end
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -207,26 +207,18 @@ class InatImportsControllerTest < FunctionalTestCase
                  "Failed to save inat_ids at maximum length")
   end
 
-  def test_strips_trailing_commas_and_space_chars_from_id_list
-    inat_import = inat_imports(:rolf_inat_import)
-    user = inat_import.user
-    assert_equal("Unstarted", inat_import.state,
-                 "Need a Unstarted inat_import fixture")
-    id_list = "123,456,789, \n"
-    expected_saved_id_list = "123,456,789"
-
-    login(user.login)
-
+  def test_illegal_chars_preserved_in_reloaded_form
+    login
     post(:create,
-         params: { inat_ids: id_list,
-                   inat_username: "", # omit this to force form reload
-                   consent: 1 })
+         params: { inat_ids: "123*", inat_username: "anything", consent: 1 })
 
-    assert_form_action(action: :create)
+    assert_flash_text(:runtime_illegal_inat_id.l,
+                      "Should warn about illegal characters")
     assert_select(
       "textarea#inat_import_inat_ids",
-      { text: expected_saved_id_list, count: 1 },
-      "inat_ids textarea should have trailing commas and whitespace stripped"
+      { text: "123*", count: 1 },
+      "Reloaded form should show raw input so user can identify " \
+      "the illegal character"
     )
   end
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -230,6 +230,52 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
+  def test_newline_delimited_ids_accepted_and_normalized
+    user = users(:rolf)
+    inat_import = inat_imports(:rolf_inat_import)
+    assert_equal("Unstarted", inat_import.state,
+                 "Need an Unstarted inat_import fixture")
+    inat_ids = "368966299\n368983890\n368951839"
+    expected_ids = "368966299,368983890,368951839"
+
+    login(user.login)
+
+    post(:create,
+         params: { inat_ids: inat_ids, inat_username: "rolf",
+                   consent: 1, confirmed: 1 })
+
+    assert_redirected_to(INAT_AUTHORIZATION_URL,
+                         "Newline-delimited IDs should pass validation")
+    assert_equal(expected_ids, inat_import.reload.inat_ids,
+                 "Newline-delimited IDs should be normalized to " \
+                 "comma-separated")
+    assert_equal(3, inat_import.reload.importables,
+                 "importables_count should reflect the number of IDs")
+  end
+
+  def test_header_row_ignored_in_id_list
+    user = users(:rolf)
+    inat_import = inat_imports(:rolf_inat_import)
+    assert_equal("Unstarted", inat_import.state,
+                 "Need an Unstarted inat_import fixture")
+    inat_ids = "id\n368966299\n368983890\n368951839"
+    expected_ids = "368966299,368983890,368951839"
+
+    login(user.login)
+
+    post(:create,
+         params: { inat_ids: inat_ids, inat_username: "rolf",
+                   consent: 1, confirmed: 1 })
+
+    assert_redirected_to(INAT_AUTHORIZATION_URL,
+                         "Input with a header row should pass validation")
+    assert_equal(expected_ids, inat_import.reload.inat_ids,
+                 "Non-digit header token should be stripped from " \
+                 "stored inat_ids")
+    assert_equal(3, inat_import.reload.importables,
+                 "importables_count should not include the header row token")
+  end
+
   def test_create_too_many_ids_listed
     # generate an id list that's barely too long
     id_list = ""

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -166,6 +166,39 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_flash_text(:runtime_illegal_inat_id.l)
   end
 
+  def test_no_numeric_ids_in_list_rejected
+    login
+    post(:create,
+         params: { inat_ids: "id\nobservation", inat_username: "anything",
+                   consent: 1 })
+
+    assert_flash_text(:runtime_illegal_inat_id.l,
+                      "Input with no numeric IDs should be rejected")
+    assert_form_action(action: :create)
+    assert_select(
+      "textarea#inat_import_inat_ids",
+      { text: "id\nobservation", count: 1 },
+      "Reloaded form should show the original input"
+    )
+  end
+
+  def test_alphanumeric_token_rejected_as_malformed_id
+    login
+    post(:create,
+         params: { inat_ids: "id\n123456a", inat_username: "anything",
+                   consent: 1 })
+
+    assert_flash_text(:runtime_illegal_inat_id.l,
+                      "Alphanumeric token (e.g. 123456a) should be " \
+                      "rejected as a malformed ID")
+    assert_form_action(action: :create)
+    assert_select(
+      "textarea#inat_import_inat_ids",
+      { text: "id\n123456a", count: 1 },
+      "Reloaded form should show the original input"
+    )
+  end
+
   def test_create_no_consent
     params = { inat_username: "anything", inat_ids: 123,
                consent: 0 }
@@ -207,26 +240,18 @@ class InatImportsControllerTest < FunctionalTestCase
                  "Failed to save inat_ids at maximum length")
   end
 
-  def test_strips_trailing_commas_and_space_chars_from_id_list
-    inat_import = inat_imports(:rolf_inat_import)
-    user = inat_import.user
-    assert_equal("Unstarted", inat_import.state,
-                 "Need a Unstarted inat_import fixture")
-    id_list = "123,456,789, \n"
-    expected_saved_id_list = "123,456,789"
-
-    login(user.login)
-
+  def test_illegal_chars_preserved_in_reloaded_form
+    login
     post(:create,
-         params: { inat_ids: id_list,
-                   inat_username: "", # omit this to force form reload
-                   consent: 1 })
+         params: { inat_ids: "123*", inat_username: "anything", consent: 1 })
 
-    assert_form_action(action: :create)
+    assert_flash_text(:runtime_illegal_inat_id.l,
+                      "Should warn about illegal characters")
     assert_select(
       "textarea#inat_import_inat_ids",
-      { text: expected_saved_id_list, count: 1 },
-      "inat_ids textarea should have trailing commas and whitespace stripped"
+      { text: "123*", count: 1 },
+      "Reloaded form should show raw input so user can identify " \
+      "the illegal character"
     )
   end
 


### PR DESCRIPTION
Delivers #4466

## Manual test

1. Go to `/inat_imports/new` (must be logged in).

2. **Newline-delimited list** — paste a list like the following 
(ideally a list of unimported fungal observations) 
into the IDs field, leave Username blank, submit:
368966299
368983890
368951839

- [x] Form reloads with a missing-username warning
- [x] Textarea shows `368966299,368983890,368951839` (normalized, no newlines)

4. **Header row ignored** — paste the following, fill in a valid iNat
username, submit:
id
368966299
368983890
368951839

- [x] Reaches the confirmation page
- [x] Shows correct number of importable observations ("id" not counted)

5. **Mixed comma + whitespace** — paste `368966299, 368983890  368951839`
(comma-space after first, double-space before third), submit with a
valid username.
- [x] Confirmation page shows correct number of importable observations ("id" not counted)

6. **Illegal characters still rejected** — paste `368966299*368983890`,
submit.
- [x] Form reloads with flash warning: "iNat observation IDs can
  contain only numbers, letters, commas, and whitespace"