### PR TITLE
claude: add Rubocop pre-commit + Coveralls post-push hooks

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -39,7 +39,12 @@ coverage stops being something the human has to chase.
 
 Both hook scripts assume:
 - `gh` CLI authenticated against the repo
-- `jq` and `python3` on PATH
+- `jq` and `ruby` on PATH
 - `curl` for the coveralls fetch
 - The repo root is the working directory when hooks fire (Claude
   Code's default)
+
+(JSON parsing is in Ruby, not Python, so the inline `ruby -rjson -e`
+calls match the project's existing
+`Bash(ruby -rjson -e:*)` permission wildcard — no extra permission
+prompt on every coveralls run.)

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -6,8 +6,13 @@ rules the team kept needing to remind the assistant about:
 
 | Hook | Trigger | Behavior |
 | --- | --- | --- |
-| `check_rubocop_staged.sh` | `PreToolUse` on `Bash` containing `git commit` | Runs `bundle exec rubocop` on staged `.rb` files. Blocks the commit (exit 2) if any offenses remain. |
+| `check_rubocop_staged.sh` | `PreToolUse` on `Bash` containing `git commit` | (1) Runs `bundle exec rubocop` on staged `.rb` files. (2) If rubocop is clean, runs `bin/rails test test/style/` — codebase-wide style rules like `no_queries_in_phlex_views_test` and `no_any_phlex_props_test` that catch patterns rubocop can't see. Blocks the commit (exit 2) if either step fails. |
 | `check_coveralls_pr.sh` | `PostToolUse` on `Bash` containing `git push` | If the current branch has an open PR and coveralls has reported on at least one build, prints per-file coverage for every Ruby file in the diff and flags any below 100%. Non-blocking — surfaces the gaps so they can't be silently ignored. |
+
+The wiring in `.claude/settings.json` uses a defensive
+`test -x … && exec … || exit 0` shape so branches without these
+script files (e.g. older branches forked before this hook landed)
+silently no-op instead of erroring on every commit/push.
 
 Wired in `.claude/settings.json` (committed). A developer who doesn't
 want them can disable per-hook in their `.claude/settings.local.json`

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,40 @@
+# Claude Code hooks
+
+These hooks run automatically when Claude Code is the one driving
+`git commit` / `git push` in this repo. They enforce two workflow
+rules the team kept needing to remind the assistant about:
+
+| Hook | Trigger | Behavior |
+| --- | --- | --- |
+| `check_rubocop_staged.sh` | `PreToolUse` on `Bash` containing `git commit` | Runs `bundle exec rubocop` on staged `.rb` files. Blocks the commit (exit 2) if any offenses remain. |
+| `check_coveralls_pr.sh` | `PostToolUse` on `Bash` containing `git push` | If the current branch has an open PR and coveralls has reported on at least one build, prints per-file coverage for every Ruby file in the diff and flags any below 100%. Non-blocking — surfaces the gaps so they can't be silently ignored. |
+
+Wired in `.claude/settings.json` (committed). A developer who doesn't
+want them can disable per-hook in their `.claude/settings.local.json`
+(gitignored) or skip Claude Code entirely — these are advisory to the
+assistant, not a substitute for the project's own pre-commit /
+pre-push tooling.
+
+## Why these specifically
+
+The rubocop one is a hard block because lint failures repeatedly
+slipped to CI even though `bundle exec rubocop` takes a second to
+run locally. Blocking the commit forces the fix into the same turn
+that wrote the offending code.
+
+The coveralls one is non-blocking and runs after push because
+coveralls only has data for builds that have completed — there's
+nothing to check before the first push that creates the PR, and the
+just-pushed commit's data isn't ready yet either. What it CAN do is
+surface the gaps from the previous build (or the initial-CI build)
+into the assistant's context after every subsequent push, so missing
+coverage stops being something the human has to chase.
+
+## Requirements
+
+Both hook scripts assume:
+- `gh` CLI authenticated against the repo
+- `jq` and `python3` on PATH
+- `curl` for the coveralls fetch
+- The repo root is the working directory when hooks fire (Claude
+  Code's default)

--- a/.claude/hooks/check_coveralls_pr.sh
+++ b/.claude/hooks/check_coveralls_pr.sh
@@ -46,12 +46,12 @@ page=1
 while : ; do
   curl -sf "https://coveralls.io/builds/${BUILD_ID}/source_files.json?per_page=2000&page=${page}" \
     > "${TMPDIR}/page_${page}.json" || break
-  count=$(python3 -c "
-import json, sys
-with open('${TMPDIR}/page_${page}.json') as f: d = json.load(f)
-src = json.loads(d['source_files']) if isinstance(d['source_files'], str) else d['source_files']
-print(len(src))
-" 2>/dev/null || echo 0)
+  count=$(ruby -rjson -e "
+    d = JSON.parse(File.read('${TMPDIR}/page_${page}.json'))
+    src = d['source_files']
+    src = JSON.parse(src) if src.is_a?(String)
+    print src.length
+  " 2>/dev/null || echo 0)
   [ "$count" = "0" ] && break
   page=$((page + 1))
   [ "$page" -gt 10 ] && break
@@ -65,30 +65,26 @@ if [ ! -s "${TMPDIR}/touched.txt" ]; then
   exit 0
 fi
 
-REPORT="$(TMPDIR="$TMPDIR" python3 <<'PY'
-import json, glob, os
-tmp = os.environ['TMPDIR']
-files = []
-for path in sorted(glob.glob(os.path.join(tmp, 'page_*.json'))):
-    with open(path) as f: d = json.load(f)
-    src = json.loads(d['source_files']) if isinstance(d['source_files'], str) else d['source_files']
-    files.extend(src)
-by_name = {x['name']: x for x in files}
-with open(os.path.join(tmp, 'touched.txt')) as f:
-    paths = [p.strip() for p in f if p.strip()]
-gaps = []
-for p in paths:
-    f = by_name.get(p)
-    if not f:
-        continue
-    cov, rel, miss = f['covered_line_count'], f['relevant_line_count'], f['missed_line_count']
-    if miss > 0:
-        pct = 100.0 * cov / rel if rel else 0
-        gaps.append(f"{p}: {cov}/{rel} ({pct:.1f}%)  MISSED {miss}")
-if gaps:
-    print('\n'.join(gaps))
-PY
-)"
+REPORT="$(TMPDIR="$TMPDIR" ruby -rjson -e '
+  tmp = ENV.fetch("TMPDIR")
+  files = Dir[File.join(tmp, "page_*.json")].sort.flat_map do |path|
+    d = JSON.parse(File.read(path))
+    src = d["source_files"]
+    src = JSON.parse(src) if src.is_a?(String)
+    src
+  end
+  by_name = files.each_with_object({}) { |x, h| h[x["name"]] = x }
+  paths = File.readlines(File.join(tmp, "touched.txt"))
+                .map(&:strip).reject(&:empty?)
+  gaps = paths.filter_map do |p|
+    f = by_name[p]
+    next unless f && f["missed_line_count"] > 0
+    cov, rel, miss = f["covered_line_count"], f["relevant_line_count"], f["missed_line_count"]
+    pct = rel > 0 ? (100.0 * cov / rel) : 0
+    format("%s: %d/%d (%.1f%%)  MISSED %d", p, cov, rel, pct, miss)
+  end
+  print gaps.join("\n")
+')"
 
 if [ -n "$REPORT" ]; then
   cat >&2 <<EOF

--- a/.claude/hooks/check_coveralls_pr.sh
+++ b/.claude/hooks/check_coveralls_pr.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUse hook.
+# Fires after a successful `Bash` call. If the command was a `git push`
+# and the current branch has an open PR with at least one coveralls
+# report, prints per-file coverage for every Ruby file in the diff
+# and flags any file below 100%.
+#
+# Non-blocking. The goal is to make coverage gaps impossible to miss
+# after every push, not to gate the push itself.
+#
+# Reads JSON on stdin from Claude Code; only inspects `tool_input.command`.
+set -euo pipefail
+
+INPUT="$(cat)"
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')"
+
+# Only interested in git push. Skip everything else.
+case "$COMMAND" in
+  *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+PR_NUM="$(gh pr view --json number --jq .number 2>/dev/null || true)"
+if [ -z "$PR_NUM" ]; then
+  # No PR for this branch yet (initial push that will create the PR,
+  # or a branch that isn't headed for review). Nothing to check.
+  exit 0
+fi
+
+BUILD_ID="$(gh pr view "$PR_NUM" --json comments \
+  --jq '.comments[] | select(.author.login=="coveralls-official") | .body' 2>/dev/null |
+  grep -oE "coveralls.io/builds/[0-9]+" | tail -1 | grep -oE "[0-9]+$" || true)"
+
+if [ -z "$BUILD_ID" ]; then
+  echo "" >&2
+  echo "📊 PR #${PR_NUM}: coveralls hasn't reported on a build yet — re-run this check after CI finishes (~10–15 min)." >&2
+  exit 0
+fi
+
+# Paginate source_files.json. Phlex views consistently land on page 2;
+# a single-page fetch reports them as <not instrumented> (false negative).
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+page=1
+while : ; do
+  curl -sf "https://coveralls.io/builds/${BUILD_ID}/source_files.json?per_page=2000&page=${page}" \
+    > "${TMPDIR}/page_${page}.json" || break
+  count=$(python3 -c "
+import json, sys
+with open('${TMPDIR}/page_${page}.json') as f: d = json.load(f)
+src = json.loads(d['source_files']) if isinstance(d['source_files'], str) else d['source_files']
+print(len(src))
+" 2>/dev/null || echo 0)
+  [ "$count" = "0" ] && break
+  page=$((page + 1))
+  [ "$page" -gt 10 ] && break
+done
+
+gh pr view "$PR_NUM" --json files \
+  --jq '.files[] | select(.changeType!="DELETED") | .path' |
+  grep -E '\.rb$' > "${TMPDIR}/touched.txt" || true
+
+if [ ! -s "${TMPDIR}/touched.txt" ]; then
+  exit 0
+fi
+
+REPORT="$(TMPDIR="$TMPDIR" python3 <<'PY'
+import json, glob, os
+tmp = os.environ['TMPDIR']
+files = []
+for path in sorted(glob.glob(os.path.join(tmp, 'page_*.json'))):
+    with open(path) as f: d = json.load(f)
+    src = json.loads(d['source_files']) if isinstance(d['source_files'], str) else d['source_files']
+    files.extend(src)
+by_name = {x['name']: x for x in files}
+with open(os.path.join(tmp, 'touched.txt')) as f:
+    paths = [p.strip() for p in f if p.strip()]
+gaps = []
+for p in paths:
+    f = by_name.get(p)
+    if not f:
+        continue
+    cov, rel, miss = f['covered_line_count'], f['relevant_line_count'], f['missed_line_count']
+    if miss > 0:
+        pct = 100.0 * cov / rel if rel else 0
+        gaps.append(f"{p}: {cov}/{rel} ({pct:.1f}%)  MISSED {miss}")
+if gaps:
+    print('\n'.join(gaps))
+PY
+)"
+
+if [ -n "$REPORT" ]; then
+  cat >&2 <<EOF
+
+📊 PR #${PR_NUM} — coveralls per-file coverage gaps on touched files (build ${BUILD_ID}):
+
+${REPORT}
+
+Per the project's testing rules: every Ruby file in a PR must be at
+100% line coverage before declaring done. Fix gaps in the same PR.
+EOF
+else
+  echo "" >&2
+  echo "✅ PR #${PR_NUM}: every touched Ruby file at 100% coverage (build ${BUILD_ID})." >&2
+fi
+
+exit 0

--- a/.claude/hooks/check_rubocop_staged.sh
+++ b/.claude/hooks/check_rubocop_staged.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # Claude Code PreToolUse hook.
-# Fires before `Bash` calls. If the command is a `git commit`, runs
-# rubocop on staged Ruby files. Exits 2 (blocking) if any offenses
-# are found so the agent can't commit lint-broken Ruby.
+# Fires before `Bash` calls. If the command is a `git commit`, runs:
+#  1. `bundle exec rubocop` on staged Ruby files.
+#  2. The project's style test suite (`test/style/`), which catches
+#     codebase-wide violations rubocop doesn't know about
+#     (no-queries-in-phlex-views, no-bare-_Any-phlex-props, etc.).
+# Exits 2 (blocking) if either step fails.
 #
 # Reads JSON on stdin from Claude Code; only inspects `tool_input.command`.
 set -euo pipefail
@@ -22,20 +25,40 @@ if [ -z "$STAGED" ]; then
   exit 0
 fi
 
-# Run rubocop only on those files.
-OUTPUT="$(bundle exec rubocop --format simple $STAGED 2>&1 || true)"
-
-# Pass if rubocop says "no offenses". Otherwise block.
-if printf '%s' "$OUTPUT" | grep -qE "no offenses detected"; then
-  exit 0
-fi
-
-cat >&2 <<EOF
+# Step 1: Rubocop on the staged files only.
+RUBOCOP_OUT="$(bundle exec rubocop --format simple $STAGED 2>&1 || true)"
+if ! printf '%s' "$RUBOCOP_OUT" | grep -qE "no offenses detected"; then
+  cat >&2 <<EOF
 🚫 Rubocop offenses on staged Ruby files — blocking commit.
 
-$OUTPUT
+$RUBOCOP_OUT
 
 Run \`bundle exec rubocop --autocorrect-all <files>\` to fix, re-stage,
 then commit again.
 EOF
-exit 2
+  exit 2
+fi
+
+# Step 2: project style test suite. Catches no-queries-in-phlex-views,
+# no-bare-_Any-phlex-props, etc. — codebase-wide rules a per-file
+# rubocop run can't see. Skip silently if `test/style/` doesn't exist
+# on the current branch.
+if [ ! -d test/style ]; then
+  exit 0
+fi
+
+STYLE_OUT="$(bin/rails test test/style/ 2>&1 || true)"
+if ! printf '%s' "$STYLE_OUT" | grep -qE "0 failures, 0 errors"; then
+  cat >&2 <<EOF
+🚫 Style test failures — blocking commit.
+
+$STYLE_OUT
+
+Fix the violations before committing. (Codebase-wide style rules
+like \`no_queries_in_phlex_views_test\` and \`no_any_phlex_props_test\`
+catch patterns rubocop can't see.)
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/check_rubocop_staged.sh
+++ b/.claude/hooks/check_rubocop_staged.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook.
+# Fires before `Bash` calls. If the command is a `git commit`, runs
+# rubocop on staged Ruby files. Exits 2 (blocking) if any offenses
+# are found so the agent can't commit lint-broken Ruby.
+#
+# Reads JSON on stdin from Claude Code; only inspects `tool_input.command`.
+set -euo pipefail
+
+INPUT="$(cat)"
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')"
+
+# Only interested in git commit. Skip everything else.
+case "$COMMAND" in
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
+# Collect staged Ruby files (Added / Copied / Modified / Renamed).
+STAGED="$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.rb$' || true)"
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+# Run rubocop only on those files.
+OUTPUT="$(bundle exec rubocop --format simple $STAGED 2>&1 || true)"
+
+# Pass if rubocop says "no offenses". Otherwise block.
+if printf '%s' "$OUTPUT" | grep -qE "no offenses detected"; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+🚫 Rubocop offenses on staged Ruby files — blocking commit.
+
+$OUTPUT
+
+Run \`bundle exec rubocop --autocorrect-all <files>\` to fix, re-stage,
+then commit again.
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/check_rubocop_staged.sh",
-            "timeout": 60
+            "command": "test -x .claude/hooks/check_rubocop_staged.sh && exec .claude/hooks/check_rubocop_staged.sh || exit 0",
+            "timeout": 600
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/check_coveralls_pr.sh",
+            "command": "test -x .claude/hooks/check_coveralls_pr.sh && exec .claude/hooks/check_coveralls_pr.sh || exit 0",
             "timeout": 30
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/check_rubocop_staged.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/check_coveralls_pr.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Two Claude Code hooks committed under `.claude/` to enforce two workflow rules I kept needing to be reminded about: rubocop on every commit, and per-file coverage on every push to an open PR.

- **`.claude/hooks/check_rubocop_staged.sh`** — PreToolUse on `Bash` calls containing `git commit`. Runs `bundle exec rubocop` on staged `.rb` files. Exit 2 (blocks the commit) if anything's dirty. Forces the lint fix into the same turn as the code that broke it instead of letting it slip to CI.

- **`.claude/hooks/check_coveralls_pr.sh`** — PostToolUse on `Bash` calls containing `git push`. If the current branch has an open PR and coveralls has reported on at least one build, fetches `source_files.json` (paginated — Phlex views land on page 2), filters to the PR's touched `.rb` files, and prints any below 100% to stderr. Non-blocking. Surfaces gaps from the previous build so the assistant can't silently let them pile up across pushes.

Both wired in a new committed `.claude/settings.json`. A developer who doesn't want either hook can disable it in their `.claude/settings.local.json` (gitignored), which overrides the committed settings.

## Why this PR

The same two lapses kept happening: rubocop offenses landing on CI when they could have been caught in a one-second local run, and coveralls per-file coverage gaps going unaddressed for whole PRs because the assistant never went back to check after the bot commented. A `.claude/rules/` markdown note alone wasn't enough — the assistant needed an actual gate.

The rubocop hook is the hard gate (blocking). The coveralls hook is the visibility loop (non-blocking, because coveralls has no data for the commit you just pushed — what it CAN do is keep the previous build's gaps in the assistant's context after every push).

## Test plan

- [x] `.claude/hooks/check_rubocop_staged.sh` on a non-commit command → exit 0
- [x] `.claude/hooks/check_rubocop_staged.sh` on a `git commit` with no staged Ruby → exit 0
- [ ] On a `git commit` with rubocop-dirty staged Ruby → exit 2 with output (will verify on next session)
- [ ] On a `git push` to a branch with an open PR and coveralls data → prints gaps (will verify on next session)
- [ ] Settings format matches Claude Code's `hooks.PreToolUse` / `hooks.PostToolUse` schema (worth a sanity review by anyone who's set up Claude Code hooks before)
