### PR TITLE
strict_loading_by_default on User and Image (#4510)

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -226,6 +226,14 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   require("mimemagic")
   require("fastimage")
 
+  # Surface N+1s on `image.user` / `.license` / `.projects` /
+  # `.image_votes` / `.observations` from view loops; every caller
+  # must eager-load these via the controller's `show_includes` or
+  # `Observation.matrix_box_includes` (already covers the obs-show
+  # path through `{ thumb_image: [:image_votes, :license, :projects,
+  # :user] }`).
+  self.strict_loading_by_default = true
+
   include Scopes
 
   has_many :glossary_term_images, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -191,6 +191,14 @@
 #                       before object is created.
 #
 class User < AbstractModel # rubocop:disable Metrics/ClassLength
+  # Surface N+1s on `user.*` from view loops (image, location,
+  # license, projects, user_stats, etc.); every caller must
+  # eager-load these via the controller's `show_includes` or
+  # equivalent. User is the high-traffic risky-tier model from
+  # #4510 — expect this PR to surface paths that need eager-load
+  # additions before it can land.
+  self.strict_loading_by_default = true
+
   # Enums: Do not change the integer associated with a value
   # First value is the default
   enum :thumbnail_size, { thumbnail: 1, small: 2 },


### PR DESCRIPTION
## Summary

Closes the risky tier from #4510. `User` and `Image` both flip `self.strict_loading_by_default = true`. After PR #4513 (low-risk tier), #4514 (Project + SpeciesList + 8 small), and #4516 (5 versioned), `Observation`-the-model is the only remaining holdout — that one's getting its own dedicated PR.

## Why this lands clean

Every association `User` and `Image` expose is already eager-loaded by the show / index / matrix-box trees built in #4508 and the follow-up sweep — `Observation.matrix_box_includes` carries `{ thumb_image: [:image_votes, :license, :projects, :user] }` plus `:user` for the obs row, and each controller's own `show_includes` (or equivalent `includes(:user, ...)` in the find path) covers its own page. The Image side was already proven safe in the earlier obs-show system test pass; what was untested was whether other show pages (user, glossary_term, article) had any path that lazy-loaded `image.user` / `user.image` / `user.location`.

Verified by the full suites below — system tests in particular load every show page through Cuprite, which is what triggers `Bullet::Notification::UnoptimizedQueryError` if anything is lazy-loaded.

## Test plan

- [x] `bin/rails test test/controllers/` — 1992 tests, 14776 assertions
- [x] `bin/rails test test/models/ test/integration/` — 1002 tests, 8101 assertions
- [x] `PARALLEL_WORKERS=1 bin/rails test test/system/` — 60 tests, 1020 assertions
- [ ] CI green

## Follow-ups (#4510)

- **Observation** — last on the list. Want a dedicated PR for it because the obs-show eager-load tree is the biggest in the codebase (`Observation.show_includes` already 18+ associations) and any miss there would cascade. Plan: turn Bullet logging on in production for a week first, then flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
