### PR TITLE
observations: drop unused user: prop from 4 Phlex views

### DIFF
--- a/app/controllers/observations/emails_controller.rb
+++ b/app/controllers/observations/emails_controller.rb
@@ -14,7 +14,7 @@ module Observations
       respond_to do |format|
         format.html do
           render(Views::Controllers::Observations::Emails::New.new(
-                   observation: @observation, user: @user
+                   observation: @observation
                  ))
         end
         format.turbo_stream do
@@ -54,7 +54,7 @@ module Observations
       flash_error(:runtime_missing.t(field: :message.l))
       @observation = observation
       render(Views::Controllers::Observations::Emails::New.new(
-               observation: observation, user: @user
+               observation: observation
              ))
       false
     end

--- a/app/controllers/observations/species_lists_controller.rb
+++ b/app/controllers/observations/species_lists_controller.rb
@@ -56,8 +56,7 @@ module Observations
           observation: @observation,
           all_lists: @all_lists,
           obs_lists: @obs_lists,
-          other_lists: @other_lists,
-          user: @user
+          other_lists: @other_lists
         ),
         **render_opts
       )

--- a/app/views/controllers/observations/emails/new.rb
+++ b/app/views/controllers/observations/emails/new.rb
@@ -6,7 +6,6 @@
 module Views::Controllers::Observations::Emails
   class New < Views::Base
     prop :observation, ::Observation
-    prop :user, _Nilable(::User), default: nil
 
     def view_template
       add_page_title(

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -111,7 +111,7 @@ module Views::Controllers::Observations
       render(SpeciesListsPanel.new(obs: @observation, user: @user))
       render(AssociatedObservationsPanel.new(
                obs: @observation, occurrence: @occurrence,
-               siblings: @sibling_observations, user: @user
+               siblings: @sibling_observations
              ))
     end
 
@@ -122,9 +122,9 @@ module Views::Controllers::Observations
         div(class: content_for(:left_columns)) do
           render_namings_and_comments
         end
-        if @user
-          div(class: content_for(:right_columns)) do
-            render_thumbnail_map_if_shown
+        div(class: content_for(:right_columns)) do
+          if @user&.thumbnail_maps
+            render(ThumbnailMapPanel.new(obs: @observation))
           end
         end
       end
@@ -154,24 +154,6 @@ module Views::Controllers::Observations
 
     def render_source_credit
       trusted_html(@observation.source_credit.tpl)
-    end
-
-    def render_thumbnail_map_if_shown
-      return unless show_thumbnail_map?
-
-      render(ThumbnailMapPanel.new(
-               obs: @observation, user: @user
-             ))
-    end
-
-    # Only called from inside the `if @user` branch of
-    # `render_secondary_row`, so `@user` is always truthy here.
-    # The legacy ERB computed a `show_map` value with a
-    # `!@user`-then-session fallback, but the value was only used
-    # inside its own `if @user` block — the fallback branch was
-    # never reachable. Mirror reality.
-    def show_thumbnail_map?
-      @user.thumbnail_maps
     end
 
     def render_footer

--- a/app/views/controllers/observations/show/associated_observations_panel.rb
+++ b/app/views/controllers/observations/show/associated_observations_panel.rb
@@ -10,7 +10,6 @@ class Views::Controllers::Observations::Show::AssociatedObservationsPanel < View
   prop :obs, ::Observation
   prop :occurrence, _Nilable(::Occurrence), default: nil
   prop :siblings, _Array(::Observation), default: -> { [] }
-  prop :user, _Nilable(::User), default: nil
 
   def view_template
     render(Components::Panel.new(

--- a/app/views/controllers/observations/show/thumbnail_map_panel.rb
+++ b/app/views/controllers/observations/show/thumbnail_map_panel.rb
@@ -15,7 +15,6 @@ class Views::Controllers::Observations::Show::ThumbnailMapPanel < Views::Base
   include Phlex::Rails::Helpers::ImageURL
 
   prop :obs, ::Observation
-  prop :user, _Nilable(::User), default: nil
 
   def view_template
     render(Components::Panel.new(

--- a/app/views/controllers/observations/species_lists/edit.rb
+++ b/app/views/controllers/observations/species_lists/edit.rb
@@ -12,7 +12,6 @@ module Views::Controllers::Observations::SpeciesLists
     prop :all_lists, ::Query::SpeciesLists
     prop :obs_lists, _Array(::SpeciesList)
     prop :other_lists, _Array(::SpeciesList)
-    prop :user, _Nilable(::User), default: nil
 
     def view_template
       add_page_title(

--- a/test/views/controllers/observations/show/associated_observations_panel_test.rb
+++ b/test/views/controllers/observations/show/associated_observations_panel_test.rb
@@ -8,7 +8,6 @@ class Views::Controllers::Observations::Show::AssociatedObservationsPanelTest <
   ComponentTestCase
   def setup
     super
-    @user = users(:rolf)
     @obs = observations(:detailed_unknown_obs)
   end
 
@@ -48,7 +47,7 @@ class Views::Controllers::Observations::Show::AssociatedObservationsPanelTest <
 
   def panel_with(siblings:, occurrence:)
     Views::Controllers::Observations::Show::AssociatedObservationsPanel.new(
-      obs: @obs, occurrence: occurrence, siblings: siblings, user: @user
+      obs: @obs, occurrence: occurrence, siblings: siblings
     )
   end
 end

--- a/test/views/controllers/observations/show/thumbnail_map_panel_test.rb
+++ b/test/views/controllers/observations/show/thumbnail_map_panel_test.rb
@@ -6,7 +6,6 @@ class Views::Controllers::Observations::Show::ThumbnailMapPanelTest <
   ComponentTestCase
   def setup
     super
-    @user = users(:rolf)
     @obs = observations(:detailed_unknown_obs)
   end
 
@@ -22,8 +21,6 @@ class Views::Controllers::Observations::Show::ThumbnailMapPanelTest <
   private
 
   def panel_with(obs)
-    Views::Controllers::Observations::Show::ThumbnailMapPanel.new(
-      obs: obs, user: @user
-    )
+    Views::Controllers::Observations::Show::ThumbnailMapPanel.new(obs: obs)
   end
 end


### PR DESCRIPTION
## Summary

Pilot for a possible broader sweep — four observations-domain Phlex views took `prop :user, _Nilable(::User), default: nil` but never read `@user`. Now that `Components::Base` registers `current_user` (#4488), the prop is dead code. Dropping it lets callers stop forwarding `user: @user` too.

Views: `Show::ThumbnailMapPanel`, `Show::AssociatedObservationsPanel`, `Emails::New`, `SpeciesLists::Edit`. Callers updated in `app/views/controllers/observations/show.rb`, `app/controllers/observations/emails_controller.rb`, `app/controllers/observations/species_lists_controller.rb`.

While in `observations/show.rb`, `render_secondary_row` folds the `if @user&.thumbnail_maps` guard inline in place of the standalone `render_thumbnail_map_if_shown` + `show_thumbnail_map?` pair. The right-column wrapper now emits unconditionally (intentional — keeps the layout grid column). Empty viewer-side wrapper is acceptable per discussion.

## Scope decision

This is a **pilot** — 4 files where `@user` was already unused. The branch name (`-drop-current-user-query-props`) hints at a wider sweep across ~80 more files, but we're tabling that for now to canvas other devs on whether they prefer the explicit `prop :user` shape or the `current_user` helper fallback.

## Test plan
- [x] `bin/rails test test/views/controllers/observations/show/thumbnail_map_panel_test.rb test/views/controllers/observations/show/associated_observations_panel_test.rb` — 3 tests, 14 assertions
- [x] `bin/rails test test/controllers/observations/emails_controller_test.rb test/controllers/observations/species_lists_controller_test.rb` — 12 tests, 103 assertions
- [x] `bin/rails test test/controllers/observations_controller_show_test.rb` — 33 tests, 433 assertions
- [x] `bundle exec rubocop` clean on all 9 touched files
- [x] CI green
- [x] Coveralls 100% per-file on touched files (excluding ApplicationController — none touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
