### PR TITLE
Document: never `cd` back to the session working directory in Bash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,24 @@ bin/rails console
 bin/rails routes
 ```
 
+## Shell Commands
+
+**Never prepend a `cd` back to the directory each Bash call already
+starts in.** Bash calls begin in the session's working directory (shown
+as "Primary working directory" at session start) and that directory
+persists across every call, so `cd` to it is a pure no-op. Worse, a `cd`
+combined with `&&`/`;`/newlines and output redirection trips a built-in
+approval prompt ("path resolution bypass"), interrupting the user — a
+hook cannot suppress it, so the only fix is not to emit it.
+
+The test is specific: **a leading `cd` is redundant only when its target
+resolves to the current working directory** — what the `pwd` command (or
+the `$PWD` variable) prints. Check the target against `$PWD` before
+writing it. A `cd` into a *different* directory is legitimate and not the
+anti-pattern; just prefer absolute paths
+(`bin/rails test test/...`, `sed -n '1,5p' "$PWD/path/file"`) over
+`cd`-then-relative when practical.
+
 ## Test
 
 Framework: **MiniTest** (not RSpec). System tests use **Capybara + Cuprite**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ The test is specific: **a leading `cd` is redundant only when its target
 resolves to the current working directory** — what the `pwd` command (or
 the `$PWD` variable) prints. Check the target against `$PWD` before
 writing it. A `cd` into a *different* directory is legitimate and not the
-anti-pattern; just prefer absolute paths
+anti-pattern. Prefer absolute paths
 (`bin/rails test test/...`, `sed -n '1,5p' "$PWD/path/file"`) over
 `cd`-then-relative when practical.
 


### PR DESCRIPTION
## Summary

Adds a **Shell Commands** section to `CLAUDE.md` documenting that an agent should never prepend a `cd` back to the directory each Bash call already starts in.

Bash calls in a Claude Code session begin in the project working directory (shown as *Primary working directory* at session start), and that directory persists across every call — so `cd` back to it is a pure no-op. Worse, a `cd` combined with `&&`/`;`/newlines and output redirection trips a **built-in** Claude Code safety prompt ("Compound command contains cd with output redirection — manual approval required to prevent path resolution bypass"). That prompt is not a configurable permission rule, so a hook cannot suppress it; the only fix is not to emit the `cd`. In practice it was firing repeatedly on otherwise-allowlisted commands (e.g. `cd <repo> && git status …`) and interrupting the developer.

## Why this belongs in `CLAUDE.md`

The guidance previously lived only in a per-developer agent memory, which is delivered as background context and was reliably losing to the strong `cd <dir> && <cmd>` shell idiom. `CLAUDE.md` is the authoritative, always-applied instruction surface, so the rule belongs here.

## Notes

- **Path-agnostic.** The rule keys off `$PWD` / the `pwd` command, not any hardcoded path, so it holds for every contributor's working directory.
- **Not a blanket `cd` ban.** A `cd` into a *different* directory is legitimate; the anti-pattern is specifically the redundant `cd <current-dir> && …`. The documented test is "target resolves to `$PWD`."

## Test plan

- [x] Docs-only change; no code paths affected.
- [x] Verified the new section renders correctly and is path-agnostic.
