### PR TITLE
Guard nil verified date in user profile heading (#4551)

### DIFF
--- a/app/views/controllers/users/show/_profile.erb
+++ b/app/views/controllers/users/show/_profile.erb
@@ -1,8 +1,8 @@
 <%
 heading = [
   tag.strong(:show_user_joined.t), ": ",
-  tag.span(@show_user.verified.strftime("%Y-%m-%d"),
-           data: { time: @show_user.verified.strftime("%Y-%m-%dT%H:%M:%S") })
+  tag.span(@show_user.verified&.strftime("%Y-%m-%d"),
+           data: { time: @show_user.verified&.strftime("%Y-%m-%dT%H:%M:%S") })
 ].safe_join
 heading_links =
   if @show_user != @user && !@show_user.no_emails &&

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -148,6 +148,19 @@ class UsersControllerTest < FunctionalTestCase
     assert_redirected_to({ action: :index })
   end
 
+  # An unverified user has verified: nil; the profile heading must not
+  # crash on nil.strftime when rendering the "Joined" date (#4551).
+  def test_show_unverified_user
+    user = users(:unverified)
+    assert_nil(user.verified)
+
+    login
+    get(:show, params: { id: user.id })
+
+    assert_response(:success)
+    assert_select("body.users__show")
+  end
+
   #   ---------------------
   #    show_selected users
   #   ---------------------


### PR DESCRIPTION
## Summary

Viewing the profile of an **unverified** user crashed with `NoMethodError: undefined method 'strftime' for nil`. The "Joined" heading in `app/views/controllers/users/show/_profile.erb` called `@show_user.verified.strftime(...)` unconditionally, but unverified users have `verified: nil`. The `users#show` action doesn't redirect unverified users, so the partial rendered for them and the page returned a 500.

This guards both `strftime` calls with safe navigation (`verified&.strftime`), so the "Joined" value is simply blank for unverified users.

## Why now

This is live in production, and the April–May 2026 SMTP outage left a large batch of unverified accounts — their profiles can't be viewed (e.g. by an admin triaging them) without hitting this crash. The fix was salvaged from an old abandoned branch (`njw-user-purging`); the rest of that branch was a local-only purge-interval experiment and was discarded.

## Test plan

- [x] New controller test `test_show_unverified_user` renders `users#show` for the `unverified` fixture (`verified: nil`) and asserts `:success`. Verified it errors with `undefined method 'strftime' for nil` without the fix and passes with it.
- [x] `bundle exec rubocop test/controllers/users_controller_test.rb` — no offenses

Fixes #4551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
