### PR TITLE
Fix advanced search: JSON-encode Stimulus Array values in top_nav (#4492)

### DIFF
--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -111,8 +111,12 @@ class Views::Layouts::TopNav < Views::Base
       div(class: "collapse w-100", id: "search_nav",
           data: {
             controller: "search-type",
-            search_type_help_types_value: SEARCH_HELP_TYPES,
-            search_type_form_types_value: SEARCH_FORM_TYPES
+            # Stimulus Array values must be JSON. Rails' tag helper
+            # JSON-encodes arrays automatically; Phlex space-joins them
+            # ("a b"), which breaks JSON.parse in the controller and
+            # silently disables the help/advanced-search forms (#4492).
+            search_type_help_types_value: SEARCH_HELP_TYPES.to_json,
+            search_type_form_types_value: SEARCH_FORM_TYPES.to_json
           }) do
         # `_search_bar.html.erb` stays ERB for now — rendered via
         # Phlex's `partial(...)` wrapper. The identify-search variant

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -25,6 +25,25 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_response(:redirect)
   end
 
+  # Regression for #4492: the top-nav `search-type` Stimulus controller
+  # reads its help/form type lists as Array values, which Stimulus parses
+  # as JSON. Phlexifying top_nav emitted the arrays space-joined ("a b")
+  # instead of JSON-encoded, so JSON.parse threw and silently disabled the
+  # advanced-search and help forms. The attributes must be valid JSON.
+  def test_search_nav_stimulus_array_values_are_json
+    login
+    get(:index)
+
+    node = css_select("#search_nav").first
+    assert_not_nil(node, "search nav not rendered")
+    %w[data-search-type-form-types-value
+       data-search-type-help-types-value].each do |attr|
+      parsed = JSON.parse(node[attr])
+      assert_kind_of(Array, parsed, "#{attr} must be a JSON array")
+      assert_includes(parsed, "observations", "#{attr} must list observations")
+    end
+  end
+
   BUNCH_OF_NAMES = Name.take(10)
   BUNCH_OF_REGIONS = [
     "Connecticut, USA",


### PR DESCRIPTION
## Summary

Fixes the broken Advanced Search on the observations (and other) index pages reported in #4492: clicking the magnifying glass opens the single-field search, but clicking the advanced-search "+" collapses the search bar without ever showing the advanced form.

## Root cause

The top-nav `search-type` Stimulus controller declares `static values = { helpTypes: Array, formTypes: Array }`. Stimulus reads `Array` values by `JSON.parse`-ing the data attribute. Rails' `tag` helper JSON-encodes array data values automatically, but when `top_nav` was phlexified the values moved into a Phlex `div(data: {...})`, and Phlex **space-joins** an array instead of JSON-encoding it:

```
Rails: data-search-type-form-types-value="[&quot;observations&quot;,…]"   ✅ valid JSON
Phlex: data-search-type-form-types-value="observations names …"            ❌ not JSON
```

So `getForm()` (run on `connect()`) throws when it evaluates `this.formTypesValue.includes(controller)` — reading the malformed `Array` value blows up. `getForm()` and `getHelp()` bail before fetching the form into `#search_nav_form`, so it stays empty. The server-rendered "+" remains visible; clicking it runs the intended accordion (Bootstrap shows the empty `#search_nav_form`, `closeBar` hides the simple bar), which looks like the whole search bar collapsing with no form. The server side was never broken — the `observations/search#new` turbo-stream renders correctly (37 existing controller tests green).

## Fix

`app/views/layouts/top_nav.rb` — JSON-encode the two Stimulus `Array` values so Phlex emits valid JSON, matching the Rails tag helper's prior output:

```ruby
search_type_help_types_value: SEARCH_HELP_TYPES.to_json,
search_type_form_types_value: SEARCH_FORM_TYPES.to_json,
```

This is the only occurrence: `search-type` is the only Stimulus controller using `Array` values, and no other Phlex view passes a raw array to a `_value:` data attribute.

## Test

Adds `test_search_nav_stimulus_array_values_are_json` to the observations index controller test: renders the real page and asserts both `data-search-type-*-types-value` attributes parse as JSON arrays containing `"observations"`. Verified it errors with `JSON::ParserError` without the fix, so it pins the exact regression.

## Test plan
- [x] `bin/rails test test/controllers/observations_controller_index_test.rb`
- [x] `bin/rails test test/views/layouts/top_nav_test.rb test/controllers/observations/search_controller_test.rb`
- [x] Confirmed new test fails (JSON::ParserError) without the fix
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
