### PR TITLE
Fix Name show panels rendering HTML entity codes instead of characters (#4491)

### DIFF
--- a/app/views/controllers/names/show/classification_panel.rb
+++ b/app/views/controllers/names/show/classification_panel.rb
@@ -80,7 +80,7 @@ class Views::Controllers::Names::Show::ClassificationPanel < Views::Base
       plain("#{rank_as_string(node.rank)}: ")
       i do
         a(href: name_path(node.id)) do
-          plain(node.text_name.t.strip_html)
+          trusted_html(node.text_name.t)
         end
       end
       render_alias_suffix if node == approved && approved != @name
@@ -93,7 +93,7 @@ class Views::Controllers::Names::Show::ClassificationPanel < Views::Base
   def render_alias_suffix
     span(class: "ml-4") do
       plain("(= ")
-      i { plain(@name.text_name.t.strip_html) }
+      i { trusted_html(@name.text_name.t) }
       plain(")")
     end
   end

--- a/app/views/controllers/names/show/nomenclature.rb
+++ b/app/views/controllers/names/show/nomenclature.rb
@@ -100,7 +100,10 @@ class Views::Controllers::Names::Show::Nomenclature < Views::Base
   end
 
   def render_authority_paragraph
-    p { plain("#{:AUTHORITY.l}: #{@name.author.to_s.t.strip_html}") }
+    p do
+      plain("#{:AUTHORITY.l}: ")
+      trusted_html(@name.author.to_s.t)
+    end
   end
 
   def render_citation_paragraph
@@ -202,7 +205,7 @@ class Views::Controllers::Names::Show::Nomenclature < Views::Base
       plain("#{:show_name_misspelling_correct.l}: ")
       if @name.correct_spelling
         a(href: name_path(@name.correct_spelling_id)) do
-          plain(@name.correct_spelling.user_display_name(@user).t.strip_html)
+          trusted_html(@name.correct_spelling.user_display_name(@user).t)
         end
       else
         plain(@name.correct_spelling_id.to_s)
@@ -237,7 +240,7 @@ class Views::Controllers::Names::Show::Nomenclature < Views::Base
       plain("#{label}: ")
       names.each_with_index do |n, idx|
         a(href: name_path(n.id)) do
-          plain(n.user_display_name(@user).t.strip_html)
+          trusted_html(n.user_display_name(@user).t)
         end
         plain(", ") if idx < names.length - 1
       end

--- a/test/controllers/names_controller_show_test.rb
+++ b/test/controllers/names_controller_show_test.rb
@@ -39,6 +39,25 @@ class NamesControllerShowTest < FunctionalTestCase
     assert_select("#nomenclature")
   end
 
+  # Regression for #4491: name text (author, synonyms, classification
+  # rows) is textile-safe HTML. The Phlex conversion emitted it via
+  # `plain`, which re-escaped the entities, so panels showed literal
+  # codes like "&amp;" / "&#8212;" instead of "&" / "—". Same root cause
+  # / fix (`trusted_html`) in the nomenclature and classification panels.
+  def test_show_name_renders_html_entities_not_codes
+    login
+    # author is "(Bull.) Vilgalys, Hopple & Jacq. Johnson"
+    name = names(:coprinellus_micaceus)
+    get(:show, params: { id: name.id })
+    assert_response(:success)
+
+    nomenclature = css_select("#nomenclature").text
+    assert_includes(nomenclature, "Hopple & Jacq. Johnson",
+                    "ampersand should render as a character, not a code")
+    assert_not_includes(nomenclature, "&amp;",
+                        "HTML entity codes should not be visible as text")
+  end
+
   def test_show_name_species_with_icn_id
     # Name's icn_id is filled in
     name = names(:coprinus_comatus)


### PR DESCRIPTION
## Summary

Fixes #4491: on the Name show page, the **Nomenclature** and **Classification** panels displayed literal HTML codes (`&amp;`, `&#8212;`, `&#8220;…`) instead of the actual characters.

## Root cause

These name/author strings are textile-safe HTML — `name.author.to_s.t` yields e.g. `Kühner &amp; Maire`, where `&amp;` is the correct HTML encoding of `&`. The original ERB emitted them with `<%= … %>`, so the browser decoded the entities and rendered the formatting.

The recent Phlex conversion of the name show panels (`2adf245a2`) made two mistakes on these lines:

1. Added `.strip_html`, dropping the textile italic/bold formatting of the scientific names.
2. Output the result via `plain(…)`, which **re-escapes** the already-encoded HTML. So `&amp;` became `&amp;amp;` and rendered as the literal code `&amp;`. (Confirmed by reverting the fix — the rendered HTML contained `Hopple &amp;amp; Jacq.`.)

The citation line in the same panel already did this correctly with `trusted_html`.

## Fix

Five lines across the two panels now emit `X.t` via `trusted_html` (dropping `.strip_html`), restoring the original behavior:

- `app/views/controllers/names/show/nomenclature.rb` — authority, correct-spelling link, synonym links
- `app/views/controllers/names/show/classification_panel.rb` — classification-row names, the alias suffix

This fixes the entity display **and** restores the italic/bold formatting that `.strip_html` had removed. The NAME line keeps `plain(@name.user_real_text_name(@user))` — the original escaped it with `h(...)`, so plain text is correct there.

## Test

Adds `test_show_name_renders_html_entities_not_codes`: renders the show page for `coprinellus_micaceus` (author `(Bull.) Vilgalys, Hopple & Jacq. Johnson`) and asserts the nomenclature panel's text shows `Hopple & Jacq. Johnson`, not a code. Verified it fails without the fix (catches `&amp;amp;`). The classification panel takes the identical `plain → trusted_html` change.

## Test plan
- [x] `bin/rails test test/controllers/names_controller_show_test.rb`
- [x] Confirmed the new test fails without the fix
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
