### PR TITLE
bump mo_acts_as_versioned 0.8.0 + drop :extend blocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,7 @@ gem("blankslate")
 
 # Simple version models and tables for classes
 # Use our own fork, which stores enum attrs as integers in the db
-gem("mo_acts_as_versioned", ">= 0.6.6",
+gem("mo_acts_as_versioned", ">= 0.8.0",
     git: "https://github.com/MushroomObserver/acts_as_versioned")
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -635,7 +635,7 @@ DEPENDENCIES
   minitest (< 6)
   minitest-reporters
   mission_control-jobs
-  mo_acts_as_versioned (>= 0.6.6)!
+  mo_acts_as_versioned (>= 0.8.0)!
   oauth2
   phlex-rails
   phlex-slotable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/MushroomObserver/acts_as_versioned
-  revision: 56891f7f915610e9f884e3a932bfb6934303b3b8
+  revision: 6c49beb3e205cbe0a597792eaa9587c931d7d923
   specs:
-    mo_acts_as_versioned (0.6.6)
+    mo_acts_as_versioned (0.8.0)
       activerecord (>= 3.0.9)
 
 GEM

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -30,19 +30,10 @@ class GlossaryTerm < AbstractModel
   validate :must_have_description_or_image
 
   ALL_TERM_FIELDS = [:name, :description].freeze
-  # See `Name` for the rationale behind the `:extend` block — same
-  # pattern wires `belongs_to :user` onto `GlossaryTerm::Version`
-  # so `show_includes` can carry `{ versions: :user }`.
   acts_as_versioned(
     if_changed: ALL_TERM_FIELDS,
     association_options: { dependent: :nullify }
-  ) do
-    def self.included(base)
-      return if base.reflect_on_association(:user)
-
-      base.belongs_to(:user, class_name: "::User", optional: true)
-    end
-  end
+  )
   non_versioned_columns.push(
     "thumb_image_id",
     "created_at",

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -122,16 +122,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     center_lng
   ].freeze
 
-  # See `Name` for the rationale behind the `:extend` block — same
-  # pattern wires `belongs_to :user` onto `Location::Version` so
-  # `show_includes` can carry `{ versions: :user }`.
-  acts_as_versioned(if_changed: VERSIONED_COLUMNS) do
-    def self.included(base)
-      return if base.reflect_on_association(:user)
-
-      base.belongs_to(:user, class_name: "::User", optional: true)
-    end
-  end
+  acts_as_versioned(if_changed: VERSIONED_COLUMNS)
   non_versioned_columns.push(
     "created_at",
     "updated_at",

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -356,22 +356,7 @@ class Name < AbstractModel
     icn_id
   ].freeze
 
-  # The `:extend` block (see `acts_as_versioned` docs) wires
-  # `belongs_to :user` onto `Name::Version` — the table has a
-  # `user_id` column but the gem only defines the reverse
-  # `belongs_to :name` by default. With this in place
-  # `show_includes` can eager-load `{ versions: :user }` and views
-  # can read `version.user` without an N+1. The `return if
-  # reflect_on_association(:user)` guard skips `Name` itself (which
-  # already declares its own `belongs_to :user`) — the gem includes
-  # the block on both the host and the version class.
-  acts_as_versioned(if_changed: VERSIONED_COLUMNS) do
-    def self.included(base)
-      return if base.reflect_on_association(:user)
-
-      base.belongs_to(:user, class_name: "::User", optional: true)
-    end
-  end
+  acts_as_versioned(if_changed: VERSIONED_COLUMNS)
   non_versioned_columns.push(
     "created_at",
     "updated_at",


### PR DESCRIPTION
## Summary

Bumps `mo_acts_as_versioned` from `0.6.6` → `0.8.0` and removes the now-redundant MO-side `:extend` blocks.

The new gem release brings two MO-relevant changes:

1. **Auto-wires `belongs_to :user`** on every generated Version class when the table carries a `user_id` column. Replaces the `:extend` block workaround we landed in #4508 for `Name`, `Location`, `GlossaryTerm`. The gem uses the same `class_name: "::User", optional: true` we set by hand.
2. **Syncs the parent's loaded `versions` collection** when `save_version` runs (via `versions.build` instead of `versioned_class.new + rev.save`). Unblocks `strict_loading_by_default = true` on versioned MO models — previously, a `loc.versions.last` + `loc.save` + `loc.versions.last` pattern returned the stale cached row under strict loading (see `LocationTest#test_versioning`, which failed in the dropped third batch of #4514).

## Changes

- `Gemfile`: floor moves to `>= 0.8.0`.
- `Gemfile.lock`: regenerated.
- `Name`, `Location`, `GlossaryTerm`: drop the `:extend` block. `acts_as_versioned(if_changed: VERSIONED_COLUMNS)` is now sufficient.

## Verified

- `Name::Version`, `Location::Version`, `GlossaryTerm::Version`, `NameDescription::Version`, `LocationDescription::Version` all carry `belongs_to :user` with the exact same options (`class_name: "::User"`, `optional: true`) after the bump.
- `Name.first.versions.first.user` resolves to a `User` row — the auto-wire works against the existing `name_versions.user_id` data.

## Test plan

- [x] `bin/rails test test/models/ test/controllers/` — 2830 tests, 21245 assertions
- [x] `bin/rails test test/integration/` — 164 tests, 1632 assertions
- [x] `bin/rails test test/models/location_test.rb -n test_versioning` — was the canary for the cache bug; now passes
- [ ] CI green

## Follow-up

Unblocks PR(s) flipping `strict_loading_by_default = true` on `Location`, `Name`, `LocationDescription`, `NameDescription`, `GlossaryTerm`. Will batch those into the #4510 sweep once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
