### PR TITLE
Record iNat image provenance structurally, not in original_name (#4529)

### DIFF
--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -4,6 +4,7 @@ class Inat
   # builds an MO Observation from an ::Inat::Obs
   class MoObservationBuilder
     include NamingReasons
+    include ImageHandling
 
     attr_reader :inat_obs, :user, :skipped_images, :unlicensed_obs
 
@@ -230,41 +231,6 @@ class Inat
 
     def user_api_key
       APIKey.find_by(user: user, notes: MO_API_KEY_NOTES).key
-    end
-
-    def add_inat_images(inat_obs_photos)
-      inat_obs_photos.each do |obs_photo|
-        photo = Inat::ObsPhoto.new(obs_photo)
-        if photo.license_code.blank?
-          handle_unlicensed_image(photo)
-        else
-          API2.execute(post_photo_params(photo))
-        end
-      end
-    end
-
-    # Own-observation imports: apply user's default MO license.
-    # Others' observations: skip and count for end-of-import reporting.
-    def handle_unlicensed_image(photo)
-      if @import_others
-        @skipped_images += 1
-      else
-        API2.execute(post_photo_params(photo, license: @user.license_id))
-      end
-    end
-
-    def post_photo_params(photo, license: photo.license_id)
-      {
-        method: :post,
-        action: :image,
-        api_key: user_api_key,
-        upload_url: photo.url,
-        notes: photo.notes,
-        copyright_holder: photo.copyright_holder,
-        license: license,
-        original_name: photo.original_name,
-        observations: @observation.id
-      }
     end
 
     def update_names_and_proposals

--- a/app/classes/inat/mo_observation_builder/image_handling.rb
+++ b/app/classes/inat/mo_observation_builder/image_handling.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class Inat
+  class MoObservationBuilder
+    # Uploads each iNat observation photo as an MO Image (applying the
+    # user's default license to unlicensed own-observation photos, skipping
+    # unlicensed others'-observation photos) and records structured import
+    # provenance — source + iNat photo id — directly on the created image.
+    # Mixed into MoObservationBuilder.
+    module ImageHandling
+      private
+
+      def add_inat_images(inat_obs_photos)
+        inat_obs_photos.each do |obs_photo|
+          photo = Inat::ObsPhoto.new(obs_photo)
+          image = create_inat_image(photo)
+          record_image_provenance(image, photo) if image
+        end
+      end
+
+      def create_inat_image(photo)
+        if photo.license_code.blank?
+          handle_unlicensed_image(photo)
+        else
+          upload_inat_image(post_photo_params(photo))
+        end
+      end
+
+      # Own-observation imports: apply user's default MO license.
+      # Others' observations: skip and count for end-of-import reporting.
+      def handle_unlicensed_image(photo)
+        if @import_others
+          @skipped_images += 1
+          nil
+        else
+          upload_inat_image(post_photo_params(photo, license: @user.license_id))
+        end
+      end
+
+      def upload_inat_image(params)
+        API2.execute(params).results.first
+      end
+
+      # Recorded directly on the image so it survives regardless of the
+      # uploader's `keep_filenames` preference (which the Image API applies
+      # to the filename-bearing `original_name`). See #4529.
+      def record_image_provenance(image, photo)
+        image.update_columns(source_id: @inat_source.id,
+                             external_id: photo.external_id)
+      end
+
+      def post_photo_params(photo, license: photo.license_id)
+        {
+          method: :post,
+          action: :image,
+          api_key: user_api_key,
+          upload_url: photo.url,
+          notes: photo.notes,
+          copyright_holder: photo.copyright_holder,
+          license: license,
+          observations: @observation.id
+        }
+      end
+    end
+  end
+end

--- a/app/classes/inat/obs_photo.rb
+++ b/app/classes/inat/obs_photo.rb
@@ -56,10 +56,12 @@ class Inat
       "Imported from iNat #{DateTime.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")}"
     end
 
-    # iNat doesn't preserve user's original filename
-    # Preserve photo_id and uuid for purposed of syncing updates
-    def original_name
-      "iNat photo_id: #{@photo[:photo_id]}, uuid: #{@photo[:uuid]}"
+    # The iNat photo id, recorded structurally on the MO image as
+    # `external_id` (with `source_id`) for syncing updates (#4529). This
+    # replaces stashing it in `original_name`, which API2::ImageAPI nulls
+    # out for users whose `keep_filenames` preference is "toss".
+    def external_id
+      @photo[:photo_id]
     end
 
     # Convert the url returned by the iNat API to

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -253,6 +253,13 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   belongs_to :user
   belongs_to :license
 
+  # External data source for imported images (#4208/#4529). `source_id` +
+  # `external_id` record where the image came from (e.g. the iNat photo id),
+  # mirroring the Observation source/external_id pair.
+  belongs_to :external_source, class_name: "Source",
+                               foreign_key: :source_id, optional: true,
+                               inverse_of: :images
+
   has_many :copyright_changes, as: :target,
                                dependent: :destroy,
                                inverse_of: :target

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -33,6 +33,7 @@ class Source < AbstractModel
 
   has_many :observations, dependent: :restrict_with_exception,
                           inverse_of: :external_source
+  has_many :images, dependent: :nullify, inverse_of: :external_source
 
   validates :name, presence: true, length: { maximum: 100 },
                    uniqueness: { case_sensitive: false }

--- a/db/migrate/20260616120000_add_source_provenance_to_images.rb
+++ b/db/migrate/20260616120000_add_source_provenance_to_images.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Structured per-image import provenance (#4529). Records the source and
+# the source-system photo id for imported images, mirroring the
+# observations.source_id / external_id pair. Replaces the fragile use of
+# images.original_name to carry the iNat photo id — API2::ImageAPI nulls
+# original_name out for users whose keep_filenames preference is "toss",
+# which dropped provenance on ~87% of imported images.
+class AddSourceProvenanceToImages < ActiveRecord::Migration[7.2]
+  def change
+    change_table(:images, bulk: true) do |t|
+      t.bigint(:source_id)
+      t.string(:external_id, limit: 64)
+      t.index([:source_id, :external_id])
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_16_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_16_120000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -197,6 +197,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_16_000000) do
     t.boolean "transferred", default: false, null: false
     t.boolean "gps_stripped", default: false, null: false
     t.boolean "diagnostic", default: true, null: false
+    t.bigint "source_id"
+    t.string "external_id", limit: 64
+    t.index ["source_id", "external_id"], name: "index_images_on_source_id_and_external_id"
   end
 
   create_table "inat_import_job_trackers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -224,6 +227,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_16_000000) do
     t.datetime "last_obs_start"
     t.boolean "cancel"
     t.boolean "import_others", default: false, null: false
+    t.text "inat_url"
     t.integer "writeback", default: 0, null: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -227,7 +227,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_16_120000) do
     t.datetime "last_obs_start"
     t.boolean "cancel"
     t.boolean "import_others", default: false, null: false
-    t.text "inat_url"
     t.integer "writeback", default: 0, null: false
   end
 

--- a/test/classes/inat_obs_photo_test.rb
+++ b/test/classes/inat_obs_photo_test.rb
@@ -19,10 +19,8 @@ class InatObsPhotoTest < UnitTestCase
     assert_equal("(c) Tim C., some rights reserved (CC BY-NC)",
                  photo.copyright_holder)
     inat_photo = inat_obs[:observation_photos].first
-    assert_equal(
-      "iNat photo_id: #{inat_photo[:photo_id]}, uuid: #{inat_photo[:uuid]}",
-      photo.original_name
-    )
+    assert_equal(inat_photo[:photo_id], photo.external_id,
+                 "iNat photo id should map to Image#external_id (#4529)")
     assert_equal(
       "Imported from iNat #{DateTime.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")}",
       photo.notes

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -178,11 +178,12 @@ class InatImportJobTest < ActiveJob::TestCase
     imported_img = obs.images.first
     assert_equal(@user, imported_img.user,
                  "Image should belong to importing user")
-    assert_equal(
-      "iNat photo_id: #{inat_photo[:photo_id]}, uuid: #{inat_photo[:uuid]}",
-      imported_img.original_name,
-      "Image original_name should be iNat photo_id and uuid"
-    )
+    # Structured provenance (#4529): source + iNat photo id on the image,
+    # not stashed in the keep_filenames-governed original_name.
+    assert_equal(Source.inaturalist, imported_img.external_source,
+                 "Imported image should record its source")
+    assert_equal(inat_photo[:photo_id].to_s, imported_img.external_id,
+                 "Imported image should record the iNat photo id")
 
     assert(obs.sequences.none?)
   end


### PR DESCRIPTION
## Summary

Part of #4529 — the **go-forward capture**. (Backfill of existing imports is the remaining half, tracked separately on the issue.)

The iNat importer recorded each photo's provenance by stashing `"iNat photo_id: <id>, uuid: <uuid>"` in the MO image's **`original_name`**. But `original_name` is a privacy-governed filename field: `API2::ImageAPI#parse_original_name` (`app/classes/api2/image_api.rb:127`) does `return nil if @user&.keep_filenames == "toss"`. So for any user whose `keep_filenames` preference is `"toss"`, the API **nulls `original_name` out** — discarding the provenance the importer just passed.

On a production-copy DB that's **159,656 of 186,838 imported images (87%)** with no provenance, 159,628 of them belonging to `keep_filenames = "toss"` users. (Full root-cause writeup on #4529.)

## Change

Store provenance where `keep_filenames` can't reach it — a structured pair on `images`, mirroring the existing `observations.source_id` / `external_id`:

- **Migration:** `images.source_id` (FK → `sources`) + `images.external_id` (string) + index.
- **`Inat::ObsPhoto`** exposes `#external_id` (the iNat photo id) instead of building the `original_name` string.
- **`MoObservationBuilder`** captures the created image (`API2.execute(...).results.first`) and writes `(source_id, external_id)` directly on it — so it survives regardless of `keep_filenames`. It no longer passes the provenance as `original_name`.
- **`Image`** gains `belongs_to :external_source` (class `Source`); **`Source`** gains `has_many :images`.
- The image-upload methods move to a new `MoObservationBuilder::ImageHandling` concern (mirrors the existing `NamingReasons` mixin) to keep the builder under `Metrics/ClassLength` — the class was already at 249/250.

## Not in this PR

- **Backfill** of the 186,838 existing imports — parse the surviving `original_name` (24,285) and position-infer the rest (159,656, where the value was never stored). That's the larger second half of #4529.

## Test plan

- [x] `inat_import_job_test`: imported image now asserts `external_source == Source.inaturalist` and `external_id == <iNat photo id>` (was asserting `original_name`).
- [x] `inat_obs_photo_test`: `#external_id` maps the iNat photo id (was `#original_name`).
- [x] `bin/rails test` across the iNat import suite, Image/Source model tests — 0 failures.
- [x] RuboCop clean (ClassLength resolved by the concern extraction; no cop disables).

Refs #4529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
