### PR TITLE
projects/list_item: drop .list-group-item wrapper, let caller supply it

### DIFF
--- a/app/views/controllers/projects/index.html.erb
+++ b/app/views/controllers/projects/index.html.erb
@@ -11,7 +11,9 @@ flash_error(@error) if @error && @objects.empty?
 <%= paginated_results do %>
   <%= tag.div(class: "list-group") do %>
     <% @objects.each do |project| %>
-      <%= render(Views::Controllers::Projects::ListItem.new(project: project)) %>
+      <%= tag.div(class: "list-group-item d-flex align-items-start") do %>
+        <%= render(Views::Controllers::Projects::ListItem.new(project: project)) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/controllers/projects/list_item.rb
+++ b/app/views/controllers/projects/list_item.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
-# Renders a single project in a list-group. Rendered by
-# `projects/index.html.erb` for each project in the result set.
+# Inner content of one row in the projects index list-group. The
+# `<div class="list-group-item …">` wrapper is supplied by the
+# caller (the ERB index template, soon `Components::ListGroup`);
+# this class only emits the two-column body (id badge + title /
+# meta column).
 module Views::Controllers::Projects
   class ListItem < Views::Base
     def initialize(project:)
@@ -10,16 +13,14 @@ module Views::Controllers::Projects
     end
 
     def view_template
-      div(class: "list-group-item d-flex align-items-start") do
-        div(class: "text-larger") do
-          render(Components::IdBadge.new(
-                   object: @project, extra_class: "rss-id mr-4"
-                 ))
-        end
-        div do
-          render_title_row
-          render_meta_row
-        end
+      div(class: "text-larger") do
+        render(Components::IdBadge.new(
+                 object: @project, extra_class: "rss-id mr-4"
+               ))
+      end
+      div do
+        render_title_row
+        render_meta_row
       end
     end
 

--- a/test/views/controllers/projects/list_item_test.rb
+++ b/test/views/controllers/projects/list_item_test.rb
@@ -14,8 +14,8 @@ module Views::Controllers::Projects
       project = projects(:eol_project)
       html = render(ListItem.new(project: project))
 
-      # Container
-      assert_html(html, "div.list-group-item")
+      # No `.list-group-item` wrapper — supplied by the caller.
+      assert_no_html(html, "div.list-group-item")
 
       # Title link
       assert_html(html, "a[href*='projects/#{project.id}']")


### PR DESCRIPTION
## Summary

Splits the row-content concern out of `Views::Controllers::Projects::ListItem`. The class now emits only the two-column body (id badge + title / meta column); the `<div class="list-group-item d-flex align-items-start">` wrapper moves up to the caller — `projects/index.html.erb` for now.

Precursor for `nimmo-projects-remaining-erbs-to-phlex` (the follow-up PR converts `projects/index.html.erb` to a Phlex view backed by `Components::ListGroup`). Splitting this out keeps the conversion PR's parity diff clean: with the wrapper concern already at the call site, the Phlex `Components::ListGroup#item(class: ...)` call slots in for the ERB's `tag.div(class: ...)` and the rendered HTML stays byte-identical.

## Changes

- `app/views/controllers/projects/list_item.rb` — drop the `<div class="list-group-item d-flex align-items-start">` wrapper from `view_template`. Updated docstring.
- `app/views/controllers/projects/index.html.erb` — wrap each `render(ListItem.new(...))` in `tag.div(class: "list-group-item d-flex align-items-start")` so the rendered HTML is unchanged.
- `test/views/controllers/projects/list_item_test.rb` — flip the wrapper assertion to `assert_no_html(html, "div.list-group-item")` to reflect the new contract.

## Test plan

- [x] `bin/rails test test/views/controllers/projects/list_item_test.rb` — 3 tests, 12 assertions, green
- [x] `bin/rails test test/controllers/projects_controller_test.rb -n /index/` — 3 tests, 16 assertions, green
- [x] `bundle exec rubocop` clean on touched Ruby files
- [ ] Browser test: `/projects` renders the same list as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
