### PR TITLE
Sweep _Any prop violations + add regression guard test

### DIFF
--- a/app/components/application_form/select_range_field.rb
+++ b/app/components/application_form/select_range_field.rb
@@ -24,8 +24,15 @@ class Components::ApplicationForm < Superform::Rails::Form
     # an array of `[label, value]` tuples. Callers mix both — rank
     # passes flat strings ("Form", "Variety", ...), confidence
     # passes `[label, numeric]` tuples — so the element type is a
-    # union of those two shapes.
-    prop :options, _Array(_Union(_Nilable(String), _Tuple(String, _Any?)))
+    # union of those two shapes. The tuple value type mirrors the
+    # `value` prop above (String / Integer / Float).
+    prop :options,
+         _Array(
+           _Union(
+             _Nilable(String),
+             _Tuple(String, _Nilable(_Union(String, Integer, Float)))
+           )
+         )
     prop :value, _Nilable(_Union(String, Integer, Float)), default: nil
     prop :range_value, _Nilable(_Union(String, Integer, Float)), default: nil
     prop :label, String

--- a/app/views/controllers/comments/comments_for_object.rb
+++ b/app/views/controllers/comments/comments_for_object.rb
@@ -23,12 +23,17 @@ module Views::Controllers::Comments
     include Phlex::Rails::Helpers::TurboStreamFrom
     include Phlex::Rails::Helpers::DOMID
 
-    # `object` is whatever commentable model is being shown
-    # (Observation, Name, Project, Location, SpeciesList, …); the
-    # panel only reads `.id`, `.class.name`, and uses it as the
-    # Action Cable broadcast key, so a concrete type isn't needed.
-    prop :object, _Any
-    prop :comments, _Any
+    # `object` is whatever commentable model is being shown.
+    # `Comment::ALL_TYPES` enumerates the polymorphic target set
+    # (Observation, Name, Project, Location, SpeciesList,
+    # LocationDescription, NameDescription); all inherit from
+    # `AbstractModel`.
+    prop :object, ::AbstractModel
+    prop :comments,
+         _Nilable(
+           _Union(Array, ::ActiveRecord::Relation,
+                  ::ActiveRecord::Associations::CollectionProxy)
+         )
     prop :user, _Nilable(::User), default: nil
     # When true, render the "+ Add comment" header link, per-row
     # mod-links, and the footer "and N more" link. Callers pass

--- a/app/views/controllers/comments/edit.rb
+++ b/app/views/controllers/comments/edit.rb
@@ -9,7 +9,7 @@
 module Views::Controllers::Comments
   class Edit < Views::Base
     prop :comment, ::Comment
-    prop :target, _Any
+    prop :target, ::AbstractModel
     prop :user, _Nilable(::User), default: nil
 
     def view_template

--- a/app/views/controllers/comments/index.rb
+++ b/app/views/controllers/comments/index.rb
@@ -10,9 +10,11 @@
 # Replaces `app/views/controllers/comments/index.html.erb`.
 module Views::Controllers::Comments
   class Index < Views::Base
-    prop :query, _Any
-    prop :pagination_data, _Any
-    prop :objects, _Any
+    prop :query, ::Query::Comments
+    prop :pagination_data, ::PaginationData
+    prop :objects,
+         _Union(Array, ::ActiveRecord::Relation,
+                ::ActiveRecord::Associations::CollectionProxy)
     prop :user, _Nilable(::User), default: nil
     prop :error, _Nilable(String), default: nil
 

--- a/app/views/controllers/comments/new.rb
+++ b/app/views/controllers/comments/new.rb
@@ -10,7 +10,7 @@
 module Views::Controllers::Comments
   class New < Views::Base
     prop :comment, ::Comment
-    prop :target, _Any
+    prop :target, ::AbstractModel
     prop :user, _Nilable(::User), default: nil
 
     def view_template

--- a/app/views/controllers/comments/show.rb
+++ b/app/views/controllers/comments/show.rb
@@ -8,7 +8,7 @@
 module Views::Controllers::Comments
   class Show < Views::Base
     prop :comment, ::Comment
-    prop :target, _Any
+    prop :target, ::AbstractModel
     prop :user, _Nilable(::User), default: nil
 
     def view_template

--- a/app/views/controllers/locations/show/alt_descriptions_panel.rb
+++ b/app/views/controllers/locations/show/alt_descriptions_panel.rb
@@ -16,7 +16,11 @@ module Views::Controllers::Locations::Show
     prop :user, _Nilable(::User), default: nil
     prop :object, ::Location
     prop :projects, _Nilable(_Array(::Project)), default: nil
-    prop :current, _Nilable(_Any), default: nil
+    # Forwarded to `Descriptions::List#current` (typed there as
+    # `_Nilable(::Description)`). The currently-shown description
+    # of the parent Location, used to suppress its self-link in
+    # the alts list.
+    prop :current, _Nilable(::Description), default: nil
 
     def view_template
       render(Components::Panel.new(panel_id: "alt_descriptions")) do |panel|

--- a/app/views/controllers/observations/namings/suggestions/show.rb
+++ b/app/views/controllers/observations/namings/suggestions/show.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Observations::Namings::Suggestions
   class Show < Views::Base
     prop :observation, ::Observation
     prop :user, _Nilable(::User), default: nil
-    prop :suggestions, _Array(_Any), default: -> { [] }
+    prop :suggestions, _Array(::Suggestion), default: -> { [] }
 
     def view_template
       add_chrome

--- a/test/style/no_any_phlex_props_test.rb
+++ b/test/style/no_any_phlex_props_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Enforces the "concrete prop types over `_Any`" rule from
+# `.claude/rules/phlex_conversions.md` ("ALWAYS use concrete prop
+# types — never `_Any` when the type is known").
+#
+# Scans every `app/components/**/*.rb` and `app/views/**/*.rb` file
+# for `prop … _Any …` lines and fails on uses outside the one
+# sanctioned context: `_Hash(Key, _Any)` (and its nilable cousin
+# `_Hash(Key, _Any?)`). The Hash carve-out covers HTML-attribute
+# pass-throughs (`attributes`, `data`, `args`, `extra_data`, …)
+# where the value type genuinely is arbitrary.
+#
+# Why we draw the line at `_Any`:
+#
+#   - Concrete types (`prop :user, ::User`) raise
+#     `Literal::TypeError` at construction time when a caller
+#     passes the wrong shape; `_Any` accepts anything and the
+#     failure surfaces later as a cryptic `NoMethodError` deep
+#     inside `view_template`.
+#   - Most "any" props really aren't — they're an
+#     `ActiveRecord::Relation`, an `Array` of a known model, or a
+#     duck-typed shape reachable via `_Interface(:method_name)`.
+#   - Even when the value really is polymorphic (a Comment
+#     target, an InlineModLinks target, …), `_Interface(:type_tag,
+#     :id)` pins the contract more tightly than `_Any` and still
+#     accepts the full polymorphic set.
+class NoAnyPhlexPropsTest < ActiveSupport::TestCase
+  PHLEX_GLOBS = %w[
+    app/components/**/*.rb
+    app/views/**/*.rb
+  ].freeze
+
+  # Match `prop :name, …` lines that contain `_Any` (with or
+  # without `?`). Captures the file and line for the failure
+  # message; classification happens below.
+  PROP_RE = /^\s*prop\s+:\w+\s*,/
+
+  # A `_Any` token is sanctioned when the line also contains
+  # `_Hash(...)` somewhere before it — i.e. the `_Any` is the
+  # value-type slot of a Hash declaration. The simple "line
+  # contains `_Hash(`" check is sufficient because Hash and
+  # non-Hash `_Any` props don't co-occur on the same prop line in
+  # MO's codebase.
+  HASH_GUARD_RE = /_Hash\(/
+
+  def test_no_bare_any_phlex_props
+    offenders = scan_for_bare_any_props
+    assert_empty(offenders, build_failure_message(offenders))
+  end
+
+  private
+
+  # Returns `{ "relative/path.rb" => [[line_no, snippet], …] }`
+  # for every file with a non-Hash `_Any` prop declaration.
+  def scan_for_bare_any_props
+    files = PHLEX_GLOBS.flat_map { |g| Rails.root.glob(g) }
+    files.each_with_object({}) do |path, acc|
+      rel = Pathname.new(path).relative_path_from(Rails.root).to_s
+      hits = File.foreach(path).with_index(1).filter_map do |line, n|
+        next unless prop_line_with_any?(line)
+        next if hash_value_any?(line)
+
+        [n, line.rstrip]
+      end
+      acc[rel] = hits if hits.any?
+    end
+  end
+
+  def prop_line_with_any?(line)
+    line.match?(PROP_RE) && line.include?("_Any")
+  end
+
+  def hash_value_any?(line)
+    line.match?(HASH_GUARD_RE)
+  end
+
+  def build_failure_message(offenders)
+    return "" if offenders.empty?
+
+    rendered = offenders.flat_map do |path, lines|
+      lines.map { |(n, snippet)| "  #{path}:#{n}: #{snippet.strip}" }
+    end
+    <<~MSG
+      Bare `_Any` prop declarations found in Phlex view/component files.
+
+      Concrete prop types catch caller mistakes at construction time
+      (`Literal::TypeError`) rather than failing later inside
+      `view_template` with a cryptic `NoMethodError`. Replace `_Any`
+      with the concrete class (`::User`, `::Name`, ...), a generic
+      (`_Array(::Foo)`, `_Union(Array, ActiveRecord::Relation)`),
+      or a duck-typed `_Interface(:method_name)`.
+
+      The one sanctioned shape is `_Hash(Key, _Any)` (and its
+      nilable cousin) — for HTML-attribute pass-throughs where the
+      value type genuinely is arbitrary.
+
+      Offenders:
+      #{rendered.join("\n")}
+    MSG
+  end
+end


### PR DESCRIPTION
## Summary

Sweeps the remaining bare `_Any` (and `_Array(_Any)`) prop declarations that survived PR [#4448](https://github.com/MushroomObserver/mushroom-observer/pull/4448), and adds a regression guard test that fails any future PR that re-introduces them.

`_Hash(Key, _Any)` stays sanctioned — that's the HTML-attribute pass-through pattern (`attributes`, `data`, `args`, `extra_data`, …) where the value type genuinely is arbitrary.

## Concrete types

| File | Prop | Before | After |
| --- | --- | --- | --- |
| `comments/comments_for_object.rb` | `:object` | `_Any` | `::AbstractModel` |
| `comments/comments_for_object.rb` | `:comments` | `_Any` | `_Nilable(_Union(Array, ActiveRecord::Relation, ActiveRecord::Associations::CollectionProxy))` |
| `comments/index.rb` | `:query` | `_Any` | `::Query::Comments` |
| `comments/index.rb` | `:pagination_data` | `_Any` | `::PaginationData` |
| `comments/index.rb` | `:objects` | `_Any` | `_Union(Array, ActiveRecord::Relation, ActiveRecord::Associations::CollectionProxy)` |
| `comments/show.rb` / `new.rb` / `edit.rb` | `:target` | `_Any` | `::AbstractModel` |
| `locations/show/alt_descriptions_panel.rb` | `:current` | `_Nilable(_Any)` | `_Nilable(::Description)` (matches `Descriptions::List#current`) |
| `observations/namings/suggestions/show.rb` | `:suggestions` | `_Array(_Any)` | `_Array(::Suggestion)` |
| `application_form/select_range_field.rb` | `:options` tuple-value | `_Any?` | `_Nilable(_Union(String, Integer, Float))` (mirrors the `value` / `range_value` prop types) |

The Comment target props use `::AbstractModel` (not a duck-typed `_Interface(...)`) because all 7 entries in `Comment::ALL_TYPES` (Observation, Name, Project, Location, SpeciesList, LocationDescription, NameDescription) inherit from it. Tests pass real model fixtures, not stubs.

## Guard test

`test/style/no_any_phlex_props_test.rb` (NEW):

- Scans every `prop :…, …` declaration in `app/components/**/*.rb` and `app/views/**/*.rb`.
- Flags any `_Any` token NOT on a line that also contains `_Hash(`.
- Failure message lists every offender as `path:line:snippet` so the right type is obvious from context.

Currently green. Any future PR that adds `prop :foo, _Any` (or `_Array(_Any)`, `_Nilable(_Any)`, `_Tuple(…, _Any)`) without a `_Hash(...)` wrapper on the line will fail CI with a pointed failure message.

## Why

From `.claude/rules/phlex_conversions.md`:

> Concrete prop types (`prop :user, ::User`) raise `Literal::TypeError` at construction time when a caller passes the wrong shape; `_Any` accepts anything and the failure surfaces later as a cryptic `NoMethodError` deep inside `view_template`.

PR #4448 swept most of the codebase. This PR cleans the long tail and locks the door behind it.

## Test plan

- [x] `bin/rails test test/style/no_any_phlex_props_test.rb` — green
- [x] `bin/rails test test/views/controllers/comments/ test/controllers/comments_controller_test.rb` — 71 tests / 316 assertions, all green
- [x] `bin/rails test test/controllers/locations_controller_test.rb test/controllers/observations/namings/suggestions_controller_test.rb` — 68 tests / 574 assertions, all green
- [x] Rubocop clean on touched files
- [ ] CI green
