### PR TITLE
Add request-scoped current_user + current_query helpers for Phlex views

### DIFF
--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -15,6 +15,13 @@ class Components::Base < Phlex::HTML
   # Register custom value helpers (return values)
   register_value_helper :permission?
   register_value_helper :in_admin_mode?
+  # The logged-in User (or nil). Reads off the controller's
+  # before-filter-set `@user` ivar — request-scoped, no thread-
+  # local. Views that need "the viewer" can call `current_user`
+  # instead of taking a `prop :user, _Nilable(::User)`; views that
+  # need a non-viewer subject User keep the prop. See
+  # `ApplicationController::Authentication#current_user`.
+  register_value_helper :current_user
   register_value_helper :url_for
   register_value_helper :image_vote_as_short_string
   register_value_helper :image_vote_as_help_string

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -28,6 +28,15 @@ class Components::Base < Phlex::HTML
   register_value_helper :sequence_archive_options
   register_value_helper :add_q_param
   register_value_helper :q_param
+  # The Query for "what the user is currently looking at" — pulled
+  # from the controller's `@query` ivar, the URL's `q` param, or the
+  # session's stored query_record (in that order, via
+  # `ApplicationController::Queries#current_query`). Lets Phlex
+  # views accept a typed `prop :query, ::Query` for validated input
+  # AND fall back to "whatever query the session knows about" when
+  # the prop is omitted, without having to thread `@query` through
+  # every chrome-y caller.
+  register_value_helper :current_query
   register_value_helper :add_args_to_url
   register_value_helper :controller_name
   register_value_helper :controller_path

--- a/app/controllers/application_controller/authentication.rb
+++ b/app/controllers/application_controller/authentication.rb
@@ -14,7 +14,18 @@
 #
 module ApplicationController::Authentication
   def self.included(base)
-    base.helper_method(:permission?, :reviewer?, :in_admin_mode?)
+    base.helper_method(:permission?, :reviewer?, :in_admin_mode?,
+                       :current_user)
+  end
+
+  # Request-scoped accessor for the logged-in User. Lives on the
+  # controller so the request/session boundary is the only thing
+  # that can answer "who's looking at this page" — model-level
+  # `User.current` is thread-local global state that ought to die.
+  # `helper_method` exposes it to ERB; `Components::Base`
+  # registers it as a value helper for Phlex views.
+  def current_user
+    @user
   end
 
   ##############################################################################

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -24,7 +24,7 @@ module ApplicationController::Queries
   def self.included(base)
     base.helper_method(
       :query_from_session, :query_params, :add_q_param, :q_param,
-      :find_or_create_query
+      :find_or_create_query, :current_query
     )
   end
 

--- a/test/components/base_test.rb
+++ b/test/components/base_test.rb
@@ -29,6 +29,14 @@ class BaseTest < ComponentTestCase
     end
   end
 
+  # Reads the registered `current_query` value helper. Used by the
+  # `Components::Base.current_query` tests below.
+  class CurrentQueryReader < Components::Base
+    def view_template
+      plain(current_query&.id&.to_s || "no-query")
+    end
+  end
+
   def test_trusted_html_with_plain_string
     html = render_component(TestComponent.new)
     doc = Nokogiri::HTML(html)
@@ -87,5 +95,22 @@ class BaseTest < ComponentTestCase
     controller.instance_variable_set(:@user, nil)
 
     assert_equal("nobody", render(CurrentUserReader.new))
+  end
+
+  # `current_query` is a `register_value_helper`'d alias for
+  # `controller.current_query` — the typed `Query` view a Phlex view
+  # can fall back to when its `prop :query, _Nilable(::Query)` isn't
+  # passed, without round-tripping through the URL's q param.
+  def test_current_query_reads_controllers_current_query
+    query = ::Query.lookup_and_save(:Observation)
+    controller.instance_variable_set(:@query, query)
+
+    assert_equal(query.id.to_s, render(CurrentQueryReader.new))
+  end
+
+  def test_current_query_is_nil_when_no_query_on_controller
+    controller.instance_variable_set(:@query, nil)
+
+    assert_equal("no-query", render(CurrentQueryReader.new))
   end
 end

--- a/test/components/base_test.rb
+++ b/test/components/base_test.rb
@@ -21,6 +21,14 @@ class BaseTest < ComponentTestCase
     end
   end
 
+  # Reads the registered `current_user` value helper. Used by the
+  # `Components::Base.current_user` tests below.
+  class CurrentUserReader < Components::Base
+    def view_template
+      plain(current_user&.login || "nobody")
+    end
+  end
+
   def test_trusted_html_with_plain_string
     html = render_component(TestComponent.new)
     doc = Nokogiri::HTML(html)
@@ -63,5 +71,21 @@ class BaseTest < ComponentTestCase
     html = render_component(TestComponent.new)
 
     assert_not_includes(html, "<!-- Before")
+  end
+
+  # `current_user` is a `register_value_helper`'d alias for the
+  # controller's `@user`; views call it instead of taking a
+  # `prop :user, _Nilable(::User)` when they only need "the viewer".
+  def test_current_user_reads_controllers_user_ivar
+    user = users(:rolf)
+    controller.instance_variable_set(:@user, user)
+
+    assert_equal(user.login, render(CurrentUserReader.new))
+  end
+
+  def test_current_user_is_nil_when_no_one_logged_in
+    controller.instance_variable_set(:@user, nil)
+
+    assert_equal("nobody", render(CurrentUserReader.new))
   end
 end


### PR DESCRIPTION
## Summary

Adds two small request-scoped helpers available to both ERB and Phlex views: `current_user` and `current_query`. Both follow the same pattern (`helper_method` on the relevant `ApplicationController` concern + `register_value_helper` on `Components::Base`).

## Motivation

Phlex views currently take `prop :user, _Nilable(::User), default: nil` on most chrome / action templates / panels — anywhere they need to know who's looking at the page. The same pattern was about to start with `prop :query, _Nilable(::Query)` on view chrome that mints URLs.

The alternatives we want to avoid:

- `User.current` — thread-local global, layering violation (the model knowing about request context) and a real thread-safety hazard under Puma's worker pool and inside background jobs.
- Raw `query_param: Hash` props — for views that don't *execute* the query, the Hash form is fine; but anywhere a view inspects the query, a Hash is "whatever the URL gave us," which means a URL-tampering attempt can fill it with garbage. A `Query` object has already been through `query_from_q_param`'s validated path.

A controller-level `current_user` and `current_query` is the clean alternative: request-scoped (no thread-local), already at the request/session boundary where authentication / query lookup happens, and registering them as value helpers makes them reachable from Phlex views the same way `permission?` / `in_admin_mode?` / `q_param` already are.

## Changes

- `ApplicationController::Authentication#current_user` returns the before-filter-set `@user`. Exposed via `helper_method` so ERB views see it too.
- `ApplicationController::Queries#current_query` is the existing fallback chain `@query || query_from_q_param || query_from_session`. Added to the concern's `helper_method` list so it's reachable from views.
- `Components::Base` registers both as value helpers so any Phlex view subclass can call them directly.
- Four tests on `BaseTest` exercise both helpers' read paths and their nil fallbacks.

## How this lands in views (follow-ups, not this PR)

The intended usage pattern, once this ships:

```ruby
# Before
class Views::Controllers::Some::Chrome < Views::Base
  prop :user, _Nilable(::User), default: nil
  prop :query, _Nilable(::Query), default: nil
  # ...
end

# After — chrome that only needs "the viewer's current context"
class Views::Controllers::Some::Chrome < Views::Base
  # No `:user` or `:query` props; the view just needs the request
  # context.
  def view_template
    something_that_needs(current_user)
    something_that_needs(current_query)
  end
end
```

Subject views (`Views::Controllers::Users::Show`, profile pages, anywhere `User` or `Query` is the *subject* of the view) keep explicit props — the contract is load-bearing there. Sweep happens in follow-up PRs.

## Test plan

- [x] `bin/rails test test/components/base_test.rb` — 9 tests, 25 assertions, green
- [x] `bundle exec rubocop` on touched files — clean
- [x] CI: full suite (no production code paths change behavior; both helpers are additive)
