### PR TITLE
Serve maintenance-page logo past the maintenance gate (#4312)

### DIFF
--- a/config/etc/nginx.conf
+++ b/config/etc/nginx.conf
@@ -202,6 +202,14 @@ http {
       try_files $uri =404;
     }
 
+    # Browsers auto-request /favicon.ico on any page, including the
+    # maintenance page. It's a real static file at the document root
+    # (public/favicon.ico), so the same gate caught it and returned the
+    # maintenance HTML in its place. Exempt it too (Copilot review, #4541).
+    location = /favicon.ico {
+      try_files $uri =404;
+    }
+
     # Default: maintenance gate, then existing static-or-app behavior.
     # Replaces the bare `try_files $uri @app;` previously at server level
     # (had to wrap in a location block so /test could opt out — see the

--- a/config/etc/nginx.conf
+++ b/config/etc/nginx.conf
@@ -191,6 +191,17 @@ http {
       try_files $uri @app;
     }
 
+    # The maintenance page references this logo by absolute path, so it
+    # must be served as a real static file even while the gate is up.
+    # Without this exact-match exemption the request falls into
+    # `location /` below, returns 503 → @maintenance, and the browser gets
+    # the maintenance HTML in place of the PNG — the logo renders broken
+    # (#4312). Exact-match locations outrank the `location /` prefix, so
+    # this wins regardless of $maint.
+    location = /MO-Full-Logo-Dark-400.png {
+      try_files $uri =404;
+    }
+
     # Default: maintenance gate, then existing static-or-app behavior.
     # Replaces the bare `try_files $uri @app;` previously at server level
     # (had to wrap in a location block so /test could opt out — see the


### PR DESCRIPTION
## Summary

During a deploy, the maintenance page shows but its MO logo renders broken. The page (`public/maintenance.html.tmpl`) references the logo by absolute path, `<img src="/MO-Full-Logo-Dark-400.png">`, but the nginx maintenance gate in `location /` returns `503` for **every** root-level path — including the logo request — before `try_files` ever checks disk. `error_page 503 @maintenance` then rewrites that request to the maintenance HTML, so the browser receives `text/html` in place of the PNG and the `<img>` fails.

Assets under `/assets/` already bypass the gate via their own `^~ /assets/` location, but the logo lives at the document root, so it was always caught.

This is not a regression — the logo has been unservable on every production maintenance window since the page shipped in #4312 (~90 deploys). It renders in dev only because `config/etc/nginx_dev.conf` has no maintenance gate (a bare server-level `try_files $uri @app`), which is why it looked fine in local testing.

## Fix

Add an exact-match location that serves the logo straight from disk:

```nginx
location = /MO-Full-Logo-Dark-400.png {
  try_files $uri =404;
}
```

Exact-match locations outrank the `location /` prefix, so this wins regardless of `$maint`. `try_files $uri =404` serves the file with the correct `image/png` content type, and 404s rather than falling back into the gate if it's ever missing.

## Deploy note

`script/deploy.sh` does not touch nginx, so this needs a manual `sudo nginx -s reload` (or nginx restart) on the server after the code lands — pulling the code alone won't apply it.

## Test plan

- [x] Confirmed production `/etc/nginx/nginx.conf` matches `config/etc/nginx.conf` (no drift) — `diff` is clean on the box.
- [x] Verified the logo path is unchanged since #4312 and lives at the document root (not under `/assets/`).
- [ ] After deploy + `nginx -s reload`: trigger a maintenance window (or `touch public/maintenance.html`) and confirm `/MO-Full-Logo-Dark-400.png` returns `200 image/png` while other paths return the `503` maintenance body.
