### PR TITLE
phlex.rb: drop dead Tabs::*Helper auto-include block

### DIFF
--- a/config/initializers/phlex.rb
+++ b/config/initializers/phlex.rb
@@ -24,25 +24,3 @@ Rails.autoloaders.main.push_dir(
 Rails.autoloaders.main.push_dir(
   Rails.root.join("app/components"), namespace: Components
 )
-
-# Auto-include every top-level `Tabs::*Helper` module into
-# `Views::Base` so they're callable from any Phlex view without
-# `helpers.*` or per-class `register_value_helper`. Guards
-# `defined?(Tabs)` because the `tabs/` helpers directory is
-# currently empty — there are no top-level Tabs helpers right
-# now, so referencing the constant unguarded would NameError.
-#
-# Nested helpers under `Tabs::Sidebar::*`, `Tabs::Locations::*`,
-# `Tabs::Names::*` are NOT included here — they stay scoped to
-# their specific callers (e.g. `Views::Layouts::ApplicationSidebar`
-# includes `Tabs::Sidebar::AdminHelper` etc. explicitly).
-Rails.application.config.to_prepare do
-  next unless defined?(Tabs)
-
-  Tabs.constants.each do |name|
-    next unless name.to_s.end_with?("Helper")
-
-    mod = Tabs.const_get(name)
-    Views::Base.include(mod) if mod.is_a?(Module)
-  end
-end


### PR DESCRIPTION
## Summary

Deletes the `Rails.application.config.to_prepare do Tabs.constants.each ... end` block in `config/initializers/phlex.rb`. It was a no-op kept alive by the `next unless defined?(Tabs)` guard added in #4477 — the last top-level `Tabs::*Helper` module (`Tabs::ObservationsHelper`) was deleted that same PR, leaving `app/helpers/tabs/` empty and the `Tabs` constant undefined.

## Verification

- `bin/rails runner 'puts defined?(Tabs)'` → nil (boot succeeds, constant doesn't exist)
- `grep -rn 'Tabs::' app/` returns only documentation comments in Tab POROs noting which legacy helper each PORO replaced. No live code paths depend on the auto-include.

## Test plan

- [x] Boot the Rails app — clean (no NameError, no warnings)
- [ ] CI: full suite confirms nothing was secretly leaning on a `Tabs::*Helper` being auto-mixed into `Views::Base`
