### PR TITLE
test: sweep assert_template → stable element / body-class assertions

### DIFF
--- a/app/views/controllers/locations/search/_help.erb
+++ b/app/views/controllers/locations/search/_help.erb
@@ -1,4 +1,6 @@
-<%= tag.p("#{:LOCATIONS.t} #{:SEARCHES.t}",
-          class: "mt-3 font-weight-bold") %>
-<%= :pattern_search_terms_help.tp %>
-<%= PatternSearch::Location.terms_help.tp %>
+<div id="locations_search_help">
+  <%= tag.p("#{:LOCATIONS.t} #{:SEARCHES.t}",
+            class: "mt-3 font-weight-bold") %>
+  <%= :pattern_search_terms_help.tp %>
+  <%= PatternSearch::Location.terms_help.tp %>
+</div>

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -558,7 +558,13 @@ module ControllerExtensions
         controller = @controller.controller_name
         msg += "Expected it to render <#{controller}/#{arg}#{got}>"
         super(:success, msg)
-        assert_template(arg.to_s, msg)
+        # `assert_template` doesn't see Phlex action views — use the
+        # layout's `<body class="<controller>__<action>">` action
+        # marker instead. The arg may be a bare action ("show") or a
+        # "controller/action" path; strip any path prefix so the body
+        # class lookup uses the action name only.
+        action = arg.to_s.split("/").last
+        assert_select("body.#{controller}__#{action}", true, msg)
       elsif arg == :index
         msg += "Expected redirect to <root>#{got}"
         assert_redirected_to("/", msg)

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -414,7 +414,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     # Test turbo shows flash warning
     patch(:update, params:, format: :turbo_stream)
     assert_flash_text(/permission denied/i)
-    assert_template("shared/_modal_flash_update")
+    assert_select("turbo-stream[action='update'][target$='_flash']")
 
     login("rolf")
     patch(:update, params: params.deep_merge(collection_number: { name: "" }))

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -243,7 +243,7 @@ class CommentsControllerTest < FunctionalTestCase
 
     # Test turbo shows flash error
     get(:new, params:, format: :turbo_stream)
-    assert_template("shared/_modal_flash_update")
+    assert_select("turbo-stream[action='update'][target$='_flash']")
     assert_flash_error
   end
 

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -28,7 +28,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     # make sure public can access
     term = glossary_terms(:plane_glossary_term)
     get(:index, params: { letter: "P" })
-    assert_template("index")
+    assert_select("body.glossary_terms__index")
     assert_select(
       "a[href *= '#{glossary_term_path(term.id)}']", true,
       "Glossary Index at `P` missing link to #{term.unique_text_name})"
@@ -38,7 +38,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
   def test_index_by_id
     term = glossary_terms(:plane_glossary_term)
     get(:index, params: { id: term.id })
-    assert_template("index")
+    assert_select("body.glossary_terms__index")
     assert_select(
       "a[href *= '#{glossary_term_path(term.id)}']", true,
       "Glossary Index at `P` missing link to #{term.unique_text_name})"
@@ -56,7 +56,7 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     login
     get(:index, params: q_pattern("con"))
     assert_session_query_record_is_correct
-    assert_template("index")
+    assert_select("body.glossary_terms__index")
     assert_select(
       "a[href*='glossary_terms/#{conic.id}']", text: conic.name
     )

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -474,7 +474,7 @@ class HerbariaControllerTest < FunctionalTestCase
     assert_equal(herbarium_count, Herbarium.count)
     assert_response(:success)
     # Should render modal_form_reload partial to update modal with flash
-    assert_template("shared/_modal_form_reload")
+    assert_select("turbo-stream[action='replace'][target$='_form']")
   end
 
   # Successful turbo_stream create hits
@@ -494,7 +494,7 @@ class HerbariaControllerTest < FunctionalTestCase
 
     assert_response(:success)
     assert_equal(herbarium_count + 1, Herbarium.count)
-    assert_template("herbaria/_update_observation")
+    assert_select("turbo-stream[action='remove'][target='modal_herbarium']")
   end
 
   def test_create_duplicate_name
@@ -711,7 +711,7 @@ class HerbariaControllerTest < FunctionalTestCase
     assert_equal(last_update, nybg.reload.updated_at)
     assert_response(:success)
     # Should render modal_form_reload partial to update modal with flash
-    assert_template("shared/_modal_form_reload")
+    assert_select("turbo-stream[action='replace'][target$='_form']")
   end
 
   def test_update_by_non_curator

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -331,7 +331,7 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     post(:create, params:, format: :turbo_stream)
     assert_equal(herbarium_record_count, HerbariumRecord.count)
     assert_flash_text(/already exists/i)
-    assert_template("shared/_modal_flash_update")
+    assert_select("turbo-stream[action='update'][target$='_flash']")
   end
 
   # I keep thinking only curators should be able to add herbarium_records.
@@ -469,7 +469,7 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     # Test turbo shows flash
     post(:update, params: { id: nybg.id }, format: :turbo_stream)
     assert_flash_text(/missing/i)
-    assert_template("shared/_modal_form_reload")
+    assert_select("turbo-stream[action='replace'][target$='_form']")
   end
 
   def test_update_herbarium_record_wrong_user
@@ -482,7 +482,7 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     # Test turbo shows flash
     post(:update, params: { id: nybg.id }, format: :turbo_stream)
     assert_flash_text(/permission denied/i)
-    assert_template("shared/_modal_flash_update")
+    assert_select("turbo-stream[action='update'][target$='_flash']")
   end
 
   def test_update_herbarium_record_label_already_used

--- a/test/controllers/images/emails_controller_test.rb
+++ b/test/controllers/images/emails_controller_test.rb
@@ -41,7 +41,7 @@ module Images
              params: { id: image.id, email: { message: "" } })
       end
       assert_flash_error
-      assert_template(:new)
+      assert_select("body.emails__new")
     end
 
     def test_new_turbo_stream

--- a/test/controllers/images/licenses_controller_test.rb
+++ b/test/controllers/images/licenses_controller_test.rb
@@ -47,7 +47,7 @@ module Images
       }
       put_requires_login(:update, params)
       # assert_redirected_to(images_edit_licenses_path)
-      assert_template("images/licenses/edit")
+      assert_select("body.licenses__edit")
       assert_equal(10, rolf.reload.contribution)
 
       target_count_after = Image.
@@ -86,7 +86,7 @@ module Images
         }
       }
       put_requires_login(:update, params)
-      assert_template("images/licenses/edit")
+      assert_select("body.licenses__edit")
       example_image.reload
       assert_equal("A. H. Smith", example_image.copyright_holder,
                    "Name of new copyright holder is incorrect")

--- a/test/controllers/images/votes/anonymity_controller_test.rb
+++ b/test/controllers/images/votes/anonymity_controller_test.rb
@@ -16,7 +16,7 @@ module Images::Votes
       assert(ImageVote.find_by(image_id: img2.id, user_id: rolf.id).anonymous)
 
       requires_login(:edit)
-      assert_template("edit")
+      assert_select("body.anonymity__edit")
 
       login("rolf")
       post(:update,

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -28,7 +28,7 @@ class ImagesControllerTest < FunctionalTestCase
     login
     get(:index, params: { by_user: user.id })
 
-    assert_template("index")
+    assert_select("body.images__index")
     assert_select(".matrix-box")
     assert_page_title(:IMAGES.l)
     assert_displayed_filters("#{:query_by_users.l}: #{user.legal_name}")
@@ -52,7 +52,7 @@ class ImagesControllerTest < FunctionalTestCase
     login
     get(:index, params: { project: project.id })
 
-    assert_template("index", partial: "_image")
+    assert_select(".matrix-box")
     assert_page_title(:IMAGES.l)
     assert_displayed_filters("#{:query_projects.l}: #{project.title}")
   end
@@ -116,7 +116,7 @@ class ImagesControllerTest < FunctionalTestCase
     login
     get(:index, params:)
 
-    assert_template("index", partial: "_image")
+    assert_select(".matrix-box")
     assert_page_title(:IMAGES.l)
     assert_displayed_filters("#{:query_pattern.l}: #{pattern}")
   end
@@ -129,7 +129,7 @@ class ImagesControllerTest < FunctionalTestCase
     get(:index, params:)
 
     assert_flash_text(:runtime_no_matches.l(type: :images.l))
-    assert_template("index")
+    assert_select("body.images__index")
   end
 
   # Regression for #4360: a cross-model q param (Observation query
@@ -145,7 +145,7 @@ class ImagesControllerTest < FunctionalTestCase
     login
     get(:index, params:)
 
-    assert_template("index", partial: "_image")
+    assert_select(".matrix-box")
     # Should NOT have flashed "no matches" — the bridge produces hits.
     assert_no_flash
   end
@@ -160,7 +160,7 @@ class ImagesControllerTest < FunctionalTestCase
     # Zero matching Observations → zero matching Images → "no matches"
     # flash, not a silent fall-back to the unfiltered Image index.
     assert_flash_text(:runtime_no_matches.l(type: :images.l))
-    assert_template("index")
+    assert_select("body.images__index")
   end
 
   def test_show_image
@@ -170,12 +170,12 @@ class ImagesControllerTest < FunctionalTestCase
     num_views = image.num_views
     login
     get(:show, params: { id: image.id })
-    assert_template("show", partial: "_form_ccbyncsa25")
+    assert_select("body.images__show")
     image.reload
     assert_equal(num_views + 1, image.num_views)
     (Image::ALL_SIZES + [:original]).each do |size|
       get(:show, params: { id: image.id, size: size })
-      assert_template("show", partial: "_form_ccbyncsa25")
+      assert_select("body.images__show")
     end
   end
 
@@ -207,7 +207,7 @@ class ImagesControllerTest < FunctionalTestCase
     get(:show, params: { id: image.id })
 
     assert_response(:success)
-    assert_template("show", partial: "_form_ccbyncsa25")
+    assert_select("body.images__show")
   end
 
   # Prove show works when params include obs
@@ -218,7 +218,7 @@ class ImagesControllerTest < FunctionalTestCase
     login(obs.user.login)
 
     get(:show, params: { id: image.id, obs: obs.id })
-    assert_template("show", partial: "_form_ccbyncsa25")
+    assert_select("body.images__show")
     # first_query = Query.find(QueryRecord.first.id)
     # second_query = Query.find(QueryRecord.second.id)
     # assert_equal(Observation, first_query.model)
@@ -237,11 +237,11 @@ class ImagesControllerTest < FunctionalTestCase
     login
     get(:show, params: { id: image.id })
 
-    assert_template("show", partial: "_form_ccbyncsa25")
+    assert_select("body.images__show")
     assert_equal(num_views + 1, image.reload.num_views)
     (Image::ALL_SIZES + [:original]).each do |size|
       get(:show, params: { id: image.id, size: size })
-      assert_template("show", partial: "_form_ccbyncsa25")
+      assert_select("body.images__show")
     end
   end
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -455,7 +455,7 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1 })
 
     assert_response(:success)
-    assert_template(:confirm)
+    assert_select("#estimated_count")
     body = @response.body
     assert_match(:inat_import_confirm_estimate_caption.l, body)
     assert_select("#estimated_count", "2")
@@ -487,7 +487,7 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1, import_others: "1" })
 
     assert_response(:success)
-    assert_template(:confirm)
+    assert_select("#estimated_count")
     assert_select(
       "#estimated_count", "1",
       "Estimate should not filter by user_login if a super_importer " \
@@ -542,7 +542,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_username: user.inat_username, all: 1, consent: 1 })
 
     assert_response(:success)
-    assert_template(:confirm)
+    assert_select("#estimated_count")
     assert_select(
       "#estimated_count", "1",
       "Estimate for a super_importer's own import-all should filter " \
@@ -568,7 +568,7 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1 })
 
     assert_response(:success)
-    assert_template(:confirm)
+    assert_select("#estimated_count")
     assert_select(
       "#estimated_count", "1",
       "Estimate should include unlicensed own observations"
@@ -598,7 +598,7 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1, import_others: "1" })
 
     assert_response(:success)
-    assert_template(:confirm)
+    assert_select("#estimated_count")
     assert_select(
       "#estimated_count", "3",
       "Estimate for import-others should be licensed obs count"
@@ -621,7 +621,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_ids: "1,2,3", inat_username: "rolf", consent: 1 })
 
     assert_response(:success)
-    assert_template(:confirm)
+    assert_select("#estimated_count")
     assert_select(
       "#unlicensed_obs_count", "",
       "Unlicensed count should be blank when licensed estimate fails"
@@ -756,7 +756,7 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1, all: 1, import_others: "1" })
 
     assert_response(:success)
-    assert_template(:confirm)
+    assert_select("#estimated_count")
   end
 
   def test_superimporter_not_own_import_all_without_username_blocked
@@ -862,7 +862,7 @@ class InatImportsControllerTest < FunctionalTestCase
     get(:cancel, params: { id: import.id })
 
     assert_response(:success)
-    assert_template(:show)
+    assert_select("[data-controller='inat-import-job']")
     assert(import.reload.canceled?,
            "Clicking cancel button should make InatImport.canceled? == true")
   end

--- a/test/controllers/info_controller_test.rb
+++ b/test/controllers/info_controller_test.rb
@@ -7,19 +7,19 @@ class InfoControllerTest < FunctionalTestCase
   def test_page_loads
     login
     get(:how_to_help)
-    assert_template(:how_to_help)
+    assert_select("body.info__how_to_help")
 
     get(:how_to_use)
-    assert_template(:how_to_use)
+    assert_select("body.info__how_to_use")
 
     get(:intro)
-    assert_template(:intro)
+    assert_select("body.info__intro")
 
     get(:search_bar_help)
     assert_response(:success)
 
     get(:news)
-    assert_template(:news)
+    assert_select("body.info__news")
 
     get(:textile_sandbox)
     assert_response(:success)

--- a/test/controllers/interests_controller_test.rb
+++ b/test/controllers/interests_controller_test.rb
@@ -12,7 +12,7 @@ class InterestsControllerTest < FunctionalTestCase
     Interest.create(target: names(:agaricus_campestris), user: rolf,
                     state: true)
     get(:index)
-    assert_template("index")
+    assert_select("body.interests__index")
   end
 
   def test_set_interest_another_user

--- a/test/controllers/locations/descriptions_controller_test.rb
+++ b/test/controllers/locations/descriptions_controller_test.rb
@@ -101,7 +101,7 @@ module Locations
       login
       get(:index, params: { by_author: user.id })
 
-      assert_template("index")
+      assert_select("body.descriptions__index")
       assert_page_title(:LOCATION_DESCRIPTIONS.l)
       assert_displayed_filters("#{:query_by_author.l}: #{user.name}")
       assert_equal(
@@ -120,7 +120,7 @@ module Locations
       get(:index, params: { by_author: user.id })
 
       assert_flash_text("No matching location descriptions found.")
-      assert_template("index")
+      assert_select("body.descriptions__index")
     end
 
     def test_index_by_author_bad_user_id
@@ -167,7 +167,7 @@ module Locations
       login
       get(:index, params: { by_editor: user.id })
 
-      assert_template("index")
+      assert_select("body.descriptions__index")
       assert_page_title(:LOCATION_DESCRIPTIONS.l)
       assert_displayed_filters("#{:query_by_editor.l}: #{user.name}")
       assert_select("a:match('href',?)", %r{^/locations/descriptions/\d+},
@@ -182,7 +182,7 @@ module Locations
       get(:index, params: { by_editor: user.id })
 
       assert_flash_text("No matching location descriptions found.")
-      assert_template("index")
+      assert_select("body.descriptions__index")
     end
 
     def test_index_by_editor_bad_user_id

--- a/test/controllers/locations/search_controller_test.rb
+++ b/test/controllers/locations/search_controller_test.rb
@@ -10,13 +10,13 @@ module Locations
     def test_show_help
       login
       get(:show)
-      assert_template("locations/search/_help")
+      assert_select("#locations_search_help")
     end
 
     def test_show_help_turbo
       login
       get(:show, format: :turbo_stream)
-      assert_template("locations/search/_help")
+      assert_select("#locations_search_help")
     end
 
     def test_new_locations_search

--- a/test/controllers/locations/versions_controller_test.rb
+++ b/test/controllers/locations/versions_controller_test.rb
@@ -11,8 +11,11 @@ module Locations
       login
       get(:show,
           params: { id: location.id, version: location.version - 1 })
-      assert_template("locations/versions/show")
-      assert_template("locations/show/_notes")
+      assert_select("body.versions__show")
+      # Original `assert_template("locations/show/_notes")` was vacuous —
+      # the partial wraps its body in `unless @location.notes.blank?`,
+      # so for past versions without notes nothing renders. The body-
+      # class check above proves the version page rendered.
     end
 
     def test_show_past_location_no_version

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -75,10 +75,10 @@ class LocationsControllerTest < FunctionalTestCase
     case page
     when :create
       post_requires_login(page, params)
-      assert_template("new")
+      assert_select("body.locations__new")
     when :update
       put_requires_login(page, params)
-      assert_template("edit")
+      assert_select("body.locations__edit")
     end
     assert_select("#location_form")
     assert_equal(loc_count, Location.count)
@@ -107,10 +107,10 @@ class LocationsControllerTest < FunctionalTestCase
     log_updated_at = location.rss_log.updated_at
     login
     get(:show, params: { id: location.id })
-    assert_template("show")
-    assert_template("locations/show/_notes")
+    assert_select("body.locations__show")
+    assert_select("#location_notes")
     assert_select("#comments_for_object")
-    assert_template("locations/show/_general_description_panel")
+    assert_select("#location_general_description")
 
     location.reload
     assert_equal(updated_at, location.updated_at)
@@ -172,10 +172,10 @@ class LocationsControllerTest < FunctionalTestCase
   end
 
   def assert_show_location
-    assert_template("locations/show")
-    assert_template("locations/show/_notes")
+    assert_select("body.locations__show")
+    assert_select("#location_notes")
     assert_select("#comments_for_object")
-    assert_template("locations/show/_general_description_panel")
+    assert_select("#location_general_description")
   end
 
   def test_show_location_next_flow
@@ -208,7 +208,7 @@ class LocationsControllerTest < FunctionalTestCase
     login
     get(:show, params: { id: loc.id })
 
-    assert_template("show")
+    assert_select("body.locations__show")
     assert_nil(assigns(:description))
   end
 
@@ -219,7 +219,7 @@ class LocationsControllerTest < FunctionalTestCase
     login
     get(:show, params: { id: loc.id, desc: bad_desc_id })
 
-    assert_template("show")
+    assert_select("body.locations__show")
     assert_flash_text(:runtime_object_not_found.t(type: :description,
                                                   id: bad_desc_id))
   end
@@ -237,7 +237,7 @@ class LocationsControllerTest < FunctionalTestCase
     login("dick") # Dick is not a reader
     get(:show, params: { id: loc.id, desc: desc.id })
 
-    assert_template("show")
+    assert_select("body.locations__show")
     # Description should be nil (not shown) because user can't read it
     assert_nil(assigns(:description))
   end
@@ -368,7 +368,7 @@ class LocationsControllerTest < FunctionalTestCase
     get(:index, params:)
 
     assert_response(:success)
-    assert_template("index")
+    assert_select("body.locations__index")
     assert_select(
       "#content a:match('href', ?)", %r{#{locations_path}/\d+},
       { count: matches.count }, "Wrong number of Locations"
@@ -465,7 +465,7 @@ class LocationsControllerTest < FunctionalTestCase
     login
     get(:index, params: { country: country })
 
-    assert_template("index")
+    assert_select("body.locations__index")
     assert_flash_text(:runtime_no_matches.l(type: :locations.l))
     assert_select(
       "#content a:match('href', ?)", %r{#{locations_path}/\d+},
@@ -479,7 +479,7 @@ class LocationsControllerTest < FunctionalTestCase
     login
     get(:index, params: { by_user: user.id })
 
-    assert_template("index")
+    assert_select("body.locations__index")
     assert_page_title(:LOCATIONS.l)
     assert_displayed_filters("#{:query_by_users.l}: #{user.name}")
     assert_select(
@@ -507,7 +507,7 @@ class LocationsControllerTest < FunctionalTestCase
     login
     get(:index, params: { by_user: user.id })
 
-    assert_template("index")
+    assert_select("body.locations__index")
     assert_flash_text(:runtime_no_matches.l(type: :locations.l))
   end
 
@@ -560,7 +560,7 @@ class LocationsControllerTest < FunctionalTestCase
     login
     get(:index, params: { by_editor: user.id })
 
-    assert_template("index")
+    assert_select("body.locations__index")
     assert_flash_text(:runtime_no_matches.l(type: :locations.l))
   end
 
@@ -595,13 +595,13 @@ class LocationsControllerTest < FunctionalTestCase
     login
     # First verify that undefined locations appear without letter filter
     get(:index)
-    assert_template("index")
+    assert_select("body.locations__index")
     # Check that @undef_data is set (the letter filter applies to this)
     assert(assigns(:undef_data).present?, "Should have undefined locations")
 
     # Now request with letter2=a should filter to only "A" locations
     get(:index, params: { letter2: "a" })
-    assert_template("index")
+    assert_select("body.locations__index")
     # The letter filter is applied, verify the data is filtered
     undef_data = assigns(:undef_data)
     return if undef_data.blank?
@@ -1059,7 +1059,7 @@ class LocationsControllerTest < FunctionalTestCase
     make_admin("rolf")
     put(:update, params: params)
 
-    # assert_template("locations/show")
+    # assert_select("body.locations__show")
     assert_redirected_to(location_path(to_stay.id))
     assert_equal(loc_count - 1, Location.count)
     assert_equal(desc_count, LocationDescription.count)

--- a/test/controllers/names/descriptions_controller_test.rb
+++ b/test/controllers/names/descriptions_controller_test.rb
@@ -56,7 +56,7 @@ module Names
       login
       get(:index, params: { by_author: user })
 
-      assert_template("index")
+      assert_select("body.descriptions__index")
       assert_page_title(:NAME_DESCRIPTIONS.l)
       assert_displayed_filters("#{:query_by_author.l}: #{user.name}")
       assert_select("a:match('href',?)", %r{^/names/descriptions/\d+},
@@ -71,7 +71,7 @@ module Names
       get(:index, params: { by_author: user })
 
       assert_flash_text("No matching name descriptions found.")
-      assert_template("index")
+      assert_select("body.descriptions__index")
     end
 
     def test_index_by_author_bad_user_id
@@ -117,7 +117,7 @@ module Names
       login
       get(:index, params: { by_editor: user.id })
 
-      assert_template("index")
+      assert_select("body.descriptions__index")
       assert_page_title(:NAME_DESCRIPTIONS.l)
       assert_displayed_filters("#{:query_by_editor.l}: #{user.name}")
       assert_select("a:match('href',?)", %r{^/names/descriptions/\d+},
@@ -132,7 +132,7 @@ module Names
       get(:index, params: { by_editor: user.id })
 
       assert_flash_text("No matching name descriptions found.")
-      assert_template("index")
+      assert_select("body.descriptions__index")
     end
 
     def test_index_by_editor_bad_user_id

--- a/test/controllers/observations/external_links_controller_test.rb
+++ b/test/controllers/observations/external_links_controller_test.rb
@@ -58,7 +58,7 @@ module Observations
       login("dick")
       post(:create, params:, format: :turbo_stream)
       assert_flash_warning
-      assert_template("shared/_modal_flash_update")
+      assert_select("turbo-stream[action='update'][target$='_flash']")
     end
 
     # rolf can because he owns it

--- a/test/controllers/observations/images_controller_test.rb
+++ b/test/controllers/observations/images_controller_test.rb
@@ -34,7 +34,10 @@ module Observations
         }
       }
       put_requires_login(:update, params)
-      assert_template("images/show")
+      # Action is `:update` (body class would be `images__edit`); the
+      # update success branch does `render("images/show", ...)`. Pin a
+      # stable element from the show page instead.
+      assert_select("#image_votes_container")
       assert_equal(10, rolf.reload.contribution)
 
       assert(obs.reload.rss_log)

--- a/test/controllers/publications_controller_test.rb
+++ b/test/controllers/publications_controller_test.rb
@@ -104,7 +104,7 @@ class PublicationsControllerTest < FunctionalTestCase
     put(:update, params: { id: publications(:one_pub).id,
                            publication: { full: "" } })
     assert_response(:success)
-    assert_template(:edit)
+    assert_select("body.publications__edit")
   end
 
   def test_should_not_destroy_publication_without_permission

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -12,10 +12,12 @@ class RssLogsControllerTest < FunctionalTestCase
     assert_link_in_html(:app_intro.t, info_intro_path)
 
     get(:rss)
-    assert_template(:rss)
+    # `rss` is an XML feed (`render_xml(layout: false)`) — no `<body>`
+    # to anchor on; assert successful render instead.
+    assert_response(:success)
 
     get(:show, params: { id: rss_logs(:detailed_unknown_obs_rss_log).id })
-    assert_template(:show)
+    assert_select("body.rss_logs__show")
   end
 
   def test_rss_with_article_in_feed
@@ -30,17 +32,17 @@ class RssLogsControllerTest < FunctionalTestCase
     login
     # Show none.
     post(:index)
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
 
     # Show all via q param
     get(:index, params: { q: { type: "all" } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
 
     get(:index, params: { q: { type: %w[article glossary_term] } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
 
     get(:index, params: { q: { type: [] } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
 
     # Old-style top level :type param now redirects
     get(:index, params: { type: "all" })
@@ -85,7 +87,7 @@ class RssLogsControllerTest < FunctionalTestCase
     # Test that this actually works
     q = @controller.q_param(QueryRecord.last.query)
     get(:index, params: { q: q })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
   end
 
   # Prove that user content_filter works on rss_log
@@ -195,35 +197,35 @@ class RssLogsControllerTest < FunctionalTestCase
     # Invalid type string via q param should be sanitized to "none"
     get(:index, params: { q: { model: "RssLog",
                                type: "bad_code; DROP TABLE users;" } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
     types = @controller.instance_variable_get(:@types)
     assert_equal(["none"], types)
 
     # Mixed valid and invalid types (string) - only valid ones kept
     get(:index, params: { q: { model: "RssLog",
                                type: "observation bad_stuff name" } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
     types = @controller.instance_variable_get(:@types)
     # Order preserved from input
     assert_equal(%w[name observation], types)
 
     # All invalid types via q param string
     get(:index, params: { q: { model: "RssLog", type: "evil<script>" } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
     types = @controller.instance_variable_get(:@types)
     assert_equal(["none"], types)
 
     # Invalid types in array format via q param
     get(:index, params: { q: { model: "RssLog",
                                type: %w[bad_code evil<script>] } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
     types = @controller.instance_variable_get(:@types)
     assert_equal(["none"], types)
 
     # Mixed valid and invalid in array format via q param
     get(:index, params: { q: { model: "RssLog",
                                type: %w[observation bad_stuff name] } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
     types = @controller.instance_variable_get(:@types)
     assert_equal(%w[name observation], types)
   end
@@ -236,7 +238,7 @@ class RssLogsControllerTest < FunctionalTestCase
     get(:index, params: {
           q: { model: "RssLog", type: %w[observation name] }
         })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
     types = @controller.instance_variable_get(:@types)
     # Check both types are present (order may vary)
     assert_includes(types, "observation")
@@ -278,7 +280,7 @@ class RssLogsControllerTest < FunctionalTestCase
     # First, create a query with additional params (order_by)
     get(:index, params: { q: { model: "RssLog", type: "observation",
                                order_by: "created_at" } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
     query = QueryRecord.last.query
     assert_equal("observation", query.params[:type])
     assert_equal("created_at", query.params[:order_by])
@@ -286,7 +288,7 @@ class RssLogsControllerTest < FunctionalTestCase
     # Now change type filter - order_by should be preserved
     get(:index, params: { q: { model: "RssLog", type: "name",
                                order_by: "created_at" } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
     query = QueryRecord.last.query
     assert_equal("name", query.params[:type])
     assert_equal("created_at", query.params[:order_by],
@@ -297,7 +299,7 @@ class RssLogsControllerTest < FunctionalTestCase
     login
 
     get(:index, params: { q: { model: "RssLog", type: "observation" } })
-    assert_template(:index)
+    assert_select("body.rss_logs__index")
 
     # Check that the filter links don't have duplicate q[model] or q[type]
     body = @response.body

--- a/test/controllers/sequences_controller_test.rb
+++ b/test/controllers/sequences_controller_test.rb
@@ -413,7 +413,7 @@ class SequencesControllerTest < FunctionalTestCase
     # Test turbo shows flash warning
     get(:edit, params: { id: sequence.id }, format: :turbo_stream)
     assert_flash_warning
-    assert_template("shared/_modal_flash_update")
+    assert_select("turbo-stream[action='update'][target$='_flash']")
   end
 
   def test_edit_redirect

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -27,7 +27,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
   end
 
   def assert_create_species_list
-    assert_template("new")
+    assert_select("body.species_lists__new")
     # See `assert_edit_species_list` below: `species_lists/_form` was
     # folded into `Components::SpeciesListForm`. Phlex components don't
     # show in `assert_template`; assert the form's root element.

--- a/test/controllers/support_controller_test.rb
+++ b/test/controllers/support_controller_test.rb
@@ -18,14 +18,14 @@ class SupportControllerTest < FunctionalTestCase
       :wrapup_2012
     ].each do |template|
       get(template)
-      assert_template(template)
+      assert_select("body.support__#{template}")
     end
   end
 
   def test_donate
     login("rolf")
     get(:donate)
-    assert_template(:donate)
+    assert_select("body.support__donate")
     assert_select("form input[value=\"#{users(:rolf).name}\"]")
   end
 
@@ -41,7 +41,7 @@ class SupportControllerTest < FunctionalTestCase
     params = donation_params(amount, rolf, anon, recurring)
     params[:donation][:other_amount] = other_amount
     post(:confirm, params: params)
-    assert_template(:confirm)
+    assert_select("body.support__confirm")
     assert_donations(donations + 1, final_amount, false, params[:donation])
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -15,7 +15,7 @@ class UsersControllerTest < FunctionalTestCase
   def test_page_loads
     login
     get(:show, params: { id: rolf.id })
-    assert_template(:show)
+    assert_select("body.users__show")
   end
 
   #   -------------
@@ -61,7 +61,7 @@ class UsersControllerTest < FunctionalTestCase
     unmatched_pattern = "NonexistentUserContent"
     get_without_clearing_flash(:index,
                                params: { pattern: unmatched_pattern })
-    assert_template("users/index")
+    assert_select("body.users__index")
 
     assert_page_title(:USERS.l)
     assert_empty(css_select(".sorts"), "There should be no sort links")
@@ -109,7 +109,7 @@ class UsersControllerTest < FunctionalTestCase
     login
     get(:show, params: { id: user.id })
 
-    assert_template(:show)
+    assert_select("body.users__show")
     assert_select(
       "a[href = '#{location_descriptions_index_path}?by_author=#{user.id}']"
     )


### PR DESCRIPTION
## Summary

Sweep every active `assert_template(…)` call in `test/controllers/` and `test/controller_extensions.rb` to a CSS-selector check against a stable identifier on the rendered DOM. `assert_template` doesn't see Phlex views — so as the ERB → Phlex conversion progresses, every untouched `assert_template` silently becomes a no-op the moment its template is converted. Replacing them now closes that gap before it bites again.

Substitution patterns used:

- `assert_template(:action)` / `("action")` / `("controller/action")` → `assert_select("body.<controller>__<action>")` using the per-action body class stamped by `application.html.erb` (`controller_name__action_name`, with `create → new` / `update → edit`).
- Partials with a stable wrapper id → assert the id: `_notes` → `#location_notes`, `_general_description_panel` → `#location_general_description`, `_help` → `#locations_search_help` (id added to the partial in this PR).
- Modal turbo_stream partials → assert the turbo-stream action: `_modal_flash_update` → `turbo-stream[action='update'][target$='_flash']`, `_modal_form_reload` → `turbo-stream[action='replace'][target$='_form']`, `herbaria/_update_observation` → `turbo-stream[action='remove'][target='modal_herbarium']`.
- Confirmation pages / explicit `render(:other_template)` paths where the body class won't match the rendered template (`render(:confirm)` from `create`, `render('images/show')` from `update`) → assert a stable element id on the rendered page (`#estimated_count`, `#image_votes_container`, `[data-controller='inat-import-job']`).
- `rss_logs#rss` is an XML feed (`render_xml(layout: false)`) with no body element → `assert_response(:success)`.

Other changes:

- `test/controller_extensions.rb`: `assert_response(String)` wrapper no longer chains through `assert_template`; uses the body-class assertion directly, normalizing `controller/action` to the action segment.
- `app/views/controllers/locations/search/_help.erb`: wrap the help content in `<div id="locations_search_help">` so both the HTML and turbo_stream tests can anchor on it.
- `Locations::VersionsControllerTest#test_show_past_location` was already asserting nothing useful (`_notes` wraps its body in `unless @location.notes.blank?`); the body-class check above the removed line is sufficient.

Numbers:

- 124 active call sites swept across 27 files.
- 0 calls remain in `test/controllers/` outside the three files already in flight: `articles_controller_test.rb` (#4522), `admin/donations_controller_test.rb` (#4521), `admin/emails/webmaster_questions_controller_test.rb` (#4521).

## Test plan

- [x] `bin/rails test:controllers` — 1996 tests, 14796 assertions, 0 failures
- [x] `bundle exec rubocop` on all touched `.rb` files — no offenses
- [ ] CI green
