### PR TITLE
copilot-review workflow: defensive token trim + reviewer slug fix

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,7 +1,7 @@
 # Trigger a Copilot review when a @nimmolo PR becomes Ready for Review
-# using tokens from jdc's Copilot account
-# Uses GitHub token stored in the repository ecrets
-# to authenticate the request to add '@copilot' as a reviewer on the PR
+# using tokens from jdc's Copilot account.
+# Uses a GitHub token stored in the repository secrets
+# to authenticate the request to add '@copilot' as a reviewer on the PR.
 
 name: Request Copilot Review
 
@@ -18,8 +18,18 @@ jobs:
     steps:
       - name: Request Copilot review
         env:
-          GH_TOKEN: ${{ secrets.COPILOT_REVIEW_PAT }}
+          # Read into RAW_PAT first so the inline trim below can
+          # strip any stray whitespace before `gh` builds the
+          # Authorization header. Go's `net/http` rejects header
+          # values containing CR/LF/etc. with the cryptic
+          # "invalid header field value for \"Authorization\""
+          # error — most often caused by a trailing newline
+          # baked into the secret when it was pasted via the
+          # GitHub Secrets web UI.
+          RAW_PAT: ${{ secrets.COPILOT_REVIEW_PAT }}
         run: |
+          GH_TOKEN=$(printf '%s' "$RAW_PAT" | tr -d '\r\n ')
+          export GH_TOKEN
           gh pr edit ${{ github.event.pull_request.number }} \
-            --add-reviewer "@copilot" \
+            --add-reviewer "copilot-pull-request-reviewer" \
             --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary

Fixes the `Request Copilot Review` workflow that's been failing with:

```
Post "https://api.github.com/graphql": net/http: invalid header field value for "Authorization"
```

Three changes to `.github/workflows/copilot-review.yml`:

### 1. Defensive token trim

Go's `net/http` rejects header values containing CR / LF / etc. with the cryptic "invalid header field value for \"Authorization\"" error. The `COPILOT_REVIEW_PAT` secret almost certainly has a trailing newline baked in from being pasted via the GitHub Secrets web UI — a very common copy-paste gotcha.

Read the secret into `RAW_PAT` first, then `printf '%s' "$RAW_PAT" | tr -d '\r\n '` before exporting `GH_TOKEN`. This makes the workflow resilient to a future re-paste with whitespace too.

### 2. Reviewer slug fix

`"@copilot"` is the UI alias for the reviewer; the API needs the bot's actual login. Changed to `"copilot-pull-request-reviewer"`.

### 3. Typo

Comment on line 3 said "ecrets" — fixed to "secrets".

## Joe should also do this

The defensive trim is backup — the root fix is re-creating the secret cleanly. Run on his machine:

```bash
gh secret set COPILOT_REVIEW_PAT --repo MushroomObserver/mushroom-observer
```

(Paste the raw PAT when prompted — the gh CLI strips trailing whitespace on entry, avoiding the web-UI gotcha.)

## Test plan

- [ ] Mark a nimmolo-owned draft PR as ready-for-review after this lands, confirm the `Request Copilot Review` workflow goes green and Copilot is added as a reviewer.
- [ ] If still failing, check the workflow log for the actual API error from `gh pr edit` (auth issues will now surface with a different, more diagnosable error than the Go header-validation one).
