### PR TITLE
Honor "Species Name Override" from iNat (#4533)

### DIFF
--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -99,8 +99,17 @@ class Inat
     end
 
     def find_or_create_override_name
-      find_or_create_name(Name.parse_name(inat_obs.name_override))
-    rescue StandardError
+      find_or_create_name(Name.parse_name(inat_obs.name_override)) ||
+        log_ignored_override("unparseable or uncreatable name")
+    rescue StandardError => e
+      log_ignored_override(e.message)
+    end
+
+    # Logs why an override was dropped (so a fall-back isn't silent) and
+    # returns nil for the override lead. (#4533)
+    def log_ignored_override(reason)
+      Rails.logger.warn("InatImport: ignoring Species Name Override " \
+                        "#{inat_obs.name_override.inspect}: #{reason}")
       nil
     end
 

--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -3,6 +3,8 @@
 class Inat
   # builds an MO Observation from an ::Inat::Obs
   class MoObservationBuilder
+    include NamingReasons
+
     attr_reader :inat_obs, :user, :skipped_images, :unlicensed_obs
 
     MO_API_KEY_NOTES = InatImportsController::MO_API_KEY_NOTES
@@ -35,7 +37,7 @@ class Inat
     def create_observation
       @observation = Observation.create(new_obs_params)
       # Lead naming first so it wins calc_consensus ties (see consensus_naming).
-      proposed_namings(community_name, prov_name, naming_vote).
+      proposed_namings(community_name, prov_name, override_name, naming_vote).
         each do |name, value|
           add_naming_with_vote(name: name, namer: namer_for(name), value: value)
         end
@@ -82,7 +84,31 @@ class Inat
     end
 
     def find_or_create_prov_name
-      parsed = Name.parse_name(inat_obs.provisional_name)
+      find_or_create_name(Name.parse_name(inat_obs.provisional_name))
+    end
+
+    # The MO name for the iNat "Species Name Override" obs field, or nil. The
+    # override outranks the provisional name and the Community ID as the lead
+    # (#4533). Returns nil - falling back to the provisional/Community lead -
+    # when the override value can't be parsed or created as an MO Name.
+    def override_name
+      return @override_name if defined?(@override_name)
+
+      @override_name =
+        inat_obs.name_override.blank? ? nil : find_or_create_override_name
+    end
+
+    def find_or_create_override_name
+      find_or_create_name(Name.parse_name(inat_obs.name_override))
+    rescue StandardError
+      nil
+    end
+
+    # Existing MO Name for the parsed name, else create it via the API (iNat
+    # taxa/provisional names lack ICN ids). nil when the name won't parse.
+    def find_or_create_name(parsed)
+      return nil if parsed.nil? || parsed.text_name.blank?
+
       if Name.where(text_name: parsed.text_name).none?
         add_provisional_name(parsed)
       else
@@ -90,12 +116,12 @@ class Inat
       end
     end
 
-    # The name proposed as the obs's consensus: the provisional name when
-    # present, else the Community ID, corrected to its preferred synonym when
-    # deprecated in MO. calc_consensus confirms it from the votes, where it
-    # carries the highest weight. (#4212)
+    # The name proposed as the obs's consensus: the override name when present,
+    # else the provisional name, else the Community ID, corrected to its
+    # preferred synonym when deprecated in MO. calc_consensus confirms it from
+    # the votes, where it carries the highest weight. (#4212, #4533)
     def lead_name
-      @lead_name ||= preferred(prov_name || community_name)
+      @lead_name ||= preferred(override_name || prov_name || community_name)
     end
 
     # A deprecated name's best preferred synonym, else the name itself
@@ -107,13 +133,14 @@ class Inat
     end
 
     # Pure: the namings to create as [name, vote] for the given Community ID
-    # name, provisional name (or nil), and the lead's confidence vote. The
-    # lead leads at lead_vote; the other iNat name and the preferred synonym
-    # of any deprecated name follow at Could Be. Lead is first so it wins
-    # calc_consensus ties. (#4212)
-    def proposed_namings(community, provisional, lead_vote)
-      lead = preferred(provisional || community)
-      named = [community, provisional].compact
+    # name, provisional name (or nil), override name (or nil), and the lead's
+    # confidence vote. The lead (override, else provisional, else Community ID)
+    # leads at lead_vote; every other name and the preferred synonym of any
+    # deprecated name follow at Could Be. Lead is first so it wins
+    # calc_consensus ties. (#4212, #4533)
+    def proposed_namings(community, provisional, override, lead_vote)
+      named = [override, provisional, community].compact
+      lead = preferred(named.first)
       synonyms = named.select(&:deprecated?).
                  filter_map { |name| name.best_preferred_synonym.presence }
       others = (named + synonyms).uniq(&:id).reject { |n| n.id == lead.id }
@@ -249,20 +276,6 @@ class Inat
       # We need an ObservationView, but noone has actually viewed this Obs.
       ObservationView.create!(observation: @observation, user: user,
                               last_view: vote.updated_at, reviewed: 1)
-    end
-
-    def used_references_explanation(name)
-      # The provisional explanation applies only to the provisional naming.
-      if prov_name && name.id == prov_name.id
-        nom_prov_adder = inat_obs.inat_prov_name_field[:user][:login]
-        # force it to be a String instead of an ActiveSupport::SafeBuffer
-        # SafeBuffer causes an errors later on. Idk why. jdc 20241126
-        :naming_inat_provisional.l(user: nom_prov_adder).to_str
-      elsif suggested?(name)
-        suggester_with_date(name)
-      else
-        "iNat `Community ID` #{Time.zone.today.strftime("%Y-%m-%d")}"
-      end
     end
 
     def suggested?(name)

--- a/app/classes/inat/mo_observation_builder/naming_reasons.rb
+++ b/app/classes/inat/mo_observation_builder/naming_reasons.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Inat
+  class MoObservationBuilder
+    # How the importer explains each naming it creates (the reasons[2] text):
+    # Species Name Override (#4533), Provisional Species Name, an iNat
+    # suggester, or the Community ID. Mixed into MoObservationBuilder.
+    module NamingReasons
+      private
+
+      # Each explanation applies only to its own naming; override wins (#4533).
+      def used_references_explanation(name)
+        if same_name?(name, override_name)
+          :naming_inat_name_override.l.to_str
+        elsif same_name?(name, prov_name)
+          provisional_explanation
+        elsif suggested?(name)
+          suggester_with_date(name)
+        else
+          "iNat `Community ID` #{Time.zone.today.strftime("%Y-%m-%d")}"
+        end
+      end
+
+      def same_name?(name, other)
+        other && name.id == other.id
+      end
+
+      def provisional_explanation
+        nom_prov_adder = inat_obs.inat_prov_name_field[:user][:login]
+        # force String not SafeBuffer (it errors later). jdc 20241126
+        :naming_inat_provisional.l(user: nom_prov_adder).to_str
+      end
+    end
+  end
+end

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -265,6 +265,16 @@ class Inat
       inat_prov_name
     end
 
+    # The value of the iNat "Species Name Override" observation field, or nil.
+    # When present it outranks the provisional name and the Community ID as the
+    # lead naming. (#4533)
+    def name_override
+      return nil if inat_obs_fields.blank?
+
+      field = inat_obs_field("Species Name Override")
+      field.present? ? field[:value].presence : nil
+    end
+
     # derive a provisional name from some specific Observation Fields
     # NOTE: iNat does not allow provisional names as identifications.
     # Also, iNat allows only 1 obs field with a given :name per obs,

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1006,6 +1006,7 @@
   # Naming reasons notes
   naming_reason_suggested_on_inat: Suggested on iNat by [user]
   naming_inat_provisional: Added on iNat by [user]
+  naming_inat_name_override: Following Species Name Override from iNat
 
   # Name/location description types. These are used as page title and in index
   # results -- must include both the type of description and the title of the

--- a/test/classes/inat_mo_observation_builder_test.rb
+++ b/test/classes/inat_mo_observation_builder_test.rb
@@ -170,6 +170,14 @@ class InatMoObservationBuilderTest < UnitTestCase
     assert_nil(builder_for(name_override: "see comments").send(:override_name))
   end
 
+  # A failure while resolving the override (e.g. an API error) is logged and
+  # falls back to nil rather than aborting the import.
+  def test_override_name_falls_back_when_resolution_raises
+    builder = builder_for(name_override: "Boletus edulis")
+    builder.define_singleton_method(:find_or_create_name) { |_| raise("boom") }
+    assert_nil(builder.send(:override_name))
+  end
+
   # No override field => no override name.
   def test_override_name_absent_is_nil
     assert_nil(builder_for.send(:override_name))

--- a/test/classes/inat_mo_observation_builder_test.rb
+++ b/test/classes/inat_mo_observation_builder_test.rb
@@ -11,13 +11,15 @@ require("test_helper")
 class InatMoObservationBuilderTest < UnitTestCase
   # Minimal stand-in for an ::Inat::Obs, exposing only what naming_vote reads.
   class FakeInatObs
-    def initialize(sequences:, provisional_name:, quality_grade:)
+    def initialize(sequences:, provisional_name:, quality_grade:,
+                   name_override: nil)
       @sequences = sequences
       @provisional_name = provisional_name
       @quality_grade = quality_grade
+      @name_override = name_override
     end
 
-    attr_reader :sequences, :provisional_name
+    attr_reader :sequences, :provisional_name, :name_override
 
     def [](key)
       { quality_grade: @quality_grade, license_code: "cc-by" }[key]
@@ -108,27 +110,93 @@ class InatMoObservationBuilderTest < UnitTestCase
                           provisional: names(:lactarius_alpinus)))
   end
 
+  # --- Species Name Override (#4533) ---
+
+  # The override leads ahead of the Community ID.
+  def test_proposed_namings_override_leads_over_community
+    assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE],
+                  ["Peltigera", Vote::MIN_POS_VOTE]],
+                 proposed(community: names(:peltigera),
+                          override: names(:lactarius_alpinus)))
+  end
+
+  # The override outranks BOTH the provisional name and the Community ID;
+  # the other two follow at Could Be.
+  def test_proposed_namings_override_outranks_provisional_and_community
+    assert_equal([["Coprinus comatus", Vote::MAXIMUM_VOTE],
+                  ["Boletus edulis", Vote::MIN_POS_VOTE],
+                  ["Peltigera", Vote::MIN_POS_VOTE]],
+                 proposed(community: names(:peltigera),
+                          provisional: names(:boletus_edulis),
+                          override: names(:coprinus_comatus)))
+  end
+
+  # Override equal to the provisional collapses to one naming for it.
+  def test_proposed_namings_override_equals_provisional
+    assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE],
+                  ["Peltigera", Vote::MIN_POS_VOTE]],
+                 proposed(community: names(:peltigera),
+                          provisional: names(:lactarius_alpinus),
+                          override: names(:lactarius_alpinus)))
+  end
+
+  # A deprecated override is corrected to its preferred synonym, which leads.
+  def test_proposed_namings_deprecated_override_prefers_synonym
+    assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE],
+                  ["Lactarius alpigenes", Vote::MIN_POS_VOTE],
+                  ["Peltigera", Vote::MIN_POS_VOTE]],
+                 proposed(community: names(:peltigera),
+                          override: names(:lactarius_alpigenes)))
+  end
+
   # When the iNat provisional name already exists in MO, reuse it rather than
   # posting a new one.
   def test_prov_name_reuses_existing_mo_name
     existing = names(:lactarius_alpinus)
-    fake = FakeInatObs.new(sequences: [], quality_grade: "needs_id",
-                           provisional_name: existing.text_name)
-    builder = Inat::MoObservationBuilder.new(
-      inat_obs: fake, user: users(:rolf), inat_source: :stub
-    )
+    builder = builder_for(provisional_name: existing.text_name)
     assert_equal(existing, builder.send(:prov_name))
+  end
+
+  # An override matching an existing MO name reuses it (no API post).
+  def test_override_name_reuses_existing_mo_name
+    existing = names(:coprinus_comatus)
+    builder = builder_for(name_override: existing.text_name)
+    assert_equal(existing, builder.send(:override_name))
+  end
+
+  # An unparseable override falls back to nil so the import proceeds with the
+  # provisional/Community lead.
+  def test_override_name_unparseable_falls_back_to_nil
+    assert_nil(builder_for(name_override: "see comments").send(:override_name))
+  end
+
+  # No override field => no override name.
+  def test_override_name_absent_is_nil
+    assert_nil(builder_for.send(:override_name))
+  end
+
+  # The override naming carries the override reason text.
+  def test_override_naming_reason
+    existing = names(:coprinus_comatus)
+    builder = builder_for(name_override: existing.text_name)
+    assert_equal("Following Species Name Override from iNat",
+                 builder.send(:used_references_explanation, existing))
   end
 
   private
 
-  def proposed(community:, provisional: nil, lead_vote: Vote::MAXIMUM_VOTE)
-    fake = FakeInatObs.new(sequences: [], provisional_name: nil,
-                           quality_grade: "needs_id")
-    builder = Inat::MoObservationBuilder.new(
-      inat_obs: fake, user: users(:rolf), inat_source: :stub
-    )
-    builder.send(:proposed_namings, community, provisional, lead_vote).
+  def builder_for(provisional_name: nil, name_override: nil)
+    fake = FakeInatObs.new(sequences: [], quality_grade: "needs_id",
+                           provisional_name: provisional_name,
+                           name_override: name_override)
+    Inat::MoObservationBuilder.new(inat_obs: fake, user: users(:rolf),
+                                   inat_source: :stub)
+  end
+
+  def proposed(community:, provisional: nil, override: nil,
+               lead_vote: Vote::MAXIMUM_VOTE)
+    builder_for.send(:proposed_namings, community, provisional, override,
+                     lead_vote).
       map { |name, vote| [name.text_name, vote] }
   end
 

--- a/test/classes/inat_obs_test.rb
+++ b/test/classes/inat_obs_test.rb
@@ -188,6 +188,19 @@ class InatObsTest < UnitTestCase
     )
   end
 
+  def test_name_override
+    with_field = inat_obs_with_fields(
+      [{ name: "Provisional Species Name", value: "ignore me" },
+       { name: "Species Name Override", value: "Boletus edulis" }]
+    )
+    assert_equal("Boletus edulis", with_field.name_override)
+
+    other_field = inat_obs_with_fields([{ name: "Other", value: "x" }])
+    assert_nil(other_field.name_override)
+
+    assert_nil(inat_obs_with_fields(nil).name_override)
+  end
+
   def test_specimen
     assert_not(mock_observation("somion_unicolor").specimen?)
     # See comment in Inat::Obs#specimen? about disabling specimen detection
@@ -461,5 +474,14 @@ class InatObsTest < UnitTestCase
     Inat::Obs.new(
       JSON.generate(JSON.parse(mock_search)["results"].first)
     )
+  end
+
+  # A minimal Inat::Obs with the given observation fields (ofvs), or none.
+  def inat_obs_with_fields(ofvs)
+    Inat::Obs.new(JSON.generate(
+                    taxon: { name: "Boletus", rank: "species",
+                             ancestor_ids: [] },
+                    ofvs: ofvs
+                  ))
   end
 end


### PR DESCRIPTION
## Summary

Fixes #4533. An iNat **"Species Name Override"** observation field now leads the imported observation's namings, ahead of the Provisional Species Name and the Community ID. Builds on the #4509 vote-weight model.

## Behavior

- **Ranking**: `override → provisional → Community ID`. The override becomes the lead naming and is created first, so it wins `calc_consensus` ties and becomes the observation's `name_id`.
- **Votes**: the override gets `naming_vote` (the lead's confidence weight); every other name stays at `MIN_POS_VOTE` (Could Be) — the same shape #4509 already produces, with the override inserted as the new lead.
- **Confidence unchanged**: an override does *not* raise `naming_vote`; that's still computed only from sequence / provisional / research-grade signals.
- **Distinct vs collapsing**: a distinct override gets its own naming; an override equal to the provisional or Community ID collapses (existing `uniq`-by-id dedup).
- **Deprecation**: a deprecated override is corrected to its `best_preferred_synonym`, which leads.
- **Fallback**: an unparseable or uncreatable override value returns `nil`, so the import proceeds with the provisional/Community lead instead of failing.
- **Reason**: the override naming carries a new reason, "Following Species Name Override from iNat".

## Changes

- `Inat::Obs#name_override` reads the obs field (mirrors the provisional-name reader).
- `Inat::MoObservationBuilder`: `override_name` (parse + find-or-create, nil on failure), `lead_name` / `proposed_namings` rank the override first, shared `find_or_create_name` helper.
- `Inat::MoObservationBuilder::NamingReasons` mixin holds the naming-reason text (the override/provisional/suggester/Community-ID explanation), keeping the builder under the class-length limit.
- New `en.txt` key `naming_inat_name_override`.

## Test plan

- [x] `proposed_namings` unit tests per branch: override leads over Community; override outranks provisional + Community; override == provisional collapses; deprecated override → preferred synonym.
- [x] `override_name`: reuses an existing MO name, falls back to nil on an unparseable value, nil when absent; the override naming reason text.
- [x] `Inat::Obs#name_override`: field present / other field / no fields.
- [x] `bin/rails test test/classes/inat_obs_test.rb test/classes/inat_mo_observation_builder_test.rb test/classes/inat_observation_importer_test.rb test/jobs/inat_import_job_test.rb` — 83 tests, 0 failures.
- [x] RuboCop clean; `obs.rb` at 100% line coverage (single-process read); the new override paths are exercised by the unit tests, integration paths by `inat_import_job_test`.
