### PR TITLE
enforce strict_loading_by_default: Project, SpeciesList + 8 small models (#4510)

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -23,6 +23,10 @@
 #  unique_text_name     name + id without formatting
 #
 class Article < AbstractModel
+  # Surface N+1s on `article.user` / `.rss_log`; every caller must
+  # eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :user
   belongs_to :rss_log
 

--- a/app/models/copyright_change.rb
+++ b/app/models/copyright_change.rb
@@ -25,6 +25,10 @@
 ################################################################################
 
 class CopyrightChange < AbstractModel
+  # Surface N+1s on `copyright_change.user` / `.license` / `.target`;
+  # every caller must eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :user
   belongs_to :license
   belongs_to :target, polymorphic: true

--- a/app/models/external_site.rb
+++ b/app/models/external_site.rb
@@ -11,6 +11,10 @@
 #                  may edit external_links to this site for any observation.
 #
 class ExternalSite < AbstractModel
+  # Surface N+1s on `external_site.project` / `.external_links` /
+  # `.observations`; every caller must eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :project
   has_many   :external_links
   has_many   :observations, through: :external_links

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -4,6 +4,11 @@
 # code:    string, unique code for field slip, starts with project prefix
 
 class FieldSlip < AbstractModel
+  # Surface N+1s on `field_slip.occurrence` / `.project` / `.user`
+  # / `.observation` / `.observations`; every caller must eager-load
+  # these via `FieldSlip.show_includes` / `.index_includes_tree`.
+  self.strict_loading_by_default = true
+
   attr_reader :current_user
 
   has_one :occurrence, dependent: :nullify

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -90,14 +90,16 @@ class FieldSlip < AbstractModel
 
   # Eager-load trees for `FieldSlipPanel` / `Components::MatrixBox`.
   # Reuses `Observation.matrix_box_includes` so the obs subtree
-  # matches observations#index and collection_numbers#show.
+  # matches observations#index and collection_numbers#show. The
+  # panel also reads `@field_slip.project` and `@field_slip.user`,
+  # so both have to ride along.
   def self.show_includes_tree
-    [{ occurrence: { observations: Observation.matrix_box_includes } }]
+    [{ occurrence: { observations: Observation.matrix_box_includes } },
+     :project, :user]
   end
 
   # Index variant: the page renders one panel per slip and also
-  # walks `occurrence.primary_observation`; the panel's `:project`
-  # and `:user` lines need those preloaded too.
+  # walks `occurrence.primary_observation`.
   def self.index_includes_tree
     [{ occurrence: [:primary_observation,
                     { observations: Observation.matrix_box_includes }] },

--- a/app/models/image_vote.rb
+++ b/app/models/image_vote.rb
@@ -26,6 +26,10 @@
 ################################################################################
 
 class ImageVote < AbstractModel
+  # Surface N+1s on `image_vote.user` / `.image`; every caller must
+  # eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :user
   belongs_to :image
 end

--- a/app/models/observation_view.rb
+++ b/app/models/observation_view.rb
@@ -12,6 +12,10 @@
 #  reviewed::               Boolean.
 
 class ObservationView < AbstractModel
+  # Surface N+1s on `observation_view.observation` / `.user`; every
+  # caller must eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :observation
   belongs_to :user
 

--- a/app/models/observation_view.rb
+++ b/app/models/observation_view.rb
@@ -35,14 +35,17 @@ class ObservationView < AbstractModel
     end
   end
 
+  # Pick the FK directly so strict_loading on `view.observation`
+  # isn't a problem — one extra `find_by` is cheaper than an extra
+  # `includes` per call.
   def self.last(user)
-    view = ObservationView.where(user:).order(last_view: :desc).first
-    view&.observation
+    obs_id = where(user:).order(last_view: :desc).pick(:observation_id)
+    obs_id && Observation.find_by(id: obs_id)
   end
 
   def self.previous(user, observation)
-    view = ObservationView.where(user:).
-           where.not(observation:).order(last_view: :desc).first
-    view&.observation
+    obs_id = where(user:).where.not(observation:).
+             order(last_view: :desc).pick(:observation_id)
+    obs_id && Observation.find_by(id: obs_id)
   end
 end

--- a/app/models/occurrence.rb
+++ b/app/models/occurrence.rb
@@ -17,6 +17,10 @@
 #  updated_at::               timestamp
 #
 class Occurrence < AbstractModel
+  # Surface N+1s on `occurrence.observations` / `.primary_observation`
+  # / `.field_slip`; every caller must eager-load these.
+  self.strict_loading_by_default = true
+
   include Occurrence::ProjectGaps
   include Occurrence::Logging
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -55,6 +55,12 @@
 class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   include Date
 
+  # Surface N+1s on `project.user` / `.location` / `.image` /
+  # `.admin_group` / `.user_group` / `.members` / `.observations`
+  # / `.species_lists` from view loops; every caller must
+  # eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :admin_group, class_name: "UserGroup"
   belongs_to :location
   belongs_to :image

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -40,7 +40,9 @@ class Publication < AbstractModel
 
   validate :check_requirements
   def check_requirements # :nodoc:
-    unless user
+    # Check the FK directly so strict_loading doesn't force an
+    # extra `users` lookup during validation.
+    unless user_id
       errors.add(:user, "missing user") # sign of internal error,
       # should never happen
     end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -32,6 +32,10 @@
 ################################################################################
 
 class Publication < AbstractModel
+  # Surface N+1s on `publication.user`; every caller must
+  # eager-load this.
+  self.strict_loading_by_default = true
+
   belongs_to :user
 
   validate :check_requirements

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -82,6 +82,11 @@
 ################################################################################
 #
 class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
+  # Surface N+1s on `species_list.user` / `.location` / `.rss_log`
+  # / `.observations` / `.projects` from view loops; every caller
+  # must eager-load these.
+  self.strict_loading_by_default = true
+
   belongs_to :location
   belongs_to :rss_log
   belongs_to :user


### PR DESCRIPTION
## Summary

Second strict-loading batch from #4510, stacked on #4513 (low-risk tier). 10 models flip `self.strict_loading_by_default = true`:

| Risky tier | Small models |
|---|---|
| Project | ImageVote |
| SpeciesList | ObservationView |
|  | ExternalSite |
|  | Publication |
|  | CopyrightChange |
|  | Article |
|  | Occurrence |
|  | FieldSlip |

Every association these models expose is already eager-loaded by the obs-show / index / field-slip / herbarium-record tree we built in #4508. Flipping the flag now catches the next regression at boot rather than in production.

## Models dropped from this batch

- **Location, Name, LocationDescription, NameDescription** — all use `acts_as_versioned`. The gem's `save_version` doesn't push the new version row into the parent's loaded `versions` collection. Under strict_loading, the first `obj.versions.last` access force-loads the collection; the subsequent save then leaves the cache stale, so the next `obj.versions.last` returns the wrong row. Surfaced in `LocationTest#test_versioning`. Needs a gem-side fix before any versioned MO model can flip the flag.

## Test plan

- [x] `bin/rails test test/controllers/` — 1992 tests, 14776 assertions
- [x] `bin/rails test test/models/ test/integration/` — 1002 tests, 8101 assertions
- [x] CI green

## Follow-ups (#4510)

- **Gem PR on `acts_as_versioned`** — fix `save_version` so it pushes the new row into the loaded `versions` collection. Unblocks Location, Name, GlossaryTerm, LocationDescription, NameDescription.
- **Image / Observation / User** — high-traffic show pages; need a per-model `show_includes` audit before flipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
