### PR TITLE
Phlex views: queries → controllers; ContentPadded + MatrixTable sweep; rename ObjectFooter → VersionsFooter

### DIFF
--- a/app/components/authors_and_editors.rb
+++ b/app/components/authors_and_editors.rb
@@ -79,7 +79,7 @@ module Components
       type = @obj.type_tag
       versions = @versions || []
 
-      editors_list = versions.map(&:user).compact.uniq - [@obj.user]
+      editors_list = versions.filter_map(&:user).uniq - [@obj.user]
 
       p do
         render_user_list(:"show_#{type}_creator", [@obj.user])

--- a/app/components/authors_and_editors.rb
+++ b/app/components/authors_and_editors.rb
@@ -71,13 +71,15 @@ module Components
       end
     end
 
-    # Renders authors and editors for non-description objects
+    # Renders authors and editors for non-description objects.
+    # Reads editors from `versions.map(&:user)` — the host page's
+    # `show_includes` scope eager-loads `{ versions: :user }`, so
+    # no DB queries here.
     def non_description_authors_and_editors
       type = @obj.type_tag
       versions = @versions || []
 
-      editor_ids = versions.map(&:user_id).uniq - [@obj.user_id]
-      editors_list = User.where(id: editor_ids).to_a
+      editors_list = versions.map(&:user).compact.uniq - [@obj.user]
 
       p do
         render_user_list(:"show_#{type}_creator", [@obj.user])

--- a/app/components/translators_credit.rb
+++ b/app/components/translators_credit.rb
@@ -9,7 +9,7 @@ module Components
   #
   class TranslatorsCredit < Base
     def view_template
-      lang = Language.find_by(locale: I18n.locale)
+      lang = Language.for_locale(I18n.locale)
       return unless lang && (!lang.official || Language.tracking_usage?)
 
       div(id: "translators_credit", class: "hidden-print") do

--- a/app/components/versions_footer.rb
+++ b/app/components/versions_footer.rb
@@ -7,16 +7,16 @@ module Components
   # and links to activity logs.
   #
   # @example Basic usage (non-versioned object)
-  #   render(Components::ObjectFooter.new(user: @user, obj: @sequence))
+  #   render(Components::VersionsFooter.new(user: @user, obj: @sequence))
   #
   # @example Versioned object with versions
-  #   render(Components::ObjectFooter.new(
+  #   render(Components::VersionsFooter.new(
   #     user: @user,
   #     obj: @name,
   #     versions: @versions
   #   ))
   #
-  class ObjectFooter < Base
+  class VersionsFooter < Base
     prop :user, _Nilable(User)
     # Polymorphic across many model classes (Article, Description,
     # FieldSlip, GlossaryTerm, Image, Location, Name, Observation,

--- a/app/controllers/account/preferences_controller.rb
+++ b/app/controllers/account/preferences_controller.rb
@@ -68,7 +68,8 @@ module Account
 
     def render_edit
       render(Views::Controllers::Account::Preferences::Edit.new(
-               user: @user, licenses: @licenses
+               user: @user, licenses: @licenses,
+               languages: Language.all.to_a
              ))
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,6 @@
 #  extra_gc::               (filter: calls <tt>ObjectSpace.garbage_collect</tt>)
 #
 #  ==== Other stuff
-#  observation_matrix_box_image_includes:: Hash of includes for eager-loading
 #  name_flash_for_project::      Flash message for adding obs to projects
 #  default_thumbnail_size::      Default thumbnail size: :thumbnail or :small.
 #  default_thumbnail_size_set::  Change default thumbnail size for current user.
@@ -224,12 +223,6 @@ class ApplicationController < ActionController::Base
   #  :section: Other stuff
   #
   ##############################################################################
-
-  def observation_matrix_box_image_includes
-    { thumb_image: [:image_votes, :license, :projects, :user] }.freeze
-    # for matrix_box_carousels:
-    # { images: [:image_votes, :license, :projects, :user] }.freeze
-  end
 
   def name_flash_for_project(name, project)
     return unless name && project

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -74,15 +74,7 @@ class CollectionNumbersController < ApplicationController
     end
 
     @canonical_url = CollectionNumber.show_url(params[:id])
-    # Eager-load `observations` (+ associations the MatrixTable
-    # render reaches into) so the show view doesn't re-query when
-    # iterating `@collection_number.observations`.
-    @collection_number = CollectionNumber.
-                         includes(observations: [:thumb_image, :user]).
-                         find_by(id: params[:id]) ||
-                         flash_error_and_goto_index(
-                           CollectionNumber, params[:id]
-                         )
+    @collection_number = find_collection_number_for_show
     return unless @collection_number
 
     render(Views::Controllers::CollectionNumbers::Show.new(
@@ -156,12 +148,17 @@ class CollectionNumbersController < ApplicationController
 
   def set_ivars_for_edit
     @layout = calc_layout_params
-    @collection_number = CollectionNumber.
-                         includes(observations: [:thumb_image, :user]).
-                         find_by(id: params[:id]) ||
-                         flash_error_and_goto_index(
-                           CollectionNumber, params[:id]
-                         )
+    @collection_number = find_collection_number_for_show
+  end
+
+  # Eager-loads `observations` (+ associations the MatrixTable
+  # render reaches into) so the show / edit views don't re-query
+  # when iterating `@collection_number.observations`.
+  def find_collection_number_for_show
+    CollectionNumber.
+      includes(observations: [:thumb_image, :user]).
+      find_by(id: params[:id]) ||
+      flash_error_and_goto_index(CollectionNumber, params[:id])
   end
 
   def render_new_phlex

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -74,7 +74,15 @@ class CollectionNumbersController < ApplicationController
     end
 
     @canonical_url = CollectionNumber.show_url(params[:id])
-    @collection_number = find_or_goto_index(CollectionNumber, params[:id])
+    # Eager-load `observations` (+ associations the MatrixTable
+    # render reaches into) so the show view doesn't re-query when
+    # iterating `@collection_number.observations`.
+    @collection_number = CollectionNumber.
+                         includes(observations: [:thumb_image, :user]).
+                         find_by(id: params[:id]) ||
+                         flash_error_and_goto_index(
+                           CollectionNumber, params[:id]
+                         )
     return unless @collection_number
 
     render(Views::Controllers::CollectionNumbers::Show.new(
@@ -148,7 +156,12 @@ class CollectionNumbersController < ApplicationController
 
   def set_ivars_for_edit
     @layout = calc_layout_params
-    @collection_number = find_or_goto_index(CollectionNumber, params[:id])
+    @collection_number = CollectionNumber.
+                         includes(observations: [:thumb_image, :user]).
+                         find_by(id: params[:id]) ||
+                         flash_error_and_goto_index(
+                           CollectionNumber, params[:id]
+                         )
   end
 
   def render_new_phlex

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -151,13 +151,12 @@ class CollectionNumbersController < ApplicationController
     @collection_number = find_collection_number_for_show
   end
 
-  # Eager-loads `observations` (+ associations the MatrixTable
-  # render reaches into) so the show / edit views don't re-query
-  # when iterating `@collection_number.observations`.
+  # Uses `CollectionNumber.show_includes` so the show / edit views
+  # don't re-query when iterating `@collection_number.observations`
+  # (the MatrixTable / MatrixBox render walks down through
+  # `Observation::NamingConsensus` into votes + naming.name).
   def find_collection_number_for_show
-    CollectionNumber.
-      includes(observations: [:thumb_image, :user]).
-      find_by(id: params[:id]) ||
+    CollectionNumber.show_includes.find_by(id: params[:id]) ||
       flash_error_and_goto_index(CollectionNumber, params[:id])
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,7 +9,7 @@
 #  update::
 #  destroy::
 #
-class CommentsController < ApplicationController
+class CommentsController < ApplicationController # rubocop:disable Metrics/ClassLength
   before_action :login_required
   before_action :store_location, only: [:show]
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -273,14 +273,29 @@ class CommentsController < ApplicationController
 
   def render_phlex_new
     render(Views::Controllers::Comments::New.new(
-             comment: @comment, target: @target, user: @user
+             comment: @comment, target: @target, user: @user,
+             comments: load_target_comments
            ))
   end
 
   def render_phlex_edit
     render(Views::Controllers::Comments::Edit.new(
-             comment: @comment, target: @target, user: @user
+             comment: @comment, target: @target, user: @user,
+             comments: load_target_comments
            ))
+  end
+
+  # Comments-for-target list used by the read-only `CommentsForObject`
+  # block on both the `new` and `edit` Phlex pages. Pulled into the
+  # controller so the views don't run a query.
+  #
+  # Eager-loads `:user` (each `CommentItem` reads `comment.user`
+  # multiple times — UserLink, avatar image, display name) and
+  # `:target` (the polymorphic target — `CommentItem` calls
+  # `comment.target.show_link_args` / `target.class.name`, which
+  # would otherwise issue one query per comment).
+  def load_target_comments
+    Comment.includes(:user, :target).where(target: @target).to_a
   end
 
   # The identifier needs to be more specific for an edit form, because

--- a/app/controllers/field_slips_controller/index.rb
+++ b/app/controllers/field_slips_controller/index.rb
@@ -55,7 +55,7 @@ module FieldSlipsController::Index
   def field_slip_includes
     [{ occurrence: [:primary_observation,
                     { observations: [:location, :name, :namings,
-                                     :rss_log, :user] }] },
+                                     :rss_log, :thumb_image, :user] }] },
      :project, :user]
   end
 end

--- a/app/controllers/field_slips_controller/index.rb
+++ b/app/controllers/field_slips_controller/index.rb
@@ -46,16 +46,12 @@ module FieldSlipsController::Index
     [query, {}]
   end
 
+  # `show_index_of_objects` consumes `:include` as an array of
+  # association names (with nested hashes for deeper associations).
+  # Pull it from `FieldSlip.index_includes_tree` so the same shape
+  # used by the `index_includes` scope is the one applied here.
   def index_display_opts(opts, _query)
     { num_per_page: 50,
-      include: field_slip_includes }.merge(opts)
-  end
-
-  # Used on index, but could be used on show, edit? update? as well.
-  def field_slip_includes
-    [{ occurrence: [:primary_observation,
-                    { observations: [:location, :name, :namings,
-                                     :rss_log, :thumb_image, :user] }] },
-     :project, :user]
+      include: FieldSlip.index_includes_tree }.merge(opts)
   end
 end

--- a/app/controllers/field_slips_controller/show.rb
+++ b/app/controllers/field_slips_controller/show.rb
@@ -17,21 +17,10 @@ module FieldSlipsController::Show
 
   def resolve_field_slip_from_params
     if params[:id].match?(/^\d+$/)
-      @field_slip = field_slip_with_observations.find_by(id: params[:id])
+      @field_slip = FieldSlip.show_includes.find_by(id: params[:id])
     else
       handle_by_code
     end
-  end
-
-  # Eager-loads everything `FieldSlipPanel` reads — observations
-  # plus the associations `Components::MatrixBox` reaches into
-  # (`:name`, `:user`, `:thumb_image`, `:location`, `:namings`,
-  # `:rss_log`). Without this, the panel triggers an N+1.
-  def field_slip_with_observations
-    FieldSlip.includes(occurrence: {
-                         observations: [:location, :name, :namings,
-                                        :rss_log, :thumb_image, :user]
-                       })
   end
 
   # `handle_by_code` may have already redirected to an observation
@@ -52,8 +41,7 @@ module FieldSlipsController::Show
   end
 
   def handle_by_code
-    @field_slip = field_slip_with_observations.
-                  find_by(code: params[:id].upcase)
+    @field_slip = FieldSlip.show_includes.find_by(code: params[:id].upcase)
     return unless @field_slip&.observations&.any?
 
     obs = @field_slip.observation

--- a/app/controllers/field_slips_controller/show.rb
+++ b/app/controllers/field_slips_controller/show.rb
@@ -17,10 +17,21 @@ module FieldSlipsController::Show
 
   def resolve_field_slip_from_params
     if params[:id].match?(/^\d+$/)
-      set_field_slip
+      @field_slip = field_slip_with_observations.find_by(id: params[:id])
     else
       handle_by_code
     end
+  end
+
+  # Eager-loads everything `FieldSlipPanel` reads — observations
+  # plus the associations `Components::MatrixBox` reaches into
+  # (`:name`, `:user`, `:thumb_image`, `:location`, `:namings`,
+  # `:rss_log`). Without this, the panel triggers an N+1.
+  def field_slip_with_observations
+    FieldSlip.includes(occurrence: {
+                         observations: [:location, :name, :namings,
+                                        :rss_log, :thumb_image, :user]
+                       })
   end
 
   # `handle_by_code` may have already redirected to an observation
@@ -41,7 +52,8 @@ module FieldSlipsController::Show
   end
 
   def handle_by_code
-    @field_slip = FieldSlip.find_by(code: params[:id].upcase)
+    @field_slip = field_slip_with_observations.
+                  find_by(code: params[:id].upcase)
     return unless @field_slip&.observations&.any?
 
     obs = @field_slip.observation

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -183,10 +183,10 @@ class HerbariumRecordsController < ApplicationController
                         )
   end
 
+  # Reuses `Observation.matrix_box_includes` so the obs subtree
+  # matches every other MatrixBox-rendering controller.
   def herbarium_record_includes
-    [:user,
-     { observations: [:external_source, :user,
-                      observation_matrix_box_image_includes] }]
+    [:user, { observations: Observation.matrix_box_includes }]
   end
 
   def default_herbarium_record

--- a/app/controllers/names/versions_controller.rb
+++ b/app/controllers/names/versions_controller.rb
@@ -29,10 +29,11 @@ module Names
 
     # Looks up the user the version's classification was inherited
     # from, if any — keeps the look-up out of
-    # `Views::Controllers::Names::Versions::Show`.
+    # `Views::Controllers::Names::Versions::Show`. `find_by(version:)`
+    # hits the `(name_id, version)` index instead of loading every
+    # version into memory like `.find { ... }` would.
     def inherited_classification_user
-      version = params[:version].to_i
-      row = @versions.find { |v| v.version == version }
+      row = @versions.find_by(version: params[:version].to_i)
       data = row && @name.classification_at_version(row)
       return unless data && data[:source] == :inherited
 

--- a/app/controllers/names/versions_controller.rb
+++ b/app/controllers/names/versions_controller.rb
@@ -22,8 +22,22 @@ module Names
 
       render(Views::Controllers::Names::Versions::Show.new(
                name: @name, user: @user, versions: @versions,
-               version: params[:version].to_i
+               version: params[:version].to_i,
+               inherited_classification_user: inherited_classification_user
              ))
+    end
+
+    # Looks up the user the version's classification was inherited
+    # from, if any — keeps the look-up out of
+    # `Views::Controllers::Names::Versions::Show`.
+    def inherited_classification_user
+      version = params[:version].to_i
+      row = @versions.find { |v| v.version == version }
+      data = row && @name.classification_at_version(row)
+      return unless data && data[:source] == :inherited
+
+      user_id = data.dig(:inherited_from, :user_id)
+      user_id && User.find_by(id: user_id)
     end
 
     def show_includes

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -186,8 +186,12 @@ class NamesController < ApplicationController
 
     init_projects_ivar
     init_related_query_ivars
-    @has_name_tracker = NameTracker.where(name_id: @name.id,
-                                          user_id: @user&.id).exists?
+    @has_name_tracker = if @user
+                          NameTracker.where(name_id: @name.id,
+                                            user_id: @user.id).exists?
+                        else
+                          false
+                        end
 
     render(Views::Controllers::Names::Show.new(
              name: @name, user: @user,

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -186,6 +186,8 @@ class NamesController < ApplicationController
 
     init_projects_ivar
     init_related_query_ivars
+    @has_name_tracker = NameTracker.where(name_id: @name.id,
+                                          user_id: @user&.id).exists?
 
     render(Views::Controllers::Names::Show.new(
              name: @name, user: @user,
@@ -193,6 +195,7 @@ class NamesController < ApplicationController
              description: @name.description,
              comments: @comments, obss: @obss,
              has_subtaxa: @has_subtaxa,
+             has_name_tracker: @has_name_tracker,
              subtaxa_query: @subtaxa_query,
              children_query: @children_query,
              first_child: @first_child,

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -93,13 +93,14 @@ module Observations
         include: observation_identify_index_includes }.merge(opts)
     end
 
+    # `matrix_box_includes` + identify-specific preloads: name
+    # synonyms (for name comparison), per-user observation_views,
+    # and `naming.name` (the identify queue's naming column).
+    # `:name`, `:namings`, and `:projects` from the shared tree
+    # are merged by Rails' includes hash-merge.
     def observation_identify_index_includes
-      [observation_matrix_box_image_includes,
-       :external_source, :location, { occurrence: :observations },
-       :observation_views,
-       { name: :synonym },
-       { namings: [:name, :votes] },
-       :rss_log, :user]
+      Observation.matrix_box_includes +
+        [:observation_views, { name: :synonym }, { namings: :name }]
     end
   end
 end

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -238,14 +238,11 @@ class ObservationsController
       opts
     end
 
-    # An { images: } hash is necessary if we're adding the index carousels.
-    # :projects required by Bullet because it's needed to compute
-    # `can_edit?` for an image.
+    # Reuses `Observation.matrix_box_includes` — the canonical tree
+    # shared by every matrix-box render (field_slips show/index,
+    # collection_numbers show).
     def observation_index_includes
-      [observation_matrix_box_image_includes,
-       :external_source, :location, :name,
-       { namings: :votes },
-       { occurrence: :observations }, :projects, :rss_log, :user]
+      Observation.matrix_box_includes
     end
   end
 end

--- a/app/controllers/projects/aliases_controller.rb
+++ b/app/controllers/projects/aliases_controller.rb
@@ -13,7 +13,8 @@ module Projects
 
     def index
       @project = Project.find(params[:project_id])
-      @project_aliases = ProjectAlias.where(project: @project).order(name: :asc)
+      @project_aliases = ProjectAlias.includes(:target).
+                         where(project: @project).order(name: :asc)
       respond_to do |format|
         format.html do
           render(Views::Controllers::Projects::Aliases::Index.new(
@@ -137,7 +138,7 @@ module Projects
     # `projects/aliases/_target_update.erb` partial. Emits four
     # turbo_stream actions.
     def render_project_alias_target_change(project)
-      project_aliases = project.aliases.order(name: :asc)
+      project_aliases = project.aliases.includes(:target).order(name: :asc)
       render(turbo_stream: [
                replace_target_alias_widget,
                replace_aliases_table(project_aliases),

--- a/app/controllers/projects/field_slips_controller.rb
+++ b/app/controllers/projects/field_slips_controller.rb
@@ -12,9 +12,11 @@ module Projects
       return unless find_project!
 
       @field_slip_max = field_slip_max
+      @trackers = @project.trackers.order(id: :desc).to_a
       render(Views::Controllers::Projects::FieldSlips::New.new(
                project: @project, user: @user,
-               field_slip_max: @field_slip_max
+               field_slip_max: @field_slip_max,
+               trackers: @trackers
              ), layout: true)
     end
 

--- a/app/controllers/projects/updates_controller.rb
+++ b/app/controllers/projects/updates_controller.rb
@@ -93,12 +93,7 @@ module Projects
       scope.
         offset(pagination.from).
         limit(pagination.num_per_page).
-        includes(
-          observation_matrix_box_image_includes,
-          :external_source, :location, :name, :rss_log, :user,
-          { namings: :votes },
-          { occurrence: :observations }, :projects
-        )
+        includes(Observation.matrix_box_includes)
     end
 
     def require_admin

--- a/app/controllers/projects/violations_controller.rb
+++ b/app/controllers/projects/violations_controller.rb
@@ -48,16 +48,27 @@ module Projects
       obs = Observation.safe_find(params[:obs_id])
       return head(:not_found) unless project && obs && project.is_admin?(@user)
 
+      existing_locations = lookup_existing_target_suffixes(obs)
       respond_to do |format|
         format.turbo_stream do
           render(
             Views::Controllers::Projects::Violations::TargetLocationModal.new(
-              project: project, obs: obs, user: @user
+              project: project, obs: obs, user: @user,
+              existing_locations: existing_locations
             ),
             layout: false
           )
         end
       end
+    end
+
+    # Pre-loads `name => Location` for every suffix of `obs.where`
+    # that has a corresponding Location row. `TargetLocationForm`
+    # would otherwise run this query itself when rendering.
+    def lookup_existing_target_suffixes(obs)
+      suffixes = Views::Controllers::Projects::Violations::
+                 TargetLocationForm.suffixes_for(obs)
+      Location.where(name: suffixes).index_by(&:name)
     end
 
     def controller_model_name

--- a/app/controllers/projects/violations_controller.rb
+++ b/app/controllers/projects/violations_controller.rb
@@ -62,15 +62,6 @@ module Projects
       end
     end
 
-    # Pre-loads `name => Location` for every suffix of `obs.where`
-    # that has a corresponding Location row. `TargetLocationForm`
-    # would otherwise run this query itself when rendering.
-    def lookup_existing_target_suffixes(obs)
-      suffixes = Views::Controllers::Projects::Violations::
-                 TargetLocationForm.suffixes_for(obs)
-      Location.where(name: suffixes).index_by(&:name)
-    end
-
     def controller_model_name
       "Project"
     end
@@ -85,6 +76,15 @@ module Projects
     end
 
     private
+
+    # Pre-loads `name => Location` for every suffix of `obs.where`
+    # that has a corresponding Location row. `TargetLocationForm`
+    # would otherwise run this query itself when rendering.
+    def lookup_existing_target_suffixes(obs)
+      suffixes = Views::Controllers::Projects::Violations::
+                 TargetLocationForm.suffixes_for(obs)
+      Location.where(name: suffixes).index_by(&:name)
+    end
 
     # Eager-loaded variant of `find_or_goto_index` for the index
     # action, which renders the full violations list. `find_by`

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -152,10 +152,7 @@ class RssLogsController < ApplicationController
       glossary_term: :user,
       location: :user,
       name: :user,
-      observation: [
-        :external_source, :location, :name, :user,
-        observation_matrix_box_image_includes
-      ],
+      observation: Observation.matrix_box_includes,
       project: [:location, :user],
       species_list: [:location, :user]
     }

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -180,8 +180,7 @@ class SequencesController < ApplicationController
   end
 
   def sequence_includes
-    [{ observation: [:external_source,
-                     observation_matrix_box_image_includes] }]
+    [{ observation: Observation.matrix_box_includes }]
   end
 
   def figure_out_where_to_go_back_to

--- a/app/controllers/visual_groups_controller.rb
+++ b/app/controllers/visual_groups_controller.rb
@@ -6,8 +6,10 @@ class VisualGroupsController < ApplicationController
   # GET /visual_groups or /visual_groups.json
   def index
     @visual_model = VisualModel.find(params[:visual_model_id])
+    @visual_groups = @visual_model.visual_groups.order(:name).to_a
     render(Views::Controllers::VisualGroups::Index.new(
-             visual_model: @visual_model
+             visual_model: @visual_model,
+             visual_groups: @visual_groups
            ))
   end
 

--- a/app/controllers/visual_models_controller.rb
+++ b/app/controllers/visual_models_controller.rb
@@ -14,10 +14,12 @@ class VisualModelsController < ApplicationController
   # GET /visual_models/1
   def show
     @visual_model = VisualModel.find(params[:id])
+    @visual_groups = @visual_model.visual_groups.order(:name).to_a
     respond_to do |format|
       format.html do
         render(Views::Controllers::VisualModels::Show.new(
-                 visual_model: @visual_model
+                 visual_model: @visual_model,
+                 visual_groups: @visual_groups
                ))
       end
       format.json { render(json: @visual_model) }

--- a/app/controllers/visual_models_controller.rb
+++ b/app/controllers/visual_models_controller.rb
@@ -14,9 +14,9 @@ class VisualModelsController < ApplicationController
   # GET /visual_models/1
   def show
     @visual_model = VisualModel.find(params[:id])
-    @visual_groups = @visual_model.visual_groups.order(:name).to_a
     respond_to do |format|
       format.html do
+        @visual_groups = @visual_model.visual_groups.order(:name).to_a
         render(Views::Controllers::VisualModels::Show.new(
                  visual_model: @visual_model,
                  visual_groups: @visual_groups

--- a/app/models/collection_number.rb
+++ b/app/models/collection_number.rb
@@ -82,11 +82,10 @@ class CollectionNumber < AbstractModel
   }
 
   # Eager-loads the observations + everything `Components::MatrixBox`
-  # reaches into while rendering them (`Observation::NamingConsensus`
-  # walks `namings.flat_map(&:votes)` and `naming.name`).
+  # reaches into. Reuses `Observation.matrix_box_includes` so this
+  # matches observations#index / field_slips show + index.
   scope :show_includes, lambda {
-    includes(observations: [:location, :name, :rss_log, :thumb_image,
-                            :user, { namings: [:votes, :name, :user] }])
+    includes(observations: Observation.matrix_box_includes)
   }
 
   def format_name

--- a/app/models/collection_number.rb
+++ b/app/models/collection_number.rb
@@ -81,6 +81,14 @@ class CollectionNumber < AbstractModel
     search_columns(cols, phrase)
   }
 
+  # Eager-loads the observations + everything `Components::MatrixBox`
+  # reaches into while rendering them (`Observation::NamingConsensus`
+  # walks `namings.flat_map(&:votes)` and `naming.name`).
+  scope :show_includes, lambda {
+    includes(observations: [:location, :name, :rss_log, :thumb_image,
+                            :user, { namings: [:votes, :name, :user] }])
+  }
+
   def format_name
     "#{name} #{number}"
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -104,6 +104,10 @@
 class Comment < AbstractModel
   include Callbacks
 
+  # Surface N+1 queries on `comment.user` / `comment.target` from
+  # view loops — every caller must eager-load these associations.
+  self.strict_loading_by_default = true
+
   belongs_to :user
   belongs_to :target, polymorphic: true
 

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -83,13 +83,11 @@ class FieldSlip < AbstractModel
       where("code LIKE ?", "#{sanitize_sql_like(prefix.to_s.upcase)}%")
   }
 
-  # Eager-load trees for `FieldSlipPanel` / `Components::MatrixBox`
-  # (`Observation::NamingConsensus` walks `namings.flat_map(&:votes)`
-  # and `naming.name`). Exposed as class methods so the index path —
-  # which feeds the array directly into `show_index_of_objects` via
-  # `:include` — can reuse the same shape the show scope applies.
+  # Eager-load trees for `FieldSlipPanel` / `Components::MatrixBox`.
+  # Reuses `Observation.matrix_box_includes` so the obs subtree
+  # matches observations#index and collection_numbers#show.
   def self.show_includes_tree
-    [{ occurrence: { observations: observation_show_associations } }]
+    [{ occurrence: { observations: Observation.matrix_box_includes } }]
   end
 
   # Index variant: the page renders one panel per slip and also
@@ -97,13 +95,8 @@ class FieldSlip < AbstractModel
   # and `:user` lines need those preloaded too.
   def self.index_includes_tree
     [{ occurrence: [:primary_observation,
-                    { observations: observation_show_associations }] },
+                    { observations: Observation.matrix_box_includes }] },
      :project, :user]
-  end
-
-  def self.observation_show_associations
-    [:location, :name, :rss_log, :thumb_image, :user,
-     { namings: [:votes, :name, :user] }]
   end
 
   scope :show_includes, -> { includes(show_includes_tree) }

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -83,6 +83,32 @@ class FieldSlip < AbstractModel
       where("code LIKE ?", "#{sanitize_sql_like(prefix.to_s.upcase)}%")
   }
 
+  # Eager-load trees for `FieldSlipPanel` / `Components::MatrixBox`
+  # (`Observation::NamingConsensus` walks `namings.flat_map(&:votes)`
+  # and `naming.name`). Exposed as class methods so the index path —
+  # which feeds the array directly into `show_index_of_objects` via
+  # `:include` — can reuse the same shape the show scope applies.
+  def self.show_includes_tree
+    [{ occurrence: { observations: observation_show_associations } }]
+  end
+
+  # Index variant: the page renders one panel per slip and also
+  # walks `occurrence.primary_observation`; the panel's `:project`
+  # and `:user` lines need those preloaded too.
+  def self.index_includes_tree
+    [{ occurrence: [:primary_observation,
+                    { observations: observation_show_associations }] },
+     :project, :user]
+  end
+
+  def self.observation_show_associations
+    [:location, :name, :rss_log, :thumb_image, :user,
+     { namings: [:votes, :name, :user] }]
+  end
+
+  scope :show_includes, -> { includes(show_includes_tree) }
+  scope :index_includes, -> { includes(index_includes_tree) }
+
   def current_user=(a_user)
     @current_user = a_user
     return if user

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -38,10 +38,14 @@ class GlossaryTerm < AbstractModel
   # doesn't wire its `belongs_to :user` — the table has `user_id`
   # but the gem only adds the reverse `belongs_to :glossary_term`.
   # Add it here so `show_includes` can eager-load `{ versions: :user }`
-  # and views can read `version.user` without an N+1. Remove once
-  # the gem fork (mo_acts_as_versioned) handles this automatically.
-  const_get(:Version).belongs_to(:user, class_name: "::User",
-                                        optional: true)
+  # and views can read `version.user` without an N+1. Guarded by
+  # `reflect_on_association` so a future gem fix (or another
+  # initializer that defines it) is a safe no-op. Remove once the
+  # gem fork (mo_acts_as_versioned) handles this automatically.
+  unless const_get(:Version).reflect_on_association(:user)
+    const_get(:Version).belongs_to(:user, class_name: "::User",
+                                          optional: true)
+  end
   non_versioned_columns.push(
     "thumb_image_id",
     "created_at",

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -30,21 +30,18 @@ class GlossaryTerm < AbstractModel
   validate :must_have_description_or_image
 
   ALL_TERM_FIELDS = [:name, :description].freeze
+  # See `Name` for the rationale behind the `:extend` block — same
+  # pattern wires `belongs_to :user` onto `GlossaryTerm::Version`
+  # so `show_includes` can carry `{ versions: :user }`.
   acts_as_versioned(
     if_changed: ALL_TERM_FIELDS,
     association_options: { dependent: :nullify }
-  )
-  # The `acts_as_versioned` gem builds `GlossaryTerm::Version` but
-  # doesn't wire its `belongs_to :user` — the table has `user_id`
-  # but the gem only adds the reverse `belongs_to :glossary_term`.
-  # Add it here so `show_includes` can eager-load `{ versions: :user }`
-  # and views can read `version.user` without an N+1. Guarded by
-  # `reflect_on_association` so a future gem fix (or another
-  # initializer that defines it) is a safe no-op. Remove once the
-  # gem fork (mo_acts_as_versioned) handles this automatically.
-  unless const_get(:Version).reflect_on_association(:user)
-    const_get(:Version).belongs_to(:user, class_name: "::User",
-                                          optional: true)
+  ) do
+    def self.included(base)
+      return if base.reflect_on_association(:user)
+
+      base.belongs_to(:user, class_name: "::User", optional: true)
+    end
   end
   non_versioned_columns.push(
     "thumb_image_id",

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -34,6 +34,14 @@ class GlossaryTerm < AbstractModel
     if_changed: ALL_TERM_FIELDS,
     association_options: { dependent: :nullify }
   )
+  # The `acts_as_versioned` gem builds `GlossaryTerm::Version` but
+  # doesn't wire its `belongs_to :user` — the table has `user_id`
+  # but the gem only adds the reverse `belongs_to :glossary_term`.
+  # Add it here so `show_includes` can eager-load `{ versions: :user }`
+  # and views can read `version.user` without an N+1. Remove once
+  # the gem fork (mo_acts_as_versioned) handles this automatically.
+  const_get(:Version).belongs_to(:user, class_name: "::User",
+                                        optional: true)
   non_versioned_columns.push(
     "thumb_image_id",
     "created_at",
@@ -71,7 +79,7 @@ class GlossaryTerm < AbstractModel
       { thumb_image: :image_votes },
       :rss_log,
       :user,
-      :versions
+      { versions: :user }
     )
   }
 

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -48,6 +48,15 @@ class Language < AbstractModel
     where(official: false)
   end
 
+  # Lookup a Language record by its locale string, memoized per
+  # process. Languages don't change at runtime, so callers (e.g.
+  # `Components::TranslatorsCredit` on every page render) avoid a
+  # per-request `find_by(locale: …)` query.
+  def self.for_locale(locale)
+    @for_locale_cache ||= {}
+    @for_locale_cache[locale.to_s] ||= find_by(locale: locale)
+  end
+
   # Returns an Array of pairs containing language name and locale.
   # Useful for building pulldown menus using <tt>select_tag</tt> helper.
   def self.menu_options

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -51,10 +51,15 @@ class Language < AbstractModel
   # Lookup a Language record by its locale string, memoized per
   # process. Languages don't change at runtime, so callers (e.g.
   # `Components::TranslatorsCredit` on every page render) avoid a
-  # per-request `find_by(locale: …)` query.
+  # per-request `find_by(locale: …)` query. Uses `Hash#fetch` so a
+  # nil result (unknown locale) is cached too, instead of re-querying
+  # every call.
   def self.for_locale(locale)
     @for_locale_cache ||= {}
-    @for_locale_cache[locale.to_s] ||= find_by(locale: locale)
+    key = locale.to_s
+    @for_locale_cache.fetch(key) do
+      @for_locale_cache[key] = find_by(locale: locale)
+    end
   end
 
   # Returns an Array of pairs containing language name and locale.

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -121,6 +121,14 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
       center_lng
     ]
   )
+  # The `acts_as_versioned` gem builds `Location::Version` but
+  # doesn't wire its `belongs_to :user` — the table has `user_id`
+  # but the gem only adds the reverse `belongs_to :location`. Add
+  # it here so `show_includes` can eager-load `{ versions: :user }`
+  # and views can read `version.user` without an N+1. Remove once
+  # the gem fork (mo_acts_as_versioned) handles this automatically.
+  const_get(:Version).belongs_to(:user, class_name: "::User",
+                                        optional: true)
   non_versioned_columns.push(
     "created_at",
     "updated_at",

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -125,10 +125,14 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   # doesn't wire its `belongs_to :user` — the table has `user_id`
   # but the gem only adds the reverse `belongs_to :location`. Add
   # it here so `show_includes` can eager-load `{ versions: :user }`
-  # and views can read `version.user` without an N+1. Remove once
-  # the gem fork (mo_acts_as_versioned) handles this automatically.
-  const_get(:Version).belongs_to(:user, class_name: "::User",
-                                        optional: true)
+  # and views can read `version.user` without an N+1. Guarded by
+  # `reflect_on_association` so a future gem fix (or another
+  # initializer that defines it) is a safe no-op. Remove once the
+  # gem fork (mo_acts_as_versioned) handles this automatically.
+  unless const_get(:Version).reflect_on_association(:user)
+    const_get(:Version).belongs_to(:user, class_name: "::User",
+                                          optional: true)
+  end
   non_versioned_columns.push(
     "created_at",
     "updated_at",

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -106,32 +106,31 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   has_many :herbaria     # should be at most one, but nothing preventing more
   has_many :users        # via profile location
 
-  acts_as_versioned(
-    if_changed: %w[
-      name
-      north
-      south
-      west
-      east
-      high
-      low
-      notes
-      box_area
-      center_lat
-      center_lng
-    ]
-  )
-  # The `acts_as_versioned` gem builds `Location::Version` but
-  # doesn't wire its `belongs_to :user` — the table has `user_id`
-  # but the gem only adds the reverse `belongs_to :location`. Add
-  # it here so `show_includes` can eager-load `{ versions: :user }`
-  # and views can read `version.user` without an N+1. Guarded by
-  # `reflect_on_association` so a future gem fix (or another
-  # initializer that defines it) is a safe no-op. Remove once the
-  # gem fork (mo_acts_as_versioned) handles this automatically.
-  unless const_get(:Version).reflect_on_association(:user)
-    const_get(:Version).belongs_to(:user, class_name: "::User",
-                                          optional: true)
+  # Columns whose change creates a new `Location::Version` row.
+  # Companion to the gem's `non_versioned_columns` setting below.
+  VERSIONED_COLUMNS = %w[
+    name
+    north
+    south
+    west
+    east
+    high
+    low
+    notes
+    box_area
+    center_lat
+    center_lng
+  ].freeze
+
+  # See `Name` for the rationale behind the `:extend` block — same
+  # pattern wires `belongs_to :user` onto `Location::Version` so
+  # `show_includes` can carry `{ versions: :user }`.
+  acts_as_versioned(if_changed: VERSIONED_COLUMNS) do
+    def self.included(base)
+      return if base.reflect_on_association(:user)
+
+      base.belongs_to(:user, class_name: "::User", optional: true)
+    end
   end
   non_versioned_columns.push(
     "created_at",

--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -201,11 +201,11 @@ module Location::Scopes
       strict_loading.includes(
         { comments: :user },
         { description: { comments: :user } },
-        { descriptions: [:authors, :editors] },
+        { descriptions: [:authors, :editors, :user] },
         :interests,
         :observations,
         :rss_log,
-        :versions
+        { versions: :user }
       )
     }
   end

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -355,6 +355,14 @@ class Name < AbstractModel
       icn_id
     ]
   )
+  # The `acts_as_versioned` gem builds `Name::Version` but doesn't
+  # wire its `belongs_to :user` — the table has `user_id` but the
+  # gem only adds the reverse `belongs_to :name`. Add it here so
+  # `show_includes` can eager-load `{ versions: :user }` and views
+  # can read `version.user` without an N+1. Remove once the gem
+  # fork (mo_acts_as_versioned) handles this automatically.
+  const_get(:Version).belongs_to(:user, class_name: "::User",
+                                        optional: true)
   non_versioned_columns.push(
     "created_at",
     "updated_at",

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -338,34 +338,39 @@ class Name < AbstractModel
   has_many :namings
   has_many :observations
 
-  acts_as_versioned(
-    if_changed: %w[
-      rank
-      text_name
-      search_name
-      sort_name
-      display_name
-      author
-      citation
-      classification
-      deprecated
-      correct_spelling
-      notes
-      lifeform
-      icn_id
-    ]
-  )
-  # The `acts_as_versioned` gem builds `Name::Version` but doesn't
-  # wire its `belongs_to :user` — the table has `user_id` but the
-  # gem only adds the reverse `belongs_to :name`. Add it here so
+  # Columns whose change creates a new `Name::Version` row.
+  # Companion to the gem's `non_versioned_columns` setting below.
+  VERSIONED_COLUMNS = %w[
+    rank
+    text_name
+    search_name
+    sort_name
+    display_name
+    author
+    citation
+    classification
+    deprecated
+    correct_spelling
+    notes
+    lifeform
+    icn_id
+  ].freeze
+
+  # The `:extend` block (see `acts_as_versioned` docs) wires
+  # `belongs_to :user` onto `Name::Version` — the table has a
+  # `user_id` column but the gem only defines the reverse
+  # `belongs_to :name` by default. With this in place
   # `show_includes` can eager-load `{ versions: :user }` and views
-  # can read `version.user` without an N+1. Guarded by
-  # `reflect_on_association` so a future gem fix (or another
-  # initializer that defines it) is a safe no-op. Remove once the
-  # gem fork (mo_acts_as_versioned) handles this automatically.
-  unless const_get(:Version).reflect_on_association(:user)
-    const_get(:Version).belongs_to(:user, class_name: "::User",
-                                          optional: true)
+  # can read `version.user` without an N+1. The `return if
+  # reflect_on_association(:user)` guard skips `Name` itself (which
+  # already declares its own `belongs_to :user`) — the gem includes
+  # the block on both the host and the version class.
+  acts_as_versioned(if_changed: VERSIONED_COLUMNS) do
+    def self.included(base)
+      return if base.reflect_on_association(:user)
+
+      base.belongs_to(:user, class_name: "::User", optional: true)
+    end
   end
   non_versioned_columns.push(
     "created_at",

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -359,10 +359,14 @@ class Name < AbstractModel
   # wire its `belongs_to :user` — the table has `user_id` but the
   # gem only adds the reverse `belongs_to :name`. Add it here so
   # `show_includes` can eager-load `{ versions: :user }` and views
-  # can read `version.user` without an N+1. Remove once the gem
-  # fork (mo_acts_as_versioned) handles this automatically.
-  const_get(:Version).belongs_to(:user, class_name: "::User",
-                                        optional: true)
+  # can read `version.user` without an N+1. Guarded by
+  # `reflect_on_association` so a future gem fix (or another
+  # initializer that defines it) is a safe no-op. Remove once the
+  # gem fork (mo_acts_as_versioned) handles this automatically.
+  unless const_get(:Version).reflect_on_association(:user)
+    const_get(:Version).belongs_to(:user, class_name: "::User",
+                                          optional: true)
+  end
   non_versioned_columns.push(
     "created_at",
     "updated_at",

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -331,7 +331,8 @@ module Name::Scopes
         { comments: :user },
         :correct_spelling,
         { description: [:authors, :reviewer] },
-        { descriptions: [:authors, :editors, :reviewer, :writer_groups] },
+        { descriptions: [:authors, :editors, :reviewer, :user,
+                         :writer_groups] },
         { interests: :user },
         :misspellings,
         # { namings: [:user] },
@@ -339,7 +340,7 @@ module Name::Scopes
         :rss_log,
         { synonym: :names },
         :user,
-        :versions
+        { versions: :user }
       )
     }
   end

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -148,7 +148,12 @@ class NameDescription < Description
   }
 
   scope :show_includes, lambda {
-    strict_loading
+    strict_loading.includes(
+      :authors,
+      :editors,
+      :user,
+      { name: { descriptions: [:authors, :editors, :user] } }
+    )
   }
 
   EOL_NOTE_FIELDS = [

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -276,6 +276,28 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     :where, :text_name, :notes
   ].freeze
 
+  # Eager-load tree every `Components::MatrixBox` render of an
+  # observation reaches into — image with vote/license/project/user
+  # for `can_edit?`, location, name, namings (+ votes for
+  # `Observation::NamingConsensus`), occurrence (+ observations for
+  # the multi-obs occurrence link), projects, rss_log, user.
+  # Shared by observations#index, field_slips show/index,
+  # collection_numbers#show, herbarium_records#show, rss_logs#index,
+  # sequences#new/edit, projects/updates#index, and the identify
+  # queue (extends with `:observation_views`, `{ name: :synonym }`,
+  # `{ namings: :name }`).
+  #
+  # Swap the `thumb_image:` hash for the matrix_box_carousels
+  # alternative below when the carousel feature lands.
+  def self.matrix_box_includes
+    [{ thumb_image: [:image_votes, :license, :projects, :user] },
+     # for matrix_box_carousels:
+     # { images: [:image_votes, :license, :projects, :user] },
+     :external_source, :location, :name,
+     { namings: :votes },
+     { occurrence: :observations }, :projects, :rss_log, :user]
+  end
+
   # Only the field-slip flow builds observations this way, so the
   # collector default-to-creator is always skipped: a foray recorder is
   # never auto-claimed as collector. The caller assigns the resolved

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -586,6 +586,9 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       joins(:sequences).subquery(:Sequence, hash)
     }
 
+    # `Descriptions::List#visible?` reads each description's `.user`
+    # to decide visibility — without `name: { descriptions: :user }`
+    # this is N+1 per description on the show page.
     scope :show_includes, lambda {
       strict_loading.includes(
         :collection_numbers,
@@ -595,7 +598,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         { images: [:image_votes, :license, :projects, :user] },
         { interests: :user },
         :location,
-        { name: { synonym: :names } },
+        { name: [{ synonym: :names }, { descriptions: :user }] },
         { namings: [:name, :user, { votes: [:observation, :user] }] },
         { occurrence: :field_slip },
         { projects: :admin_group },
@@ -611,7 +614,7 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         { comments: :user },
         { images: [:image_votes, :license, :user] },
         :location,
-        { name: { synonym: :names } },
+        { name: [{ synonym: :names }, { descriptions: :user }] },
         { namings: [:name, :user, { votes: [:observation, :user] }] },
         :projects,
         :thumb_image,

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -57,7 +57,7 @@
 #
 #  5) Add "show log" link at bottom of model's show page:
 #
-#       <%= render(Components::ObjectFooter.new(user: @user, obj: @object)) %>
+#       <%= render(Components::VersionsFooter.new(user: @user, obj: @object)) %>
 #
 #
 #  == Usage

--- a/app/views/controllers/account/preferences/edit.rb
+++ b/app/views/controllers/account/preferences/edit.rb
@@ -8,13 +8,14 @@
 module Views::Controllers::Account::Preferences
   class Edit < Views::Base
     prop :user, _Nilable(User)
-    prop :licenses, _Array(_Tuple(String, Integer)), default: -> { [] }
+    prop :licenses, _Array(_Tuple(String, Integer))
+    prop :languages, _Array(::Language)
 
     def view_template
       add_page_title(:prefs_title.t)
       add_context_nav(Tab::Account::PreferencesEditActions.new)
 
-      render(Form.new(@user, licenses: @licenses))
+      render(Form.new(@user, licenses: @licenses, languages: @languages))
     end
   end
 end

--- a/app/views/controllers/account/preferences/form.rb
+++ b/app/views/controllers/account/preferences/form.rb
@@ -23,8 +23,9 @@ class Views::Controllers::Account::Preferences::Form <
   # `Metrics/ClassLength` limit.
   include EmailSection
 
-  def initialize(user, licenses:, **)
+  def initialize(user, licenses:, languages:, **)
     @licenses = licenses
+    @languages = languages
     super(user, id: "account_preferences_form", **)
   end
 
@@ -219,7 +220,7 @@ class Views::Controllers::Account::Preferences::Form <
   end
 
   def locale_values
-    Language.all.map do |lang|
+    @languages.map do |lang|
       name = lang.name
       name += " (beta)" if lang.beta
       [name, lang.locale]

--- a/app/views/controllers/articles/show.html.erb
+++ b/app/views/controllers/articles/show.html.erb
@@ -13,4 +13,4 @@ add_edit_icons(@article, @user)
   <%= panel.with_body { @article.body.tpl } %>
 <% end %>
 
-<%= render(Components::ObjectFooter.new(user: @user, obj: @article)) %>
+<%= render(Components::VersionsFooter.new(user: @user, obj: @article)) %>

--- a/app/views/controllers/comments/edit.rb
+++ b/app/views/controllers/comments/edit.rb
@@ -11,6 +11,9 @@ module Views::Controllers::Comments
     prop :comment, ::Comment
     prop :target, ::AbstractModel
     prop :user, _Nilable(::User), default: nil
+    # Comments on `target` pre-loaded by the controller, fed into
+    # `CommentsForObject` below.
+    prop :comments, _Array(::Comment)
 
     def view_template
       add_page_title(:comment_edit_title.t(
@@ -32,12 +35,11 @@ module Views::Controllers::Comments
     private
 
     # Mirrors `_object.html.erb`: render the comments-for-object
-    # panel for the target. `@comments` isn't set on the edit
-    # action, so fall back to a fresh fetch.
+    # panel for the target.
     def render_object_panel
       render(CommentsForObject.new(
                object: @target,
-               comments: ::Comment.where(target: @target).to_a,
+               comments: @comments,
                user: @user, editable: false, limit: 10
              ))
     end

--- a/app/views/controllers/comments/new.rb
+++ b/app/views/controllers/comments/new.rb
@@ -12,6 +12,9 @@ module Views::Controllers::Comments
     prop :comment, ::Comment
     prop :target, ::AbstractModel
     prop :user, _Nilable(::User), default: nil
+    # Comments on `target` pre-loaded by the controller, fed into
+    # `CommentsForObject` below.
+    prop :comments, _Array(::Comment)
 
     def view_template
       container_class(:full)
@@ -40,7 +43,7 @@ module Views::Controllers::Comments
     def render_object_panel
       render(CommentsForObject.new(
                object: @target,
-               comments: ::Comment.where(target: @target).to_a,
+               comments: @comments,
                user: @user, editable: false, limit: 10
              ))
     end

--- a/app/views/controllers/descriptions/list.rb
+++ b/app/views/controllers/descriptions/list.rb
@@ -34,10 +34,15 @@ module Views::Controllers::Descriptions
 
     private
 
+    # `@object.descriptions` is expected to be pre-loaded with
+    # `:user` (and friends) by the host page's `show_includes`
+    # scope. The `Name.show_includes` and `Location.show_includes`
+    # scopes carry that — new callers must keep it that way to
+    # avoid an N+1 here.
     def visible_descriptions
       @visible_descriptions ||=
         sort_descriptions(
-          @object.descriptions.includes(:user).select { |d| visible?(d) }
+          @object.descriptions.select { |d| visible?(d) }
         )
     end
 

--- a/app/views/controllers/descriptions/versions/show.rb
+++ b/app/views/controllers/descriptions/versions/show.rb
@@ -8,7 +8,7 @@
 #     suffix).
 #   - Per-type `VersionActions` context-nav.
 #   - The shared past-versions table.
-#   - The same `DetailsAndAltsPanel` and `ObjectFooter` the regular
+#   - The same `DetailsAndAltsPanel` and `VersionsFooter` the regular
 #     description show page uses.
 #
 # Subclasses provide:
@@ -40,7 +40,7 @@ module Views::Controllers::Descriptions::Versions
                description: @description, user: @user,
                versions: @versions, projects: @projects
              ))
-      render(Components::ObjectFooter.new(
+      render(Components::VersionsFooter.new(
                user: @user, obj: @description, versions: @versions
              ))
     end

--- a/app/views/controllers/field_slips/field_slip_panel.rb
+++ b/app/views/controllers/field_slips/field_slip_panel.rb
@@ -124,15 +124,9 @@ module Views::Controllers::FieldSlips
     end
 
     def render_observations_matrix(all_obs)
-      ul(class: "row list-unstyled mt-3",
-         data: { controller: "matrix-table",
-                 action: "resize@window->matrix-table#rearrange" }) do
-        all_obs.each do |obs_item|
-          render(Components::MatrixBox.new(
-                   user: current_user, object: obs_item
-                 ))
-        end
-      end
+      render(Components::MatrixTable.new(
+               objects: all_obs, user: current_user
+             ))
     end
   end
 end

--- a/app/views/controllers/field_slips/field_slip_panel.rb
+++ b/app/views/controllers/field_slips/field_slip_panel.rb
@@ -111,9 +111,12 @@ module Views::Controllers::FieldSlips
       br
     end
 
+    # Reads `@field_slip.observations` without running a query —
+    # the controller eager-loads `occurrence: { observations: [...]}`
+    # at lookup time, so this hits the cached collection. New
+    # callers of `FieldSlipPanel` must preserve that contract.
     def render_observations_section
-      all_obs = @field_slip.observations.
-                includes(:name, :user, :thumb_image).to_a
+      all_obs = @field_slip.observations.to_a
       strong { plain("#{:OBSERVATIONS.t}:") }
       if all_obs.any?
         render_observations_matrix(all_obs)
@@ -124,9 +127,15 @@ module Views::Controllers::FieldSlips
     end
 
     def render_observations_matrix(all_obs)
-      render(Components::MatrixTable.new(
-               objects: all_obs, user: current_user
-             ))
+      ul(class: "row list-unstyled mt-3",
+         data: { controller: "matrix-table",
+                 action: "resize@window->matrix-table#rearrange" }) do
+        all_obs.each do |obs_item|
+          render(Components::MatrixBox.new(
+                   user: current_user, object: obs_item
+                 ))
+        end
+      end
     end
   end
 end

--- a/app/views/controllers/field_slips/show.rb
+++ b/app/views/controllers/field_slips/show.rb
@@ -28,7 +28,7 @@ module Views::Controllers::FieldSlips
       end
 
       render(Components::VersionsFooter.new(user: current_user,
-                                          obj: @field_slip))
+                                            obj: @field_slip))
     end
   end
 end

--- a/app/views/controllers/field_slips/show.rb
+++ b/app/views/controllers/field_slips/show.rb
@@ -20,10 +20,7 @@ module Views::Controllers::FieldSlips
         render(Components::Alert.new(message: @notice, level: :success))
       end
 
-      # Match the wrapper that the ERB-era `content_padded` helper
-      # emitted (`<div class="p-3">`). Registering the helper on
-      # `Views::Base` isn't worth it for one caller in the codebase.
-      div(class: "p-3") do
+      render(Components::ContentPadded.new) do
         render(FieldSlipPanel.new(field_slip: @field_slip))
       end
 

--- a/app/views/controllers/field_slips/show.rb
+++ b/app/views/controllers/field_slips/show.rb
@@ -3,7 +3,7 @@
 # Action template for `FieldSlipsController#show` — the single
 # field-slip page. Sets page chrome (title + edit icons), renders
 # any flash notice as an Alert, then the `FieldSlipPanel` inside the
-# padded content wrapper, then the standard `Components::ObjectFooter`.
+# padded content wrapper, then the standard `Components::VersionsFooter`.
 #
 # Replaces `app/views/controllers/field_slips/show.html.erb`.
 module Views::Controllers::FieldSlips
@@ -27,7 +27,7 @@ module Views::Controllers::FieldSlips
         render(FieldSlipPanel.new(field_slip: @field_slip))
       end
 
-      render(Components::ObjectFooter.new(user: current_user,
+      render(Components::VersionsFooter.new(user: current_user,
                                           obj: @field_slip))
     end
   end

--- a/app/views/controllers/field_slips/show.rb
+++ b/app/views/controllers/field_slips/show.rb
@@ -20,7 +20,10 @@ module Views::Controllers::FieldSlips
         render(Components::Alert.new(message: @notice, level: :success))
       end
 
-      render(Components::ContentPadded.new) do
+      # Match the wrapper that the ERB-era `content_padded` helper
+      # emitted (`<div class="p-3">`). Registering the helper on
+      # `Views::Base` isn't worth it for one caller in the codebase.
+      div(class: "p-3") do
         render(FieldSlipPanel.new(field_slip: @field_slip))
       end
 

--- a/app/views/controllers/glossary_terms/versions/show.html.erb
+++ b/app/views/controllers/glossary_terms/versions/show.html.erb
@@ -24,4 +24,4 @@ column_classes(:six)
 <% end %>
 <!--.row-->
 
-<%= render(Components::ObjectFooter.new(user: @user, obj: @glossary_term, versions: @versions)) %>
+<%= render(Components::VersionsFooter.new(user: @user, obj: @glossary_term, versions: @versions)) %>

--- a/app/views/controllers/images/show.html.erb
+++ b/app/views/controllers/images/show.html.erb
@@ -54,7 +54,7 @@ column_classes(:six)
   <% end %>
   <!--.col-->
   <%= tag.div(class: yield(:right_columns)) do %>
-    <%= render(Components::ObjectFooter.new(user: @user, obj: @image)) %>
+    <%= render(Components::VersionsFooter.new(user: @user, obj: @image)) %>
   <% end %>
   <!--.col-sm-6-->
 <% end %>

--- a/app/views/controllers/locations/descriptions/show.rb
+++ b/app/views/controllers/locations/descriptions/show.rb
@@ -26,7 +26,7 @@ module Views::Controllers::Locations::Descriptions
       render(Views::Controllers::Descriptions::AuthorsAndEditorsPanel.new(
                description: @description, user: @user, versions: @versions
              ))
-      render(Components::ObjectFooter.new(
+      render(Components::VersionsFooter.new(
                user: @user, obj: @description, versions: @versions
              ))
     end

--- a/app/views/controllers/locations/show.html.erb
+++ b/app/views/controllers/locations/show.html.erb
@@ -37,5 +37,5 @@ column_classes(:seven_five)
 <!--.row-->
 
 <%= tag.div(class: "mt-3") do %>
-  <%= render(Components::ObjectFooter.new(user: @user, obj: @location, versions: @versions)) %>
+  <%= render(Components::VersionsFooter.new(user: @user, obj: @location, versions: @versions)) %>
 <% end %>

--- a/app/views/controllers/locations/versions/show.html.erb
+++ b/app/views/controllers/locations/versions/show.html.erb
@@ -23,4 +23,4 @@ column_classes(:seven_five)
       obj: @location, versions: @versions
     )) %>
 
-<%= render(Components::ObjectFooter.new(user: @user, obj: @location, versions: @versions)) %>
+<%= render(Components::VersionsFooter.new(user: @user, obj: @location, versions: @versions)) %>

--- a/app/views/controllers/names/descriptions/show.rb
+++ b/app/views/controllers/names/descriptions/show.rb
@@ -26,7 +26,7 @@ module Views::Controllers::Names::Descriptions
       render(Views::Controllers::Descriptions::AuthorsAndEditorsPanel.new(
                description: @description, user: @user, versions: @versions
              ))
-      render(Components::ObjectFooter.new(
+      render(Components::VersionsFooter.new(
                user: @user, obj: @description, versions: @versions
              ))
     end

--- a/app/views/controllers/names/show.rb
+++ b/app/views/controllers/names/show.rb
@@ -10,7 +10,7 @@
 #            lifeform side-by-side, optional notes, alt-descriptions,
 #            optional projects, name footer (authors/editors +
 #            previous-version + export-status), and finally the
-#            ObjectFooter.
+#            VersionsFooter.
 #
 # Side-effects (page chrome) are issued from `view_template` before
 # emission: `Textile.user_register_name`, `add_show_title`,
@@ -64,7 +64,7 @@ module Views::Controllers::Names
         render_right_column
       end
 
-      render(Components::ObjectFooter.new(
+      render(Components::VersionsFooter.new(
                user: @user, obj: @name, versions: @versions
              ))
     end

--- a/app/views/controllers/names/show.rb
+++ b/app/views/controllers/names/show.rb
@@ -43,6 +43,11 @@ module Views::Controllers::Names
     # `0` as “no subtaxa” and only renders the subtaxa-observations link
     # when this value is positive.
     prop :has_subtaxa, Integer, default: 0
+    # Whether the current user already has a NameTracker on this
+    # name (the menu's "edit tracker" vs "new tracker" link picker
+    # toggles on this). Pre-computed by the controller so the view
+    # doesn't run an `exists?` query.
+    prop :has_name_tracker, _Boolean
     prop :subtaxa_query, _Nilable(::Query::Observations), default: nil
     prop :children_query, _Nilable(::Query::Names), default: nil
     prop :first_child, _Nilable(::Name), default: nil
@@ -114,7 +119,8 @@ module Views::Controllers::Names
       render(Show::ObservationsMenu.new(
                name: @name, obss: @obss,
                subtaxa_query: @subtaxa_query,
-               has_subtaxa: @has_subtaxa, user: @user
+               has_subtaxa: @has_subtaxa,
+               has_name_tracker: @has_name_tracker, user: @user
              ))
       render(Show::Nomenclature.new(name: @name, user: @user))
       render_classification_and_lifeform_row

--- a/app/views/controllers/names/show/observations_menu.rb
+++ b/app/views/controllers/names/show/observations_menu.rb
@@ -17,6 +17,10 @@ class Views::Controllers::Names::Show::ObservationsMenu < Views::Base
   prop :obss, _Interface(:of_taxon_this_name)
   prop :subtaxa_query, _Nilable(::Query::Observations), default: nil
   prop :has_subtaxa, Integer, default: 0
+  # Whether the current user has a NameTracker on this name. The
+  # controller pre-computes this so `tracker_tab` doesn't fire an
+  # `exists?` query.
+  prop :has_name_tracker, _Boolean
   prop :user, _Nilable(::User), default: nil
 
   def view_template
@@ -36,7 +40,7 @@ class Views::Controllers::Names::Show::ObservationsMenu < Views::Base
   end
 
   def tracker_tab
-    if NameTracker.find_by(name_id: @name.id, user_id: @user&.id)
+    if @has_name_tracker
       Tab::Name::EditTracker.new(name: @name)
     else
       Tab::Name::NewTracker.new(name: @name)

--- a/app/views/controllers/names/versions/show.rb
+++ b/app/views/controllers/names/versions/show.rb
@@ -8,7 +8,7 @@
 # (as captured at this version; if `cls[:source] == :inherited`,
 # annotates with the source-Name / date / editor). Right column:
 # the versions table. Notes panel appears when the historic name
-# has notes; ObjectFooter at the bottom.
+# has notes; VersionsFooter at the bottom.
 module Views::Controllers::Names::Versions
   class Show < Views::Base
     prop :name, ::Name
@@ -29,7 +29,7 @@ module Views::Controllers::Names::Versions
         render_right_column
       end
 
-      render(Components::ObjectFooter.new(
+      render(Components::VersionsFooter.new(
                user: @user, obj: @name, versions: @versions
              ))
     end

--- a/app/views/controllers/names/versions/show.rb
+++ b/app/views/controllers/names/versions/show.rb
@@ -16,6 +16,10 @@ module Views::Controllers::Names::Versions
     prop :versions, _Union(Array, ::ActiveRecord::Associations::CollectionProxy)
     # `version` is the requested historic version number.
     prop :version, Integer
+    # User the version's classification was inherited from, if any.
+    # The controller pre-computes it so this view doesn't do a
+    # per-render `User.find_by(...)`.
+    prop :inherited_classification_user, _Nilable(::User)
 
     def view_template
       page_chrome_side_effects
@@ -101,11 +105,10 @@ module Views::Controllers::Names::Versions
 
     def inherited_classification_text
       src = classification_data[:inherited_from]
-      editor = src[:user_id] && ::User.find_by(id: src[:user_id])
       :show_past_name_classification_inherited.t(
         name: name_link_for_source(src),
         date: src[:edited_at].to_date.to_s,
-        user: editor ? editor.unique_text_name : "—"
+        user: @inherited_classification_user&.unique_text_name || "—"
       )
     end
 

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -4,7 +4,7 @@
 # obs-show sub-panel (`Components::Carousel`,
 # `ObservationDetailsPanel`, `NameInfoPanel`, `SpeciesListsPanel`,
 # `AssociatedObservationsPanel`, `ThumbnailMapPanel`, namings
-# partial, comments partial, `Components::ObjectFooter`) into a
+# partial, comments partial, `Components::VersionsFooter`) into a
 # two-column layout. Replaces `observations/show.html.erb`.
 #
 # Renders `add_show_title` + owner-naming line + pager / interest /
@@ -151,7 +151,7 @@ module Views::Controllers::Observations
     end
 
     def render_footer
-      render(Components::ObjectFooter.new(user: @user, obj: @observation))
+      render(Components::VersionsFooter.new(user: @user, obj: @observation))
     end
   end
 end

--- a/app/views/controllers/observations/species_lists/edit.rb
+++ b/app/views/controllers/observations/species_lists/edit.rb
@@ -34,10 +34,7 @@ module Views::Controllers::Observations::SpeciesLists
 
       div(class: "navbar-flex mb-2") { content_for(:sorter) }
 
-      # Inline `<div class="p-3">` instead of calling the
-      # `content_padded` helper — only used here, so the helper
-      # registration isn't worth carrying on `Views::Base`.
-      div(class: "p-3") { render_sections }
+      render(Components::ContentPadded.new) { render_sections }
     end
 
     private

--- a/app/views/controllers/observations/species_lists/edit.rb
+++ b/app/views/controllers/observations/species_lists/edit.rb
@@ -34,7 +34,10 @@ module Views::Controllers::Observations::SpeciesLists
 
       div(class: "navbar-flex mb-2") { content_for(:sorter) }
 
-      render(Components::ContentPadded.new) { render_sections }
+      # Inline `<div class="p-3">` instead of calling the
+      # `content_padded` helper — only used here, so the helper
+      # registration isn't worth carrying on `Views::Base`.
+      div(class: "p-3") { render_sections }
     end
 
     private

--- a/app/views/controllers/occurrences/show.rb
+++ b/app/views/controllers/occurrences/show.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Occurrences
       add_edit_icons(@occurrence, @user)
       render_location_warning
       render_observation_grid
-      render(Components::ObjectFooter.new(user: @user, obj: @occurrence))
+      render(Components::VersionsFooter.new(user: @user, obj: @occurrence))
     end
 
     private

--- a/app/views/controllers/projects/aliases/table.rb
+++ b/app/views/controllers/projects/aliases/table.rb
@@ -11,9 +11,13 @@ module Views::Controllers::Projects::Aliases
   class Table < Views::Base
     TABLE_ID = "index_project_alias_table"
 
+    # Callers must eager-load `:target` so the per-row
+    # `link_to(alias_.target.try(:format_name), alias_.target)` cell
+    # doesn't trigger N+1 queries. The `Projects::AliasesController`
+    # paths supply that.
     def initialize(project_aliases:)
       super()
-      @project_aliases = project_aliases.includes(:target)
+      @project_aliases = project_aliases
     end
 
     def view_template

--- a/app/views/controllers/projects/field_slips/new.rb
+++ b/app/views/controllers/projects/field_slips/new.rb
@@ -4,11 +4,12 @@ module Views::Controllers::Projects::FieldSlips
   # Phlex view for the field slips form page.
   # Replaces field_slips/new.html.erb.
   class New < Views::Base
-    def initialize(project:, user:, field_slip_max:)
+    def initialize(project:, user:, field_slip_max:, trackers:)
       super()
       @project = project
       @user = user
       @field_slip_max = field_slip_max
+      @trackers = trackers
     end
 
     def view_template
@@ -72,7 +73,7 @@ module Views::Controllers::Projects::FieldSlips
     # the entire `<tr>` per tracker via `TrackerRow`.
     def render_tracker_table
       render(Components::Table.new(
-               @project.trackers.order(id: :desc),
+               @trackers,
                class: "mt-3", tbody_id: "field_slip_job_trackers"
              )) do |table|
         define_tracker_columns(table)

--- a/app/views/controllers/projects/show.rb
+++ b/app/views/controllers/projects/show.rb
@@ -22,7 +22,7 @@ module Views::Controllers::Projects
       render_summary_panel
       render_actions
       render_comments
-      render(Components::ObjectFooter.new(
+      render(Components::VersionsFooter.new(
                user: @user, obj: @project
              ))
     end

--- a/app/views/controllers/projects/violations/target_location_form.rb
+++ b/app/views/controllers/projects/violations/target_location_form.rb
@@ -83,9 +83,12 @@ module Views::Controllers::Projects::Violations
       (0..(parts.length - 1)).map { |i| parts[i..].join(", ") }
     end
 
-    def initialize(obs:, project:, **)
+    def initialize(obs:, project:, existing_locations:, **)
       @obs = obs
       @project = project
+      # `name => Location` for every suffix that already has a row;
+      # pre-loaded by `Projects::ViolationsController#target_location_modal`.
+      @existing_locations = existing_locations
       # The project is the thing being mutated (a target_location
       # entry is added to its target_locations list), so it's the
       # natural Superform "model" for dom.id. No fields bind to it —
@@ -197,10 +200,11 @@ module Views::Controllers::Projects::Violations
     end
 
     # Existing Locations whose name matches one of the suffixes,
-    # indexed by name. Batch-loaded in a single query (Copilot review
-    # on PR #4182).
+    # indexed by name. Pre-loaded by
+    # `Projects::ViolationsController#target_location_modal` and
+    # passed in as `existing_locations:`.
     def existing
-      @existing ||= Location.where(name: suffixes).index_by(&:name)
+      @existing_locations
     end
 
     # Pre-check the first suffix that has a Location, not the first

--- a/app/views/controllers/projects/violations/target_location_modal.rb
+++ b/app/views/controllers/projects/violations/target_location_modal.rb
@@ -18,11 +18,12 @@ module Views::Controllers::Projects::Violations
   # one-controller-action modal wrappers — it isn't reusable, it's
   # the rendering of one specific controller action.
   class TargetLocationModal < Views::Base
-    def initialize(project:, obs:, user:)
+    def initialize(project:, obs:, user:, existing_locations:)
       super()
       @project = project
       @obs = obs
       @user = user
+      @existing_locations = existing_locations
     end
 
     def view_template
@@ -34,7 +35,8 @@ module Views::Controllers::Projects::Violations
         if Views::Controllers::Projects::Violations::TargetLocationForm.applicable?(@obs)
           m.with_form_content do
             render(Views::Controllers::Projects::Violations::TargetLocationForm.new(
-                     obs: @obs, project: @project
+                     obs: @obs, project: @project,
+                     existing_locations: @existing_locations
                    ))
           end
         else

--- a/app/views/controllers/sequences/edit.html.erb
+++ b/app/views/controllers/sequences/edit.html.erb
@@ -18,7 +18,7 @@ obs = @sequence.observation
       <%= render(Components::UserLink.new(user: @sequence.user)) %>
     </div>
 
-    <%= render(Components::ObjectFooter.new(user: @user, obj: @sequence)) %>
+    <%= render(Components::VersionsFooter.new(user: @user, obj: @sequence)) %>
   </div>
 
   <div class="col-xs-12 col-sm-5">

--- a/app/views/controllers/sequences/show.html.erb
+++ b/app/views/controllers/sequences/show.html.erb
@@ -63,4 +63,4 @@ container_class(:wide)
   <%= render(Components::UserLink.new(user: @sequence.user)) %>
 </div>
 
-<%= render(Components::ObjectFooter.new(user: @user, obj: @sequence)) %>
+<%= render(Components::VersionsFooter.new(user: @user, obj: @sequence)) %>

--- a/app/views/controllers/species_lists/show.rb
+++ b/app/views/controllers/species_lists/show.rb
@@ -62,7 +62,7 @@ module Views::Controllers::SpeciesLists
       render_list_search
       paginated_results { render_observations }
       render_comments
-      render(Components::ObjectFooter.new(
+      render(Components::VersionsFooter.new(
                user: @user, obj: @species_list
              ))
     end

--- a/app/views/controllers/visual_groups/index.rb
+++ b/app/views/controllers/visual_groups/index.rb
@@ -6,10 +6,12 @@
 module Views::Controllers::VisualGroups
   class Index < Views::Base
     prop :visual_model, VisualModel
+    prop :visual_groups, _Array(VisualGroup)
 
     def view_template
       render(Views::Controllers::VisualModels::VisualGroupTable.new(
-               visual_model: @visual_model
+               visual_model: @visual_model,
+               visual_groups: @visual_groups
              ))
     end
   end

--- a/app/views/controllers/visual_models/show.rb
+++ b/app/views/controllers/visual_models/show.rb
@@ -6,9 +6,11 @@
 module Views::Controllers::VisualModels
   class Show < Views::Base
     prop :visual_model, VisualModel
+    prop :visual_groups, _Array(VisualGroup)
 
     def view_template
-      render(VisualGroupTable.new(visual_model: @visual_model))
+      render(VisualGroupTable.new(visual_model: @visual_model,
+                                  visual_groups: @visual_groups))
     end
   end
 end

--- a/app/views/controllers/visual_models/visual_group_table.rb
+++ b/app/views/controllers/visual_models/visual_group_table.rb
@@ -12,6 +12,10 @@
 module Views::Controllers::VisualModels
   class VisualGroupTable < Views::Base
     prop :visual_model, VisualModel
+    # Pre-loaded by the host controllers (`VisualGroupsController#index`
+    # / `VisualModelsController#show`); the view no longer runs the
+    # `.order(:name)` query itself.
+    prop :visual_groups, _Array(VisualGroup)
 
     def view_template
       add_show_title(@visual_model)
@@ -76,7 +80,7 @@ module Views::Controllers::VisualModels
     end
 
     def groups
-      @groups ||= @visual_model.visual_groups.order(:name)
+      @visual_groups
     end
 
     def included_counts

--- a/test/components/authors_and_editors_test.rb
+++ b/test/components/authors_and_editors_test.rb
@@ -32,12 +32,18 @@ class AuthorsAndEditorsTest < ComponentTestCase
     end
   end
 
-  # Test double for version objects
+  # Test double for version objects. Matches the
+  # `mo_acts_as_versioned`-wired `belongs_to :user` API the component
+  # now reads via `versions.map(&:user)`.
   class TestVersion
     attr_reader :user_id
 
     def initialize(user_id:)
       @user_id = user_id
+    end
+
+    def user
+      User.find_by(id: @user_id)
     end
   end
 

--- a/test/components/translators_credit_test.rb
+++ b/test/components/translators_credit_test.rb
@@ -7,10 +7,15 @@ class TranslatorsCreditTest < ComponentTestCase
   def setup
     super
     Language.ignore_usage
+    # `Language.for_locale` memoizes per-process; tests that stub it
+    # need a clean cache so the stub actually fires (and a stubbed
+    # Language doesn't leak into the next test).
+    Language.instance_variable_set(:@for_locale_cache, nil)
   end
 
   def teardown
     Language.ignore_usage
+    Language.instance_variable_set(:@for_locale_cache, nil)
     super
   end
 
@@ -86,7 +91,7 @@ class TranslatorsCreditTest < ComponentTestCase
         [users(:roy).id, users(:roy).login]
       ]
       lang.define_singleton_method(:top_contributors) { |_num| contributors }
-      Language.stub(:find_by, lang) do
+      Language.stub(:for_locale, lang) do
         html = render_component
         # Should render all 5 user links
         doc = Nokogiri::HTML(html)

--- a/test/components/versions_footer_test.rb
+++ b/test/components/versions_footer_test.rb
@@ -36,7 +36,7 @@ class ObjectFooterTest < ComponentTestCase
       updated_at: Time.zone.parse("2024-01-20 15:30:00")
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: nil,
                               obj: obj
                             ))
@@ -53,7 +53,7 @@ class ObjectFooterTest < ComponentTestCase
       user: creator
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: users(:mary),
                               obj: obj
                             ))
@@ -65,7 +65,7 @@ class ObjectFooterTest < ComponentTestCase
   def test_non_versioned_object_without_timestamps
     obj = TestObject.new(created_at: nil, updated_at: nil)
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: nil,
                               obj: obj
                             ))
@@ -89,7 +89,7 @@ class ObjectFooterTest < ComponentTestCase
     version3 = TestVersion.new(user_id: users(:katrina).id)
     versions = [version1, version2, version3]
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: user,
                               obj: obj,
                               versions: versions
@@ -116,7 +116,7 @@ class ObjectFooterTest < ComponentTestCase
     version2 = TestVersion.new(user_id: nil) # No user_id
     versions = [version1, version2]
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: user,
                               obj: obj,
                               versions: versions
@@ -146,7 +146,7 @@ class ObjectFooterTest < ComponentTestCase
     version3 = TestVersion.new(user_id: katrina.id)
     versions = [version1, version2, version3]
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: rolf,
                               obj: obj,
                               versions: versions
@@ -174,7 +174,7 @@ class ObjectFooterTest < ComponentTestCase
       TestVersion.new(user_id: users(:dick).id)
     ]
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: user,
                               obj: obj,
                               versions: versions
@@ -197,7 +197,7 @@ class ObjectFooterTest < ComponentTestCase
       num_views: 1
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: user,
                               obj: obj
                             ))
@@ -218,7 +218,7 @@ class ObjectFooterTest < ComponentTestCase
       num_views: 42
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: user,
                               obj: obj
                             ))
@@ -236,7 +236,7 @@ class ObjectFooterTest < ComponentTestCase
       last_viewed_by_time: Time.zone.parse("2024-01-18 12:00:00")
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: user,
                               obj: obj
                             ))
@@ -254,7 +254,7 @@ class ObjectFooterTest < ComponentTestCase
       last_viewed_by_time: nil
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: user,
                               obj: obj
                             ))
@@ -270,7 +270,7 @@ class ObjectFooterTest < ComponentTestCase
       rss_log_id: 123
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: nil,
                               obj: obj
                             ))
@@ -287,7 +287,7 @@ class ObjectFooterTest < ComponentTestCase
       rss_log_id: nil
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: nil,
                               obj: obj
                             ))
@@ -301,7 +301,7 @@ class ObjectFooterTest < ComponentTestCase
     name = names(:fungi)
     versions = name.versions.to_a
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: users(:rolf),
                               obj: name,
                               versions: versions
@@ -316,7 +316,7 @@ class ObjectFooterTest < ComponentTestCase
     location = locations(:albion)
     versions = location.versions.to_a
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: users(:rolf),
                               obj: location,
                               versions: versions
@@ -331,7 +331,7 @@ class ObjectFooterTest < ComponentTestCase
     # Pass the collection proxy directly, not converted to array
     versions = name.versions
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: users(:rolf),
                               obj: name,
                               versions: versions
@@ -348,7 +348,7 @@ class ObjectFooterTest < ComponentTestCase
       user: users(:rolf)
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: users(:rolf),
                               obj: obj,
                               versions: []
@@ -364,7 +364,7 @@ class ObjectFooterTest < ComponentTestCase
       created_at: Time.zone.parse("2024-01-15 10:00:00")
     )
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: nil,
                               obj: obj
                             ))
@@ -384,7 +384,7 @@ class ObjectFooterTest < ComponentTestCase
     version1 = TestVersion.new(user_id: user.id)
     versions = [version1]
 
-    html = render_component(Components::ObjectFooter.new(
+    html = render_component(Components::VersionsFooter.new(
                               user: user,
                               obj: obj,
                               versions: versions

--- a/test/style/no_queries_in_phlex_views_test.rb
+++ b/test/style/no_queries_in_phlex_views_test.rb
@@ -104,7 +104,7 @@ class NoQueriesInPhlexViewsTest < ActiveSupport::TestCase
     assert_clean("Query::Filter.all.each { |f| render(f) }")
   end
 
-  def test_scanner_flags_query_inside_comment_excluded
+  def test_scanner_ignores_queries_inside_comments
     assert_clean("# @object.descriptions.includes(:user)")
     assert_clean("    # Use Foo.where(bar: 1) instead.")
   end

--- a/test/style/no_queries_in_phlex_views_test.rb
+++ b/test/style/no_queries_in_phlex_views_test.rb
@@ -49,7 +49,10 @@ class NoQueriesInPhlexViewsTest < ActiveSupport::TestCase
     /\.distinct\b/,
     /\.order\(/,
     /\.group\(/,
-    /\.exists\?\(/
+    # `.exists?` is the no-arg form (`scope.exists?`) — match the
+    # `?` boundary, not the parenthesized form, so both shapes get
+    # flagged.
+    /\.exists\?/
   ].freeze
 
   # `Query::Filter.all` is the documented exception — it returns
@@ -75,6 +78,8 @@ class NoQueriesInPhlexViewsTest < ActiveSupport::TestCase
     assert_bad("@visual_model.visual_groups.order(:name)")
     assert_bad("Foo.find_or_create_by(slug: 'x')")
     assert_bad("Foo.preload(:bar)")
+    assert_bad("NameTracker.where(name_id: 1).exists?")
+    assert_bad("@scope.exists?(id: 1)")
   end
 
   def test_scanner_does_not_flag_bare_all

--- a/test/style/no_queries_in_phlex_views_test.rb
+++ b/test/style/no_queries_in_phlex_views_test.rb
@@ -158,7 +158,7 @@ class NoQueriesInPhlexViewsTest < ActiveSupport::TestCase
       if in_str
         in_str = nil if c == in_str
         out << c
-      elsif c == '"' || c == "'"
+      elsif ['"', "'"].include?(c)
         in_str = c
         out << c
       elsif c == "#"

--- a/test/style/no_queries_in_phlex_views_test.rb
+++ b/test/style/no_queries_in_phlex_views_test.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Guards against the "Phlex view runs a DB query" anti-pattern.
+# Scans every `app/components/**/*.rb` and `app/views/**/*.rb` file
+# for ActiveRecord query-builder calls and fails if any are found.
+# Controllers (or services they call) are expected to pre-load every
+# record / collection the views render; views should accept them as
+# props and iterate.
+#
+# What we flag: high-signal `.includes(...)`, `.where(...)`,
+# `.joins(...)`, `.find_by(...)`, `.find_or_create_by(...)`,
+# `.find_or_initialize_by(...)`, `.eager_load(...)`, `.preload(...)`,
+# `.references(...)`, `.distinct(`, `.order(`, `.group(`, and
+# `.exists?(...)` method calls.
+#
+# What we leave alone:
+#   - `.all`, `.first`, `.last`, `.count`, `.size` — these have
+#     legitimate Enumerable-on-Array variants that statically look
+#     identical to the AR call, so flagging would flood the output
+#     with false positives. The real-world cases I've seen all
+#     route through one of the blocklisted methods above before
+#     they get here.
+#   - ERB files (`*.erb`). The user explicitly excluded them — this
+#     guard is about cleanly-Phlexified views.
+#   - `Query::Filter.all` — in-memory list of static filter defs,
+#     not a DB query.
+class NoQueriesInPhlexViewsTest < ActiveSupport::TestCase
+  PHLEX_GLOBS = %w[
+    app/components/**/*.rb
+    app/views/**/*.rb
+  ].freeze
+
+  # Each pattern matches the method name with a leading `.` and an
+  # opening `(` (or word boundary, for the `.distinct` shape). The
+  # `\.` requires receiver chaining — bare `where(...)` calls in
+  # controllers / scopes wouldn't match.
+  QUERY_PATTERNS = [
+    /\.includes\(/,
+    /\.where\(/,
+    /\.joins\(/,
+    /\.find_by\(/,
+    /\.find_or_create_by\(/,
+    /\.find_or_initialize_by\(/,
+    /\.eager_load\(/,
+    /\.preload\(/,
+    /\.references\(/,
+    /\.distinct\b/,
+    /\.order\(/,
+    /\.group\(/,
+    /\.exists\?\(/
+  ].freeze
+
+  # `Query::Filter.all` is the documented exception — it returns
+  # the static array of filter definitions registered at load time
+  # via `Query::Filter::Decimal`, etc. Not a DB query.
+  ALLOWED_FRAGMENTS = [
+    "Query::Filter.all"
+  ].freeze
+
+  def test_no_queries_in_phlex_views
+    offenders = scan_for_queries
+    assert_empty(offenders, build_failure_message(offenders))
+  end
+
+  # --- Unit tests for the scanner itself ------------------------
+
+  def test_scanner_flags_bare_query_methods
+    assert_bad("@object.descriptions.includes(:user).to_a")
+    assert_bad("::Comment.where(target: @target).to_a")
+    assert_bad("NameTracker.find_by(name_id: 1, user_id: 2)")
+    assert_bad("@project.trackers.order(id: :desc)")
+    assert_bad("Location.where(name: x).index_by(&:name)")
+    assert_bad("@visual_model.visual_groups.order(:name)")
+    assert_bad("Foo.find_or_create_by(slug: 'x')")
+    assert_bad("Foo.preload(:bar)")
+  end
+
+  def test_scanner_does_not_flag_bare_all
+    # `.all` (and `.first`, `.last`) match both Enumerable and
+    # AR. We don't flag them statically — too many false positives.
+    # Real-world AR query chains tend to compose them with one of
+    # the blocklisted methods (`.where(...).all`, `.includes(...).first`),
+    # which IS caught.
+    assert_clean("Language.all.map { |l| l }")
+    assert_clean("@items.first.name")
+  end
+
+  def test_scanner_allows_in_memory_array_calls
+    assert_clean("@items.find { |i| i.id == 1 }") # Enumerable#find with block
+    assert_clean("@list.first")
+    assert_clean("@list.size")
+    assert_clean("class_names('p-3', attrs[:class])")
+    assert_clean("@values.group_by(&:kind)") # Enumerable#group_by
+  end
+
+  def test_scanner_allows_documented_exceptions
+    assert_clean("Query::Filter.all.each { |f| render(f) }")
+  end
+
+  def test_scanner_flags_query_inside_comment_excluded
+    assert_clean("# @object.descriptions.includes(:user)")
+    assert_clean("    # Use Foo.where(bar: 1) instead.")
+  end
+
+  private
+
+  def assert_bad(snippet)
+    offenders = scan_file("test.rb", [snippet])
+    assert_not_empty(offenders, "expected scanner to flag:\n#{snippet}")
+  end
+
+  def assert_clean(snippet)
+    offenders = scan_file("test.rb", [snippet])
+    assert_empty(offenders, "expected scanner to allow:\n#{snippet}")
+  end
+
+  def scan_for_queries
+    files = PHLEX_GLOBS.flat_map { |g| Rails.root.glob(g) }
+    files.flat_map do |path|
+      rel = Pathname.new(path).relative_path_from(Rails.root).to_s
+      lines = File.readlines(path)
+      scan_file(rel, lines)
+    end
+  end
+
+  def scan_file(rel, lines)
+    offenders = []
+    lines.each_with_index do |raw, idx|
+      next if comment_line?(raw)
+
+      stripped = strip_inline_comment(raw)
+      next if ALLOWED_FRAGMENTS.any? { |f| stripped.include?(f) }
+
+      QUERY_PATTERNS.each do |re|
+        next unless stripped.match?(re)
+
+        offenders << {
+          path: rel, line: idx + 1, snippet: raw.strip
+        }
+        break
+      end
+    end
+    offenders
+  end
+
+  def comment_line?(line)
+    line.lstrip.start_with?("#")
+  end
+
+  # Drop everything from the first `#` outside a string literal.
+  # Simple heuristic — good enough for source we control.
+  def strip_inline_comment(line)
+    in_str = nil
+    out = +""
+    line.each_char do |c|
+      if in_str
+        in_str = nil if c == in_str
+        out << c
+      elsif c == '"' || c == "'"
+        in_str = c
+        out << c
+      elsif c == "#"
+        break
+      else
+        out << c
+      end
+    end
+    out
+  end
+
+  def build_failure_message(offenders)
+    return "" if offenders.empty?
+
+    rendered = offenders.map do |o|
+      "  #{o[:path]}:#{o[:line]}: #{o[:snippet]}"
+    end
+    <<~MSG
+      ActiveRecord query-builder calls found in Phlex view/component
+      files. Views should not run database queries — controllers (or
+      the services they call) must pre-load every record / collection
+      the view renders and pass them in as props.
+
+      Blocklisted method patterns: #{QUERY_PATTERNS.map(&:source).join(", ")}
+
+      Documented exceptions (in-memory): #{ALLOWED_FRAGMENTS.join(", ")}
+
+      Offenders:
+      #{rendered.join("\n")}
+    MSG
+  end
+end

--- a/test/views/controllers/account/preferences/edit_test.rb
+++ b/test/views/controllers/account/preferences/edit_test.rb
@@ -17,7 +17,8 @@ module Views::Controllers::Account::Preferences
     # itself now (one per related Privacy select) — see
     # AccountPreferencesFormTest for their assertions.
     def test_renders_form
-      html = render(Edit.new(user: @user, licenses: @licenses))
+      html = render(Edit.new(user: @user, licenses: @licenses,
+                             languages: Language.all.to_a))
 
       assert_html(html, "form#account_preferences_form")
       # No legacy `button_to` PUT forms sitting after the main form.

--- a/test/views/controllers/account/preferences/form_test.rb
+++ b/test/views/controllers/account/preferences/form_test.rb
@@ -216,7 +216,7 @@ class Views::Controllers::Account::Preferences::FormTest <
     fake = Struct.new(:type, :sym).new(:not_a_real_type, :bogus)
     form = Views::Controllers::Account::Preferences::Form.new(
       @user, licenses: License.available_names_and_ids(@user&.license),
-      languages: Language.all.to_a
+             languages: Language.all.to_a
     )
     assert_raises(RuntimeError) do
       form.send(:render_filter_field, fake)

--- a/test/views/controllers/account/preferences/form_test.rb
+++ b/test/views/controllers/account/preferences/form_test.rb
@@ -215,7 +215,8 @@ class Views::Controllers::Account::Preferences::FormTest <
     # produce no field. The form raises to surface the bug instead.
     fake = Struct.new(:type, :sym).new(:not_a_real_type, :bogus)
     form = Views::Controllers::Account::Preferences::Form.new(
-      @user, licenses: License.available_names_and_ids(@user&.license)
+      @user, licenses: License.available_names_and_ids(@user&.license),
+      languages: Language.all.to_a
     )
     assert_raises(RuntimeError) do
       form.send(:render_filter_field, fake)
@@ -333,7 +334,7 @@ class Views::Controllers::Account::Preferences::FormTest <
   def render_form
     licenses = License.available_names_and_ids(@user&.license)
     render(Views::Controllers::Account::Preferences::Form.new(
-             @user, licenses: licenses
+             @user, licenses: licenses, languages: Language.all.to_a
            ))
   end
 

--- a/test/views/controllers/projects/violations/target_location_form_test.rb
+++ b/test/views/controllers/projects/violations/target_location_form_test.rb
@@ -190,7 +190,8 @@ module Views::Controllers::Projects::Violations
       )
 
       html = render(TargetLocationForm.new(
-                      obs: obs, project: @project
+                      obs: obs, project: @project,
+                      existing_locations: existing_for(obs)
                     ))
 
       assert_html(html, "input[type='radio'][disabled]")
@@ -225,7 +226,8 @@ module Views::Controllers::Projects::Violations
       )
 
       html = render(TargetLocationForm.new(
-                      obs: obs, project: @project
+                      obs: obs, project: @project,
+                      existing_locations: existing_for(obs)
                     ))
 
       encoded = "Unique+County+X42%2C+California%2C+USA"
@@ -249,7 +251,8 @@ module Views::Controllers::Projects::Violations
       $stderr = stderr_io
       begin
         render(TargetLocationForm.new(
-                 obs: obs, project: @project
+                 obs: obs, project: @project,
+                 existing_locations: existing_for(obs)
                ))
       ensure
         $stderr = original_stderr
@@ -261,8 +264,17 @@ module Views::Controllers::Projects::Violations
 
     def render_form
       render(TargetLocationForm.new(
-               obs: @obs, project: @project
+               obs: @obs, project: @project,
+               existing_locations: existing_for(@obs)
              ))
+    end
+
+    # Mirrors `Projects::ViolationsController#lookup_existing_target_suffixes` —
+    # `TargetLocationForm` requires `existing_locations:` so the form
+    # doesn't run a query in `view_template`.
+    def existing_for(obs)
+      suffixes = TargetLocationForm.suffixes_for(obs)
+      Location.where(name: suffixes).index_by(&:name)
     end
 
     # Lightweight stand-in: TargetLocationForm.suffixes_for only reads


### PR DESCRIPTION
## Summary

A general Phlex-side cleanup PR. Four threads:

1. **`Components::ContentPadded`** sweep — the new `<div class="p-3">` wrapper component (from #4507) replaces the inlined `div(class: "p-3")` markers in the two Phlex views that documented the intent in comments. `Components::MatrixTable` does the same to `field_slips/field_slip_panel.rb`'s hand-rolled obs grid.
2. **Phlex views shouldn't run queries** — moved every AR query out of `app/views/**` / `app/components/**` into the controllers (or the model class). 10 view files + 2 components touched; controllers pre-load and pass props in. New `NoQueriesInPhlexViewsTest` style guard prevents regressions.
3. **One shared MatrixBox eager-load tree** — extracted `Observation.matrix_box_includes` so every controller that renders `Components::MatrixBox` per observation pulls from the same tree (was drifting across 8 controllers). Drops the `ApplicationController#observation_matrix_box_image_includes` helper.
4. **Rename** `Components::ObjectFooter` → `Components::VersionsFooter`. Class is specifically the bottom-of-show block for versioned objects.

## Query sweep — what moved where

| File | Query was | Now |
|---|---|---|
| `field_slips/field_slip_panel.rb` | `@field_slip.observations.includes(...)` | controller eager-loads via `FieldSlip.show_includes` / `index_includes` (themselves built on `Observation.matrix_box_includes`); view reads the cached collection |
| `projects/aliases/table.rb` | `project_aliases.includes(:target)` | controller eager-loads `:target` |
| `descriptions/list.rb` | `@object.descriptions.includes(:user)` | `Name.show_includes` + `Location.show_includes` carry `descriptions: [..., :user]` |
| `comments/{new,edit}.rb` | `Comment.where(target: @target)` | controller's `load_target_comments` pre-loads with `:user, :target` |
| `names/show/observations_menu.rb` | `NameTracker.find_by(name_id:, user_id:)` | controller computes `@has_name_tracker` once (short-circuits to `false` for anonymous viewers) |
| `names/versions/show.rb` | `User.find_by(id: src[:user_id])` | controller resolves `@inherited_classification_user` |
| `projects/field_slips/new.rb` | `@project.trackers.order(id: :desc)` | controller pre-loads `@trackers` |
| `projects/violations/target_location_form.rb` | `Location.where(name: suffixes)` | modal action pre-loads `existing_locations` |
| `visual_models/visual_group_table.rb` | `@visual_model.visual_groups.order(:name)` | both calling controllers pre-load `@visual_groups` |
| `account/preferences/{edit,form}.rb` | `Language.all` | controller passes `languages:` |
| `components/authors_and_editors.rb` | bulk `User.where(id: editor_ids)` | reads `versions.map(&:user)` — Name / Location / GlossaryTerm `show_includes` now carry `{ versions: :user }` |
| `components/translators_credit.rb` | per-render `Language.find_by(locale:)` | new memoized `Language.for_locale(I18n.locale)` class helper |

Where a new prop was added, the kwarg is **required** (no `default: nil` / `default: []`) — production callers always pass it, so a default branch would surface as uncovered on coveralls.

## `Observation.matrix_box_includes` — one tree, every caller

Every controller that renders `Components::MatrixBox` per observation needs the same eager-load tree, and the trees were drifting:

- `observations#index` — had the canonical tree (`{ thumb_image: [...] }`, `:external_source`, `:location`, `:name`, `{ namings: :votes }`, `{ occurrence: :observations }`, `:projects`, `:rss_log`, `:user`).
- `field_slips show/index`, `collection_numbers#show`, `herbarium_records show/edit/new`, `rss_logs#index`, `sequences new/edit`, `projects/updates#index` — were each loading partial subsets, mostly via the old `observation_matrix_box_image_includes` helper. That meant N+1 on `render_occurrence_link` (`occ.observations.size`), on `NamingConsensus#load_namings_and_votes!` (`namings.flat_map(&:votes)`), on `:projects` (Bullet uses it for `can_edit?` on the image), etc.
- `observations/identify#index` — extends the shared tree with `:observation_views`, `{ name: :synonym }`, `{ namings: :name }` (identify-queue specifics); Rails merges the duplicate `:name` / `:namings` hashes.

The `ApplicationController#observation_matrix_box_image_includes` helper goes away. The `matrix_box_carousels` future-swap comment moves onto `Observation.matrix_box_includes` itself.

## Strict loading

`Comment` flips to `self.strict_loading_by_default = true` so future N+1s on `comment.user` / `comment.target` from view loops fail loudly. Follow-up sweep for other models lives in **#4510**.

## `mo_acts_as_versioned` workaround

The gem (our fork) doesn't auto-wire `belongs_to :user` on the version classes it generates, even though every `*_versions` table carries a `user_id` column. Added `const_get(:Version).belongs_to(:user, ...)` after each `acts_as_versioned` call in `Name`, `Location`, and `GlossaryTerm` so `show_includes` can eager-load `{ versions: :user }`. To be removed once the gem itself handles this (#TBD).

## New style guard — `NoQueriesInPhlexViewsTest`

`test/style/no_queries_in_phlex_views_test.rb` scans every `.rb` under `app/components/` and `app/views/` for AR query-builder calls (`.includes(`, `.where(`, `.joins(`, `.find_by(`, `.find_or_create_by(`, `.find_or_initialize_by(`, `.eager_load(`, `.preload(`, `.references(`, `.distinct`, `.order(`, `.group(`, `.exists?(`). One sanctioned exception: `Query::Filter.all` (in-memory static list). Self-tests included so the scanner's behavior is verified.

## Test plan

- [x] `bin/rails test test/controllers/` — 1992 tests, 14776 assertions, green
- [x] `bin/rails test test/components/versions_footer_test.rb` — 19 tests, 112 assertions, green
- [x] `bin/rails test test/style/` — query + `_Any` guards green
- [x] `bundle exec rubocop` clean on touched files
- [x] CI green
- [x] Coveralls 100% per-file on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
