### PR TITLE
Index users.inat_username and users.name for collector lookups

### DIFF
--- a/db/migrate/20260610215004_add_indexes_for_collector_user_lookups.rb
+++ b/db/migrate/20260610215004_add_indexes_for_collector_user_lookups.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Index users.inat_username and users.name so collector resolution does
+# point lookups instead of full table scans.
+#
+# Observation.resolve_collector (#4211 / PR #4452) looks a collector string
+# up against User#inat_username and User#name on every resolved row — on the
+# live edit and iNat-import paths, and in bulk in the MigrateCollectorNotes
+# seeding pass. Only `login` was indexed, so each non-login lookup scanned
+# the whole users table; the seeding pass's tens of thousands of rows turned
+# that into a 25-minute run (free-text/no-match values scan the entire table
+# fruitlessly). These two indexes make each lookup O(log n).
+#
+# Deploy this on its own, ahead of and separate from the MigrateCollectorNotes
+# seeding migration (PR #4452). Building these two indexes is quick (the users
+# table is small), so its maintenance window is negligible; once the indexes
+# exist, the seeding migration's much longer offline window shrinks
+# accordingly. The seeding migration is dated later than this one so it runs
+# second and benefits from these indexes.
+class AddIndexesForCollectorUserLookups < ActiveRecord::Migration[7.2]
+  def change
+    change_table(:users, bulk: true) do |t|
+      t.index(:inat_username, name: "index_users_on_inat_username")
+      t.index(:name, name: "index_users_on_name")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_05_160002) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_10_215004) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -989,7 +989,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_05_160002) do
     t.string "inat_username"
     t.integer "original_image_quota", default: 0
     t.integer "label_format", default: 1
+    t.index ["inat_username"], name: "index_users_on_inat_username"
     t.index ["login"], name: "login_index"
+    t.index ["name"], name: "index_users_on_name"
   end
 
   create_table "visual_group_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
## Summary

Adds two indexes — `index_users_on_inat_username` and `index_users_on_name` — on the `users` table.

`Observation.resolve_collector` (#4211 / PR #4452) resolves a collector string to an MO user by looking it up against `User#inat_username` and `User#name` on every resolved row: on the live observation edit form, on the iNat import path, and — in bulk — in the `MigrateCollectorNotes` seeding pass. Until now only `login` was indexed, so each `inat_username` / `name` lookup was a full scan of the `users` table, and free-text / no-match values scanned the whole table fruitlessly. In bulk that turned the seeding pass into a ~25-minute run. These two indexes make each lookup a point lookup.

## Why a standalone migration (deploy first, ASAP)

This is a tiny, fast migration — two index builds on the small `users` table — with no real downside to shipping it on its own ahead of #4452. Deploying it first means that when the #4452 seeding migration later runs in the maintenance window, the indexes already exist and its much longer offline pass is far shorter. The migration is dated `20260610215004`, earlier than the seeding migration's `20260611000000`, so the two also sort correctly if ever applied together on a fresh database.

## Test plan

- [x] `bundle exec rubocop db/migrate/20260610215004_add_indexes_for_collector_user_lookups.rb` — clean
- [ ] Restore a prod copy, run `db:migrate`, confirm both indexes build. Then merge `main` into the #4452 branch, take a fresh prod dump, and confirm the seeding pass drops from ~25 min to a small fraction.
