### PR TITLE
Fix description form double-escaping source-name HTML entities

### DIFF
--- a/app/views/controllers/descriptions/form.rb
+++ b/app/views/controllers/descriptions/form.rb
@@ -64,7 +64,12 @@ module Views::Controllers::Descriptions
     def render_source_name_field
       if !root? && locked_source_type?
         hidden_field(:source_name)
-        plain(" #{@description.source_name.t}")
+        # `.t` is textile-safe HTML; pass the SafeBuffer straight to
+        # trusted_html (NOT interpolated — that yields a plain String and
+        # trusted_html would escape it) so entities in the source name
+        # (e.g. "&" in a project title) aren't double-escaped (#4491).
+        plain(" ")
+        trusted_html(@description.source_name.t)
       else
         text_field(:source_name, class: "form-control")
       end

--- a/test/views/controllers/descriptions/form_test.rb
+++ b/test/views/controllers/descriptions/form_test.rb
@@ -116,9 +116,14 @@ module Views::Controllers::Descriptions
       desc.source_name = "Bolete & Friends"
       html = render_form(description: desc)
 
-      # single-encoded "&amp;" is correct; "&amp;amp;" is the double-escape
-      assert_includes(html, "Bolete &amp; Friends")
-      assert_not_includes(html, "Bolete &amp;amp; Friends")
+      # Assert the *visible* read-only source name, not the hidden input's
+      # value= attribute (which carries the same string). Nokogiri's .text
+      # excludes attributes and decodes entities: a correct single-encode
+      # renders the literal "&", a double-escape bug renders the code "&amp;".
+      source_fields = Nokogiri::HTML(html).
+                      at_css("label[for='description_source']").parent
+      assert_includes(source_fields.text, "Bolete & Friends")
+      assert_not_includes(source_fields.text, "Bolete &amp; Friends")
     end
 
     def test_location_description_form

--- a/test/views/controllers/descriptions/form_test.rb
+++ b/test/views/controllers/descriptions/form_test.rb
@@ -107,6 +107,20 @@ module Views::Controllers::Descriptions
                   count: 2)
     end
 
+    # Regression for #4491: project/foreign descriptions show the source
+    # name read-only via `.t` (textile-safe HTML). It was emitted with
+    # `plain`, which re-escaped the entities, so a source name with "&"
+    # rendered the double-escaped code "&amp;" instead of "&".
+    def test_locked_source_name_renders_entities_not_codes
+      desc = name_descriptions(:draft_boletus_edulis) # source_type: project
+      desc.source_name = "Bolete & Friends"
+      html = render_form(description: desc)
+
+      # single-encoded "&amp;" is correct; "&amp;amp;" is the double-escape
+      assert_includes(html, "Bolete &amp; Friends")
+      assert_not_includes(html, "Bolete &amp;amp; Friends")
+    end
+
     def test_location_description_form
       html = render_form(description: @new_loc_desc)
 


### PR DESCRIPTION
## Summary

Fixes a double-escaping bug found while auditing recent Phlex conversions for the same pattern as #4491.

On the description form, a **project**- or **foreign**-sourced description shows its source name read-only. The name went through `.t` (textile-safe HTML) and was emitted with `plain`, which re-escapes the entities — so a source name containing `&` (e.g. a project titled `Bolete & Friends`) rendered the double-escaped code `&amp;` instead of `&`.

## Fix

`app/views/controllers/descriptions/form.rb` — pass the `.t` `SafeBuffer` straight to `trusted_html` instead of through `plain`:

```ruby
plain(" ")
trusted_html(@description.source_name.t)
```

Note: it has to be the **direct** `.t` result. Interpolating (`trusted_html(" #{...t}")`) produces a plain `String`, and `trusted_html` only emits raw for an `ActiveSupport::SafeBuffer` — for a plain String it falls back to `plain` and escapes, which would silently reintroduce the bug.

## Test

Adds `test_locked_source_name_renders_entities_not_codes`: renders the form for a project-source description whose `source_name` is `Bolete & Friends` and asserts the output is single-encoded (`&amp;`), not double-encoded (`&amp;amp;`). Verified it fails against the original `plain` rendering.

## Test plan
- [x] `bin/rails test test/views/controllers/descriptions/form_test.rb` (full file, 7 tests)
- [x] Confirmed the new test fails without the fix
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
