### PR TITLE
Body class: map create→new, update→edit (template-rendered, not action)

### DIFF
--- a/app/views/controllers/layouts/application.html.erb
+++ b/app/views/controllers/layouts/application.html.erb
@@ -2,7 +2,19 @@
 @css_theme = css_theme(@user)
 
 html_class = (Rails.env == "test") ? "" : "scroll-behavior-smooth"
-ctrlr_action = "#{controller.controller_name}__#{controller.action_name}"
+# Map the action that's actually executing to the template it
+# tends to render — `create` failures fall through to `new`,
+# `update` failures to `edit`. The body class then reflects "the
+# page the user is looking at" (the form / index / show) rather
+# than "the verb that brought us here," so test assertions like
+# `assert_select("body.<thing>__new")` don't need a separate
+# variant for the re-rendered-after-validation-failure path.
+body_class_action = case controller.action_name
+                    when "create" then "new"
+                    when "update" then "edit"
+                    else controller.action_name
+                    end
+ctrlr_action = "#{controller.controller_name}__#{body_class_action}"
 theme = "theme-#{@css_theme.underscore.dasherize}"
 location_format = "location-format-#{@user&.location_format || "postal"}"
 logged_in = @user ? "logged-in-user" : "no-user"

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -324,7 +324,7 @@ class CommentsControllerTest < FunctionalTestCase
     login
     post(:create, params: params)
     assert_response(:success)
-    assert_select("body.comments__create")
+    assert_select("body.comments__new")
     assert_select("form#comment_form")
   end
 

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -739,10 +739,11 @@ module Observations
       # Phlex view renders outside the ActionView template lookup
       # chain, so `assert_template` doesn't fire for the Phlex
       # `Views::Controllers::Observations::Namings::Edit`. The
-      # body class is also not useful as a marker here — failed
-      # `update` requests re-render the Edit view but the body
-      # class stays `namings__update` (the request's action_name).
-      # Pin the Edit-specific page title instead.
+      # layout now maps `action_name = "update"` to `"edit"` for
+      # the body class, so `body.namings__edit` fires for both the
+      # GET edit form and the failed-update re-render — could be
+      # used as a marker here. Page-title check stays as the
+      # stronger Edit-specific pin.
       assert_head_title(:edit_naming_title.l(id: assigns(:observation).id))
       # _observation_details and _images are Phlex panels now;
       # assert against their identifiers rather than the (gone)

--- a/test/integration/capybara/account_integration_test.rb
+++ b/test/integration/capybara/account_integration_test.rb
@@ -25,7 +25,7 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
       fill_in("user_login", with: "rolf")
       click_commit
     end
-    assert_selector("body.login__create")
+    assert_selector("body.login__new")
     assert_flash_text(/unsuccessful/)
 
     # Try again with incorrect password.
@@ -37,7 +37,7 @@ class AccountIntegrationTest < CapybaraIntegrationTestCase
       uncheck("user_remember_me")
       click_commit
     end
-    assert_selector("body.login__create")
+    assert_selector("body.login__new")
     assert_flash_text(/unsuccessful/)
 
     # Try yet again with correct password.

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -50,7 +50,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
       form.first("input[type='submit']").click
     end
 
-    namer_session.assert_selector("body.namings__create")
+    namer_session.assert_selector("body.namings__new")
     assert_flash_text(:form_naming_what_missing.l, session: namer_session)
     namer_session.
       # see https://github.com/MushroomObserver/mushroom-observer/issues/1796
@@ -60,7 +60,7 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
       form.fill_in("naming_name", with: text_name)
       form.first("input[type='submit']").click
     end
-    namer_session.assert_selector("body.namings__create")
+    namer_session.assert_selector("body.namings__new")
     assert_true(namer_session.has_selector?(
                   ".alert-warning",
                   text: /MO does not recognize the name.*#{text_name}/

--- a/test/integration/capybara/species_lists_integration_test.rb
+++ b/test/integration/capybara/species_lists_integration_test.rb
@@ -163,6 +163,6 @@ class SpeciesListsIntegrationTest < CapybaraIntegrationTestCase
       click_commit
     end
     assert_flash_error
-    assert_selector("body.write_in__create")
+    assert_selector("body.write_in__new")
   end
 end

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -517,7 +517,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     within("#observation_form") { click_commit }
 
     # rejected, but images uploaded
-    assert_selector("body.observations__create", wait: 12)
+    assert_selector("body.observations__new", wait: 12)
     assert_flash_for_images_uploaded
     assert_has_location_warning(/Unknown country/)
 


### PR DESCRIPTION
## Summary

The application layout previously set `<body class="<controller>__<action>">` straight from `controller.action_name`, which baked the request verb into the body class. On the failed-validation re-render path that produces a class that disagrees with the template the user is actually looking at:

```
POST /things → ThingsController#create fails validation
→ controller re-renders the `new` form template
→ body class is `things__create`, NOT `things__new`.
```

So tests asserting "the new form rendered" had to pick which class to write against, and there was no single class that fired for both the GET-the-form path and the POST-then-re-render path.

This PR maps `create → new` and `update → edit` in the layout so the body class reflects the **template** being rendered, not the action that's executing. Other actions pass through unchanged.

## Changes

`app/views/controllers/layouts/application.html.erb`:

```diff
-ctrlr_action = "#{controller.controller_name}__#{controller.action_name}"
+body_class_action = case controller.action_name
+                    when "create" then "new"
+                    when "update" then "edit"
+                    else controller.action_name
+                    end
+ctrlr_action = "#{controller.controller_name}__#{body_class_action}"
```

Test sweeps (sed swap `__create" → __new"` and `__update" → __edit"`, 7 hits total):
- `test/controllers/comments_controller_test.rb`
- `test/integration/capybara/account_integration_test.rb`
- `test/integration/capybara/namings_integration_test.rb`
- `test/integration/capybara/species_lists_integration_test.rb`
- `test/system/observation_form_system_test.rb`

Plus a comment update in `test/controllers/observations/namings_controller_test.rb` that documented the pre-fix limitation — now updated to note the body class is useful as an edit-page marker after this PR.

## Doesn't replace form-id assertions

Form-id assertions (`assert_select("#name_form")`) remain the strongest swap when a form exists with a stable id. This fix gives Phlex tests a stable per-template body-class fallback for the cases where no form id is available (or for non-form pages).

## Test plan

- [x] `bin/rails test test/controllers/comments_controller_test.rb test/controllers/observations/namings_controller_test.rb` — 75 tests / 635 assertions, all green
- [ ] CI green

Successful create/update paths are redirects so the body class never renders; only the validation-failure re-render path exercises the new behavior. The 7 test files exercising that path are the ones swapped.
