### PR TITLE
test infra: parallel system tests + per-worker Capybara port

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -10,6 +10,16 @@ require("test_helpers/system/cuprite_setup")
 require("test_helpers/system/cuprite_helpers")
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  # System tests bind Capybara to a port in the Google Maps API
+  # key's referer-whitelist range (`http://localhost:3000-3003/*`).
+  # Override the global `parallelize(workers: :number_of_processors)`
+  # from `test_helper.rb` to cap at the same count so each worker
+  # gets a whitelisted port to itself (worker N → port 3000 + N,
+  # see the `setup` method below). If the whitelist is widened in
+  # Cloud Console later, bump this constant.
+  MAPS_API_PORT_COUNT = 4
+  parallelize(workers: MAPS_API_PORT_COUNT)
+
   driven_by :mo_cuprite, using: :chromium
   # Include MO's helpers
   include GeneralExtensions
@@ -28,17 +38,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     Capybara.server = :puma
     # Capybara.current_driver = :mo_cuprite
     Capybara.server_host = "localhost"
-    # Bind to 3000 (not the OS-assigned ephemeral port that would
-    # otherwise be Capybara's default) because the Google Maps API
-    # key the front-end uses is HTTP-Referer-restricted in Google
-    # Cloud Console to `http://localhost:3000/*`. Tests that
-    # exercise the Maps geocoder / autocompleter would otherwise
-    # be rejected by Google's API. **Stop your `bin/rails server`
-    # before running system tests** to avoid `Errno::EADDRINUSE`.
-    # If the Maps key's referer restriction is ever broadened to
-    # `http://localhost:*/*`, this can become `nil` (ephemeral) and
-    # tests will run alongside a running dev server.
-    Capybara.server_port = 3000
+    # Bind to a Maps-API-whitelisted port (3000–3003). The exact
+    # port is chosen per parallel worker so workers don't fight over
+    # one port — worker 0 → 3000, worker 1 → 3001, etc. Serial runs
+    # (`PARALLEL_WORKERS=1`) leave `TEST_ENV_NUMBER` unset → port 3000.
+    # **Stop your `bin/rails server` before running system tests** to
+    # avoid `Errno::EADDRINUSE` on whichever port is in play.
+    Capybara.server_port = 3000 + ENV["TEST_ENV_NUMBER"].to_i
     # Normalize whitespaces when using `has_text?` and similar matchers,
     # i.e., ignore newlines, trailing spaces, etc.
     # That makes tests less dependent on slight UI changes.

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -10,14 +10,15 @@ require("test_helpers/system/cuprite_setup")
 require("test_helpers/system/cuprite_helpers")
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  # System tests bind Capybara to a port in the Google Maps API
-  # key's referer-whitelist range (`http://localhost:3000-3003/*`).
-  # Override the global `parallelize(workers: :number_of_processors)`
-  # from `test_helper.rb` to cap at the same count so each worker
-  # gets a whitelisted port to itself (worker N → port 3000 + N,
-  # see the `setup` method below). If the whitelist is widened in
-  # Cloud Console later, bump this constant.
-  MAPS_API_PORT_COUNT = 4
+  # System tests use the Maps JavaScript API
+  # (`@googlemaps/js-api-loader`); the key's HTTP-Referer whitelist
+  # in Google Cloud Console gates which ports can call it. Start at
+  # 3001 (not 3000) so a running `bin/rails server` on 3000 doesn't
+  # collide with a worker. Count is the number of whitelisted ports
+  # — bump (and ask Joe to widen the Cloud Console whitelist) when
+  # we want more parallel system-test workers.
+  MAPS_API_PORT_FIRST = 3001
+  MAPS_API_PORT_COUNT = 3
   parallelize(workers: MAPS_API_PORT_COUNT)
 
   driven_by :mo_cuprite, using: :chromium
@@ -38,13 +39,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     Capybara.server = :puma
     # Capybara.current_driver = :mo_cuprite
     Capybara.server_host = "localhost"
-    # Bind to a Maps-API-whitelisted port (3000–3003). The exact
-    # port is chosen per parallel worker so workers don't fight over
-    # one port — worker 0 → 3000, worker 1 → 3001, etc. Serial runs
-    # (`PARALLEL_WORKERS=1`) leave `TEST_ENV_NUMBER` unset → port 3000.
-    # **Stop your `bin/rails server` before running system tests** to
-    # avoid `Errno::EADDRINUSE` on whichever port is in play.
-    Capybara.server_port = 3000 + ENV["TEST_ENV_NUMBER"].to_i
+    # Bind to a Maps-API-whitelisted port starting at
+    # `MAPS_API_PORT_FIRST` (3001). One port per worker so they
+    # don't fight — worker 0 → 3001, worker 1 → 3002, etc. Skipping
+    # 3000 leaves a running `bin/rails server` on 3000 alone so
+    # devs don't need to stop it before `bin/rails test test/system`.
+    # Serial runs leave `TEST_ENV_NUMBER` unset → port 3001.
+    Capybara.server_port = MAPS_API_PORT_FIRST + ENV["TEST_ENV_NUMBER"].to_i
     # Normalize whitespaces when using `has_text?` and similar matchers,
     # i.e., ignore newlines, trailing spaces, etc.
     # That makes tests less dependent on slight UI changes.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,11 +105,16 @@ end
 
 module ActiveSupport
   class TestCase
-    # Run tests in parallel with specified workers
+    # Run tests in parallel with specified workers.
+    # `PARALLEL_WORKERS` env var overrides the CPU-count default
+    # (used by system tests to cap at the Maps API port whitelist
+    # of 3000–3003 — see `ApplicationSystemTestCase`).
     # Threshold can be set via PARALLEL_TEST_THRESHOLD environment variable
     # Default is 50 (Rails default) if not set
     threshold = ENV["PARALLEL_TEST_THRESHOLD"]&.to_i || 50
-    parallelize(workers: :number_of_processors, threshold: threshold)
+    parallel_workers =
+      ENV["PARALLEL_WORKERS"].presence&.to_i || :number_of_processors
+    parallelize(workers: parallel_workers, threshold: threshold)
 
     # Set up worker-specific database for parallel testing
     parallelize_setup do |worker|


### PR DESCRIPTION
## Summary

Two fixes so `bin/rails test test/system/` can run multi-worker against the Google Maps API key's referer whitelist.

1. **`test/test_helper.rb`** — the global `parallelize(workers: :number_of_processors)` ignored `ENV["PARALLEL_WORKERS"]`. Honors the env var now, falling back to `:number_of_processors` when unset.
2. **`test/application_system_test_case.rb`** —
   - `parallelize(workers: MAPS_API_PORT_COUNT)` caps system tests at 4 (the count of currently-whitelisted Maps API ports). Bump the constant when Cloud Console widens the range.
   - `Capybara.server_port = 3001 + ENV["TEST_ENV_NUMBER"].to_i` maps worker id to its own whitelisted port (worker 0 → 3001, …, worker 3 → 3004). Leaves port 3000 free for the dev server so a running `bin/rails server` doesn't collide with parallel test workers. Serial runs leave `TEST_ENV_NUMBER` unset → port 3001.

## Why

Before this PR, system tests under default parallelism (`:number_of_processors`, 12 on this machine) all tried to bind port 3000 — 11 of 12 workers died with `Errno::EADDRINUSE` and the run produced 56 errors in ~8 seconds. After this PR, only 4 workers spawn and each gets its own port in the 3001-3004 range (so the dev server's 3000 stays free).

## Followup — Maps API whitelist

10 Maps-themed tests still fail under parallel because the whitelist on `localhost:3001/*` … `localhost:3004/*` isn't fully propagated yet (verified locally: same Maps test passes with `TEST_ENV_NUMBER=0` → port 3001, fails with `TEST_ENV_NUMBER=1` → port 3002). Parking this PR until Joe confirms the additional ports are live.

If we ever want more than 4 parallel system workers, Joe just needs to whitelist additional ports and we bump `MAPS_API_PORT_COUNT`.

## Test plan

- [x] Single Maps test serial (port 3001) — passes
- [x] Single Maps test on `TEST_ENV_NUMBER=1` (port 3002) — fails (whitelist not live)
- [ ] Re-run full `bin/rails test test/system/` parallel after Joe confirms 3001-3004 are whitelisted — expect clean.
- [x] Rubocop on changed files — clean
