### PR TITLE
strict_loading_by_default on the 5 versioned models (#4510)

### DIFF
--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -7,6 +7,12 @@
 class GlossaryTerm < AbstractModel
   require("acts_as_versioned")
 
+  # Surface N+1s on `glossary_term.user` / `.thumb_image` /
+  # `.rss_log` / `.images` / `.versions` from view loops; every
+  # caller must eager-load these. See `Location` for the gem-bump
+  # context.
+  self.strict_loading_by_default = true
+
   belongs_to(:thumb_image,
              class_name: "Image",
              inverse_of: :thumb_glossary_terms)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -90,6 +90,14 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
 
   include Scopes
 
+  # Surface N+1s on `location.user` / `.description` / `.descriptions`
+  # / `.versions` / `.rss_log` / `.observations` from view loops;
+  # every caller must eager-load these via `Location.show_includes`
+  # or equivalent. Bundled with the `mo_acts_as_versioned` 0.8.0
+  # bump (#4515) which fixed the versions-cache sync that previously
+  # tripped `LocationTest#test_versioning` under strict loading.
+  self.strict_loading_by_default = true
+
   belongs_to :description, class_name: "LocationDescription" # (main one)
   belongs_to :rss_log
   belongs_to :user

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -50,6 +50,13 @@
 class LocationDescription < Description
   require("acts_as_versioned")
 
+  # Surface N+1s on `location_description.user` / `.authors` /
+  # `.editors` / `.versions` / `.location` / `.license` from view
+  # loops; every caller must eager-load these via
+  # `LocationDescription.show_includes` or equivalent. See
+  # `Location` for the gem-bump context.
+  self.strict_loading_by_default = true
+
   include Description::Scopes
 
   # Do not change the integer associated with a value

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -274,6 +274,12 @@
 class Name < AbstractModel
   require("acts_as_versioned")
 
+  # Surface N+1s on `name.user` / `.description` / `.descriptions`
+  # / `.versions` / `.synonym` / `.rss_log` from view loops; every
+  # caller must eager-load these via `Name.show_includes` or
+  # equivalent. See `Location` for the gem-bump context.
+  self.strict_loading_by_default = true
+
   # modules with instance methods and maybe class methods
   include Scopes
   include Validation

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -64,6 +64,13 @@
 class NameDescription < Description
   require("acts_as_versioned")
 
+  # Surface N+1s on `name_description.user` / `.authors` /
+  # `.editors` / `.versions` / `.name` / `.license` / `.reviewer`
+  # from view loops; every caller must eager-load these via
+  # `NameDescription.show_includes` or equivalent. See
+  # `Location` for the gem-bump context.
+  self.strict_loading_by_default = true
+
   include Description::Scopes
 
   # Do not change the integer associated with a value


### PR DESCRIPTION
## Summary

Flips `self.strict_loading_by_default = true` on the five versioned MO models that were dropped from #4514 because `acts_as_versioned` couldn't sync the parent's loaded `versions` collection on save:

- `Location`
- `Name`
- `GlossaryTerm`
- `LocationDescription`
- `NameDescription`

Stacks on #4515, which bumps `mo_acts_as_versioned` to `0.8.0` — the gem's `save_version` now goes through `versions.build` so the loaded collection stays in sync.

## Why now

#4513 + #4514 covered the non-versioned models. The versioned five were on hold for the gem bug. Now that the bug is fixed and the gem version is pinned, the same rationale applies: every association these models expose is already eager-loaded by the obs-show / name-show / location-show / description-show trees. Flipping the flag catches the next regression at boot rather than in production.

## Test plan

- [x] `bin/rails test test/models/location_test.rb -n test_versioning test/models/name_test.rb -n /version/ test/models/glossary_term_test.rb` — was the canary; passes
- [x] `bin/rails test test/models/ test/controllers/` — 2830 tests, 21245 assertions, green
- [x] `bin/rails test test/integration/` — 164 tests, 1632 assertions, green
- [ ] CI green

## Follow-ups (#4510)

Risky tier still pending: `Observation`, `Image`, `User`. Each needs a focused `show_includes` audit + a Bullet sweep across high-traffic show paths before flipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
