### PR TITLE
enforce strict_loading_by_default on 9 low-risk models (#4510)

### DIFF
--- a/app/models/collection_number.rb
+++ b/app/models/collection_number.rb
@@ -51,6 +51,11 @@
 #  None.
 #
 class CollectionNumber < AbstractModel
+  # Surface N+1s on `collection_number.observations` / `.user` from
+  # view loops; every caller must eager-load these via
+  # `CollectionNumber.show_includes` or equivalent.
+  self.strict_loading_by_default = true
+
   has_many :observation_collection_numbers, dependent: :destroy
   has_many :observations, through: :observation_collection_numbers
   belongs_to :user

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -24,6 +24,10 @@
 #  url::           Actual URL, complete with transport ("http://"), etc.
 #
 class ExternalLink < AbstractModel
+  # Surface N+1s on `external_link.observation` / `.external_site` /
+  # `.user` from view loops; every caller must eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :observation
   belongs_to :external_site
   belongs_to :user

--- a/app/models/herbarium_record.rb
+++ b/app/models/herbarium_record.rb
@@ -44,6 +44,12 @@
 #                     Herbarium.  Called after create.
 #
 class HerbariumRecord < AbstractModel
+  # Surface N+1s on `herbarium_record.observations` / `.user` /
+  # `.herbarium` from view loops; every caller must eager-load
+  # these via the controller's `herbarium_record_includes` or
+  # equivalent.
+  self.strict_loading_by_default = true
+
   belongs_to :herbarium
   belongs_to :user
 

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -50,6 +50,10 @@
 ################################################################################
 #
 class Interest < AbstractModel
+  # Surface N+1s on `interest.user` / `.target` from view loops;
+  # every caller must eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :user
   belongs_to :target, polymorphic: true
 

--- a/app/models/name_tracker.rb
+++ b/app/models/name_tracker.rb
@@ -25,6 +25,10 @@
 #  None.
 #
 class NameTracker < AbstractModel
+  # Surface N+1s on `name_tracker.user` / `.name` / `.interests`
+  # from view loops; every caller must eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :user
   belongs_to :name
   has_many :interests, as: :target, dependent: :destroy, inverse_of: :target

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -44,6 +44,10 @@
 #
 ################################################################################
 class Naming < AbstractModel
+  # Surface N+1s on `naming.observation` / `.name` / `.user` /
+  # `.votes` from view loops; every caller must eager-load these.
+  self.strict_loading_by_default = true
+
   attr_accessor :current_user
 
   belongs_to :observation

--- a/app/models/project_alias.rb
+++ b/app/models/project_alias.rb
@@ -8,6 +8,10 @@ class ProjectAlias < AbstractModel
   # aliases only work in the context of the project (specifically when
   # filling in field slip forms).
 
+  # Surface N+1s on `project_alias.target` / `.project` from view
+  # loops; every caller must eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :target, polymorphic: true
   belongs_to :project
 

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -34,6 +34,10 @@
 #  unique_format_name  name for unorphaned objects
 #
 class Sequence < AbstractModel
+  # Surface N+1s on `sequence.observation` / `.user` from view
+  # loops; every caller must eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :observation
   belongs_to :user
 

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -48,6 +48,11 @@
 ################################################################################
 
 class Vote < AbstractModel
+  # Surface N+1s on `vote.user` / `.naming` / `.observation` from
+  # `Observation::NamingConsensus` iteration; every caller must
+  # eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :user
   belongs_to :naming
   belongs_to :observation


### PR DESCRIPTION
## Summary

Enables `self.strict_loading_by_default = true` on the low-risk tier from #4510: **CollectionNumber, HerbariumRecord, Sequence, ExternalLink, Vote, Naming, Interest, NameTracker, ProjectAlias**. From now on, any view loop that reaches into one of these models' associations without eager-loading it will raise `Bullet::Notification::UnoptimizedQueryError` instead of silently N+1ing through production.

Joins the `Comment.strict_loading_by_default = true` setting that landed with #4508.

## Why now

Once the obs-show eager-load tree (`Observation.show_includes` — `{ namings: [:name, :user, { votes: [:observation, :user] }] }`, `{ interests: :user }`, `{ herbarium_records: [{ herbarium: :curators }, :user] }`, `:sequences`, `{ external_links: { external_site: { project: :user_group } } }`, `:collection_numbers`) was in place from earlier PRs, the associations these 9 models expose are already eager-loaded on every page that renders them. Flipping the flag now is a defensive backstop — Bullet catches the next regression at boot instead of in production.

## Test plan

- [x] `bin/rails test test/controllers/collection_numbers_controller_test.rb test/controllers/herbarium_records_controller_test.rb` — 77 tests
- [x] `bin/rails test test/models/ test/controllers/` — 2830 tests, 21245 assertions, green
- [x] `bin/rails test test/integration/` (Capybara/Cuprite) — 164 tests, 1632 assertions, green
- [x] `PARALLEL_WORKERS=1 bin/rails test test/system/observation_show_system_test.rb` — 5 tests, 82 assertions, green
- [x] CI green
- [ ] Coveralls 100% per-file on touched files

## Follow-up

Issue #4510 still tracks the risky tier: Observation, Image, Name, Location, Project, SpeciesList, User. Those need a per-model audit of their `show_includes` scopes (plus admin / batch-script callers) before flipping the flag; deferring to a separate PR per model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
