### PR TITLE
Promote Descriptions::Versions::Show to Views::FullPageBase

### DIFF
--- a/app/views/controllers/descriptions/versions/show.rb
+++ b/app/views/controllers/descriptions/versions/show.rb
@@ -20,7 +20,7 @@
 #   - Any extra setup (e.g. `Textile.register_name`) via a
 #     `pre_render_setup` hook.
 module Views::Controllers::Descriptions::Versions
-  class Show < Views::Base
+  class Show < Views::FullPageBase
     prop :description, ::Description
     prop :user, _Nilable(::User), default: nil
     prop :versions, _Array(_Interface(:user_id))

--- a/test/controllers/locations/descriptions/versions_controller_test.rb
+++ b/test/controllers/locations/descriptions/versions_controller_test.rb
@@ -12,7 +12,15 @@ module Locations::Descriptions
       desc.reload
       new_versions = desc.versions.length
       assert(new_versions > old_versions)
+
       get(:show, params: { id: desc.id })
+
+      # `Views::Controllers::Descriptions::Versions::Show` extends
+      # `Views::FullPageBase`, so the Application layout fires —
+      # doctype + chrome + page-title slot populated.
+      assert_response(:success)
+      assert_select("html > head > title", count: 1)
+      assert_select("body.versions__show")
       assert_select("#description_details_and_alts")
     end
   end

--- a/test/controllers/names/descriptions/versions_controller_test.rb
+++ b/test/controllers/names/descriptions/versions_controller_test.rb
@@ -12,8 +12,16 @@ module Names::Descriptions
       desc.reload
       new_versions = desc.versions.length
       assert(new_versions > old_versions)
+
       get(:show, params: { id: desc.id })
-      assert_select("#description_details_and_alts")
+
+      # `Views::Controllers::Descriptions::Versions::Show` extends
+      # `Views::FullPageBase`, so the full Application layout fires:
+      # doctype + layout chrome + the page-title slot populated by
+      # `add_page_title` from `view_template`.
+      assert_response(:success)
+      assert_select("html > head > title", count: 1)
+      assert_select("body.versions__show")
       assert_select("#description_details_and_alts")
     end
   end

--- a/test/views/controllers/descriptions/versions/show_test.rb
+++ b/test/views/controllers/descriptions/versions/show_test.rb
@@ -12,8 +12,15 @@ require "test_helper"
 class Views::Controllers::Descriptions::Versions::ShowTest <
   ComponentTestCase
   # Subclass-with-all-extension-points-implemented, so we can render
-  # the base view without going through a real controller path.
+  # the base view without going through a real controller path. Skips
+  # `around_template` so the test renders only the action body, not the
+  # full application layout (no need to stub Sidebar / TopNav /
+  # current_languages for these content-shape assertions).
   class TestSubclass < ::Views::Controllers::Descriptions::Versions::Show
+    def around_template
+      yield
+    end
+
     private
 
     def page_title_key


### PR DESCRIPTION
## Summary

`Views::Controllers::Descriptions::Versions::Show` is the abstract base for the two concrete action views (`Names::Descriptions::Versions::Show`, `Locations::Descriptions::Versions::Show`) that controllers render as full pages. It currently inherits `Views::Base` and "works" only because `add_page_title` / `add_context_nav` happen to be registered as helpers on `Views::Base` — the inheritance is wrong for what the class actually is.

This PR promotes it to `Views::FullPageBase`. The classification matches reality, and it survives the upcoming move of those helpers onto `FullPageBase` as instance methods.

## Test changes

- The existing `Views::Controllers::Descriptions::Versions::ShowTest::TestSubclass` overrides `around_template` to skip the layout wrap so the content-shape tests don't need full layout stubs.
- Both `Names::Descriptions::VersionsControllerTest` and `Locations::Descriptions::VersionsControllerTest` get display assertions on the `<title>` element + body class so the layout-wrap firing is verified end-to-end.

## Test plan

- [x] `bin/rails test test/views/controllers/descriptions/versions/show_test.rb`
- [x] `bin/rails test test/controllers/names/descriptions/versions_controller_test.rb`
- [x] `bin/rails test test/controllers/locations/descriptions/versions_controller_test.rb`
- [x] `bin/rails test test/views/full_page_base_inheritance_test.rb`
- [ ] CI green
