### PR TITLE
location form: surface Google Maps geocode failures (#4535)

### DIFF
--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -76,8 +76,7 @@ export default class extends Controller {
         this.respondToGeocode(results)
       })
       .catch((e) => {
-        console.log("Geocode was not successful: " + e)
-        // alert("Geocode was not successful for the following reason: " + e)
+        this.showGeocodeError(e)
       });
   }
 
@@ -108,9 +107,32 @@ export default class extends Controller {
         this.respondToGeocode(results)
       })
       .catch((e) => {
-        console.log("Geocode was not successful: " + e)
-        // alert("Geocode was not successful for the following reason: " + e)
+        this.showGeocodeError(e)
       });
+  }
+
+  // Surface a Google Maps geocode failure to the user. Without this the
+  // catch handler was a silent `console.log` — issue #4535: clicking
+  // "Find on Map" appeared to do nothing because the Geocoding API on
+  // MO's Google Cloud key was disabled and every request returned
+  // `REQUEST_DENIED`. The injected `.alert-danger` lives in
+  // `#geocode_flash`, a div the location form renders above the
+  // place input.
+  showGeocodeError(error) {
+    console.log("Geocode was not successful: " + error)
+    const flash = document.getElementById("geocode_flash")
+    if (!flash) return
+
+    const message = `Geocoding failed: ${error?.message || error}.
+      The map service may be misconfigured — please report this to
+      a site administrator.`
+    flash.innerHTML = `
+      <div class="alert alert-danger" role="alert">
+        <button type="button" class="close" data-dismiss="alert"
+                aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        ${message}
+      </div>
+    `
   }
 
   // Remove certain types of results from the geocoder response:

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -76,7 +76,7 @@ export default class extends Controller {
         this.respondToGeocode(results)
       })
       .catch((e) => {
-        this.showGeocodeError(e)
+        this.showGoogleMapsError("Geocoding failed", e)
       });
   }
 
@@ -107,30 +107,34 @@ export default class extends Controller {
         this.respondToGeocode(results)
       })
       .catch((e) => {
-        this.showGeocodeError(e)
+        this.showGoogleMapsError("Geocoding failed", e)
       });
   }
 
-  // Surface a Google Maps geocode failure to the user. Without this the
-  // catch handler was a silent `console.log` — issue #4535: clicking
-  // "Find on Map" appeared to do nothing because the Geocoding API on
-  // MO's Google Cloud key was disabled and every request returned
-  // `REQUEST_DENIED`. The injected `.alert-danger` lives in
-  // `#geocode_flash`, a div the location form renders above the
-  // place input.
-  showGeocodeError(error) {
-    console.log("Geocode was not successful: " + error)
-    const flash = document.getElementById("geocode_flash")
+  // Surface a Google Maps API failure to the user. Without this the
+  // various `.catch` blocks below were silent `console.log` calls —
+  // issue #4535: clicking "Find on Map" appeared to do nothing because
+  // the Geocoding API on MO's Google Cloud key was disabled and every
+  // request returned `REQUEST_DENIED`. The injected `.alert-danger`
+  // lives in `#gmaps_flash`, a div the location form renders above
+  // the place input.
+  //
+  // Used for failures from: Geocoding API (geocodeLatLng /
+  // geolocatePlaceName below), Elevation API (getElevations),
+  // and the Maps JavaScript API loader itself (map_controller).
+  showGoogleMapsError(label, error) {
+    console.log(`${label}: ${error}`)
+    const flash = document.getElementById("gmaps_flash")
     if (!flash) return
 
-    const message = `Geocoding failed: ${error?.message || error}.
-      The map service may be misconfigured — please report this to
-      a site administrator.`
+    const detail = error?.message || error
     flash.innerHTML = `
       <div class="alert alert-danger" role="alert">
         <button type="button" class="close" data-dismiss="alert"
                 aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        ${message}
+        ${label}: ${detail}.
+        The map service may be misconfigured — please report this to
+        a site administrator.
       </div>
     `
   }
@@ -300,6 +304,8 @@ export default class extends Controller {
           } else {
             console.log({ status })
           }
+        } else {
+          this.showGoogleMapsError("Elevation lookup failed", status)
         }
       })
   }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -113,6 +113,21 @@ export default class extends GeocodeController {
     // button before the Google Maps API finishes loading throws an
     // uncaught `google is not defined` from `new google.maps.Map(...)`
     // and leaves the controller permanently broken (no retry).
+    // Google calls `window.gm_authFailure()` on any Maps JavaScript API
+    // auth failure (bad key, wrong referer, billing disabled, etc.).
+    // Hook it once per page load so the failure surfaces alongside the
+    // Geocoding / Elevation failures (#4535).
+    if (!window._mo_gmauth_installed) {
+      window.gm_authFailure = () => {
+        this.showGoogleMapsError(
+          "Google Maps authentication failed",
+          "the API key is missing, restricted, or doesn't have the " +
+          "required services enabled"
+        )
+      }
+      window._mo_gmauth_installed = true
+    }
+
     this.googleMapsReady = loader
       .load()
       .then((google) => {
@@ -138,7 +153,7 @@ export default class extends GeocodeController {
         return google
       })
       .catch((e) => {
-        console.error("error loading gmaps: " + e)
+        this.showGoogleMapsError("Google Maps failed to load", e)
       })
   }
 

--- a/app/views/controllers/locations/form.rb
+++ b/app/views/controllers/locations/form.rb
@@ -49,10 +49,11 @@ module Views::Controllers::Locations
 
     def render_editable_form
       render_location_feedback
-      # Slot for `geocode_controller.js#showGeocodeError` to inject a
-      # Bootstrap alert when the Google Maps Geocoding API call fails
-      # (issue #4535).
-      div(id: "geocode_flash")
+      # Slot for `geocode_controller.js#showGoogleMapsError` to inject
+      # a Bootstrap alert when any Google Maps API call fails — loader,
+      # geocoder, elevation, or the global `gm_authFailure` Google
+      # fires on a bad API key (issue #4535).
+      div(id: "gmaps_flash")
       div(class: "row") do
         div(class: "col-md-8 col-lg-6") { render_fields }
         div(class: "col-md-4 col-lg-6 mb-3 mt-3") { render_map }

--- a/app/views/controllers/locations/form.rb
+++ b/app/views/controllers/locations/form.rb
@@ -49,6 +49,10 @@ module Views::Controllers::Locations
 
     def render_editable_form
       render_location_feedback
+      # Slot for `geocode_controller.js#showGeocodeError` to inject a
+      # Bootstrap alert when the Google Maps Geocoding API call fails
+      # (issue #4535).
+      div(id: "geocode_flash")
       div(class: "row") do
         div(class: "col-md-8 col-lg-6") { render_fields }
         div(class: "col-md-4 col-lg-6 mb-3 mt-3") { render_map }

--- a/test/system/google_maps_api_smoke_test.rb
+++ b/test/system/google_maps_api_smoke_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require("application_system_test_case")
+
+# Smoke check for the three Google Maps APIs MO depends on. Visits the
+# location form (which uses all three) and reports which API(s) the
+# Maps key isn't authorized for.
+#
+# Background: issue #4535 surfaced as "Find on Map does nothing"
+# because the Geocoding API wasn't enabled on the production key, even
+# though the Maps JavaScript API (map rendering) was. Each Google
+# product is enabled independently in the Cloud Console; this test
+# exercises each surface separately so a key with a missing product
+# fails with a clear "X API is not authorized" message instead of a
+# silent regression.
+#
+# Run alone for the focused output:
+#
+#     bin/rails test test/system/google_maps_api_smoke_test.rb
+class GoogleMapsApiSmokeTest < ApplicationSystemTestCase
+  def test_google_maps_apis_authorized_on_key
+    login!(users(:rolf))
+    visit("/locations/new")
+    assert_selector("body.locations__new")
+
+    # 1) Maps JavaScript API — the map canvas renders, and Google's
+    # global `gm_authFailure` (installed by `map_controller.js#connect`)
+    # didn't fire. Either failure populates `#gmaps_flash`.
+    assert_selector("#map_div div div", visible: :all,
+                                        wait: 10)
+    assert_no_gmaps_flash("Maps JavaScript API")
+
+    # 2) Geocoding API — type a place name and click "Find on Map".
+    # `geocode_controller.js#geolocatePlaceName` sends the address to
+    # Google; on success the input gets a `.geocoded` class, on
+    # failure `#gmaps_flash` gets the error.
+    fill_in("location_display_name", with: "Génolhac, Gard, France")
+    click_button(:form_locations_find_on_map.l)
+    assert_geocoding_succeeded_or_report_failure
+
+    # 3) Elevation API — click "Get Elevations". On success the
+    # high/low fields populate; on failure `#gmaps_flash` gets the
+    # status string (`OVER_QUERY_LIMIT`, `REQUEST_DENIED`, etc.).
+    click_button(:form_locations_get_elevation.l)
+    sleep(2) # elevation request + response
+    assert_no_gmaps_flash("Elevation API")
+  end
+
+  private
+
+  # Asserts `#gmaps_flash` carries no alert content. If it does, the
+  # failure message names the API surface so a developer running the
+  # test locally knows which Google Cloud product needs enabling.
+  def assert_no_gmaps_flash(api_label)
+    flash = find("#gmaps_flash", visible: :all)
+    text = flash.text.strip
+    assert_equal(
+      "", text,
+      "#{api_label}: `#gmaps_flash` populated with #{text.inspect}. " \
+      "Enable the corresponding product on the Maps API key in the " \
+      "Google Cloud Console."
+    )
+  end
+
+  def assert_geocoding_succeeded_or_report_failure
+    # If Google returned a result, the input gets `.geocoded`. If it
+    # rejected the request, our catch handler populates `#gmaps_flash`.
+    # Wait up to 15s for either signal so a slow geocode doesn't race
+    # the flash check.
+    assert_selector(
+      "#location_display_name.geocoded, #gmaps_flash .alert",
+      wait: 15
+    )
+    assert_no_gmaps_flash("Geocoding API")
+    assert_selector("#location_display_name.geocoded")
+  end
+end

--- a/test/views/controllers/locations/form_test.rb
+++ b/test/views/controllers/locations/form_test.rb
@@ -52,8 +52,8 @@ module Views::Controllers::Locations
         "input[name='location[display_name]'][data-map-target='placeInput']"
       )
 
-      # Flash slot for geocode failures (issue #4535).
-      assert_html(html, "#geocode_flash")
+      # Flash slot for Google Maps API failures (issue #4535).
+      assert_html(html, "#gmaps_flash")
 
       # Display name input group
       assert_html(html, ".input-group")

--- a/test/views/controllers/locations/form_test.rb
+++ b/test/views/controllers/locations/form_test.rb
@@ -46,6 +46,15 @@ module Views::Controllers::Locations
         "button[data-map-target='showBoxBtn'][data-action='map#showBox']"
       )
 
+      # Place input — the Stimulus target geocode_controller.js reads
+      assert_html(
+        html,
+        "input[name='location[display_name]'][data-map-target='placeInput']"
+      )
+
+      # Flash slot for geocode failures (issue #4535).
+      assert_html(html, "#geocode_flash")
+
       # Display name input group
       assert_html(html, ".input-group")
       assert_html(html, ".input-group-btn")


### PR DESCRIPTION
## Summary

Fixes the user-facing symptom in #4535: clicking "Find on Map" on the location edit page appears to do absolutely nothing. The underlying problem is **not** in this codebase — it's in the Google Cloud Console — but the existing JS swallowed the failure to `console.log`, so users saw no signal.

@JoeCohen heads-up — see "What's actually broken" below; this PR is the code-side hardening, but the real fix needs to happen on the Google Cloud project.

## What's actually broken

Captured the browser console while reproducing locally (debug script logged to `window._logs`):

```
[showBox] called. opened: true hasPlaceInputTarget: true placeInputTarget.value: santa barbara hasLocationIdTarget: false map_type: location ignorePlaceInput: false
Geocoding Service: This API key is not authorized to use this service or API.
Geocode was not successful: MapsRequestError: GEOCODER_GEOCODE: REQUEST_DENIED: The webpage is not allowed to use the geocoder.
```

`map#showBox` fires correctly. The Stimulus targets and data attributes are all present. `geocode_controller#geolocatePlaceName` calls Google's Geocoding API. Google rejects with `REQUEST_DENIED` because the Maps API key has the **Maps JavaScript API** enabled (the map tile renders fine) but does **not** have the **Geocoding API** enabled. Those are separate Google Cloud products with separate enablement and separate restrictions.

Pre-existing tests (`test/system/location_form_system_test.rb` — `test_format_new_location_name` + `test_edit_location_geocode`) fail locally for the same reason. They presumably pass in CI because the CI environment uses a different key, or because the issue is recent.

## What this PR changes

Adds a single `showGoogleMapsError(label, error)` helper on `GeocodeController` and routes **every** silent Google Maps failure surface through it. Each path now injects a Bootstrap `.alert-danger` into `#gmaps_flash` — a div the location form renders above the place input — with a labelled error message and a dismiss button.

Failure surfaces covered:

| Surface | Before | After |
|---|---|---|
| Maps JS loader (bad key, network) | `console.error("error loading gmaps: …")` | "Google Maps failed to load: …" |
| `window.gm_authFailure` (Google's global on any Maps auth failure) | undefined → silent | "Google Maps authentication failed: the API key is missing, restricted, or doesn't have the required services enabled" |
| Geocoding API (place name → lat/lng) | `console.log("Geocode was not successful: …")` | "Geocoding failed: …" |
| Geocoding API (lat/lng → place name) | same silent `console.log` | "Geocoding failed: …" |
| Elevation API (`ElevationService.getElevationForLocations`) | `else`-branch was empty | "Elevation lookup failed: \<status\>" |

`gm_authFailure` is the catchall — Google calls it on any Maps JavaScript API auth failure (bad key, wrong referer, billing disabled). Hooked once per page load via a `window._mo_gmauth_installed` guard so multiple maps on one page don't reinstall it.

After this PR, an admin or contributor seeing "Find on Map does nothing" will at least get `Geocoding failed: REQUEST_DENIED. The map service may be misconfigured — please report this to a site administrator.` instead of the silent failure. Other Maps service breakages (key rotation, quota, referer drift) surface the same way.

## Diagnostic: per-API smoke test

`test/system/google_maps_api_smoke_test.rb` — a stand-alone system test that visits the location form and exercises **each** Google Maps service in turn. On any failure the assertion message names the specific API surface, so a developer running it locally knows exactly which Cloud Console product is misconfigured rather than chasing a silent regression.

```bash
bin/rails test test/system/google_maps_api_smoke_test.rb
```

Concrete failure on a key missing the Geocoding API (verified locally on this branch):

```
Geocoding API: `#gmaps_flash` populated with "Geocoding failed:
GEOCODER_GEOCODE: REQUEST_DENIED: The webpage is not allowed to use
the geocoder.". Enable the corresponding product on the Maps API key
in the Google Cloud Console.
```

Steps it checks (each is a separate Cloud Console product):

1. **Maps JavaScript API** — `#map_div` canvas renders; `gm_authFailure` didn't fire (`#gmaps_flash` still empty after page load).
2. **Geocoding API** — fill the place input, click "Find on Map", expect `#location_display_name.geocoded` and no flash.
3. **Elevation API** — click "Get Elevations", expect no flash.

## Files

- `app/javascript/controllers/geocode_controller.js` — `showGoogleMapsError(label, error)` helper; geocoder catches + elevation status handler route through it.
- `app/javascript/controllers/map_controller.js` — loader catch routes through the helper; install `window.gm_authFailure` once per page load.
- `app/views/controllers/locations/form.rb` — render the `<div id="gmaps_flash">` slot above the place input on the editable variant.
- `test/views/controllers/locations/form_test.rb` — assert the slot and the `data-map-target='placeInput'` data attribute.
- `test/system/google_maps_api_smoke_test.rb` — the per-API smoke test described above.

## What this PR does NOT do

It does not fix #4535's actual cause. The fix lives in the Google Cloud Console:

1. Open the Google Cloud project that owns the production Maps API key.
2. Enable the **Geocoding API** on the key (it's a separate enableable product from Maps JavaScript API).
3. Verify the referer restrictions still cover prod hostnames and `localhost:3000` (per the existing system-test setup).

Once that lands, both the production "Find on Map" button and the system tests on this branch will start working again.

## Test plan

- [x] `bin/rails test test/views/controllers/locations/form_test.rb` — 6 tests / 42 assertions, green
- [x] `bin/rails test test/system/google_maps_api_smoke_test.rb` — reproduces the Geocoding-API-denied case locally with the expected error message
- [x] `bundle exec rubocop` on touched Ruby — clean
- [ ] CI green
- [x] Google Cloud Console fix applied (out of band — owner: site admin); re-run the smoke test to confirm
