### PR TITLE
Strip provenance-only history comments from Phlex views

### DIFF
--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -32,7 +32,7 @@
 #     end
 #   end
 #
-#   # In new.html.erb and edit.html.erb, just render the form directly:
+#   # In new.rb and edit.rb, just render the form directly:
 #   <%= render(Views::Controllers::Licenses::Form.new(@license)) %>
 #
 # @example Deriving action URL from model associations

--- a/app/components/application_form/autocompleter_field.rb
+++ b/app/components/application_form/autocompleter_field.rb
@@ -153,11 +153,10 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def autocompleter_field_attributes
-      {
-        placeholder: :start_typing.l,
-        autocomplete: "off",
-        data: input_data_attributes
-      }.deep_merge(attributes)
+      mix({ placeholder: :start_typing.l,
+            autocomplete: "off",
+            data: input_data_attributes },
+          attributes)
     end
 
     def input_data_attributes

--- a/app/components/application_form/file_field.rb
+++ b/app/components/application_form/file_field.rb
@@ -51,7 +51,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     def wrapper_class
       base = "form-group"
       wrap_class = wrapper_options[:wrap_class]
-      wrap_class.present? ? "#{base} #{wrap_class}" : base
+      class_names(base, wrap_class)
     end
 
     def wrapper_data

--- a/app/components/content_padded.rb
+++ b/app/components/content_padded.rb
@@ -3,8 +3,7 @@
 # Minimal padded-content wrapper: emits `<div class="p-3 ...">`
 # around the block. All keyword args are forwarded to the
 # underlying `<div>`; `class:` is composed with the default
-# `"p-3"`. (Replaces the now-deleted `ContentHelper#content_padded`
-# ERB helper.)
+# `"p-3"`.
 #
 # @example
 #   render(Components::ContentPadded.new(id: "details")) do

--- a/app/components/crud_button/delete.rb
+++ b/app/components/crud_button/delete.rb
@@ -7,9 +7,6 @@ class Components::CrudButton
   # `confirm:` to `:are_you_sure.l`. Caller can override any of
   # those by passing the kwarg explicitly.
   #
-  # Used as the Phlex-side equivalent of `LinkHelper#destroy_button`
-  # — that ERB helper now delegates here.
-  #
   # @example Phlex caller
   #   render(Components::CrudButton::Delete.new(target: @api_key))
   #

--- a/app/components/crud_button/download.rb
+++ b/app/components/crud_button/download.rb
@@ -10,8 +10,6 @@ class Components::CrudButton
   # is `new_download_species_list_path`), so the caller passes an
   # explicit String target rather than a model.
   #
-  # Used as the Phlex-side equivalent of `LinkHelper#download_button`.
-  #
   # @example Phlex caller (explicit-path target)
   #   render(Components::CrudButton::Download.new(
   #     name: :DOWNLOAD.t,

--- a/app/components/crud_button/edit.rb
+++ b/app/components/crud_button/edit.rb
@@ -5,9 +5,6 @@ class Components::CrudButton
   # `action: :edit`, `icon: :edit`. Path prefixing follows the parent
   # `NAMED_ROUTE_ACTIONS` whitelist (`edit_<model>_path`).
   #
-  # Used as the Phlex-side equivalent of `LinkHelper#edit_button` —
-  # that ERB helper now delegates here.
-  #
   # @example Phlex caller
   #   render(Components::CrudButton::Edit.new(target: @herbarium))
   #

--- a/app/components/crud_button/get.rb
+++ b/app/components/crud_button/get.rb
@@ -3,9 +3,7 @@
 class Components::CrudButton
   # GET `CrudButton` — emits `<a>` (link_to), not a form-wrapped
   # button. Idempotent navigations (edit, download, etc.) use this
-  # rather than the form-button branch. Used as the Phlex-side
-  # equivalent of `LinkHelper#edit_button` and `download_button`
-  # (which delegate here).
+  # rather than the form-button branch.
   #
   # The `action:` kwarg controls path-prefixing for model targets
   # via the parent `NAMED_ROUTE_ACTIONS` whitelist (`:edit`, `:new`,

--- a/app/components/crud_button/patch.rb
+++ b/app/components/crud_button/patch.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class Components::CrudButton
-  # PATCH-method `CrudButton`. Used as the Phlex-side equivalent of
-  # `LinkHelper#patch_button` (which delegates here).
+  # PATCH-method `CrudButton`.
   #
   # @example
   #   render(Components::CrudButton::Patch.new(

--- a/app/components/crud_button/post.rb
+++ b/app/components/crud_button/post.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class Components::CrudButton
-  # POST-method `CrudButton`. Used as the Phlex-side equivalent of
-  # `LinkHelper#post_button` (which delegates here).
+  # POST-method `CrudButton`.
   #
   # @example
   #   render(Components::CrudButton::Post.new(

--- a/app/components/crud_button/put.rb
+++ b/app/components/crud_button/put.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class Components::CrudButton
-  # PUT-method `CrudButton`. Used as the Phlex-side equivalent of
-  # `LinkHelper#put_button` (which delegates here).
+  # PUT-method `CrudButton`.
   #
   # @example
   #   render(Components::CrudButton::Put.new(

--- a/app/components/description/mod_links.rb
+++ b/app/components/description/mod_links.rb
@@ -12,13 +12,6 @@
 # sub-panels), but distinct in shape: this one is the icon row
 # attached to the panel heading, with " | " separators rather than
 # brackets.
-#
-# Replaces the pre-Phlex `DescriptionIconsHelper#description_change_links`
-# + its 7 sub-helpers (`#description_edit_icon`,
-# `#description_admin_icons`, `#description_state_icons`,
-# `#description_make_default_icon`, `#description_project_icon`,
-# `#description_publish_icon`, plus the inlined `destroy_button`
-# call). The helper file is deleted in the same commit.
 class Components::Description::ModLinks < Components::Base
   prop :description, ::Description
   prop :user, _Nilable(::User), default: nil

--- a/app/components/description/previous_version.rb
+++ b/app/components/description/previous_version.rb
@@ -5,10 +5,6 @@
 # exists. Used on every versioned-model show page (name, location,
 # description, glossary_term) and inside the description-details
 # panel.
-#
-# Replaces the pre-Phlex `VersionsHelper#show_previous_version` +
-# its private `previous_version_link` / `current_version_html`
-# composers.
 class Components::Description::PreviousVersion < Components::Base
   prop :obj, ::AbstractModel
   prop :versions, _Array(_Interface(:user_id)), default: -> { [] }

--- a/app/components/form/notes.rb
+++ b/app/components/form/notes.rb
@@ -3,7 +3,7 @@
 # Notes section of a form, with a collapsible Bootstrap Panel wrap.
 #
 # Shared between forms that have user-configurable notes "parts"
-# (currently observation; field-slip migration is in flight).
+# (currently observation and field-slip).
 # Owns:
 #   - The Panel (collapsible card with "Notes" heading and caret).
 #   - The panel body, containing (in order):

--- a/app/components/form/pattern_search.rb
+++ b/app/components/form/pattern_search.rb
@@ -9,9 +9,6 @@
 # land under `pattern_search[…]` — the shape
 # `SearchController#pattern` reads.
 #
-# Replaces the inner `form_with(:pattern_search …)` block of the
-# original `application/top_nav/_search_bar.html.erb` partial.
-#
 # @example In the search-bar layout
 #   render(Components::Form::PatternSearch.new(
 #            FormObject::PatternSearch.new(
@@ -20,8 +17,6 @@
 #            )
 #          ))
 class Components::Form::PatternSearch < Components::ApplicationForm
-  # Search-type options for the type select. Inlined from the
-  # since-deleted `SearchBarHelper#search_type_options`.
   SEARCH_TYPE_OPTIONS = [
     [:COMMENTS, :comments],
     [:GLOSSARY, :glossary_terms],
@@ -41,8 +36,7 @@ class Components::Form::PatternSearch < Components::ApplicationForm
   def initialize(model, **options)
     options[:id] ||= "pattern_search_form"
     options[:class] = [FORM_CLASS, options[:class]].flatten.compact.join(" ")
-    # Match Rails `form_with`'s default `<form accept-charset="UTF-8">`
-    # so HTML parity holds against the legacy ERB partial.
+    # Match Rails `form_with`'s default `<form accept-charset="UTF-8">`.
     options[:"accept-charset"] ||= "UTF-8"
     super(model, method: :get, **options)
   end

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # Superform component for rendering faceted search forms.
-# Replaces shared/search_form.erb and shared/search_panel.erb partials.
 #
 # Uses the Query model (e.g., Query::Observations) directly as the form model.
 # Field layout is determined by FIELD_COLUMNS on the controller.

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -112,8 +112,7 @@ class Components::Form::Search < Components::ApplicationForm
     end
   end
 
-  # Inlined from `SearchBarHelper#search_bar_toggle` — Bootstrap
-  # collapse-trigger button that hides the search-bar elements row
+  # Bootstrap collapse-trigger button that hides the search-bar elements row
   # in the top nav.
   def render_search_bar_toggle
     button(class: class_names(BAR_TOGGLE_CLASSES),

--- a/app/components/form/upload_gallery.rb
+++ b/app/components/form/upload_gallery.rb
@@ -7,10 +7,6 @@
 # only one image) and registers per-image slides + thumbnails via the
 # carousel's `c.item(...) { … }` / `c.thumb(...) { … }` API.
 #
-# Replaces the legacy `Components::FormCarousel`. The Bootstrap carousel
-# skeleton now lives in `Components::Carousel`; this component owns the
-# form-mode props and the slide / thumbnail iteration.
-#
 # @example
 #   render Components::Form::UploadGallery.new(
 #     user: @user,

--- a/app/components/help/note.rb
+++ b/app/components/help/note.rb
@@ -5,9 +5,6 @@
 # form fields ("(optional)", "(required)") and for short
 # textile-rendered notes that sit next to a section title.
 #
-# Replaces the `help_note` helper that lived in
-# `app/helpers/panel_helper.rb`.
-#
 # @example Inline `(optional)` marker next to a label
 #   render(Components::Help::Note.new("(#{:optional.l})"))
 #
@@ -24,9 +21,6 @@ class Components::Help::Note < Components::Base
   # coverage gap).
   prop :attributes, _Hash(_Union(Symbol, String), _Any?)
 
-  # Match the legacy helper's positional shape — callers wrote
-  # `help_note(:p, "...", class: "...")` and we want the same call
-  # site to work via `Components::Help::Note.new(:p, "...", ...)`.
   def initialize(element = :span, string = nil, **kwargs)
     extra_class = kwargs.delete(:class)
     super(element: element, string: string,

--- a/app/components/help/tooltip.rb
+++ b/app/components/help/tooltip.rb
@@ -5,8 +5,6 @@
 # Used for inline label-decorating glyphs (the `?` next to a filter
 # header, etc.).
 #
-# Replaces the `help_tooltip` helper from `panel_helper.rb`.
-#
 # @example
 #   render(Components::Help::Tooltip.new(label: "(?)",
 #                                        title: "Click for explanation"))

--- a/app/components/icon.rb
+++ b/app/components/icon.rb
@@ -105,7 +105,7 @@ class Components::Icon < Components::Base
 
   def span_class(glyph)
     base = "glyphicon glyphicon-#{glyph} link-icon"
-    @html_class ? "#{base} #{@html_class}" : base
+    class_names(base, @html_class)
   end
 
   def span_data

--- a/app/components/id_badge.rb
+++ b/app/components/id_badge.rb
@@ -4,10 +4,6 @@
 # displayed next to an object's title (matrix box, project banner,
 # species-list listing row, etc.). Clicking the badge copies the
 # numeric id into the clipboard.
-#
-# Replaces the `show_title_id_badge` helper that lived in
-# `app/helpers/header/title_helper.rb`. Callers pass the object and
-# optional extra CSS classes (defaults to `"mr-4"`).
 class Components::IdBadge < Components::Base
   prop :object, ::AbstractModel
   prop :extra_class, _Nilable(String), default: "mr-4"

--- a/app/components/image/base.rb
+++ b/app/components/image/base.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-# Abstract base class for image components.
-#
-# This component replaces the ImagePresenter class, handling all image
-# presentation logic internally through Literal properties and methods.
-#
-# Provides shared functionality for rendering images with:
+# Abstract base class for image components. Provides shared functionality
+# for rendering images with:
 # - Lazy loading with aspect ratio preservation
 # - Lightbox support
 # - Vote sections

--- a/app/components/image/export_status_controls.rb
+++ b/app/components/image/export_status_controls.rb
@@ -8,10 +8,7 @@
 # flag (`:ok_for_export`, the default) and an Image's `diagnostic`
 # flag (`:diagnostic`, used by the ML-training data pipeline).
 #
-# Drop-in replacement for the long-standing `export_status_controls`
-# and `export_status_ml_controls` helpers in
-# `app/helpers/exports_helper.rb`. Returns nothing (empty render)
-# for non-reviewer viewers.
+# Returns nothing (empty render) for non-reviewer viewers.
 #
 # @example Ok-for-export pair on a Name
 #   render(Components::Image::ExportStatusControls.new(object: @name))

--- a/app/components/image/license_badge.rb
+++ b/app/components/image/license_badge.rb
@@ -3,8 +3,6 @@
 # Tiny `<a><img/></a>` block displaying a license's badge with a
 # link to its canonical URL. Used by description show pages
 # (`DetailsAndAltsPanel`) and image show pages.
-#
-# Replaces the shared `_form_license_badge.erb` partial.
 class Components::Image::LicenseBadge < Components::Base
   prop :license, ::License
 

--- a/app/components/image_gallery.rb
+++ b/app/components/image_gallery.rb
@@ -6,11 +6,6 @@
 # (`ImageGallery::Item`) + thumbnail indicators (`ImageGallery::Thumbnail`)
 # via the carousel's `c.item(...) { … }` / `c.thumb(...) { … }` API.
 #
-# Replaces the legacy `Components::Carousel` (which inlined the Bootstrap
-# carousel skeleton). The skeleton now lives in
-# `Components::Carousel`; this component owns the Panel chrome,
-# heading, no-images fallback, and the per-image render logic.
-#
 # @example
 #   render Components::ImageGallery.new(
 #     user: @user,

--- a/app/components/link/external_site.rb
+++ b/app/components/link/external_site.rb
@@ -19,9 +19,10 @@ class Components::Link::ExternalSite < Components::Base
 
   def view_template
     if inaturalist?
-      link_to(inat_text, @link.url)
+      link_to(inat_text, @link.url, target: "_blank", rel: "noopener")
     else
-      link_to(:on_site.t(site: @link.external_site.name), @link.url)
+      link_to(:on_site.t(site: @link.external_site.name), @link.url,
+              target: "_blank", rel: "noopener")
       small { plain(" #{@link.created_at.web_date}") }
     end
   end

--- a/app/components/list_group/search.rb
+++ b/app/components/list_group/search.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 # Bootstrap panel + search-status form for list-style show pages
-# (project show, species_list show). Replaces the
-# `shared/_list_search.html.erb` partial and its single-caller inner
-# `shared/_search_status_autocompleter.erb` partial.
+# (project show, species_list show).
 #
 # The form posts to `AddDispatchController#new`, which reads flat
 # top-level params (`name`, `field_slip`, `object_id`, `object_type`,

--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -3,12 +3,10 @@
 # Interactive map component for displaying locations and observations.
 # Works with the Stimulus map controller to render Google Maps with
 # markers and bounding boxes.
-#
-# Ports the logic that previously lived in `MapHelper`,
-# `MapPopupHelper`, and `MapLegendHelper` so that those helpers can be
-# deleted. The popup markup is the richer (`#4131`) flavor: a Bootstrap
-# `.media` layout with a thumbnail for single-obs popups, and a header
-# with "Show All" / "Map All" buttons for group popups.
+
+# The popup markup is a Bootstrap `.media` layout with a thumbnail for
+# single-obs popups, and a header with "Show All" / "Map All" buttons
+# for group popups.
 #
 # The rendering logic is split across three siblings under
 # `app/components/map/`:

--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -20,9 +20,6 @@
 # - Multi-observation (group) → count header with Show All / Map All
 #   buttons pointing at filtered MO indexes, plus the top
 #   `MAX_GROUP_NAMES` observation name links and the box coords.
-#
-# Behavior ported from the deleted `MapPopupHelper#mapset_info_window`
-# chain; structure unchanged.
 class Components::Map::Popup < Components::Base
   MAX_GROUP_NAMES = 3
 

--- a/app/components/nav_tabs.rb
+++ b/app/components/nav_tabs.rb
@@ -85,8 +85,7 @@ class Components::NavTabs < Components::Base
   #
   #     tabs.tab("Details", details_path, key: "details")
   #
-  # **Array splat from a legacy `app/helpers/tabs/*_helper.rb` method**
-  # (the `[title, url, html_options]` shape):
+  # **Array splat (the `[title, url, html_options]` shape):**
   #
   #     tabs.tab(*projects_index_tab, key: "index")
   #

--- a/app/components/table.rb
+++ b/app/components/table.rb
@@ -172,11 +172,8 @@ class Components::Table < Components::Base
   private
 
   def table_attributes
-    base_class = "table"
-    combined_class =
-      @html_class ? "#{base_class} #{@html_class}" : base_class
     attrs = @attributes.dup
-    attrs[:class] = combined_class
+    attrs[:class] = class_names("table", @html_class)
     attrs[:id] = @html_id if @html_id
     attrs
   end

--- a/app/controllers/species_lists/uploads_controller.rb
+++ b/app/controllers/species_lists/uploads_controller.rb
@@ -32,8 +32,7 @@ module SpeciesLists
         @species_list.process_file_data(@user, sorter)
         init_name_vars_from_sorter(@species_list, sorter)
         init_project_vars_for_edit(@species_list)
-        # `species_lists/edit.html.erb` is now Phlex (see #4389) — render
-        # the class directly. No form re-render path here, so the
+        # render the class directly. No form re-render path here, so the
         # dubious-where / submitted-project ivars stay empty.
         render(Views::Controllers::SpeciesLists::Edit.new(
                  species_list: @species_list,

--- a/app/views/controllers/account/api_keys/edit.rb
+++ b/app/views/controllers/account/api_keys/edit.rb
@@ -4,7 +4,6 @@
 # fallback for editing an API key (JS users edit inline on the
 # index). Page chrome plus help text plus the shared form.
 #
-# Replaces `app/views/controllers/account/api_keys/edit.html.erb`.
 module Views::Controllers::Account::APIKeys
   class Edit < Views::FullPageBase
     prop :key, ::APIKey

--- a/app/views/controllers/account/api_keys/form.rb
+++ b/app/views/controllers/account/api_keys/form.rb
@@ -3,12 +3,12 @@
 module Views::Controllers::Account::APIKeys
   # Form for creating or editing an API key. Only used by the
   # api_keys controller — its three callers are `table.rb` (inline
-  # create + inline edit), `new.html.erb` (standalone create), and
-  # `edit.html.erb` (standalone edit).
+  # create + inline edit), `new.rb` (standalone create), and
+  # `edit.rb` (standalone edit).
   #
   # Four layouts:
   # - Standalone edit (persisted, no cancel_target): metadata table +
-  #   notes + Update / Cancel link. Used by `edit.html.erb` (no-JS
+  #   notes + Update / Cancel link. Used by `edit.rb` (no-JS
   #   fallback).
   # - Inline edit (persisted + cancel_target): input-group with cancel
   #   icon + notes input + Save button. Used by the JS-driven per-row
@@ -17,7 +17,7 @@ module Views::Controllers::Account::APIKeys
   #   icon + notes input + Create button. Used by the JS-driven inline
   #   create UI on the index page (collapse toggle to dismiss).
   # - Standalone create (new, no cancel_target): notes input + centered
-  #   Create button. Used by `new.html.erb` (no-JS fallback).
+  #   Create button. Used by `new.rb` (no-JS fallback).
   class Form < ::Components::ApplicationForm
     def initialize(model, cancel_target: nil, cancel_parent: nil, **)
       @cancel_target = cancel_target
@@ -97,11 +97,8 @@ module Views::Controllers::Account::APIKeys
       text_field(:notes, label: "#{:NOTES.t}:", wrap_class: "mt-3")
       div(class: "text-center mt-3") do
         submit(:UPDATE.l)
-        # Cancel is a real navigation link (was a submit button in
-        # the pre-Phlex ERB — clicking it actually submitted the form
-        # and the controller did an update with current values, the
-        # opposite of what a Cancel button should do). Now it just
-        # navigates back to the index without touching anything.
+        # A plain link (not a submit button) — Cancel should navigate
+        # back without submitting the form.
         link_to(:CANCEL.l, account_api_keys_path,
                 class: "btn btn-default ml-3")
       end

--- a/app/views/controllers/account/api_keys/index.rb
+++ b/app/views/controllers/account/api_keys/index.rb
@@ -4,7 +4,6 @@
 # "manage your API keys" page. Page chrome plus a textile-rendered
 # help block plus the `APIKeys::Table` of the user's keys.
 #
-# Replaces `app/views/controllers/account/api_keys/index.html.erb`.
 module Views::Controllers::Account::APIKeys
   class Index < Views::FullPageBase
     prop :user, ::User

--- a/app/views/controllers/account/api_keys/new.rb
+++ b/app/views/controllers/account/api_keys/new.rb
@@ -4,7 +4,6 @@
 # fallback for creating an API key (JS users use the inline collapse
 # panel on the index). Page chrome + help text + the shared form.
 #
-# Replaces `app/views/controllers/account/api_keys/new.html.erb`.
 module Views::Controllers::Account::APIKeys
   class New < Views::FullPageBase
     prop :key, ::APIKey

--- a/app/views/controllers/account/form.rb
+++ b/app/views/controllers/account/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Account
   # Signup form for creating a new user account. Rendered by the
-  # AccountController's `new.html.erb` (the top-level account
+  # AccountController's `new.rb` (the top-level account
   # controller's only form-bearing page).
   # Collects login, password, email, name, and theme preference.
   class Form < ::Components::ApplicationForm

--- a/app/views/controllers/account/form.rb
+++ b/app/views/controllers/account/form.rb
@@ -7,7 +7,7 @@ module Views::Controllers::Account
   # Collects login, password, email, name, and theme preference.
   class Form < ::Components::ApplicationForm
     def initialize(model, **)
-      # Explicit id preserves the legacy `#account_signup_form` —
+      # Explicit id preserves `#account_signup_form` —
       # integration tests use it in `within(...)` blocks, and the
       # default Views/-namespaced derive_form_id would pick
       # `account_form` (loses the "signup" specificity).

--- a/app/views/controllers/account/login/email_new_password.rb
+++ b/app/views/controllers/account/login/email_new_password.rb
@@ -4,9 +4,6 @@
 # the "I forgot my password, email me a reset link" page. Page title
 # plus the textile-rendered help/spam note plus the
 # `EmailNewPasswordForm`.
-#
-# Replaces
-# `app/views/controllers/account/login/email_new_password.html.erb`.
 module Views::Controllers::Account::Login
   class EmailNewPassword < Views::FullPageBase
     prop :new_user, _Nilable(::User)

--- a/app/views/controllers/account/login/email_new_password_form.rb
+++ b/app/views/controllers/account/login/email_new_password_form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Account::Login
   # Form for requesting a new password via email. Rendered by the
-  # account/login controller's `email_new_password.html.erb`. Keeps
+  # account/login controller's `email_new_password.rb`. Keeps
   # the descriptive name (sibling to `Login::Form`) since the login
   # controller has multiple form-bearing pages.
   class EmailNewPasswordForm < ::Components::ApplicationForm

--- a/app/views/controllers/account/login/form.rb
+++ b/app/views/controllers/account/login/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Account::Login
   # Form for user login. Rendered by the account/login controller's
-  # `new.html.erb`.
+  # `new.rb`.
   class Form < ::Components::ApplicationForm
     def view_template
       render_login_field

--- a/app/views/controllers/account/login/logout.rb
+++ b/app/views/controllers/account/login/logout.rb
@@ -2,8 +2,7 @@
 
 # Action template for `Account::LoginController#logout` — the
 # "you've been logged out" landing page. Page title plus the
-# textile-rendered farewell note. Replaces
-# `app/views/controllers/account/login/logout.html.erb`.
+# textile-rendered farewell note.
 module Views::Controllers::Account::Login
   class Logout < Views::FullPageBase
     def view_template

--- a/app/views/controllers/account/login/new.rb
+++ b/app/views/controllers/account/login/new.rb
@@ -4,7 +4,7 @@
 # page. Page title + login form, followed by three "why log in"
 # sections (signup invitation, spider/SEO explanation, what data
 # requires login). Replaces
-# `app/views/controllers/account/login/new.html.erb`.
+# `app/views/controllers/account/login/new.rb`.
 #
 # The textile content (`:login_*.t` / `.tp`) often embeds
 # `"text":url` links that the translator renders as real `<a>`

--- a/app/views/controllers/account/login/new.rb
+++ b/app/views/controllers/account/login/new.rb
@@ -3,8 +3,7 @@
 # Action template for `Account::LoginController#new` — the login
 # page. Page title + login form, followed by three "why log in"
 # sections (signup invitation, spider/SEO explanation, what data
-# requires login). Replaces
-# `app/views/controllers/account/login/new.rb`.
+# requires login).
 #
 # The textile content (`:login_*.t` / `.tp`) often embeds
 # `"text":url` links that the translator renders as real `<a>`

--- a/app/views/controllers/account/login/test_autologin.rb
+++ b/app/views/controllers/account/login/test_autologin.rb
@@ -2,8 +2,7 @@
 
 # Action template for `Account::LoginController#test_autologin` — a
 # blank "you hit the autologin test page" stub used by the manual
-# autologin flow check. Replaces
-# `app/views/controllers/account/login/test_autologin.html.erb`.
+# autologin flow check.
 module Views::Controllers::Account::Login
   class TestAutologin < Views::FullPageBase
     def view_template

--- a/app/views/controllers/account/new.rb
+++ b/app/views/controllers/account/new.rb
@@ -2,7 +2,6 @@
 
 # Action template for `AccountController#new` — the "sign up for an
 # account" page. Sets the page title and renders the signup form.
-# Replaces `app/views/controllers/account/new.html.erb`.
 module Views::Controllers::Account
   class New < Views::FullPageBase
     prop :new_user, ::User

--- a/app/views/controllers/account/preferences/form.rb
+++ b/app/views/controllers/account/preferences/form.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
-# Phlex form for `account/preferences#edit` — replaces the
-# `account/preferences/edit.html.erb` `form_with` block and its 6
-# section partials (_login, _privacy, _appearance, _filters, _notes,
-# _email) + 3 filter sub-partials.
+# Phlex form for `account/preferences#edit`.
 #
-# Multiple submit buttons (one per section) preserve the pre-Phlex
-# convenience that lets users save changes from any section without
-# scrolling to the bottom of the page. The form's URL is the
-# resource path (PATCH to `account_preferences_path`).
+# Multiple submit buttons (one per section) let users save changes
+# from any section without scrolling to the bottom of the page.
+# The form's URL is the resource path (PATCH to
+# `account_preferences_path`).
 #
 # Content-filter fields (`Query::Filter.all`) live under the
 # `user[<filter_sym>]` namespace and read their `checked` /

--- a/app/views/controllers/account/preferences/form.rb
+++ b/app/views/controllers/account/preferences/form.rb
@@ -249,8 +249,7 @@ class Views::Controllers::Account::Preferences::Form <
     div(class: "form-group mt-3") do
       span(class: "font-weight-bold") { plain(:prefs_content_filters.t) }
       # Two paragraphs: explanation, then a blank one to push the
-      # first filter row down (the ERB this replaces had an unclosed
-      # `<p>` after the explanation).
+      # first filter row down.
       p { plain(:prefs_content_filters_explanation.t) }
       p { nil }
     end

--- a/app/views/controllers/account/preferences/no_email.rb
+++ b/app/views/controllers/account/preferences/no_email.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action view for `account/preferences#no_email`. Replaces
-# `account/preferences/no_email.html.erb`. Confirms that a single email
+# Action view for `account/preferences#no_email`. Confirms that a single email
 # notification type has been turned off in response to an unsubscribe
 # link clicked from one of MO's outgoing emails.
 module Views::Controllers::Account::Preferences

--- a/app/views/controllers/account/profile/edit.rb
+++ b/app/views/controllers/account/profile/edit.rb
@@ -5,7 +5,6 @@
 # location, notes, image upload, mailing address), the user's
 # current profile image plus a remove button on the right.
 #
-# Replaces `app/views/controllers/account/profile/edit.html.erb`.
 module Views::Controllers::Account::Profile
   class Edit < Views::FullPageBase
     prop :user, ::User

--- a/app/views/controllers/account/profile/form.rb
+++ b/app/views/controllers/account/profile/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Account::Profile
   # Form for editing a user's profile. Rendered by the
-  # account/profile controller's `edit.html.erb`. Renders name,
+  # account/profile controller's `edit.rb`. Renders name,
   # location, notes, image upload, and mailing address fields. Upload
   # fields are nested under user[upload][...] via ApplicationForm's
   # upload_fields helper (namespace(:upload) inside the user form).

--- a/app/views/controllers/account/verifications/new.rb
+++ b/app/views/controllers/account/verifications/new.rb
@@ -3,8 +3,7 @@
 # Action template for `Account::VerificationsController#new` — the
 # "we just sent you a verification email" landing page. Welcomes
 # the new user by their legal name and emits the textile-rendered
-# verification instructions. Replaces
-# `app/views/controllers/account/verifications/new.rb`.
+# verification instructions.
 module Views::Controllers::Account::Verifications
   class New < Views::FullPageBase
     prop :user, ::User

--- a/app/views/controllers/account/verifications/new.rb
+++ b/app/views/controllers/account/verifications/new.rb
@@ -4,7 +4,7 @@
 # "we just sent you a verification email" landing page. Welcomes
 # the new user by their legal name and emits the textile-rendered
 # verification instructions. Replaces
-# `app/views/controllers/account/verifications/new.html.erb`.
+# `app/views/controllers/account/verifications/new.rb`.
 module Views::Controllers::Account::Verifications
   class New < Views::FullPageBase
     prop :user, ::User

--- a/app/views/controllers/account/verifications/reverify.rb
+++ b/app/views/controllers/account/verifications/reverify.rb
@@ -4,8 +4,7 @@
 # shown when an unverified user (or a logged-in user trying to verify
 # someone else) lands on a verification link. Page title plus the
 # textile-rendered reverification instructions and a "send another
-# verification email" submit. Replaces
-# `app/views/controllers/account/verifications/reverify.html.erb`.
+# verification email" submit.
 module Views::Controllers::Account::Verifications
   class Reverify < Views::FullPageBase
     prop :unverified_user, ::User

--- a/app/views/controllers/account/welcome.rb
+++ b/app/views/controllers/account/welcome.rb
@@ -5,7 +5,6 @@
 # welcome note + logout button for logged-in users, or a "no user
 # yet" textile note for anonymous viewers.
 #
-# Replaces `app/views/controllers/account/welcome.html.erb`.
 module Views::Controllers::Account
   class Welcome < Views::FullPageBase
     def view_template

--- a/app/views/controllers/account/welcome.rb
+++ b/app/views/controllers/account/welcome.rb
@@ -21,7 +21,6 @@ module Views::Controllers::Account
 
     private
 
-    # Inlined from `AccountHelper#account_welcome_title`.
     def welcome_title
       return :welcome_no_user_title.t unless current_user
 

--- a/app/views/controllers/admin/banners/form.rb
+++ b/app/views/controllers/admin/banners/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Admin::Banners
   # Form for admins to create or update site-wide banners. Rendered
-  # by the admin/banners controller's `index.html.erb`. Displays a
+  # by the admin/banners controller's `index.rb`. Displays a
   # textarea for the banner message with a submit button. Always
   # creates a new banner record (with incremented version) rather
   # than updating existing records, so always uses POST method.

--- a/app/views/controllers/admin/blocked_ips/edit.rb
+++ b/app/views/controllers/admin/blocked_ips/edit.rb
@@ -4,7 +4,7 @@ module Views::Controllers::Admin::BlockedIps
   # Action template for the IP Access Manager page. Two-column
   # layout: left has the okay-IPs and blocked-IPs Manager forms,
   # right has the optional per-IP stats panel + global most-active-
-  # users summary panel. Converted from `admin/blocked_ips/edit.rb`.
+  # users summary panel.
   class Edit < Views::FullPageBase
     prop :ip, _Nilable(::String), default: nil
     prop :stats, ::Hash

--- a/app/views/controllers/admin/blocked_ips/edit.rb
+++ b/app/views/controllers/admin/blocked_ips/edit.rb
@@ -4,7 +4,7 @@ module Views::Controllers::Admin::BlockedIps
   # Action template for the IP Access Manager page. Two-column
   # layout: left has the okay-IPs and blocked-IPs Manager forms,
   # right has the optional per-IP stats panel + global most-active-
-  # users summary panel. Converted from `admin/blocked_ips/edit.html.erb`.
+  # users summary panel. Converted from `admin/blocked_ips/edit.rb`.
   class Edit < Views::FullPageBase
     prop :ip, _Nilable(::String), default: nil
     prop :stats, ::Hash

--- a/app/views/controllers/admin/blocked_ips/edit/ip_stats.rb
+++ b/app/views/controllers/admin/blocked_ips/edit/ip_stats.rb
@@ -4,7 +4,6 @@ module Views::Controllers::Admin::BlockedIps
   class Edit
     # Sub-partial of the IP-access-manager page (the
     # right-hand column's "Stats for <ip>" panel).
-    # Converted from `admin/blocked_ips/_ip_stats.html.erb`.
     class IpStats < Views::Base
       prop :stats, ::Hash
       prop :ip, ::String

--- a/app/views/controllers/admin/blocked_ips/edit/ip_summary.rb
+++ b/app/views/controllers/admin/blocked_ips/edit/ip_summary.rb
@@ -4,7 +4,6 @@ module Views::Controllers::Admin::BlockedIps
   class Edit
     # Sub-partial of the IP-access-manager page (the
     # right-hand column's "Most active users" panel).
-    # Converted from `admin/blocked_ips/_ip_summary.html.erb`.
     class IpSummary < Views::Base
       prop :stats, ::Hash
       # `{ user_id => User }` + `{ api_key_str => APIKey }` preloaded

--- a/app/views/controllers/admin/donations/form.rb
+++ b/app/views/controllers/admin/donations/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Admin::Donations
   # Form for creating donations (admin only). Rendered by the
-  # admin/donations controller's `new.html.erb`. Allows admins to
+  # admin/donations controller's `new.rb`. Allows admins to
   # manually enter donation information.
   class Form < ::Components::ApplicationForm
     def view_template

--- a/app/views/controllers/admin/donations/review_form.rb
+++ b/app/views/controllers/admin/donations/review_form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Admin::Donations
   # Admin form for reviewing donations. Rendered by the
-  # admin/donations controller's `edit.html.erb`. Sibling to
+  # admin/donations controller's `edit.rb`. Sibling to
   # `Donations::Form` (the new-donation form); the descriptive
   # suffix distinguishes the two flows.
   # Renders a table of donations with checkboxes for marking each

--- a/app/views/controllers/admin/session/form.rb
+++ b/app/views/controllers/admin/session/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Admin::Session
   # Form for admins to switch to another user's account. Rendered by
-  # the admin/session controller's `edit.html.erb`. Allows admins to
+  # the admin/session controller's `edit.rb`. Allows admins to
   # impersonate users for debugging/support.
   class Form < ::Components::ApplicationForm
     def initialize(model, **)

--- a/app/views/controllers/admin/users/bonuses_form.rb
+++ b/app/views/controllers/admin/users/bonuses_form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Admin::Users
   # Form for editing user contribution bonuses (admin only).
-  # Rendered by the admin/users controller's `edit.html.erb`. Allows
+  # Rendered by the admin/users controller's `edit.rb`. Allows
   # admins to manually adjust user bonus points. Descriptive
   # `BonusesForm` name kept since the form is specifically for
   # bonuses, not generic user edits.

--- a/app/views/controllers/articles/form.rb
+++ b/app/views/controllers/articles/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Articles
   # Form for creating or editing articles. Rendered directly by the
-  # articles controller's `new.html.erb` and `edit.html.erb`.
+  # articles controller's `new.rb` and `edit.rb`.
   # Articles support Textile markup for formatting.
   class Form < ::Components::ApplicationForm
     def view_template

--- a/app/views/controllers/articles/index.rb
+++ b/app/views/controllers/articles/index.rb
@@ -3,8 +3,7 @@
 module Views::Controllers::Articles
   # Paginated articles index. Page chrome (title, sorter, context-nav,
   # pagination) + a `Components::ListGroup::Base` of one article-summary
-  # row per result. Converted from `articles/index.html.erb` +
-  # `articles/_object.html.erb`.
+  # row per result.
   class Index < Views::FullPageBase
     prop :query, ::Query
     prop :pagination_data, ::PaginationData

--- a/app/views/controllers/articles/index/article_item.rb
+++ b/app/views/controllers/articles/index/article_item.rb
@@ -4,7 +4,7 @@ module Views::Controllers::Articles
   class Index
     # One row of the articles index. Renders the inner contents of a
     # `Components::ListGroup::Item` (title link + byline + truncated
-    # body teaser). Converted from `articles/_object.html.erb`.
+    # body teaser).
     class ArticleItem < Views::Base
       prop :article, ::Article
 

--- a/app/views/controllers/articles/show.rb
+++ b/app/views/controllers/articles/show.rb
@@ -3,7 +3,7 @@
 module Views::Controllers::Articles
   # Show-article page. Renders the byline (author + creation time),
   # the article body inside a Panel, and the standard versions
-  # footer. Converted from `articles/show.html.erb`.
+  # footer.
   class Show < Views::FullPageBase
     prop :article, ::Article
 

--- a/app/views/controllers/checklists/panel.rb
+++ b/app/views/controllers/checklists/panel.rb
@@ -5,9 +5,8 @@ module Views::Controllers::Checklists
   # the shared Panel component. Used by the Contents component for
   # each section (unobserved / species-level / higher-level / default).
   #
-  # Inlines what used to be the `ChecklistHelper` module — every
-  # taxon row, its display content, link path, and the optional
-  # "remove target name" button now live here as private methods.
+  # Every taxon row, its display content, link path, and the optional
+  # "remove target name" button live here as private methods.
   class Panel < ::Components::Base
     def initialize(data:, context:, taxa: nil,
                    panel_id: "checklist_panel",

--- a/app/views/controllers/checklists/show.rb
+++ b/app/views/controllers/checklists/show.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Phlex view for the checklist page. Replaces show.html.erb.
+# Phlex view for the checklist page.
 module Views::Controllers::Checklists
   class Show < Views::FullPageBase
     def initialize(data:, context:)

--- a/app/views/controllers/collection_numbers/edit.rb
+++ b/app/views/controllers/collection_numbers/edit.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for `CollectionNumbersController#edit`. Replaces
-# `app/views/controllers/collection_numbers/edit.html.erb`. Wraps
+# Action template for `CollectionNumbersController#edit`. Wraps
 # the existing `Form` Phlex component with the page chrome + a
 # side-column list of MatrixBox previews (one per associated obs).
 module Views::Controllers::CollectionNumbers

--- a/app/views/controllers/collection_numbers/form.rb
+++ b/app/views/controllers/collection_numbers/form.rb
@@ -4,7 +4,7 @@ module Views::Controllers::CollectionNumbers
   # Form for creating or editing collection numbers. Collection
   # numbers are specimen identifiers assigned by collectors.
   # Rendered directly by the collection_numbers controller's
-  # `new.html.erb` and `edit.html.erb`, and dynamically by
+  # `new.rb` and `edit.rb`, and dynamically by
   # `Components::Modal::TurboForm` via `form_component_class_for`.
   class Form < ::Components::ApplicationForm
     def initialize(model, observation: nil, back: nil, **)

--- a/app/views/controllers/collection_numbers/index.rb
+++ b/app/views/controllers/collection_numbers/index.rb
@@ -27,8 +27,7 @@ module Views::Controllers::CollectionNumbers
 
     private
 
-    # Headerless `Components::Table` (`show_headers: false`) — matches
-    # the bare-table markup of the original ERB.
+    # Headerless `Components::Table` (`show_headers: false`).
     def render_rows_table
       render(Components::Table.new(@objects, class: "table-striped mt-3",
                                              show_headers: false)) do |t|

--- a/app/views/controllers/collection_numbers/index.rb
+++ b/app/views/controllers/collection_numbers/index.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for the CollectionNumbers index. Replaces
-# `app/views/controllers/collection_numbers/index.html.erb`.
+# Action template for the CollectionNumbers index.
 #
 # `CollectionNumbersController#render_index_view` overrides the
 # `ApplicationController` default to render this class directly with

--- a/app/views/controllers/collection_numbers/new.rb
+++ b/app/views/controllers/collection_numbers/new.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for `CollectionNumbersController#new`. Replaces
-# `app/views/controllers/collection_numbers/new.html.erb`. Wraps
+# Action template for `CollectionNumbersController#new`. Wraps
 # the existing `Form` Phlex component with the page chrome + a
 # side-column MatrixBox preview of the observation.
 module Views::Controllers::CollectionNumbers

--- a/app/views/controllers/collection_numbers/show.rb
+++ b/app/views/controllers/collection_numbers/show.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for `CollectionNumbersController#show`. Replaces
-# `app/views/controllers/collection_numbers/show.html.erb`.
+# Action template for `CollectionNumbersController#show`.
 module Views::Controllers::CollectionNumbers
   class Show < Views::FullPageBase
     prop :collection_number, ::CollectionNumber

--- a/app/views/controllers/comments/comment_item.rb
+++ b/app/views/controllers/comments/comment_item.rb
@@ -7,15 +7,14 @@
 #   the comments-for-object Panel. `editable:` is whether the
 #   viewer should see edit/destroy mod-links + a real author
 #   UserLink (truthy on logged-in viewers); `show_name:` is false.
-# - **`comments/index.html.erb`** — the site-wide searchable
+# - **`comments/index.rb`** — the site-wide searchable
 #   comments index. `show_name: true` adds a heading with a link
 #   to the comment's target.
 #
 # Also rendered indirectly via the `Comment` model's
 # `after_create_commit` / `after_update_commit` Turbo-Stream
 # broadcasts — those callbacks render this view to HTML and pass
-# it as the broadcast payload, replacing the legacy
-# `partial: "comments/comment"` lookup.
+# it as the broadcast payload.
 module Views::Controllers::Comments
   class CommentItem < Views::Base
     include Phlex::Rails::Helpers::ImageTag
@@ -137,7 +136,7 @@ module Views::Controllers::Comments
     #   `comment.user` so the gate passes; the markup ships
     #   unconditionally. The wrapping `[data-user-specific]`
     #   span teams up with the site-wide CSS rule (see
-    #   `_user_specific_css.html.erb`) to hide it for everyone
+    #   `_user_specific_css.rb`) to hide it for everyone
     #   except the comment's author on the receiving end. Admins
     #   bypass the CSS so they still see mod links.
     def render_mod_links_span

--- a/app/views/controllers/comments/comment_item.rb
+++ b/app/views/controllers/comments/comment_item.rb
@@ -16,8 +16,6 @@
 # broadcasts — those callbacks render this view to HTML and pass
 # it as the broadcast payload, replacing the legacy
 # `partial: "comments/comment"` lookup.
-#
-# Replaces `app/views/controllers/comments/_comment.erb`.
 module Views::Controllers::Comments
   class CommentItem < Views::Base
     include Phlex::Rails::Helpers::ImageTag
@@ -26,9 +24,7 @@ module Views::Controllers::Comments
     prop :user, _Nilable(::User), default: nil
     # When true, render edit/destroy mod-links and a real author
     # UserLink. When false, the author shows as plain text and no
-    # mod-links wrapper is emitted. The legacy ERB called this
-    # prop `controls`; the rename keeps it clear that the flag is
-    # about edit-affordance, not the comment's existence.
+    # mod-links wrapper is emitted.
     prop :editable, _Boolean, default: false
     prop :show_name, _Boolean, default: false
 
@@ -85,11 +81,10 @@ module Views::Controllers::Comments
     # ---- target heading (comments-index "show_name" mode) ---------
 
     # `target_name_link` and `target_type` are wrapped in `rescue`
-    # blocks in the legacy helper — a comment can outlive its
-    # target (deleted observation, project, etc.), and the
-    # comments-index list still needs to render the row. The
-    # rescues swallow nil-target / missing-method errors and
-    # substitute a "deleted" placeholder.
+    # blocks — a comment can outlive its target (deleted
+    # observation, project, etc.), and the comments-index list
+    # still needs to render the row. The rescues swallow nil-target
+    # / missing-method errors and substitute a "deleted" placeholder.
     def render_target_heading
       h4(class: "mt-0") do
         target_name_link

--- a/app/views/controllers/comments/comment_row.rb
+++ b/app/views/controllers/comments/comment_row.rb
@@ -8,7 +8,7 @@
 #   wrapper element with the right id and class so subsequent
 #   `broadcast_update_to(target: "comment_<id>")` calls can find
 #   the row in place.
-# - The site-wide `comments/index.html.erb` listing — each row
+# - The site-wide `comments/index.rb` listing — each row
 #   stands on its own (no surrounding `CommentsForObject` panel),
 #   so the wrapper has to live with the inner content.
 #

--- a/app/views/controllers/comments/comments_for_object.rb
+++ b/app/views/controllers/comments/comments_for_object.rb
@@ -15,9 +15,6 @@
 # - The heading carries a "+ Add comment" modal-link button.
 # - Each `CommentItem` renders mod-links + a real author UserLink.
 # - The footer shows an "and N more →" link when truncated.
-#
-# Replaces `app/views/controllers/comments/_comments_for_object.erb`
-# and inlines the `new_comment_link` helper that fed it.
 module Views::Controllers::Comments
   class CommentsForObject < Views::Base
     include Phlex::Rails::Helpers::TurboStreamFrom

--- a/app/views/controllers/comments/comments_for_object.rb
+++ b/app/views/controllers/comments/comments_for_object.rb
@@ -3,7 +3,7 @@
 # Comments-for-object panel: the boxed list of comments shown on
 # `observations/show`, `names/show`, `projects/show`,
 # `locations/show`, `species_lists/show`, and the
-# `comments/new` / `comments/edit` pages (via `_object.html.erb`).
+# `comments/new` / `comments/edit` pages (via `_object.rb`).
 #
 # Renders a `Components::Panel` whose body is a flush
 # `Components::ListGroup::Base` of `CommentItem`s — wired to an Action

--- a/app/views/controllers/comments/edit.rb
+++ b/app/views/controllers/comments/edit.rb
@@ -30,7 +30,7 @@ module Views::Controllers::Comments
 
     private
 
-    # Mirrors `_object.html.erb`: render the comments-for-object
+    # Mirrors `_object.rb`: render the comments-for-object
     # panel for the target.
     def render_object_panel
       render(CommentsForObject.new(

--- a/app/views/controllers/comments/edit.rb
+++ b/app/views/controllers/comments/edit.rb
@@ -3,9 +3,6 @@
 # Edit-comment page: the comment form followed by the
 # `CommentsForObject` panel for the target (so the editor can see
 # existing comments in context).
-#
-# Replaces `app/views/controllers/comments/edit.html.erb` (and its
-# `_object.html.erb` partial render — inlined here).
 module Views::Controllers::Comments
   class Edit < Views::FullPageBase
     prop :comment, ::Comment
@@ -21,10 +18,9 @@ module Views::Controllers::Comments
                      ))
       add_context_nav(::Tab::Comment::FormEdit.new(comment: @comment))
 
-      # `[form:comment]…[eoform:comment]` HTML-comment markers
-      # carried over from the legacy ERB (no in-tree caller; kept
-      # in case external scrapers / integration tools look for
-      # them).
+      # `[form:comment]…[eoform:comment]` HTML-comment markers.
+      # No in-tree caller; kept in case external scrapers /
+      # integration tools look for them.
       comment { "[form:comment]" }
       render(Form.new(@comment, local: true))
       comment { "[eoform:comment]" }

--- a/app/views/controllers/comments/form.rb
+++ b/app/views/controllers/comments/form.rb
@@ -2,8 +2,8 @@
 
 module Views::Controllers::Comments
   # Form for creating or editing a Comment. Rendered directly by the
-  # comments controller's `new.html.erb` and `edit.html.erb`, and
-  # also looked up dynamically by `Components::Modal::TurboForm` via
+  # comments controller's `new.rb` and `edit.rb`, and also looked up
+  # dynamically by `Components::Modal::TurboForm` via
   # `form_component_class_for(comment)`.
   class Form < ::Components::ApplicationForm
     def view_template

--- a/app/views/controllers/comments/index.rb
+++ b/app/views/controllers/comments/index.rb
@@ -6,8 +6,6 @@
 # `CommentsForObject` panel. Each row is a `CommentRow` with
 # `show_name: true` so the target each comment is attached to is
 # labeled in the heading.
-#
-# Replaces `app/views/controllers/comments/index.html.erb`.
 module Views::Controllers::Comments
   class Index < Views::FullPageBase
     prop :query, ::Query::Comments

--- a/app/views/controllers/comments/new.rb
+++ b/app/views/controllers/comments/new.rb
@@ -4,9 +4,6 @@
 # `CommentsForObject` panel for the target. When the target is an
 # Observation, a sidebar Images panel sits next to the form so the
 # commenter can reference the photos while typing.
-#
-# Replaces `app/views/controllers/comments/new.html.erb` (and its
-# `_object.html.erb` partial render — inlined here).
 module Views::Controllers::Comments
   class New < Views::FullPageBase
     prop :comment, ::Comment

--- a/app/views/controllers/comments/show.rb
+++ b/app/views/controllers/comments/show.rb
@@ -4,7 +4,6 @@
 # list and the comments index. Renders four lines: created-at,
 # by-user link, summary, and the Textile-rendered body.
 #
-# Replaces `app/views/controllers/comments/show.html.erb`.
 module Views::Controllers::Comments
   class Show < Views::FullPageBase
     prop :comment, ::Comment

--- a/app/views/controllers/comments/show.rb
+++ b/app/views/controllers/comments/show.rb
@@ -66,9 +66,7 @@ module Views::Controllers::Comments
     end
 
     def render_body
-      # Legacy ERB joined the label, ": ", and the body in one
-      # string then rendered with `.tpl` (Textile paragraph). Keep
-      # that single-textile-render shape so paragraph break
+      # Keep single-textile-render shape so paragraph break
       # placement matches.
       trusted_html(
         # rubocop:disable Rails/OutputSafety -- mirrors the legacy

--- a/app/views/controllers/contributors/index.rb
+++ b/app/views/controllers/contributors/index.rb
@@ -3,8 +3,7 @@
 module Views::Controllers::Contributors
   # Paginated contributors index. Page chrome (title, sorter,
   # context-nav, pagination) + a one-row collapsible Legend +
-  # a MatrixTable of user matrix-boxes. Converted from
-  # `contributors/index.html.erb` + `contributors/_legend.erb`.
+  # a MatrixTable of user matrix-boxes.
   class Index < Views::FullPageBase
     prop :query, ::Query
     prop :pagination_data, ::PaginationData

--- a/app/views/controllers/contributors/index/legend.rb
+++ b/app/views/controllers/contributors/index/legend.rb
@@ -76,7 +76,6 @@ module Views::Controllers::Contributors
           # no HTML markup so `plain` is sufficient.
           t.column("field") { |f| plain(:"user_stats_#{f}".t) }
           t.column("weight") { |f| plain(::UserStats::ALL_FIELDS[f][:weight]) }
-          # Original ERB rendered an empty third `<td></td>`; mirror it.
           t.column("spacer") { plain("") }
         end
       end

--- a/app/views/controllers/contributors/index/legend.rb
+++ b/app/views/controllers/contributors/index/legend.rb
@@ -13,8 +13,7 @@ module Views::Controllers::Contributors
     #    showing how a few activities sum to a total contribution
     #    score, with a footer row holding the running total.
     #
-    # Both tables run with `show_headers: false` because the
-    # original ERB rendered them without a `<thead>`.
+    # Both tables run with `show_headers: false`.
     class Legend < Views::Base
       EXAMPLE_WEIGHTS = [
         { field: :images, number: 3, text_key: :users_by_contribution_2a },

--- a/app/views/controllers/descriptions/authors_and_editors_panel.rb
+++ b/app/views/controllers/descriptions/authors_and_editors_panel.rb
@@ -3,10 +3,6 @@
 # Bottom panel on every description show page: authors + editors
 # block (via `Views::Layouts::AuthorsAndEditors`) plus an optional
 # license badge.
-#
-# Replaces the thin pre-Phlex `_show_description_authors_and_editors.erb`
-# partial + its `DescriptionsHelper#show_description_authors_and_editors`
-# composer.
 module Views::Controllers::Descriptions
   class AuthorsAndEditorsPanel < Views::Base
     prop :description, ::Description

--- a/app/views/controllers/descriptions/details_and_alts_panel.rb
+++ b/app/views/controllers/descriptions/details_and_alts_panel.rb
@@ -7,24 +7,12 @@
 # regular show — not on versions) an export-status + review-status
 # footer.
 #
-# Inlines the full chain that the pre-Phlex
-# `_description_details_and_alts_panel.erb` composed across:
-#
-#   - `DescriptionsHelper#show_description_details` + #show_alt_descriptions
-#     + #add_list_of_projects + #show_description_export_and_review +
-#     #show_description_export_status + #show_name_description_review +
-#     #show_name_description_review_status + #show_name_description_review_ui +
-#     #show_name_description_latest_review + #description_title
-#
 # The heading-links icon strip is extracted to
 # `Components::Description::ModLinks` (sibling-in-spirit to
-# `Components::Link::InlineMod`), which replaces all of
-# `DescriptionIconsHelper`. The "Version: N / Previous Version" line
+# `Components::Link::InlineMod`). The "Version: N / Previous Version" line
 # is `Components::Description::PreviousVersion`, replacing
 # `VersionsHelper#show_previous_version`. The license-badge block
-# (used by `AuthorsAndEditorsPanel`) is `Components::Image::LicenseBadge`,
-# replacing the shared `_form_license_badge.erb` partial. Both
-# description helper files are deleted in the same commit.
+# (used by `AuthorsAndEditorsPanel`) is `Components::Image::LicenseBadge`.
 module Views::Controllers::Descriptions
   class DetailsAndAltsPanel < Views::Base
     prop :description, ::Description

--- a/app/views/controllers/descriptions/list.rb
+++ b/app/views/controllers/descriptions/list.rb
@@ -4,13 +4,6 @@
 # each visible description as a `<div>` containing a link to the
 # description + its mod-controls (Edit / Destroy when the user has
 # the appropriate permission).
-#
-# Owns the full filter / sort / link / mod-link chain that the
-# pre-Phlex `DescriptionsHelper#list_descriptions` +
-# `#sort_description_list` + `#make_list_links` + `#description_link`
-# + `#description_title` + `DescriptionIconsHelper#description_mod_links`
-# composed. Both helper files have since been deleted (this view + the
-# sibling `DetailsAndAltsPanel` own every chain they used to compose).
 module Views::Controllers::Descriptions
   class List < Views::Base
     prop :user, _Nilable(::User), default: nil

--- a/app/views/controllers/descriptions/notes_panels.rb
+++ b/app/views/controllers/descriptions/notes_panels.rb
@@ -4,8 +4,6 @@
 # `Components::Panel` per non-empty notes field (general description,
 # diagnostic features, distribution, look-alikes, …) plus a
 # fallback "no notes yet" message when all notes are empty.
-#
-# Replaces the pre-Phlex `_show_description_notes.erb` partial.
 module Views::Controllers::Descriptions
   class NotesPanels < Views::Base
     prop :description, ::Description

--- a/app/views/controllers/field_slips/edit.rb
+++ b/app/views/controllers/field_slips/edit.rb
@@ -5,8 +5,6 @@
 # `Components::Occurrences::Projects::Form` modal when the
 # controller computed unresolved project memberships
 # (`@field_slip_project_gaps`) for the obs about to be linked.
-#
-# Replaces `app/views/controllers/field_slips/edit.html.erb`.
 module Views::Controllers::FieldSlips
   class Edit < Views::FullPageBase
     prop :field_slip, ::FieldSlip

--- a/app/views/controllers/field_slips/field_slip_panel.rb
+++ b/app/views/controllers/field_slips/field_slip_panel.rb
@@ -76,8 +76,6 @@ module Views::Controllers::FieldSlips
     end
 
     # Emits `<strong>LABEL: </strong>` + the block's content + `<br>`.
-    # Matches the per-row shape the ERB partial repeated for every
-    # observation-detail field.
     def labeled(key)
       strong { plain("#{key.t}: ") }
       yield

--- a/app/views/controllers/field_slips/field_slip_panel.rb
+++ b/app/views/controllers/field_slips/field_slip_panel.rb
@@ -7,7 +7,6 @@
 # field-slip `Show` action template and by the index page's
 # `ObjectRow` (one entry per slip).
 #
-# Replaces `app/views/controllers/field_slips/_field_slip.html.erb`.
 # The `:prepend` slot is the index-page's per-row heading (an `<h4>`
 # with `#{:field_slip_code.l}: <CODE>`); `Show` passes nothing.
 module Views::Controllers::FieldSlips

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -2,8 +2,6 @@
 
 module Views::Controllers::FieldSlips
   # Phlex form for creating and editing FieldSlip records.
-  # Replaces app/views/controllers/field_slips/_form.html.erb plus
-  # its matrix sub-partials (_recent_observations, _edit_observations).
   #
   # When the field slip has no code yet, renders a minimal "enter
   # code" form that GETs to /field_slips/new. Otherwise renders the

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -68,8 +68,8 @@ module Views::Controllers::FieldSlips
       # submits with the rest — hence the in-form wrap rather than a
       # page-level `container_class(:text)`.
       #
-      # `species_list` hidden field always emitted (matching ERB
-      # `hidden_field_tag`): the param key has to exist on submit;
+      # `species_list` hidden field always emitted:
+      # the param key has to exist on submit;
       # an empty value is fine and the form context
       # (`?species_list=...`) is what carries the actual id.
       hidden_field("species_list", value: @species_list)
@@ -263,9 +263,8 @@ module Views::Controllers::FieldSlips
 
     def render_observation_matrix(observations, checked_ids:, primary_id:)
       # FieldSlip submits matrix params as flat `observation_ids[]`
-      # and namespaced `field_slip[primary_observation_id]` — both
-      # unchanged from the ERB version, so the controller doesn't
-      # need to move. FieldSlip doesn't have an `observation_ids=`
+      # and namespaced `field_slip[primary_observation_id]`.
+      # FieldSlip doesn't have an `observation_ids=`
       # accessor (the join is via the occurrence), so we drive both
       # fields through the String form of `checkbox_field` /
       # `radio_field` — raw `name=` attribute, value carried by the

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -8,9 +8,6 @@
 # Body is a `Components::ListGroup::Base` of `FieldSlipPanel`-rendered
 # entries, one per `@object`, each with a per-row code-link heading
 # fed in via the panel's `:prepend` slot.
-#
-# Replaces `app/views/controllers/field_slips/index.html.erb` and
-# the `_object.erb` per-row partial it iterated.
 module Views::Controllers::FieldSlips
   class Index < Views::FullPageBase
     prop :objects, _Array(::FieldSlip)

--- a/app/views/controllers/field_slips/new.rb
+++ b/app/views/controllers/field_slips/new.rb
@@ -5,8 +5,6 @@
 # `Components::Occurrences::Projects::Form` modal when the
 # controller computed unresolved project memberships
 # (`@field_slip_project_gaps`) for the obs about to be attached.
-#
-# Replaces `app/views/controllers/field_slips/new.html.erb`.
 module Views::Controllers::FieldSlips
   class New < Views::FullPageBase
     prop :field_slip, ::FieldSlip

--- a/app/views/controllers/field_slips/qr_reader/form.rb
+++ b/app/views/controllers/field_slips/qr_reader/form.rb
@@ -7,7 +7,7 @@ module Views::Controllers::FieldSlips::QRReader
   class Form < ::Components::ApplicationForm
     def initialize(model, **options)
       options[:id] ||= "qr_reader_form"
-      options[:data] = { controller: "qr-reader" }.merge(options[:data] || {})
+      options = mix({ data: { controller: "qr-reader" } }, options)
       super(model, **options) # rubocop:disable Style/SuperArguments
     end
 

--- a/app/views/controllers/field_slips/qr_reader/new.rb
+++ b/app/views/controllers/field_slips/qr_reader/new.rb
@@ -4,7 +4,6 @@
 # "scan a QR code to find a field slip" landing page. Just a one-
 # liner intro paragraph above the `Views::Controllers::FieldSlips::QRReader::Form`.
 #
-# Replaces `app/views/controllers/field_slips/qr_reader/new.erb`.
 module Views::Controllers::FieldSlips::QRReader
   class New < Views::FullPageBase
     def view_template

--- a/app/views/controllers/field_slips/show.rb
+++ b/app/views/controllers/field_slips/show.rb
@@ -18,10 +18,7 @@ module Views::Controllers::FieldSlips
         render(Components::Alert.new(message: @notice, level: :success))
       end
 
-      # Match the wrapper that the ERB-era `content_padded` helper
-      # emitted (`<div class="p-3">`). Registering the helper on
-      # `Views::Base` isn't worth it for one caller in the codebase.
-      div(class: "p-3") do
+      render(Components::ContentPadded.new) do
         render(FieldSlipPanel.new(field_slip: @field_slip))
       end
 

--- a/app/views/controllers/field_slips/show.rb
+++ b/app/views/controllers/field_slips/show.rb
@@ -4,8 +4,6 @@
 # field-slip page. Sets page chrome (title + edit icons), renders
 # any flash notice as an Alert, then the `FieldSlipPanel` inside the
 # padded content wrapper, then the standard `Views::Layouts::ObjectFooter`.
-#
-# Replaces `app/views/controllers/field_slips/show.html.erb`.
 module Views::Controllers::FieldSlips
   class Show < Views::FullPageBase
     prop :field_slip, ::FieldSlip

--- a/app/views/controllers/glossary_terms/edit.rb
+++ b/app/views/controllers/glossary_terms/edit.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::GlossaryTerms
   # Wrap of `GlossaryTerms::Form` for the edit flow.
-  # Converted from `glossary_terms/edit.html.erb`.
   class Edit < Views::FullPageBase
     prop :glossary_term, ::GlossaryTerm
 

--- a/app/views/controllers/glossary_terms/form.rb
+++ b/app/views/controllers/glossary_terms/form.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Views::Controllers::GlossaryTerms
-  # Form for creating/editing glossary terms. Rendered directly by
-  # the glossary_terms controller's `new.html.erb` and `edit.html.erb`.
+  # Form for creating/editing glossary terms.
   class Form < ::Components::ApplicationForm
     # Override initialize to accept upload field props (only for new
     # form).

--- a/app/views/controllers/glossary_terms/images/remove.rb
+++ b/app/views/controllers/glossary_terms/images/remove.rb
@@ -2,8 +2,7 @@
 
 module Views::Controllers::GlossaryTerms
   module Images
-    # Wrap of `GlossaryTerms::Images::RemoveForm`. Converted from
-    # `glossary_terms/images/remove.html.erb`.
+    # Wrap of `GlossaryTerms::Images::RemoveForm`.
     class Remove < Views::FullPageBase
       prop :object, ::GlossaryTerm
 

--- a/app/views/controllers/glossary_terms/images/remove_form.rb
+++ b/app/views/controllers/glossary_terms/images/remove_form.rb
@@ -9,8 +9,7 @@ module Views::Controllers::GlossaryTerms::Images
   #
   # Generic across any model with an `.images` collection — currently
   # only glossary terms use it, hence its location under the nested
-  # glossary_terms/images controller subtree. Rendered by
-  # `glossary_terms/images/remove.html.erb`.
+  # glossary_terms/images controller subtree.
   #
   # @param model [#images] the parent object (e.g. a GlossaryTerm)
   # @param form_action [String, Hash] URL or url_for-compatible hash

--- a/app/views/controllers/glossary_terms/index.rb
+++ b/app/views/controllers/glossary_terms/index.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 module Views::Controllers::GlossaryTerms
-  # Paginated glossary terms index. Page chrome + a `Components::ListGroup::Base`
-  # of one `Index::Item` per term. Converted from
-  # `glossary_terms/index.html.erb` + `glossary_terms/_object.html.erb`.
+  # Paginated glossary terms index. Page chrome +
+  # a `Components::ListGroup::Base` of one `Index::Item` per term.
   class Index < Views::FullPageBase
     prop :query, ::Query
     prop :pagination_data, ::PaginationData

--- a/app/views/controllers/glossary_terms/index/item.rb
+++ b/app/views/controllers/glossary_terms/index/item.rb
@@ -31,9 +31,6 @@ module Views::Controllers::GlossaryTerms
         render_thumbnail
       end
 
-      # Inlined from the `glossary_term_destroy_button` helper —
-      # `destroy_button` is the only call there, so the helper file
-      # is deleted in this same PR.
       def render_destroy_button
         destroy_button(target: @glossary_term,
                        name: :destroy_object.t(type: :glossary_term),

--- a/app/views/controllers/glossary_terms/index/item.rb
+++ b/app/views/controllers/glossary_terms/index/item.rb
@@ -4,7 +4,7 @@ module Views::Controllers::GlossaryTerms
   class Index
     # One row in the glossary terms index list. Two columns: name +
     # description on the left, admin destroy button + thumbnail on
-    # the right. Converted from `glossary_terms/_object.html.erb`.
+    # the right.
     class Item < Views::Base
       prop :glossary_term, ::GlossaryTerm
 

--- a/app/views/controllers/glossary_terms/new.rb
+++ b/app/views/controllers/glossary_terms/new.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::GlossaryTerms
   # Wrap of `GlossaryTerms::Form` for the create-new flow.
-  # Converted from `glossary_terms/new.html.erb`.
   class New < Views::FullPageBase
     prop :glossary_term, ::GlossaryTerm
     prop :copyright_holder, _Nilable(::String), default: nil

--- a/app/views/controllers/glossary_terms/show.rb
+++ b/app/views/controllers/glossary_terms/show.rb
@@ -4,8 +4,7 @@ module Views::Controllers::GlossaryTerms
   # GlossaryTerm show page: title + edit icons in the header,
   # description + external-search panel on the left, thumbnail on
   # the right, then a strip of other-image thumbnails, the previous-
-  # version footer, and an authors/editors panel. Converted from
-  # `glossary_terms/show.html.erb`.
+  # version footer, and an authors/editors panel.
   class Show < Views::FullPageBase
     prop :glossary_term, ::GlossaryTerm
     prop :other_images, _Array(::Image)

--- a/app/views/controllers/glossary_terms/versions/show.rb
+++ b/app/views/controllers/glossary_terms/versions/show.rb
@@ -4,8 +4,7 @@ module Views::Controllers::GlossaryTerms
   module Versions
     # Past-version display for a glossary term. Two-column layout:
     # the version's `Term` summary on the left, `Versions::Table` on
-    # the right, then a shared `ObjectFooter`. Converted from
-    # `glossary_terms/versions/show.html.erb`.
+    # the right, then a shared `ObjectFooter`.
     class Show < Views::FullPageBase
       prop :glossary_term, ::GlossaryTerm
       prop :versions, _Array(::GlossaryTerm::Version)

--- a/app/views/controllers/glossary_terms/versions/show/term.rb
+++ b/app/views/controllers/glossary_terms/versions/show/term.rb
@@ -4,9 +4,7 @@ module Views::Controllers::GlossaryTerms
   module Versions
     class Show
       # The name + description + thumbnail block for a past version
-      # of a glossary term. Converted from
-      # `glossary_terms/_glossary_term.html.erb` (which was only ever
-      # rendered from the versions/show page).
+      # of a glossary term.
       class Term < Views::Base
         prop :glossary_term, ::GlossaryTerm
 

--- a/app/views/controllers/herbaria/curator_requests/form.rb
+++ b/app/views/controllers/herbaria/curator_requests/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Herbaria::CuratorRequests
   # Form for requesting to be a herbarium curator. Rendered by the
-  # herbaria/curator_requests controller's `new.html.erb`.
+  # herbaria/curator_requests controller's `new.rb`.
   class Form < ::Components::ApplicationForm
     def initialize(model, herbarium:, back: nil, q_param: nil, **options)
       @herbarium = herbarium

--- a/app/views/controllers/herbaria/curator_requests/new.rb
+++ b/app/views/controllers/herbaria/curator_requests/new.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Views::Controllers::Herbaria::CuratorRequests
-  # Action view for the herbarium curator-request form. Replaces
-  # new.html.erb.
+  # Action view for the herbarium curator-request form.
   class New < Views::FullPageBase
     def initialize(herbarium:, back: nil)
       super()

--- a/app/views/controllers/herbaria/edit.rb
+++ b/app/views/controllers/herbaria/edit.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module Views::Controllers::Herbaria
-  # Action view for the edit herbarium form page. Replaces
-  # edit.html.erb.
+  # Action view for the edit herbarium form page.
   class Edit < Views::FullPageBase
     def initialize(herbarium:, user:, top_users:)
       super()

--- a/app/views/controllers/herbaria/form.rb
+++ b/app/views/controllers/herbaria/form.rb
@@ -4,7 +4,7 @@ module Views::Controllers::Herbaria
   # Form for creating or editing herbaria (fungaria). Handles both
   # personal and institutional herbaria with optional location
   # selection via map. Rendered directly by the herbaria controller's
-  # `new.html.erb` and `edit.html.erb`, and dynamically by
+  # `new.rb` and `edit.rb`, and dynamically by
   # `Components::Modal::TurboForm` via `form_component_class_for`.
   class Form < ::Components::ApplicationForm
     # rubocop:disable Metrics/ParameterLists

--- a/app/views/controllers/herbaria/index.rb
+++ b/app/views/controllers/herbaria/index.rb
@@ -2,8 +2,7 @@
 
 module Views::Controllers::Herbaria
   # Paginated herbaria index. Page chrome + optional merge-mode
-  # Alert + `Components::Table` of one row per herbarium. Converted
-  # from `herbaria/index.html.erb`.
+  # Alert + `Components::Table` of one row per herbarium.
   class Index < Views::FullPageBase
     prop :query, ::Query
     prop :pagination_data, ::PaginationData

--- a/app/views/controllers/herbaria/new.rb
+++ b/app/views/controllers/herbaria/new.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Views::Controllers::Herbaria
-  # Action view for the new herbarium form page. Replaces new.html.erb.
+  # Action view for the new herbarium form page.
   class New < Views::FullPageBase
     def initialize(herbarium:, user:)
       super()

--- a/app/views/controllers/herbaria/search/new.rb
+++ b/app/views/controllers/herbaria/search/new.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Views::Controllers::Herbaria::Search
-  # Action view for the herbaria search form page. Replaces new.erb.
+  # Action view for the herbaria search form page.
   class New < Views::FullPageBase
     def initialize(search:, controller:, local:)
       super()

--- a/app/views/controllers/herbaria/show.rb
+++ b/app/views/controllers/herbaria/show.rb
@@ -6,8 +6,7 @@ module Views::Controllers::Herbaria
   # `Show::CuratorTable` (when curators exist), the curator-add
   # form (when current user is a curator / admin) or the
   # curator-request link, plus optional notes + mailing address;
-  # right side has the location map. Converted from
-  # `herbaria/show.html.erb`.
+  # right side has the location map.
   class Show < Views::FullPageBase
     include ::Phlex::Rails::Helpers::FormAuthenticityToken
 

--- a/app/views/controllers/herbaria/show/curator_table.rb
+++ b/app/views/controllers/herbaria/show/curator_table.rb
@@ -5,8 +5,7 @@ module Views::Controllers::Herbaria
     # Curators list rendered above the add-curator form on
     # `Herbaria::Show`. Uses `Components::Table` with the
     # `t.heading { ... }` section-heading row (single colspan th)
-    # rather than per-column headers. Converted from
-    # `herbaria/_curator_table.html.erb`.
+    # rather than per-column headers.
     class CuratorTable < Views::Base
       prop :herbarium, ::Herbarium
 

--- a/app/views/controllers/herbarium_records/edit.rb
+++ b/app/views/controllers/herbarium_records/edit.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for `HerbariumRecordsController#edit`. Replaces
-# `app/views/controllers/herbarium_records/edit.html.erb`. Wraps
+# Action template for `HerbariumRecordsController#edit`. Wraps
 # the existing `Form` Phlex component with page chrome + a
 # side-column list of MatrixBox previews (one per associated obs).
 module Views::Controllers::HerbariumRecords

--- a/app/views/controllers/herbarium_records/form.rb
+++ b/app/views/controllers/herbarium_records/form.rb
@@ -3,7 +3,7 @@
 module Views::Controllers::HerbariumRecords
   # Form for creating or editing herbarium records attached to
   # observations. Rendered directly by the herbarium_records
-  # controller's `new.html.erb` and `edit.html.erb`, and dynamically
+  # controller's `new.rb` and `edit.rb`, and dynamically
   # by `Components::Modal::TurboForm` via `form_component_class_for`.
   class Form < ::Components::ApplicationForm
     def initialize(model, observation: nil, back: nil, **)

--- a/app/views/controllers/herbarium_records/index.rb
+++ b/app/views/controllers/herbarium_records/index.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for the HerbariumRecords index. Replaces
-# `app/views/controllers/herbarium_records/index.html.erb`.
+# Action template for the HerbariumRecords index.
 #
 # `HerbariumRecordsController#render_index_view` overrides the
 # `ApplicationController` default to render this class directly

--- a/app/views/controllers/herbarium_records/new.rb
+++ b/app/views/controllers/herbarium_records/new.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for `HerbariumRecordsController#new`. Replaces
-# `app/views/controllers/herbarium_records/new.html.erb`. Wraps
+# Action template for `HerbariumRecordsController#new`. Wraps
 # the existing `Form` Phlex component with page chrome + the
 # observation header + a side-column MatrixBox preview.
 module Views::Controllers::HerbariumRecords

--- a/app/views/controllers/herbarium_records/show.rb
+++ b/app/views/controllers/herbarium_records/show.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for `HerbariumRecordsController#show`. Replaces
-# `app/views/controllers/herbarium_records/show.html.erb`.
+# Action template for `HerbariumRecordsController#show`.
 module Views::Controllers::HerbariumRecords
   class Show < Views::FullPageBase
     prop :herbarium_record, ::HerbariumRecord

--- a/app/views/controllers/images/emails/new.rb
+++ b/app/views/controllers/images/emails/new.rb
@@ -2,8 +2,7 @@
 
 module Views::Controllers::Images
   module Emails
-    # Commercial-inquiry email form for one image. Converted from
-    # `images/emails/new.erb`.
+    # Commercial-inquiry email form for one image.
     class New < Views::FullPageBase
       prop :image, ::Image
       prop :message, _Nilable(::String), default: nil

--- a/app/views/controllers/images/exif/data_table.rb
+++ b/app/views/controllers/images/exif/data_table.rb
@@ -5,9 +5,7 @@ module Views::Controllers::Images
     # EXIF key/value table chunk. Wraps the rows in
     # `<div id="exif_data_table">` so the standalone `EXIF::Show`
     # page and the controller's turbo_stream modal-body branch can
-    # share the same rendering. Split out of `EXIF::Show` when the
-    # turbo_stream branch's `images/exif/_data.html.erb` partial
-    # was deleted in the ERB→Phlex sweep.
+    # share the same rendering.
     class DataTable < Views::Base
       prop :data, _Nilable(_Array(_Array(::String))), default: nil
 

--- a/app/views/controllers/images/exif/modal.rb
+++ b/app/views/controllers/images/exif/modal.rb
@@ -3,11 +3,8 @@
 module Views::Controllers::Images
   module EXIF
     # Turbo-stream lightbox modal triggered from
-    # `Components::Image::EXIFLink`. Replaces the ERB
-    # `shared/_modal.erb` + `images/exif/_data.erb` pair the
-    # controller used to render via the legacy
-    # `render(partial: "shared/modal", locals: { body: "images/exif/data" })`
-    # shape. A Phlex view wrapper is required because controller `render`
+    # `Components::Image::EXIFLink`. A Phlex view wrapper is required
+    # because controller `render`
     # doesn't thread the block through to a Phlex component's
     # `view_template(&block)` — every `Components::Modal` caller in this
     # codebase goes through a Phlex view, not a controller render call.

--- a/app/views/controllers/images/exif/show.rb
+++ b/app/views/controllers/images/exif/show.rb
@@ -4,8 +4,7 @@ module Views::Controllers::Images
   module EXIF
     # EXIF data page for an image. Renders the EXIF data inside a
     # standalone `<div id="exif_data_table">` table (via
-    # `Components::Table` body mode). Converted from
-    # `images/exif/show.erb` + `images/exif/_data.erb`.
+    # `Components::Table` body mode).
     class Show < Views::FullPageBase
       prop :image, ::Image
       prop :data, _Nilable(_Array(_Array(::String))), default: nil

--- a/app/views/controllers/images/index.rb
+++ b/app/views/controllers/images/index.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Images
   # Paginated images index — chrome + `Components::Matrix::Table` of
-  # one image per row. Converted from `images/index.html.erb`.
+  # one image per row.
   class Index < Views::FullPageBase
     prop :query, ::Query
     prop :pagination_data, ::PaginationData

--- a/app/views/controllers/images/licenses/edit.rb
+++ b/app/views/controllers/images/licenses/edit.rb
@@ -3,7 +3,6 @@
 module Views::Controllers::Images
   module Licenses
     # Image-licenses updater page. Wrap of `Licenses::Form`.
-    # Converted from `images/licenses/edit.html.erb`.
     class Edit < Views::FullPageBase
       prop :form, ::FormObject::ImageLicenseUpdates
       prop :user, ::User

--- a/app/views/controllers/images/licenses/form.rb
+++ b/app/views/controllers/images/licenses/form.rb
@@ -8,7 +8,7 @@ module Views::Controllers::Images::Licenses
   # hash keyed by row index, each row holding new/old
   # copyright_holder and new/old license_id.
   #
-  # Rendered directly by `edit.html.erb`. Driven by
+  # Rendered directly by `edit.rb`. Driven by
   # `FormObject::ImageLicenseUpdates`, which carries an array of
   # `FormObject::ImageLicenseRow` and overrides Superform's default
   # scope so the wire shape stays `params[:updates]`.

--- a/app/views/controllers/images/show.rb
+++ b/app/views/controllers/images/show.rb
@@ -4,8 +4,7 @@ module Views::Controllers::Images
   # Image show page: two-column layout — image + license-history
   # panels on the left, info + (reviewer-only) export controls +
   # vote panel on the right, followed by the copyright /
-  # license-badge + versions-footer row. Converted from
-  # `images/show.html.erb` + four `show/_*` partials.
+  # license-badge + versions-footer row.
   class Show < Views::FullPageBase
     prop :image, ::Image
     # In the normal `Images#show` path, `set_default_size` stores

--- a/app/views/controllers/images/show/image_panel.rb
+++ b/app/views/controllers/images/show/image_panel.rb
@@ -5,8 +5,7 @@ module Views::Controllers::Images
     # Top-left panel on the image show page: image-controls bar
     # (rotate / mirror / original / EXIF links), the interactive
     # image itself, the vote interface (when logged in), and the
-    # original filename caption when the owner shares it. Converted
-    # from `images/show/_image_panel.html.erb`.
+    # original filename caption when the owner shares it.
     class ImagePanel < Views::Base
       prop :image, ::Image
       prop :size, _Nilable(_Union(::Symbol, ::String)), default: nil

--- a/app/views/controllers/images/show/info_panel.rb
+++ b/app/views/controllers/images/show/info_panel.rb
@@ -3,8 +3,7 @@
 module Views::Controllers::Images
   class Show
     # Top-right info panel: when / owner / projects / observations /
-    # profile-users / glossary-terms / notes. Converted from
-    # `images/show/_info_panel.html.erb`.
+    # profile-users / glossary-terms / notes.
     class InfoPanel < Views::Base
       prop :image, ::Image
 

--- a/app/views/controllers/images/show/license_history_panel.rb
+++ b/app/views/controllers/images/show/license_history_panel.rb
@@ -5,8 +5,7 @@ module Views::Controllers::Images
     # License-history panel — one row per `Image::CopyrightChange`
     # showing the date range, license, and copyright holder, plus a
     # final row for the current license. Hidden when the image has
-    # no copyright changes. Converted from
-    # `images/show/_license_history_panel.html.erb`.
+    # no copyright changes.
     class LicenseHistoryPanel < Views::Base
       prop :image, ::Image
 

--- a/app/views/controllers/images/show/vote_panel.rb
+++ b/app/views/controllers/images/show/vote_panel.rb
@@ -3,10 +3,7 @@
 module Views::Controllers::Images
   class Show
     # Vote panel — current vote heading + (when logged in) the
-    # vote-action grid + the per-user vote table. Converted from
-    # `images/show/_vote_panel.html.erb`. The `find_list_of_votes`
-    # helper that lived in `app/helpers/images_helper.rb` is inlined
-    # here (`#sorted_votes`) and the helper file deleted in this PR.
+    # vote-action grid + the per-user vote table.
     class VotePanel < Views::Base
       prop :image, ::Image
       prop :size, _Nilable(_Union(::Symbol, ::String)), default: nil

--- a/app/views/controllers/images/votes/anonymity/edit.rb
+++ b/app/views/controllers/images/votes/anonymity/edit.rb
@@ -4,7 +4,6 @@ module Views::Controllers::Images
   module Votes
     module Anonymity
       # Image-vote-anonymity edit page. Wrap of `Anonymity::Form`.
-      # Converted from `images/votes/anonymity/edit.html.erb`.
       class Edit < Views::FullPageBase
         prop :num_anonymous, ::Integer
         prop :num_public, ::Integer

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -3,7 +3,7 @@
 module Views::Controllers::InatImports
   # Confirmation form for iNat import. Shows estimated import count
   # and Proceed/Go Back buttons. Hidden fields carry form data
-  # through the confirmation step. Rendered by `confirm.html.erb`.
+  # through the confirmation step. Rendered by `confirm.rb`.
   class ConfirmForm < ::Components::ApplicationForm
     def initialize(model, estimate: nil, unlicensed_obs: nil,
                    inat_import: nil, **)

--- a/app/views/controllers/inat_imports/job_trackers/current.rb
+++ b/app/views/controllers/inat_imports/job_trackers/current.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 module Views::Controllers::InatImports::JobTrackers
-  # Current-status block for an iNat import job. Mirrors the ERB
-  # element-for-element so the Turbo-Stream update target's DOM
-  # stays identical. Time-format logic inlined (was the
-  # `InatImportJobTrackersHelper` helper before this conversion).
+  # Current-status block for an iNat import job.
   class Current < Views::Base
     prop :tracker, ::InatImportJobTracker
 

--- a/app/views/controllers/inat_imports/job_trackers/current.rb
+++ b/app/views/controllers/inat_imports/job_trackers/current.rb
@@ -90,13 +90,11 @@ module Views::Controllers::InatImports::JobTrackers
       br
     end
 
-    # Inlined from `InatImportJobTrackersHelper#remaining_time_…`.
     def remaining_time_in_hours_minutes_seconds(tracker)
       time = tracker.status == "Done" ? 0 : tracker.estimated_remaining_time
       time_in_hours_minutes_seconds(time)
     end
 
-    # Inlined from `InatImportJobTrackersHelper`.
     def time_in_hours_minutes_seconds(seconds)
       return :inat_import_tracker_calculating_time.l if seconds.nil?
 

--- a/app/views/controllers/inat_imports/show.rb
+++ b/app/views/controllers/inat_imports/show.rb
@@ -51,13 +51,11 @@ module Views::Controllers::InatImports
     # NOTE: when available, swap this to a link filtered to the
     # observations created by `@user` between the tracker's
     # started_at and ended_at (and ideally with `source: :InatImport`),
-    # ordered by created_at desc. For now, use the today/tomorrow
-    # pattern the ERB used. (jdc 2025-02-08)
+    # ordered by created_at desc. (jdc 2025-02-08)
     def results_observations_path
       # `Date#strftime` with no format string raises `ArgumentError`;
-      # the legacy ERB had the same bug. Use `Date#to_s` (default
-      # `:iso8601` → `YYYY-MM-DD`), which is what the observations
-      # `pattern:` parser expects anyway.
+      # use `Date#to_s` (default `:iso8601` → `YYYY-MM-DD`), which
+      # is what the observations `pattern:` parser expects.
       observations_path(
         pattern: "user:#{@user.id} created:" \
                  "#{Time.zone.today}-#{Time.zone.tomorrow}"

--- a/app/views/controllers/licenses/form.rb
+++ b/app/views/controllers/licenses/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Licenses
   # Form for creating/editing licenses. Rendered directly by the
-  # licenses controller's `new.html.erb` and `edit.html.erb`.
+  # licenses controller's `new.rb` and `edit.rb`.
   class Form < ::Components::ApplicationForm
     def view_template
       render_display_name_field

--- a/app/views/controllers/locations/maps/show.rb
+++ b/app/views/controllers/locations/maps/show.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Action template for `Locations::MapsController#show` — the map of
-# all locations matching the current Location query. Replaces
-# `locations/maps/show.html.erb`. No cap banner (Location queries
+# all locations matching the current Location query. No cap banner (Location queries
 # bound to `MO.query_max_array` rather than the obs-style 10k cap).
 module Views::Controllers::Locations::Maps
   class Show < Views::FullPageBase

--- a/app/views/controllers/locations/maps/show.rb
+++ b/app/views/controllers/locations/maps/show.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 # Action template for `Locations::MapsController#show` — the map of
-# all locations matching the current Location query. No cap banner (Location queries
-# bound to `MO.query_max_array` rather than the obs-style 10k cap).
+# all locations matching the current Location query. No cap banner
+# (Location queries bound to `MO.query_max_array` rather than the
+# obs-style 10k cap).
 module Views::Controllers::Locations::Maps
   class Show < Views::FullPageBase
     prop :query, ::Query::Locations

--- a/app/views/controllers/locations/show/alt_descriptions_panel.rb
+++ b/app/views/controllers/locations/show/alt_descriptions_panel.rb
@@ -5,12 +5,6 @@
 # `Components::Panel`; the panel heading carries a "create new
 # description" icon-link. When the caller passes a `projects:`
 # array, appends a "create draft for project" row at the bottom.
-# Replaces `_alt_descriptions_panel.html.erb`.
-#
-# The pre-Phlex partial used `safe_join(safe_br)` to vertically
-# separate descriptions while the names panel used `<div>` wrapping.
-# The visual result is identical; standardize on `<div>` to match
-# the names panel and keep `Descriptions::List` shape-agnostic.
 module Views::Controllers::Locations
   class Show
     class AltDescriptionsPanel < Views::Base

--- a/app/views/controllers/names/eol_data/preview/show.rb
+++ b/app/views/controllers/names/eol_data/preview/show.rb
@@ -21,9 +21,8 @@ class Views::Controllers::Names::EolData::Preview::Show < Views::FullPageBase
       odd_or_even = 1 - odd_or_even
       div(class: "ListLine#{odd_or_even} py-10px") do
         # Preserve textile-rendered italics/bold for scientific
-        # names — the legacy ERB used `.t` (which emits HTML). The
-        # initial conversion stripped the tags, dropping the
-        # italics; restored after Copilot review on #4474.
+        # names — `display_name.t` emits HTML, so trusted_html is
+        # required (plain text would double-escape the tags).
         trusted_html(name.display_name.t)
       end
     end

--- a/app/views/controllers/names/form.rb
+++ b/app/views/controllers/names/form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Form for creating and editing Name records.
-# Rendered by `names/{new,edit}.html.erb`.
+# Rendered by `names/{new,edit}.rb`.
 module Views::Controllers::Names
   class Form < ::Components::ApplicationForm
     def initialize(model, **options)

--- a/app/views/controllers/names/index.rb
+++ b/app/views/controllers/names/index.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for the Names index. Replaces
-# `app/views/controllers/names/index.html.erb` + its per-row
-# partial `_name.erb` + the alt-spellings alert
-# `_name_suggestions.erb` (the last of which was already moved
-# out of the misleading `show/` subdirectory in this branch).
+# Action template for the Names index.
 #
 # Composes:
 #   - page chrome (container_class, index title, context-nav,

--- a/app/views/controllers/names/index/name_suggestions_alert.rb
+++ b/app/views/controllers/names/index/name_suggestions_alert.rb
@@ -4,7 +4,6 @@
 # shown on the Names index when a pattern search returns zero
 # matches AND the controller fed back a non-empty list of
 # alt-spellings (`@name_suggestions = Name.suggest_alternate_spellings(...)`).
-# Replaces `app/views/controllers/names/_name_suggestions.erb`.
 class Views::Controllers::Names::Index::NameSuggestionsAlert < Views::Base
   prop :names, _Array(::Name)
   prop :user, _Nilable(::User), default: nil

--- a/app/views/controllers/names/index/row.rb
+++ b/app/views/controllers/names/index/row.rb
@@ -77,7 +77,7 @@ class Views::Controllers::Names::Index::Row < Views::Base
 
   # `has_descriptions` subaction columns: when a description
   # exists, show authors / note status / review status; when it
-  # doesn't, show the placeholder text the legacy ERB used.
+  # doesn't, show the placeholder text.
   def render_description_columns
     desc = @name.description
     return span { plain("--- not the default ---") } unless desc

--- a/app/views/controllers/names/index/row.rb
+++ b/app/views/controllers/names/index/row.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# A single row in the Names index list. Replaces the per-row
-# `app/views/controllers/names/_name.erb` partial.
+# A single row in the Names index list.
 #
 # Each row carries:
 #   - `Components::IdBadge` with the Name's id

--- a/app/views/controllers/names/maps/show.rb
+++ b/app/views/controllers/names/maps/show.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 # Action template for `Names::MapsController#show`. Renders the
-# observations map for a given Name. The cap banner used to be
-# inline here; it's now baked into `Components::Map`, so we just
-# instantiate the component with `clustering: true` and the
-# `observations_*_count` props.
+# observations map for a given Name. The cap banner is baked into
+# `Components::Map`, so this view just instantiates the component
+# with `clustering: true` and the `observations_*_count` props.
 class Views::Controllers::Names::Maps::Show < Views::FullPageBase
   prop :name, ::Name
   prop :query, _Nilable(::Query::Observations), default: nil

--- a/app/views/controllers/names/search/show.rb
+++ b/app/views/controllers/names/search/show.rb
@@ -2,8 +2,6 @@
 
 # Action template for `Names::SearchController#show`. Renders only
 # the search-help block — the result list lives elsewhere.
-# Replaces the 1-line `show.erb` that just rendered the help
-# partial.
 class Views::Controllers::Names::Search::Show < Views::FullPageBase
   def view_template
     render(Help.new)

--- a/app/views/controllers/names/show.rb
+++ b/app/views/controllers/names/show.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for the Name show page. Replaces
-# `app/views/controllers/names/show.html.erb`.
+# Action template for the Name show page.
 #
 # Two-column layout (`column_classes(:seven_five)` → 7/5 split):
 #   - left:  best-images carousel, best-description panel,

--- a/app/views/controllers/names/show/alt_descriptions_panel.rb
+++ b/app/views/controllers/names/show/alt_descriptions_panel.rb
@@ -3,7 +3,7 @@
 # "Descriptions" panel on the Name show page. Renders the
 # `Views::Controllers::Descriptions::List` inside a `Components::Panel`; the
 # panel heading carries a "create new description" icon-link for
-# logged-in users. Replaces `_alt_descriptions_panel.html.erb`.
+# logged-in users.
 class Views::Controllers::Names::Show::AltDescriptionsPanel < Views::Base
   prop :user, _Nilable(::User), default: nil
   prop :name, ::Name

--- a/app/views/controllers/names/show/nomenclature.rb
+++ b/app/views/controllers/names/show/nomenclature.rb
@@ -9,7 +9,6 @@
 #
 # Originally `_nomenclature.rb` (~146 lines). Now rendered by
 # `Views::Controllers::Names::Show` and `Views::Controllers::Names::Versions::Show`
-# (and any remaining legacy callers should render this view directly).
 class Views::Controllers::Names::Show::Nomenclature < Views::Base
   prop :name, ::Name
   prop :user, _Nilable(::User), default: nil

--- a/app/views/controllers/names/show/nomenclature.rb
+++ b/app/views/controllers/names/show/nomenclature.rb
@@ -7,7 +7,7 @@
 # the "correct spelling" line for misspellings, and the synonyms
 # block (approved / deprecated / misspelled groupings).
 #
-# Originally `_nomenclature.html.erb` (~146 lines). Now rendered by
+# Originally `_nomenclature.rb` (~146 lines). Now rendered by
 # `Views::Controllers::Names::Show` and `Views::Controllers::Names::Versions::Show`
 # (and any remaining legacy callers should render this view directly).
 class Views::Controllers::Names::Show::Nomenclature < Views::Base

--- a/app/views/controllers/names/show/nomenclature.rb
+++ b/app/views/controllers/names/show/nomenclature.rb
@@ -7,8 +7,8 @@
 # the "correct spelling" line for misspellings, and the synonyms
 # block (approved / deprecated / misspelled groupings).
 #
-# Originally `_nomenclature.rb` (~146 lines). Now rendered by
-# `Views::Controllers::Names::Show` and `Views::Controllers::Names::Versions::Show`
+# Rendered by `Views::Controllers::Names::Show` and
+# `Views::Controllers::Names::Versions::Show`.
 class Views::Controllers::Names::Show::Nomenclature < Views::Base
   prop :name, ::Name
   prop :user, _Nilable(::User), default: nil

--- a/app/views/controllers/names/versions/show.rb
+++ b/app/views/controllers/names/versions/show.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Action template for the Name version-show page (a Name reverted
-# to a historic version). Replaces
-# `app/views/controllers/names/versions/show.html.erb`.
+# to a historic version).
 #
 # Left column: nomenclature panel + lifeform panel + classification
 # (as captured at this version; if `cls[:source] == :inherited`,

--- a/app/views/controllers/observations/form/location_help.rb
+++ b/app/views/controllers/observations/form/location_help.rb
@@ -4,9 +4,6 @@
 # field on the observation form. Localized example locations are
 # flipped between postal and scientific order based on the current
 # user's `location_format`.
-#
-# Replaces the `observation_location_help` helper from
-# `app/helpers/observations_helper.rb`.
 module Views::Controllers::Observations
   class Form::LocationHelp < Views::Base
     POSTAL_LOC1 = "Albion, Mendocino Co., California, USA"

--- a/app/views/controllers/observations/identify/form_filter.rb
+++ b/app/views/controllers/observations/identify/form_filter.rb
@@ -3,7 +3,6 @@
 # Rendered in the top-nav of identify pages
 # (`Observations::IdentifyController`). Wraps `Identify::Form` with
 # its `FormObject::IdentifyFilter` built from `params[:filter]`.
-# Replaces the `_form_identify_filter.html.erb` partial.
 module Views::Controllers::Observations::Identify
   class FormFilter < Views::Base
     def view_template

--- a/app/views/controllers/observations/identify/index.rb
+++ b/app/views/controllers/observations/identify/index.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # Action template for the "Observations needing identification"
-# index. Replaces `app/views/controllers/observations/identify/
-# index.html.erb`.
+# index.
 #
 # Composes the page chrome (container width, index title,
 # pagination), flashes the no-matches error when the query

--- a/app/views/controllers/observations/images/form.rb
+++ b/app/views/controllers/observations/images/form.rb
@@ -103,8 +103,8 @@ module Views::Controllers::Observations::Images
       end
     end
 
-    # Same permission rule as the ERB partial: only the image owner
-    # OR a member of the project can toggle.
+    # Only the image owner
+    # or a member of the project can toggle.
     def cannot_modify_project?(project)
       model.user_id != @user.id && !project.member?(@user)
     end

--- a/app/views/controllers/observations/imported_source_banner.rb
+++ b/app/views/controllers/observations/imported_source_banner.rb
@@ -2,7 +2,7 @@
 
 # Banner shown at the top of an Observation show page when the obs
 # was imported from an external source (iNat, MyCoPortal, etc.).
-# Rendered by `observations/show.html.erb`.
+# Rendered by `observations/show.rb`.
 #
 # Renders in its own panel with two pieces:
 #  - "Imported from <Source>" — a single link to the per-observation

--- a/app/views/controllers/observations/index.rb
+++ b/app/views/controllers/observations/index.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for the Observations index. Replaces
-# `app/views/controllers/observations/index.html.erb`.
+# Action template for the Observations index.
 #
 # Composes the page chrome (project banner / observation buttons row
 # when scoped to a project, container width, index title, action-nav,
@@ -44,8 +43,7 @@ module Views::Controllers::Observations
 
     # Stash the Map / Images / Download / FieldSlips button row
     # into `content_for(:observation_buttons)` so the layout's project
-    # chrome can place it under the banner. Equivalent to the old
-    # `ProjectsHelper#project_observation_buttons` (deleted).
+    # chrome can place it under the banner.
     def add_project_observation_buttons
       content_for(:observation_buttons) do
         render(Views::Controllers::Projects::ObservationButtons.new(

--- a/app/views/controllers/observations/maps/index.rb
+++ b/app/views/controllers/observations/maps/index.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 # Action template for `Observations::MapsController#index` — the
-# "map of observations matching a query" page. Replaces the inline
-# `<div id="map_cap_banner">` + `make_map(...)` call that used to live
-# in `index.html.erb`; the cap-banner is now baked into
-# `Components::Map`, so the view just sets chrome and instantiates
-# the component.
+# "map of observations matching a query" page. The cap-banner is
+# baked into `Components::Map`, so this view just sets chrome and
+# instantiates the component.
 module Views::Controllers::Observations::Maps
   class Index < Views::FullPageBase
     prop :query, ::Query::Observations

--- a/app/views/controllers/observations/namings/index.rb
+++ b/app/views/controllers/observations/namings/index.rb
@@ -7,7 +7,6 @@
 # Wraps `Show::Namings` in a `#observation_namings` div so the
 # controller's mutation broadcasts can `turbo_stream.replace` it.
 #
-# Replaces `app/views/controllers/observations/namings/index.erb`.
 module Views::Controllers::Observations::Namings
   class Index < Views::FullPageBase
     prop :observation, ::Observation

--- a/app/views/controllers/observations/namings/suggestions/show.rb
+++ b/app/views/controllers/observations/namings/suggestions/show.rb
@@ -11,9 +11,6 @@
 #
 # A sidebar carries the observation's image carousel via
 # `Observations::Show::ImagesPanel`.
-#
-# Replaces the corresponding `show.html.erb` and inlines
-# `SuggestionsHelper#suggestion_confidence`.
 module Views::Controllers::Observations::Namings::Suggestions
   class Show < Views::FullPageBase
     prop :observation, ::Observation
@@ -125,7 +122,6 @@ module Views::Controllers::Observations::Namings::Suggestions
       @num_images ||= @observation.images.length
     end
 
-    # Inlined from `SuggestionsHelper#suggestion_confidence`.
     def suggestion_confidence(val)
       english = if val > 80
                   :suggestions_excellent.t

--- a/app/views/controllers/observations/namings/votes/form.rb
+++ b/app/views/controllers/observations/namings/votes/form.rb
@@ -115,10 +115,9 @@ module Views::Controllers::Observations::Namings::Votes
       end
     end
 
-    # Does the viewer own this naming (or are they admin)? Mirrors
-    # the legacy helper's `permission?(naming)` check — written out
-    # explicitly here so the form is self-contained and doesn't
-    # depend on `User.current` or a controller-side ivar.
+    # True when the viewer owns this naming (or is admin). Written out
+    # explicitly so the form is self-contained — no `User.current`
+    # or controller-side ivar dependency.
     def proposer_view?
       return false unless @user
 

--- a/app/views/controllers/observations/namings/votes/form.rb
+++ b/app/views/controllers/observations/namings/votes/form.rb
@@ -15,8 +15,6 @@
 #   vote-or-propose UI rendered inside a matrix box on index
 #   pages. Context: `"matrix_box"`.
 #
-# Replaces the `naming_vote_form` helper from
-# `app/helpers/namings_helper.rb`.
 module Views::Controllers::Observations::Namings::Votes
   class Form < ::Components::ApplicationForm
     # @param naming [::Naming] the naming being voted on

--- a/app/views/controllers/observations/namings/votes/index.rb
+++ b/app/views/controllers/observations/namings/votes/index.rb
@@ -5,7 +5,6 @@
 # just the `Table` rendering; the page title carries the
 # naming's display name.
 #
-# Replaces `app/views/controllers/observations/namings/votes/index.erb`.
 module Views::Controllers::Observations::Namings::Votes
   class Index < Views::FullPageBase
     # HTML index renders against a raw `Naming` because the page

--- a/app/views/controllers/observations/namings/votes/table.rb
+++ b/app/views/controllers/observations/namings/votes/table.rb
@@ -19,7 +19,6 @@
 # "Mixed-shape rows that don't share an iteration source" carve-out
 # in `.claude/rules/phlex_conversions.md`.
 #
-# Replaces `app/views/controllers/observations/namings/votes/_table.erb`.
 module Views::Controllers::Observations::Namings::Votes
   class Table < Views::Base
     prop :naming, _Union(::Naming, ::Observation::MergedNaming)

--- a/app/views/controllers/observations/search/help.rb
+++ b/app/views/controllers/observations/search/help.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # Search-bar help blurb for the observations pattern-search input.
-# Replaces `_help.erb` + the one-line `show.erb` wrapper around it.
 # Rendered by `Observations::SearchController#show` — both the
 # `format.html` standalone page and the `format.turbo_stream`
 # update of the `#search_bar_help` slot in the top-nav.

--- a/app/views/controllers/observations/search/new.rb
+++ b/app/views/controllers/observations/search/new.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Action template for `Observations::SearchController#new` — the
-# faceted observations-search form page. Replaces `new.erb`. Renders
+# faceted observations-search form page. Renders
 # `Components::Form::Search` against the controller's `@search`
 # (a `Query::Observations` instance).
 #

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -5,7 +5,7 @@
 # `ObservationDetailsPanel`, `NameInfoPanel`, `SpeciesListsPanel`,
 # `AssociatedObservationsPanel`, `ThumbnailMapPanel`, namings
 # partial, comments partial, `Views::Layouts::ObjectFooter`) into a
-# two-column layout. Replaces `observations/show.html.erb`.
+# two-column layout.
 #
 # Renders `add_show_title` + owner-naming line + pager / interest /
 # edit icons (logged-in only) into the page chrome, then a `.row`

--- a/app/views/controllers/observations/show/associated_observations_panel.rb
+++ b/app/views/controllers/observations/show/associated_observations_panel.rb
@@ -5,7 +5,6 @@
 # or to "create a new occurrence from this observation" (when none
 # exists yet). Body lists sibling observations as a tight ul.
 #
-# Replaces `_associated_observations.html.erb`.
 class Views::Controllers::Observations::Show::AssociatedObservationsPanel < Views::Base
   prop :obs, ::Observation
   prop :occurrence, _Nilable(::Occurrence), default: nil

--- a/app/views/controllers/observations/show/collection_numbers_panel.rb
+++ b/app/views/controllers/observations/show/collection_numbers_panel.rb
@@ -8,8 +8,7 @@
 # "Collection number(s): link, link"
 # When there are no records but the user can edit: "no records [ new ]"
 #
-# Replaces `_collection_numbers.erb`. Inlines no helpers itself —
-# `remove_collection_number_button` is now handled by
+# `remove_collection_number_button` is handled by
 # `Components::Link::InlineMod` which knows how to detach a
 # `CollectionNumber` from its observation.
 class Views::Controllers::Observations::Show::CollectionNumbersPanel < Views::Base

--- a/app/views/controllers/observations/show/external_links_panel.rb
+++ b/app/views/controllers/observations/show/external_links_panel.rb
@@ -4,14 +4,6 @@
 # links + sibling-obs external links (read-only) when present.
 # Header has a `[ new ]` modal link when there are any
 # eligible sites the obs doesn't already have a link to.
-#
-# Replaces `_external_links.erb`. Inlines the
-# `external_link(link)` helper as a private method (it just
-# returned a link to the site URL).
-#
-# The `sibling_external_link_items` helper lives in
-# `Observations::SiblingRecordsHelper` for now; will inline once
-# all sibling-records callers are Phlex too.
 class Views::Controllers::Observations::Show::ExternalLinksPanel < Views::Base
   prop :obs, ::Observation
   prop :user, _Nilable(::User), default: nil
@@ -60,9 +52,6 @@ class Views::Controllers::Observations::Show::ExternalLinksPanel < Views::Base
     end
   end
 
-  # Inlined from `Observations::SiblingRecordsHelper#sibling_external_link_items`
-  # (and its `sibling_external_link_content` / `sibling_attribution`
-  # / `inat_label` siblings).
   def sibling_external_links
     @siblings.flat_map do |sib|
       sib.external_links.map { |el| [el, sib] }
@@ -112,9 +101,6 @@ class Views::Controllers::Observations::Show::ExternalLinksPanel < Views::Base
     end
   end
 
-  # Inlined from `ExternalLinksHelper#external_link` — emits a
-  # plain `<a>` with the site name as the link text. Pre-Phlex
-  # the helper used `link_to` so we match that contract.
   def render_external_link(link)
     a(href: link.url, target: "_blank", rel: "noopener") do
       plain(link.site_name)

--- a/app/views/controllers/observations/show/herbarium_records_panel.rb
+++ b/app/views/controllers/observations/show/herbarium_records_panel.rb
@@ -3,7 +3,7 @@
 # Herbarium-records sub-panel — same shape as
 # `CollectionNumbersPanel` but for `HerbariumRecord`s, with an
 # additional "search MCP" indented link for records whose
-# herbarium is `web_searchable?`. Replaces `_herbarium_records.erb`.
+# herbarium is `web_searchable?`
 class Views::Controllers::Observations::Show::HerbariumRecordsPanel < Views::Base
   prop :obs, ::Observation
   prop :user, _Nilable(::User), default: nil
@@ -76,8 +76,7 @@ class Views::Controllers::Observations::Show::HerbariumRecordsPanel < Views::Bas
     end
   end
 
-  # Read-only list: column-stacked link list (matches pre-Phlex
-  # shape — `tag.div` heading + tight-list with show-link + br +
+  # Read-only list: `div` heading + tight-list with show-link + br +
   # MCP search link when web-searchable).
   def render_readonly_list(records)
     div { plain("#{:Herbarium_record.t}:") }

--- a/app/views/controllers/observations/show/images_panel.rb
+++ b/app/views/controllers/observations/show/images_panel.rb
@@ -9,10 +9,6 @@
 # Each image gets an `InteractiveImage` plus the copyright notice
 # (when the photographer ≠ obs owner) and the image's own notes
 # (textilized + truncated to 300 chars).
-#
-# Replaces `_images.erb`. The `observation_show_image_links`
-# helper that built the "reuse images" heading link is inlined as
-# a private method here.
 class Views::Controllers::Observations::Show::ImagesPanel < Views::Base
   prop :obs, ::Observation
   prop :images, _Array(::Image)
@@ -30,7 +26,6 @@ class Views::Controllers::Observations::Show::ImagesPanel < Views::Base
 
   private
 
-  # Inlined from `ObservationsHelper#observation_show_image_links`.
   # The "reuse images" link is only meaningful to a user with
   # edit permission on the obs.
   def heading_links

--- a/app/views/controllers/observations/show/images_panel.rb
+++ b/app/views/controllers/observations/show/images_panel.rb
@@ -4,7 +4,7 @@
 # to show the observation's images vertically as a list (not the
 # carousel rendered on the main obs show page — that's
 # `Components::ImageGallery`, rendered directly from
-# `observations/show.html.erb`).
+# `observations/show.rb`).
 #
 # Each image gets an `InteractiveImage` plus the copyright notice
 # (when the photographer ≠ obs owner) and the image's own notes

--- a/app/views/controllers/observations/show/name_info_panel.rb
+++ b/app/views/controllers/observations/show/name_info_panel.rb
@@ -4,13 +4,6 @@
 # columns: "On MO" (related-name links + alt-descriptions list +
 # distribution map) and "On the web" (external taxonomic search
 # sites the user has enabled).
-#
-# Replaces `_name_info.erb`. Inlines two `Tabs::ObservationsHelper`
-# helpers (`name_links_on_mo` + `user_name_links_web`) plus the
-# `obs_name_description_tabs` helper that was their bridge to
-# `DescriptionsHelper#list_descriptions` — the alt-description
-# list now renders through `Views::Controllers::Descriptions::List`
-# (the Phlex view that replaced the helper chain in #4438).
 class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
   prop :obs, ::Observation
   prop :user, _Nilable(::User), default: nil
@@ -40,7 +33,6 @@ class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
     end
   end
 
-  # Inlined from `Tabs::ObservationsHelper#name_links_on_mo`.
   # Three groups, each emitted as `<a class="d-block">` lines:
   # related-name filtered indexes, alt-descriptions list, and
   # the per-name distribution map link.
@@ -50,7 +42,6 @@ class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
     render_tab_link(occurrence_map_tab)
   end
 
-  # Inlined from `Tabs::ObservationsHelper#user_name_links_web`.
   def render_links_on_web
     web_name_tabs.each { |tab| render_tab_link(tab) }
   end
@@ -73,17 +64,14 @@ class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
 
   # Renders the alt-description list inline — same view used by
   # the names / locations show pages, just no panel chrome here.
-  # Replaces the `obs_name_description_tabs` helper.
   def render_alt_descriptions
     render(::Views::Controllers::Descriptions::List.new(
              user: @user, object: @obs.name, type: :name
            ))
   end
 
-  # Renders a single Tab::Base as `<a class="d-block">...</a>`,
-  # the shape `Tabs::ObservationsHelper` previously got through
-  # `context_nav_links(..., class: "d-block")`. The tabs in this
-  # panel are all link-style (no `button:` html_options).
+  # Renders a single Tab::Base as `<a class="d-block">...</a>`.
+  # The tabs in this panel are all link-style (no `button:` html_options).
   def render_tab_link(tab)
     content, path, opts = tab.to_a
     classes = ["d-block", opts[:class]].compact.join(" ").strip

--- a/app/views/controllers/observations/show/name_info_panel.rb
+++ b/app/views/controllers/observations/show/name_info_panel.rb
@@ -75,10 +75,8 @@ class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
   def render_tab_link(tab)
     content, path, opts = tab.to_a
     classes = ["d-block", opts[:class]].compact.join(" ").strip
-    # `:button` is consumed by `context_nav_link` to switch to
-    # `button_to`; `:target` is stripped (these tabs aren't the
-    # "open in new tab" kind). Match the legacy helper's
-    # `merge_context_nav_link_args` filter so attrs line up.
+    # Strip :class, :button, :target from opts — these are context-nav
+    # attrs, not <a> attrs; :button would switch link_to to button_to.
     attrs = opts.except(:class, :button, :target).
             merge(href: url_for(path), class: classes)
     a(**attrs) { trusted_html(content) }

--- a/app/views/controllers/observations/show/namings.rb
+++ b/app/views/controllers/observations/show/namings.rb
@@ -11,7 +11,6 @@
 # closes any open in-flight modal so the user sees the result
 # of their action immediately.
 #
-# Replaces `app/views/controllers/observations/show/_namings.erb`.
 class Views::Controllers::Observations::Show::Namings < Views::Base
   prop :obs, ::Observation
   prop :user, ::User

--- a/app/views/controllers/observations/show/namings/footer_buttons.rb
+++ b/app/views/controllers/observations/show/namings/footer_buttons.rb
@@ -5,8 +5,6 @@
 # blurb on the right. Admins / image-model beta testers also see
 # a "Suggest names" button stacked under the propose button.
 #
-# Replaces `app/views/controllers/observations/show/namings/_footer_buttons.erb`
-# and inlines `observation_naming_buttons` + `suggest_namings_link`.
 class Views::Controllers::Observations::Show::Namings::FooterButtons < Views::Base
   prop :user, ::User
   prop :obs, ::Observation
@@ -58,7 +56,7 @@ class Views::Controllers::Observations::Show::Namings::FooterButtons < Views::Ba
     )
   end
 
-  # Gating mirrors the legacy helper: a thumb image must exist (so
+  # Gating: a thumb image must exist (so
   # the JS has something to send to the model) AND the user must
   # be admin or on the image-model beta-tester list.
   def suggest_namings_enabled?
@@ -90,7 +88,7 @@ class Views::Controllers::Observations::Show::Namings::FooterButtons < Views::Ba
 
   # NOTE: the URL is never actually visited — the JS uses it as a
   # template for its fetch — so the placeholder `names: :xxx`
-  # segment matches what the legacy helper sent.
+  # segment matches the naming endpoint contract.
   def suggest_results_url
     add_q_param(
       naming_suggestions_for_observation_path(id: @obs.id, names: :xxx)

--- a/app/views/controllers/observations/show/namings/footer_legend.rb
+++ b/app/views/controllers/observations/show/namings/footer_legend.rb
@@ -6,7 +6,6 @@
 # columns of the panel-footer grid (the rightmost column matches
 # the eye gutter in the row body above).
 #
-# Replaces `app/views/controllers/observations/show/namings/_footer_legend.erb`
 # and inlines `vote_legend_yours` / `vote_legend_consensus` + their
 # `vote_icon_*` helpers.
 class Views::Controllers::Observations::Show::Namings::FooterLegend < Views::Base

--- a/app/views/controllers/observations/show/namings/header.rb
+++ b/app/views/controllers/observations/show/namings/header.rb
@@ -8,7 +8,6 @@
 # mobile-only "+" propose-naming icon button sits in the right
 # gutter where the eyes column appears below.
 #
-# Replaces `app/views/controllers/observations/show/namings/_header.erb`
 # and inlines the `naming_header_row_content` helper that fed it
 # (just four `<small>`-wrapped translation lookups + a `<h4>` for
 # the panel title).

--- a/app/views/controllers/observations/show/namings/row.rb
+++ b/app/views/controllers/observations/show/namings/row.rb
@@ -5,11 +5,6 @@
 # item">` is supplied by the parent `Show::Namings::Rows` via
 # `list.item(id: …) { render(Row.new(…)) }`.
 #
-# Replaces `app/views/controllers/observations/show/namings/_row.erb`
-# and inlines the helper methods that fed it: `naming_row_content`
-# and its collaborators (`naming_name_html`, `naming_proposer_html`,
-# `vote_tally_html`, `your_vote_html`, `vote_icons_html`,
-# `reasons_html` + their sub-helpers).
 class Views::Controllers::Observations::Show::Namings::Row < Views::Base
   # `naming` can be either a plain `Naming` (single observation) or
   # an `Observation::MergedNaming` (occurrence-grouped roll-up of
@@ -298,7 +293,7 @@ class Views::Controllers::Observations::Show::Namings::Row < Views::Base
   # `.tl` (textile-line) renderer needs unescaped textile markup
   # to interpret; without `html_safe` the `#{…}` interpolation
   # double-escapes `<i>` / `<b>` tags that legitimately appear in
-  # user-typed reason notes. Matches the legacy helper exactly.
+  # user-typed reason notes
   def simple_reason_text(reason)
     return reason.label.t if reason.notes.blank?
 

--- a/app/views/controllers/observations/show/namings/rows.rb
+++ b/app/views/controllers/observations/show/namings/rows.rb
@@ -9,7 +9,6 @@
 # `Show::Namings::Row`), so single-row swaps can target individual
 # children too.
 #
-# Replaces `app/views/controllers/observations/show/namings/_rows.erb`.
 # Reopen the parent `Namings` class so the nested `Rows` body can
 # refer to its sibling `Row` by short name. Without this nesting,
 # the lexical scope chain doesn't include `Namings`, and `Row.new`

--- a/app/views/controllers/observations/show/observation_details_panel.rb
+++ b/app/views/controllers/observations/show/observation_details_panel.rb
@@ -5,27 +5,6 @@
 # slip, collection-numbers / herbarium-records / sequences sub-
 # panels, and external links. The center column of the obs show
 # page (and also rendered into the naming form pages).
-#
-# Replaces `_observation_details.erb`. Inlines six helpers that
-# this partial was the only/primary caller of:
-#
-# - `obs_details_links` (and its `print_labels_button` dependency)
-#   — the "print labels" heading-link
-# - `observation_details_when_where_who` + 4 sub-helpers
-#   (`observation_details_when` / `_where` / `_where_gps` /
-#   `_who`)
-# - `observation_where_vague_notice`
-# - `observation_details_notes`
-#
-# The collection_numbers / herbarium_records / sequences /
-# external_links sub-panels are still rendered via Phlex views in
-# this same directory; the `sibling_*` helpers (read-only
-# aggregated records from sibling observations in an occurrence)
-# continue to live in `Observations::SiblingRecordsHelper` for now
-# — they're called from a partial we haven't converted yet
-# (`_observation_details.erb` was the only obs-show caller; once
-# the sibling-records-helper callers all go to Phlex, the helpers
-# themselves can be inlined into their respective sub-panels).
 class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::Base
   include Views::Controllers::Observations::Show::SiblingRecords
 
@@ -48,9 +27,6 @@ class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::B
 
   private
 
-  # Inlined from `Tabs::ObservationsHelper#obs_details_links` +
-  # `print_labels_button` (the only caller of either, here in
-  # the heading-link slot).
   def print_labels_button
     name = :download_observations_print_labels.l
     query = ::Query.lookup(::Observation, id_in_set: [@obs.id])
@@ -113,7 +89,6 @@ class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::B
     end
   end
 
-  # Inlined from `ObservationsHelper#observation_where_vague_notice`.
   def render_vague_notice
     return unless @obs.location&.vague?
 
@@ -225,11 +200,10 @@ class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::B
     end
   end
 
-  # Inlined from `ObservationsHelper#observation_details_notes`.
-  # Per the helper's preserved comment: passes each notes value
-  # to textile independently rather than the whole block — a
-  # `+photo` value at the start of a line would otherwise be
-  # interpreted as textile bold-emphasis across subsequent lines.
+  # Passes each notes value to textile independently rather than
+  # the whole block — a `+photo` value at the start of a line
+  # would otherwise be interpreted as textile bold-emphasis across
+  # subsequent lines.
   def render_notes
     notes = @obs.notes
     return if notes == ::Observation.no_notes

--- a/app/views/controllers/observations/show/sequences_panel.rb
+++ b/app/views/controllers/observations/show/sequences_panel.rb
@@ -4,7 +4,7 @@
 # obs-show sub-panels but with an additional `[archive]` inline
 # link when the sequence has a deposit accession URL.
 #
-# Replaces `_sequences.erb`. `Components::Link::InlineMod` handles
+# `Components::Link::InlineMod` handles
 # the `[ archive | edit | destroy ]` triplet — sequences are a
 # real-DELETE target with a `back: observation_path(obs)` query
 # string so the controller returns to the obs after destroy.

--- a/app/views/controllers/observations/show/sibling_records.rb
+++ b/app/views/controllers/observations/show/sibling_records.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 # Sibling-records concern for the observation details panel:
-# inlined from `Observations::SiblingRecordsHelper`. Extracted out
-# of `ObservationDetailsPanel` to keep that class under the Phlex
-# `Metrics/ClassLength` cop limit — the sibling rendering is a
-# distinct concern (read-only aggregation across siblings in an
-# occurrence) from the obs's own details.
+# extracted out of `ObservationDetailsPanel` to keep that class
+# under the Phlex `Metrics/ClassLength` cop limit — the sibling
+# rendering is a distinct concern (read-only aggregation across
+# siblings in an occurrence) from the obs's own details.
 #
 # Mixed into `ObservationDetailsPanel`. The methods read
 # `@siblings` directly; the host class owns the prop.
@@ -15,7 +14,6 @@ module Views::Controllers::Observations::Show::SiblingRecords
   # `(record, sibling)` per row. No-op when no siblings have
   # records for the requested association.
   #
-  # Inlined from `Observations::SiblingRecordsHelper#sibling_record_list`.
   def render_sibling_records(association)
     items = @siblings.flat_map do |sib|
       sib.send(association).map { |rec| [rec, sib] }
@@ -29,7 +27,6 @@ module Views::Controllers::Observations::Show::SiblingRecords
 
   # Renders the trailing "(MO <id>)" link in
   # `<small class="text-muted">` after every sibling row.
-  # Inlined from `Observations::SiblingRecordsHelper#sibling_attribution`.
   def sibling_attribution(sibling)
     small(class: "text-muted") do
       plain("(")
@@ -40,8 +37,6 @@ module Views::Controllers::Observations::Show::SiblingRecords
     end
   end
 
-  # Inlined from `Observations::SiblingRecordsHelper#sibling_herbarium_record_content`
-  # + `mcp_search_link`.
   def render_sibling_herbarium_record(record, sibling)
     a(href: herbarium_record_path(record.id)) do
       trusted_html(record.accession_at_herbarium.t)
@@ -61,7 +56,6 @@ module Views::Controllers::Observations::Show::SiblingRecords
     end
   end
 
-  # Inlined from `Observations::SiblingRecordsHelper#sibling_sequence_archive_link`.
   def render_sibling_sequence_archive(sequence)
     plain(" [")
     a(href: sequence.accession_url,

--- a/app/views/controllers/observations/show/species_lists_panel.rb
+++ b/app/views/controllers/observations/show/species_lists_panel.rb
@@ -6,7 +6,6 @@
 # with an inline `[REMOVE]` button for any list the user has
 # permission to edit.
 #
-# Replaces `_species_lists.erb`.
 class Views::Controllers::Observations::Show::SpeciesListsPanel < Views::Base
   prop :obs, ::Observation
   prop :user, _Nilable(::User), default: nil

--- a/app/views/controllers/observations/show/thumbnail_map_panel.rb
+++ b/app/views/controllers/observations/show/thumbnail_map_panel.rb
@@ -7,7 +7,8 @@
 # zooms / pans the image client-side. Heading link toggles the
 # panel off via a user-pref endpoint.
 #
-# `coordinates` computes the (n, s, e, w, lat, long, x, y) tuple for the map marker.
+# `coordinates` computes the (n, s, e, w, lat, long, x, y) tuple
+# for the map marker.
 class Views::Controllers::Observations::Show::ThumbnailMapPanel < Views::Base
   include Phlex::Rails::Helpers::ImageTag
   include Phlex::Rails::Helpers::ImageURL

--- a/app/views/controllers/observations/show/thumbnail_map_panel.rb
+++ b/app/views/controllers/observations/show/thumbnail_map_panel.rb
@@ -7,9 +7,7 @@
 # zooms / pans the image client-side. Heading link toggles the
 # panel off via a user-pref endpoint.
 #
-# Replaces `_thumbnail_map.erb`. The `observation_map_coordinates`
-# helper that computed (n, s, e, w, lat, long, x, y) is inlined
-# below as `coordinates`.
+# `coordinates` computes the (n, s, e, w, lat, long, x, y) tuple for the map marker.
 class Views::Controllers::Observations::Show::ThumbnailMapPanel < Views::Base
   include Phlex::Rails::Helpers::ImageTag
   include Phlex::Rails::Helpers::ImageURL

--- a/app/views/controllers/observations/species_lists/edit.rb
+++ b/app/views/controllers/observations/species_lists/edit.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Action template for `Observations::SpeciesListsController#edit` —
-# the "manage species lists for this observation" page. Replaces
-# `edit.html.erb`. Renders two `Components::ListGroup::Base`s of
+# the "manage species lists for this observation" page.
+# Renders two `Components::ListGroup::Base`s of
 # `SpeciesLists::Listing` rows: lists the observation already
 # belongs to (REMOVE button on each) and lists it doesn't (ADD
 # button on each).
@@ -54,8 +54,7 @@ module Views::Controllers::Observations::SpeciesLists
     end
 
     # Skip the heading + the list-group entirely when the source
-    # array is empty (matches the ERB's `if @obs_lists.any?` /
-    # `if @other_lists.any?` guards).
+    # No-op when the array is empty.
     def render_section(heading:, lists:, remove: false, add: false)
       return if lists.empty?
 

--- a/app/views/controllers/occurrences/projects/form.rb
+++ b/app/views/controllers/occurrences/projects/form.rb
@@ -4,7 +4,7 @@
 # Renders the intro text, project list, and Cancel/Skip/Add All
 # buttons — but no modal chrome. Callers wrap this in
 # `Components::Modal` with `auto_open: true` to get the auto-opening
-# Bootstrap modal (see `field_slips/new.html.erb` and `edit.html.erb`).
+# Bootstrap modal (see `field_slips/new.rb` and `edit.rb`).
 #
 # Two render modes:
 #   - "create" (when `selected:` is passed) — POSTs the selection

--- a/app/views/controllers/projects/admin_requests/new.rb
+++ b/app/views/controllers/projects/admin_requests/new.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects::AdminRequests
   # Phlex view for the admin request form page.
-  # Replaces admin_requests/new.html.erb.
   class New < Views::FullPageBase
     def initialize(project:)
       super()

--- a/app/views/controllers/projects/aliases/edit.rb
+++ b/app/views/controllers/projects/aliases/edit.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects::Aliases
   # Phlex view for the edit project alias form page.
-  # Replaces aliases/edit.html.erb.
   class Edit < Views::FullPageBase
     def initialize(project_alias:, project:, user:)
       super()

--- a/app/views/controllers/projects/aliases/index.rb
+++ b/app/views/controllers/projects/aliases/index.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # Phlex view for the project aliases index page.
-# Replaces aliases/index.html.erb.
 module Views::Controllers::Projects::Aliases
   class Index < Views::FullPageBase
     def initialize(project:, project_aliases:)

--- a/app/views/controllers/projects/aliases/new.rb
+++ b/app/views/controllers/projects/aliases/new.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects::Aliases
   # Phlex view for the new project alias form page.
-  # Replaces aliases/new.html.erb.
   class New < Views::FullPageBase
     def initialize(project_alias:, project:, user:)
       super()

--- a/app/views/controllers/projects/aliases/show.rb
+++ b/app/views/controllers/projects/aliases/show.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects::Aliases
   # Phlex view for the project alias show page.
-  # Replaces aliases/show.html.erb.
   class Show < Views::FullPageBase
     def initialize(project:, project_alias:)
       super()

--- a/app/views/controllers/projects/field_slips/new.rb
+++ b/app/views/controllers/projects/field_slips/new.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects::FieldSlips
   # Phlex view for the field slips form page.
-  # Replaces field_slips/new.html.erb.
   class New < Views::FullPageBase
     def initialize(project:, user:, field_slip_max:, trackers:)
       super()

--- a/app/views/controllers/projects/field_slips/tracker_row.rb
+++ b/app/views/controllers/projects/field_slips/tracker_row.rb
@@ -74,9 +74,6 @@ module Views::Controllers::Projects::FieldSlips
              ))
     end
 
-    # Inlined from `ProjectsHelper#field_slip_link` — this was the
-    # only caller, and the helper's body is small enough that a
-    # private method keeps the rendering logic local.
     def render_field_slip_link
       if @tracker.status == "Done" && @user == @tracker.user
         link_to(@tracker.filename, @tracker.link)

--- a/app/views/controllers/projects/index.rb
+++ b/app/views/controllers/projects/index.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for the Projects index. Replaces
-# `app/views/controllers/projects/index.html.erb`.
+# Action template for the Projects index.
 #
 # `ProjectsController#render_index_view` overrides the
 # `ApplicationController` default to render this class directly with

--- a/app/views/controllers/projects/list_item.rb
+++ b/app/views/controllers/projects/list_item.rb
@@ -2,7 +2,7 @@
 
 # Inner content of one row in the projects index list-group. The
 # `<div class="list-group-item …">` wrapper is supplied by the
-# caller (the ERB index template, soon `Components::ListGroup::Base`);
+# caller (`Components::ListGroup::Base`);
 # this class only emits the two-column body (id badge + title /
 # meta column).
 module Views::Controllers::Projects

--- a/app/views/controllers/projects/locations/index.rb
+++ b/app/views/controllers/projects/locations/index.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for the Project Locations index. Replaces
-# `app/views/controllers/projects/locations/index.html.erb`.
+# Action template for the Project Locations index.
 #
 # Renders the project banner + (admins only) the target-location
 # form, then the grouped-locations table.

--- a/app/views/controllers/projects/members/edit.rb
+++ b/app/views/controllers/projects/members/edit.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects::Members
   # Phlex view for the change member status page.
-  # Replaces members/edit.html.erb.
   class Edit < Views::FullPageBase
     def initialize(project:, project_member:, user:)
       super()

--- a/app/views/controllers/projects/members/index.rb
+++ b/app/views/controllers/projects/members/index.rb
@@ -37,7 +37,7 @@ module Views::Controllers::Projects::Members
     end
 
     # Column class lands on BOTH `<th>` and `<td>` (current
-    # Table#column behavior). The pre-conversion ERB had distinct
+    # Table#column behavior). An earlier version had distinct
     # th-only / td-only classes; consolidated here to a single
     # per-column class (the redundant `.align-middle` on single-line
     # thead rows is invisible in standard Bootstrap).

--- a/app/views/controllers/projects/members/index.rb
+++ b/app/views/controllers/projects/members/index.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects::Members
   # Phlex view for the project members index page.
-  # Replaces members/index.html.erb.
   class Index < Views::FullPageBase
     def initialize(project:, users:, project_member:,
                    user:)

--- a/app/views/controllers/projects/members/new.rb
+++ b/app/views/controllers/projects/members/new.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects::Members
   # Phlex view for the add members page.
-  # Replaces members/new.html.erb.
   class New < Views::FullPageBase
     def initialize(project:, users:, project_member:,
                    user:)

--- a/app/views/controllers/projects/new.rb
+++ b/app/views/controllers/projects/new.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects
   # Phlex view for the new project form page.
-  # Replaces new.html.erb.
   class New < Views::FullPageBase
     def initialize(project:, dates_any:, upload_params:)
       super()

--- a/app/views/controllers/projects/show.rb
+++ b/app/views/controllers/projects/show.rb
@@ -183,10 +183,8 @@ module Views::Controllers::Projects
       ) { plain(:show_project_admin_request.l) }
     end
 
-    # Inlined from `Tabs::ProjectsHelper#violations_button` — single
-    # caller, and not a CrudButton candidate (it's a count-badge link
-    # with `btn-warning` styling when constraints are violated, not
-    # an action button).
+    # Not a CrudButton candidate — count-badge link with `btn-warning`
+    # styling when constraints are violated, not a standard action button.
     def render_violations_button
       return unless @project.constraints?
 

--- a/app/views/controllers/projects/show.rb
+++ b/app/views/controllers/projects/show.rb
@@ -2,7 +2,6 @@
 
 module Views::Controllers::Projects
   # Phlex view for the project show page.
-  # Replaces show.html.erb.
   class Show < Views::FullPageBase
     def initialize(project:, user:, drafts:, comments:, object_names:)
       super()

--- a/app/views/controllers/projects/violations/index.rb
+++ b/app/views/controllers/projects/violations/index.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action template for the Project Violations index. Replaces
-# `app/views/controllers/projects/violations/index.html.erb`.
+# Action template for the Project Violations index.
 #
 # Renders the project banner + the violations form.
 #

--- a/app/views/controllers/publications/form.rb
+++ b/app/views/controllers/publications/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Publications
   # Form for creating/editing publications. Rendered directly by the
-  # publications controller's `new.html.erb` and `edit.html.erb`.
+  # publications controller's `new.rb` and `edit.rb`.
   class Form < ::Components::ApplicationForm
     def view_template
       render_full_field

--- a/app/views/controllers/rss_logs/type_filters.rb
+++ b/app/views/controllers/rss_logs/type_filters.rb
@@ -2,8 +2,7 @@
 
 # Type-filter form for the rss_logs (activity logs) index. Renders
 # a row of checkbox buttons (one per RssLog type) plus an "all"
-# button and an Apply submit. Rendered by
-# `Header::TypeFilterHelper#add_type_filters_for_activity_log`.
+# button and an Apply submit.
 module Views::Controllers::RssLogs
   class TypeFilters < Views::Base
     prop :query, _Nilable(::Query)

--- a/app/views/controllers/sequences/form.rb
+++ b/app/views/controllers/sequences/form.rb
@@ -4,7 +4,7 @@ module Views::Controllers::Sequences
   # Form for creating or editing DNA sequences attached to
   # observations. Sequences can contain genetic data (bases) or
   # reference external archives. Rendered directly by the sequences
-  # controller's `new.html.erb` and `edit.html.erb`, and dynamically
+  # controller's `new.rb` and `edit.rb`, and dynamically
   # by `Components::Modal::TurboForm` via `form_component_class_for`.
   class Form < ::Components::ApplicationForm
     def initialize(model, observation: nil, back: nil, **)

--- a/app/views/controllers/sequences/form.rb
+++ b/app/views/controllers/sequences/form.rb
@@ -142,7 +142,6 @@ module Views::Controllers::Sequences
       @observation || model.observation
     end
 
-    # Inlined from the now-deleted `SequencesHelper#sequence_archive_options`.
     # Dropdown options for the archive select: each entry is a
     # `[label, value]` pair where label == value == archive name.
     def sequence_archive_options

--- a/app/views/controllers/shared/images_to_reuse_form.rb
+++ b/app/views/controllers/shared/images_to_reuse_form.rb
@@ -2,8 +2,7 @@
 
 # "Reuse an existing image" page rendered by the `reuse` action of
 # `Observations::ImagesController`, `Account::Profile::ImagesController`,
-# and `GlossaryTerms::ImagesController`. Replaces the
-# `app/views/controllers/shared/_images_to_reuse.erb` partial.
+# and `GlossaryTerms::ImagesController`.
 #
 # Two parts:
 # - `Components::Image::ReuseForm` — the small form that takes an Image

--- a/app/views/controllers/species_lists/details.rb
+++ b/app/views/controllers/species_lists/details.rb
@@ -62,8 +62,7 @@ module Views::Controllers::SpeciesLists
     end
 
     # `location_link` raises if `@species_list.where` is blank — fall
-    # back to a plain `:UNKNOWN.t` label in that case (matches the
-    # `rescue :UNKNOWN.t` in the original ERB).
+    # back to a plain `:UNKNOWN.t` label in that case.
     def render_where
       div do
         b { plain("#{:WHERE.t}:") }
@@ -98,9 +97,8 @@ module Views::Controllers::SpeciesLists
       end
     end
 
-    # Notes get the same `*NOTES:* …`-into-textile treatment the ERB
-    # used; render through `trusted_html` because `.tpl` returns
-    # already-safe markup.
+    # Notes get the `*NOTES:* …`-into-textile treatment;
+    # render through `trusted_html` because `.tpl` returns already-safe markup.
     def render_notes
       div do
         trusted_html("*#{:NOTES.t}:* #{@species_list.notes}".tpl)

--- a/app/views/controllers/species_lists/downloads/form.rb
+++ b/app/views/controllers/species_lists/downloads/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::SpeciesLists::Downloads
   # Form for printing labels for species list observations.
-  # Rendered by `species_lists/downloads/new.html.erb`.
+  # Rendered by `species_lists/downloads/new.rb`.
   #
   # @example
   #   render(Views::Controllers::SpeciesLists::Downloads::Form.new(

--- a/app/views/controllers/species_lists/form.rb
+++ b/app/views/controllers/species_lists/form.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::SpeciesLists
   # Phlex Superform for the SpeciesList create/edit page. Rendered
-  # directly by `species_lists/new.html.erb` and `edit.html.erb`.
+  # directly by `species_lists/new.rb` and `edit.rb`.
   #
   # Preserves the existing controller contract exactly:
   # - SpeciesList attributes posted as `species_list[title]`,

--- a/app/views/controllers/species_lists/listing.rb
+++ b/app/views/controllers/species_lists/listing.rb
@@ -4,7 +4,7 @@
 # `Components::ListGroup::Base#item`. Used by:
 #   - `Views::Controllers::SpeciesLists::Index#render_list` (the
 #     species_lists index page)
-#   - `observations/species_lists/edit.html.erb` (the
+#   - `observations/species_lists/edit.rb` (the
 #     "manage species lists for this observation" page)
 # Title row + place / user row on the left, optional REMOVE / ADD
 # button on the right (mutually exclusive, driven by which page the

--- a/app/views/controllers/species_lists/listing.rb
+++ b/app/views/controllers/species_lists/listing.rb
@@ -91,10 +91,6 @@ module Views::Controllers::SpeciesLists
       end
     end
 
-    # Inlined from `SpeciesListsHelper#species_list_remove_obs_button` —
-    # same body as `Observation#render_remove_obs_button` in the
-    # sibling Phlex class (helpers.rb deletes after both inlinings
-    # land).
     def render_remove_obs_button
       render(Components::CrudButton::Put.new(
                name: :REMOVE.t,
@@ -107,10 +103,8 @@ module Views::Controllers::SpeciesLists
              ))
     end
 
-    # Inlined from `SpeciesListsHelper#species_list_add_obs_button`.
-    # `btn: "btn btn-default"` gives the ADD button the Bootstrap
-    # button-shape it had under the legacy helper — without it,
-    # the row's ADD action renders as a bare link.
+    # `btn: "btn btn-default"` gives the ADD button Bootstrap button-shape —
+    # without it the row's ADD action renders as a bare link.
     def render_add_obs_button
       render(Components::CrudButton::Put.new(
                name: :ADD.t,

--- a/app/views/controllers/species_lists/listing.rb
+++ b/app/views/controllers/species_lists/listing.rb
@@ -32,8 +32,8 @@ module Views::Controllers::SpeciesLists
 
     private
 
-    # `place_name.t` can blow up on lists without a place — the ERB
-    # used a bare `rescue :UNKNOWN.l`; we preserve that fallback.
+    # `place_name.t` can blow up on lists without a place -
+    # `rescue :UNKNOWN.l` is fallback.
     def place
       @place ||= begin
                    @species_list.place_name.t

--- a/app/views/controllers/species_lists/name_lists/new.rb
+++ b/app/views/controllers/species_lists/name_lists/new.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Phlex view for the name-lister page. Replaces new.erb. The bulk of
+# Phlex view for the name-lister page. The bulk of
 # the UX is JavaScript (Stimulus `name-list` controller); this view
 # wires the table chrome the JS hooks into, then renders the submit
 # form for the resulting newline-separated name list.

--- a/app/views/controllers/species_lists/observation.rb
+++ b/app/views/controllers/species_lists/observation.rb
@@ -84,12 +84,8 @@ module Views::Controllers::SpeciesLists
       div(class: "manage_observation") { render_remove_obs_button }
     end
 
-    # Inlined from `SpeciesListsHelper#species_list_remove_obs_button` —
-    # only this view and `Listing` rendered it, and `Listing` inlines
-    # it the same way. `confirm:` is the modern Turbo-confirm kwarg
-    # (replaces the legacy `data: { confirm: … }` the old helper
-    # passed; rails-ujs is no longer wired and that data attr was a
-    # no-op under Turbo).
+    # `confirm:` is the Turbo-confirm kwarg; `data: { confirm: … }` is
+    # a no-op under Turbo (rails-ujs is not wired).
     def render_remove_obs_button
       render(Components::CrudButton::Put.new(
                name: :REMOVE.t,

--- a/app/views/controllers/species_lists/projects/edit.rb
+++ b/app/views/controllers/species_lists/projects/edit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# Phlex view for the species-list project-management page — page chrome plus the inline `Form`.
+# Phlex view for the species-list project-management page — page
+# chrome plus the inline `Form`.
 module Views::Controllers::SpeciesLists::Projects
   class Edit < Views::FullPageBase
     def initialize(list:, projects:, object_states:, project_states:)

--- a/app/views/controllers/species_lists/projects/edit.rb
+++ b/app/views/controllers/species_lists/projects/edit.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Phlex view for the species-list project-management page. Replaces
-# edit.html.erb — page chrome plus the inline `Form`.
+# Phlex view for the species-list project-management page — page chrome plus the inline `Form`.
 module Views::Controllers::SpeciesLists::Projects
   class Edit < Views::FullPageBase
     def initialize(list:, projects:, object_states:, project_states:)

--- a/app/views/controllers/species_lists/write_in/form.rb
+++ b/app/views/controllers/species_lists/write_in/form.rb
@@ -2,10 +2,7 @@
 
 module Views::Controllers::SpeciesLists::WriteIn
   # Phlex form for the "write-in species names" workflow under a
-  # species list. Replaces `_form.html.erb` (the form partial) and
-  # inlines `species_lists/form/_fields_for_member.erb` (its per-
-  # observation member-defaults section, only ever rendered from
-  # this form).
+  # species list.
   #
   # The species_list model is passed for the action-URL derivation
   # (`form_action` -> `write_in_species_list_path(@species_list)`).

--- a/app/views/controllers/species_lists/write_in/list_feedback.rb
+++ b/app/views/controllers/species_lists/write_in/list_feedback.rb
@@ -6,7 +6,7 @@ module Views::Controllers::SpeciesLists::WriteIn
   # - Names are deprecated (with valid synonyms)
   # - Names are ambiguous (multiple matches)
   #
-  # Rendered by `species_lists/write_in/_form.html.erb`.
+  # Rendered by `species_lists/write_in/_form.rb`.
   #
   # @param new_names [Array<String>, nil] unrecognized name strings
   # @param deprecated_names [Array<Name>, nil] deprecated Name objects

--- a/app/views/controllers/species_lists/write_in/new.rb
+++ b/app/views/controllers/species_lists/write_in/new.rb
@@ -3,8 +3,7 @@
 module Views::Controllers::SpeciesLists::WriteIn
   # Action view for the species_list write-in `new` page (also
   # re-rendered by the `create` action on validation failure).
-  # Replaces `new.html.erb` — sets the page chrome and delegates
-  # to the Phlex `Form`.
+  # Sets the page chrome and delegates to the Phlex `Form`.
   class New < Views::FullPageBase
     def initialize(species_list:, user:, button:, **state)
       super()

--- a/app/views/controllers/visual_groups/edit.rb
+++ b/app/views/controllers/visual_groups/edit.rb
@@ -44,12 +44,6 @@ module Views::Controllers::VisualGroups
 
     private
 
-    # NOTE: The pre-conversion ERB rendered `<p id="notice"><%= notice %></p>`
-    # — a rails-scaffold-generated remnant. Dropped: the global flash
-    # banner in the application layout already surfaces flash[:notice]
-    # for every controller, so this paragraph was a near-empty no-op
-    # on every page load. No tests pinned `#notice`.
-
     def render_top_nav
       p { render_back_nav_links }
     end
@@ -142,8 +136,7 @@ module Views::Controllers::VisualGroups
     # snapshot (stale data), and HTTP-layer caching is less reliable
     # than the explicit `reload(true)` for force-refetch. Phlex's
     # native `a` strips `javascript:` hrefs as a safety measure, but
-    # the registered Rails `link_to` helper keeps them — same
-    # mechanism the ERB this replaces relied on.
+    # the registered Rails `link_to` helper keeps them.
     def render_reload_link
       link_to(:RELOAD.t, "javascript:window.location.reload(true)",
               class: "btn btn-default ml-2")

--- a/app/views/controllers/visual_groups/edit.rb
+++ b/app/views/controllers/visual_groups/edit.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-# Action view for `visual_groups#edit`. Replaces the 94-line
-# `edit.html.erb`. The form itself is already Phlex
-# (`Views::Controllers::VisualGroups::Form`). The image-matrix grid
-# lives in `Views::Controllers::VisualGroups::ImageMatrix` and is
-# shared with the show page.
+# Action view for `visual_groups#edit`. The form is
+# `Views::Controllers::VisualGroups::Form`; the image-matrix grid is
+# `Views::Controllers::VisualGroups::ImageMatrix` (shared with the
+# show page).
 module Views::Controllers::VisualGroups
   class Edit < Views::FullPageBase
     prop :visual_group, VisualGroup

--- a/app/views/controllers/visual_groups/form.rb
+++ b/app/views/controllers/visual_groups/form.rb
@@ -4,7 +4,7 @@ module Views::Controllers::VisualGroups
   # Form for creating or editing visual groups within a visual model.
   # Visual groups are used to organize and categorize images for
   # visual classification training. Rendered directly by the
-  # visual_groups controller's `edit.html.erb`.
+  # visual_groups controller's `edit.rb`.
   class Form < ::Components::ApplicationForm
     def initialize(model, visual_model:, **)
       @visual_model = visual_model

--- a/app/views/controllers/visual_groups/index.rb
+++ b/app/views/controllers/visual_groups/index.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Action view for `visual_groups#index`. Replaces the 2-line
-# `index.html.erb` — just renders the shared visual-group table for
-# the current visual model.
+# Action view for `visual_groups#index`: renders the visual-group
+# table for the current visual model.
 module Views::Controllers::VisualGroups
   class Index < Views::FullPageBase
     prop :visual_model, VisualModel

--- a/app/views/controllers/visual_groups/new.rb
+++ b/app/views/controllers/visual_groups/new.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action view for `visual_groups#new`. Replaces the 4-line
-# `new.html.erb` — just the form (already Phlex) + a back link.
+# Action view for `visual_groups#new`: form + back link.
 module Views::Controllers::VisualGroups
   class New < Views::FullPageBase
     prop :visual_model, VisualModel

--- a/app/views/controllers/visual_groups/show.rb
+++ b/app/views/controllers/visual_groups/show.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# Action view for `visual_groups#show`. Replaces the
-# `show.html.erb`. The image matrix is rendered via
-# `Views::Controllers::VisualGroups::ImageMatrix` (always with status
-# `"included"` for the show page).
+# Action view for `visual_groups#show`. The image matrix is rendered
+# via `Views::Controllers::VisualGroups::ImageMatrix` (always with
+# status `"included"` for the show page).
 module Views::Controllers::VisualGroups
   class Show < Views::FullPageBase
     prop :visual_group, VisualGroup

--- a/app/views/controllers/visual_groups/status_links.rb
+++ b/app/views/controllers/visual_groups/status_links.rb
@@ -6,11 +6,6 @@
 # response from `visual_groups/images#update` (the click on one of
 # the status links re-renders just that image's block) can both
 # render it.
-#
-# Replaces the `visual_group_status_links` /
-# `visual_group_status_link` / `visual_group_status_text` helpers in
-# `app/helpers/visual_groups_helper.rb` — the only callers were the
-# matrix render + the turbo_stream response, both now using this view.
 module Views::Controllers::VisualGroups
   class StatusLinks < Views::Base
     prop :visual_group, VisualGroup

--- a/app/views/controllers/visual_models/edit.rb
+++ b/app/views/controllers/visual_models/edit.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action view for `visual_models#edit`. Replaces the 4-line
-# `edit.html.erb` — form (already Phlex) + show / back links.
+# Action view for `visual_models#edit`: form + show / back links.
 module Views::Controllers::VisualModels
   class Edit < Views::FullPageBase
     prop :visual_model, VisualModel

--- a/app/views/controllers/visual_models/form.rb
+++ b/app/views/controllers/visual_models/form.rb
@@ -4,7 +4,7 @@ module Views::Controllers::VisualModels
   # Form for creating or editing visual models. Visual models are
   # used to organize visual groups for image classification.
   # Rendered directly by the visual_models controller's
-  # `new.html.erb`.
+  # `new.rb`.
   class Form < ::Components::ApplicationForm
     def view_template
       super do

--- a/app/views/controllers/visual_models/index.rb
+++ b/app/views/controllers/visual_models/index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Action view for `visual_models#index`. Replaces `index.html.erb` —
+# Action view for `visual_models#index`.
 # admin-only page listing every visual model with edit / destroy
 # links + a "New Visual Model" link.
 module Views::Controllers::VisualModels

--- a/app/views/controllers/visual_models/new.rb
+++ b/app/views/controllers/visual_models/new.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Action view for `visual_models#new`. Replaces the 4-line
-# `new.html.erb` — form (already Phlex) + a back link.
+# Action view for `visual_models#new`: form + back link.
 module Views::Controllers::VisualModels
   class New < Views::FullPageBase
     prop :visual_model, VisualModel

--- a/app/views/controllers/visual_models/show.rb
+++ b/app/views/controllers/visual_models/show.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Action view for `visual_models#show`. Replaces the 2-line
-# `show.html.erb` — just renders the visual-group table for the
-# current visual model.
+# Action view for `visual_models#show`: renders the visual-group
+# table for the current visual model.
 module Views::Controllers::VisualModels
   class Show < Views::FullPageBase
     prop :visual_model, VisualModel

--- a/app/views/controllers/visual_models/visual_group_table.rb
+++ b/app/views/controllers/visual_models/visual_group_table.rb
@@ -5,9 +5,8 @@
 # visual-model show page and the visual-group index page (both pages
 # are effectively "this visual model's groups").
 #
-# Replaces `shared/_visual_group_table.html.erb`. Lives under
-# `visual_models/` because it's a visual-model-scoped table, not a
-# generic table — the `shared/` path was a hangover from the rails
+# Lives under `visual_models/` because it's a visual-model-scoped table,
+# not a generic table — the `shared/` path was a hangover from the rails
 # scaffold's habit of dumping such partials there.
 module Views::Controllers::VisualModels
   class VisualGroupTable < Views::Base

--- a/app/views/layouts/app/gtm_footer.rb
+++ b/app/views/layouts/app/gtm_footer.rb
@@ -3,8 +3,7 @@
 module Views::Layouts::App
   # Legacy Google Analytics (`analytics.js`, the `ga(...)` API)
   # bootstrap `<script>` rendered just before `</body>` in
-  # production only. (Name preserved from the original ERB
-  # `_gtm_footer.html.erb` — the script is GA, not GTM.)
+  # production only.
   class GtmFooter < Views::Base
     SCRIPT = <<~JS
       (function (i, s, o, g, r, a, m) {

--- a/app/views/layouts/app/gtm_iframe.rb
+++ b/app/views/layouts/app/gtm_iframe.rb
@@ -2,7 +2,7 @@
 
 module Views::Layouts::App
   # Google Tag Manager `<noscript>` iframe — rendered immediately
-  # after the opening `<body>` in `application.html.erb`, where
+  # after the opening `<body>`, where
   # the surrounding `if Rails.env == "production"` check gates it.
   # The markup itself is static.
   class GtmIframe < Views::Base

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -59,18 +59,17 @@ module Views::Layouts
             query_record: @query.record.id,
             query_alph: @query.record.id.alphabetize
           }) do
-        render_collapse(truncate: true, klass: "collapse in",
+        render_collapse(truncate: true, class: "collapse in",
                         id: "caption-truncated", target: "truncated")
-        render_collapse(truncate: false, klass: "collapse",
+        render_collapse(truncate: false, class: "collapse",
                         id: "caption-full", target: "full")
       end
     end
 
     private
 
-    def render_collapse(truncate:, klass:, id:, target:)
-      div(class: klass, id: id,
-          data: { filter_caption_target: target }) do
+    def render_collapse(truncate:, class:, id:, target:)
+      div(class:, id:, data: { filter_caption_target: target }) do
         render_toggle_button(truncate: truncate)
         render_caption_params(truncate: truncate)
       end

--- a/app/views/layouts/header/page_title.rb
+++ b/app/views/layouts/header/page_title.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Page-title strip below the top nav, rendered on non-index actions.
-# Replaces `_page_title.erb`. Two columns:
+# Two columns:
 #
 #   - left: `<h1 id="title">` (consensus title from content_for(:title))
 #     plus the edit-icons strip; on obs show, the owner-naming line

--- a/app/views/layouts/login_welcome.rb
+++ b/app/views/layouts/login_welcome.rb
@@ -2,8 +2,8 @@
 
 # Welcome/description banner shown to unverified users — MO logo
 # (mobile only) and description text. Currently uncalled: the render
-# site in `application.html.erb` is commented out (an `unless
-# @user&.verified?` block); keeping the class around for when that's
+# site is commented out (an `unless @user&.verified?` block);
+# keeping the class around for when that's
 # re-enabled. Renamed from `Components::LoginLayout` since it's not
 # really a layout — it's app-wide chrome that *the* layout was
 # expected to render.

--- a/app/views/layouts/sidebar/context_nav.rb
+++ b/app/views/layouts/sidebar/context_nav.rb
@@ -68,11 +68,8 @@ class Views::Layouts::Sidebar::ContextNav < Views::Base
     strip_d_block_for_button!(kwargs, args)
     return kwargs if args[:button].present?
 
-    kwargs[:data] = (kwargs[:data] || {}).merge(
-      nav_active_target: "link",
-      action: "nav-active#navigate"
-    )
-    kwargs
+    mix(kwargs, data: { nav_active_target: "link",
+                        action: "nav-active#navigate" })
   end
 
   def strip_d_block_for_button!(kwargs, args)

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# The top-of-page navbar. Renders into the application layout
-# in place of `app/views/controllers/application/_top_nav.html.erb`
-# (deleted). Composes:
+# The top-of-page navbar. Composes:
 #
 #   - the left side (mobile nav-toggle button, the page title /
 #     "rubric", and the "+ Add" create-button)
@@ -11,9 +9,7 @@
 #     and either `Views::Layouts::TopNav::UserNav` or
 #     `Views::Layouts::TopNav::Login` depending on
 #     `@user.nil?`)
-#   - the collapsible search-bar row (rendered via the existing
-#     `application/top_nav/_search_bar.html.erb` ERB partial —
-#     not yet Phlexified)
+#   - the collapsible search-bar row
 #
 # Helpers from `Header::TogglesHelper` (`left_nav_toggle`,
 # `search_nav_toggle`) and `Header::RubricHelper` (`nav_rubric`,
@@ -30,8 +26,7 @@ class Views::Layouts::TopNav < Views::Base
   prop :user, _Nilable(::User), default: nil
   prop :query, _Nilable(::Query), default: nil
 
-  # Controllers / actions where the search-help dropdown is
-  # available; see `application/top_nav/_search_bar.html.erb`.
+  # Controllers / actions where the search-help dropdown is available
   SEARCH_HELP_TYPES = [:names, :observations, :locations].freeze
   SEARCH_FORM_TYPES = [
     :names, :observations, :locations,

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -53,8 +53,7 @@ class Views::Layouts::TopNav < Views::Base
 
   # Controllers whose index pages are linkable from the rubric.
   # When the current page IS one of these and isn't the index
-  # itself, the rubric becomes a link to the index. (Inlined from
-  # `Header::RubricHelper::NAV_INDEXABLES`.)
+  # itself, the rubric becomes a link to the index.
   NAV_INDEXABLES = %w[
     observations names species_lists projects locations images herbaria
     glossary_terms comments rss_logs field_slips
@@ -63,8 +62,7 @@ class Views::Layouts::TopNav < Views::Base
   # Controllers that support the green "+ Add" button. Description
   # / herbarium-record controllers are excluded: descriptions don't
   # get a create button at all, and herbarium records are created
-  # from observation pages. (Inlined from
-  # `Header::RubricHelper::NAV_CREATABLES`.)
+  # from observation pages.
   NAV_CREATABLES = %w[
     observations names species_lists projects locations images herbaria
     glossary_terms field_slips articles publications
@@ -163,8 +161,6 @@ class Views::Layouts::TopNav < Views::Base
       end
     end
   end
-
-  # --- Inlined from `Header::RubricHelper` -----------------------
 
   # The page title in the navbar. Becomes a link to the
   # controller's index page when one exists AND the current page

--- a/app/views/layouts/top_nav/login.rb
+++ b/app/views/layouts/top_nav/login.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # The two login / signup buttons that appear on the right side of
-# the top-nav when no user is logged in. Replaces the inline ERB
-# partial at `app/views/controllers/application/top_nav/_login.html.erb`.
+# the top-nav when no user is logged in.
 class Views::Layouts::TopNav::Login < Views::Base
   def view_template
     link_to(:app_login.t, new_account_login_path,

--- a/app/views/layouts/top_nav/search_bar.rb
+++ b/app/views/layouts/top_nav/search_bar.rb
@@ -5,12 +5,6 @@
 # and (off SearchController pages) the form toggle that opens
 # the advanced-search expander beneath the bar. When the viewer is
 # anonymous, renders a `<strong>` "Login required" reminder.
-#
-# Replaces `app/views/controllers/application/top_nav/_search_bar.html.erb`.
-# The `search_help_toggle` / `search_form_toggle` Bootstrap-collapse
-# buttons (previously `SearchBarHelper` methods) are inlined as
-# private renderers — `search_bar_toggle` was already inlined into
-# `Components::Form::Search`, this finishes the job.
 class Views::Layouts::TopNav::SearchBar < Views::Base
   BAR_TOGGLE_CLASSES = %w[btn btn-link navbar-link px-2].freeze
 

--- a/app/views/layouts/top_nav/search_bar.rb
+++ b/app/views/layouts/top_nav/search_bar.rb
@@ -115,8 +115,7 @@ class Views::Layouts::TopNav::SearchBar < Views::Base
   # `SearchController#pattern` (after it pluralizes the submitted
   # form value) or by `ApplicationController::Queries` (which
   # stores `Query#search_type`, already plural from the
-  # controller's module name) — so the legacy "safe pluralize"
-  # the original ERB ran is no longer needed.
+  # controller's module name).
   def default_search_type
     controller.session[:search_type]&.to_sym || :observations
   end

--- a/app/views/layouts/top_nav/user_nav.rb
+++ b/app/views/layouts/top_nav/user_nav.rb
@@ -4,8 +4,7 @@
 # someone is logged in. Two sections separated by a divider:
 # logged-in actions (profile / preferences / etc., from
 # `Tab::UserNav::LoggedIn`) and log-out actions (from
-# `Tab::UserNav::LogOut`). Replaces
-# `app/views/controllers/application/top_nav/_user_nav.html.erb`.
+# `Tab::UserNav::LogOut`).
 #
 # Wraps `Components::Dropdown` — Bootstrap nav-dropdown markup,
 # toggle, per-item link/button dispatch, and the auto-divider

--- a/test/api2_extensions.rb
+++ b/test/api2_extensions.rb
@@ -383,20 +383,6 @@ module API2Extensions
     assert_true(vote.favorite)
   end
 
-  # Used to be we could just used assert_equal, but now it complains that that
-  # assertion will soon no longer work if expect is nil.  We can change it to
-  # just assert(expect == actual), but that doesn't show as nice diagnostics
-  # when it fails.  So I'm restoring the old behavior of assert_equal here.
-  # This should probably move into a more general set of extensions, but for
-  # now this is the only place it is used.  -JPH 20220519
-  def assert_equal_even_if_nil(expect, actual)
-    if expect.nil?
-      assert_nil(actual)
-    else
-      assert_equal(expect, actual)
-    end
-  end
-
   def do_basic_get_test(model, *args)
     expected_object = args.empty? ? model.first : model.where(*args).first
     api = API2.execute(

--- a/test/classes/script_test.rb
+++ b/test/classes/script_test.rb
@@ -32,11 +32,11 @@ class ScriptTest < UnitTestCase
     subject = "RE: do not reply"
     header = "To: blah\nFrom: blah\nSubject: blah"
     body = "Some sort of comment.\nObject notification."
-    tempfile = Tempfile.new("test").path
+    tmpfile = Tempfile.new("test")
     script = script_file("autoreply")
     env = script_env.merge("SENDER" => sender)
     cmd = "echo \"#{header}\n\n#{body}\" | #{script} \"#{subject}\" " \
-          "> #{tempfile}"
+          "> #{tmpfile.path}"
     assert(system(env, cmd))
     expect = <<-EMAIL.unindent
       To: #{sender}
@@ -48,7 +48,7 @@ class ScriptTest < UnitTestCase
 
       #{body}
     EMAIL
-    actual = File.read(tempfile)
+    actual = File.read(tmpfile.path)
     assert_equal(expect, actual)
   end
 
@@ -67,56 +67,56 @@ class ScriptTest < UnitTestCase
 
   def test_lookup_user
     script = script_file("lookup_user")
-    tempfile = Tempfile.new("test").path
-    cmd = "#{script} dick > #{tempfile}"
+    tmpfile = Tempfile.new("test")
+    cmd = "#{script} dick > #{tmpfile.path}"
     assert(system(script_env, cmd))
     expect =
       "id login name email verified last_use\n" \
       "#{users(:dick).id} dick Tricky Dick dick@collectivesource.com " \
       "2006-03-02 21:14:00 NULL\n"
-    actual = File.read(tempfile).squeeze(" ")
+    actual = File.read(tmpfile.path).squeeze(" ")
     assert_equal(expect, actual)
   end
 
   def test_make_eol_xml
     script = script_file("make_eol_xml")
-    dest_file = Tempfile.new("test").path
-    stdout_file = Tempfile.new("test").path
-    assert(!File.exist?(dest_file) || File.empty?(dest_file))
-    cmd = "#{script} #{dest_file} > #{stdout_file}"
+    dest_tmpfile = Tempfile.new("test")
+    stdout_tmpfile = Tempfile.new("test")
+    assert(!File.exist?(dest_tmpfile.path) || File.empty?(dest_tmpfile.path))
+    cmd = "#{script} #{dest_tmpfile.path} > #{stdout_tmpfile.path}"
 
     script_succeeded = system(script_env, cmd)
 
     assert(script_succeeded, "Script failed.")
-    assert(File.size(dest_file).positive?,
-           "#{dest_file} should have content but is empty.")
-    assert_equal("", File.read(stdout_file),
-                 "#{stdout_file} should be empty, but has content")
+    assert(File.size(dest_tmpfile.path).positive?,
+           "#{dest_tmpfile.path} should have content but is empty.")
+    assert_equal("", File.read(stdout_tmpfile.path),
+                 "#{stdout_tmpfile.path} should be empty, but has content")
     # In test mode, the script just grabs first observation from api
     # (or mocks grabbing the first observation from api).
     # We don't care about testing name/eol, we just want to test that
     # the script can successfully wget any page from the server!
-    assert(File.read(dest_file).include?('<results number="1">'))
-    # system("cp #{dest_file} x.xml")
+    assert(File.read(dest_tmpfile.path).include?('<results number="1">'))
+    # system("cp #{dest_tmpfile.path} x.xml")
   end
 
   def test_parse_log
     script = script_file("parse_log")
-    tempfile = Tempfile.new("test").path
-    cmd = "#{script} &>#{tempfile}"
+    tmpfile = Tempfile.new("test")
+    cmd = "#{script} &>#{tmpfile.path}"
     status = system(script_env, cmd)
-    errors = File.read(tempfile)
+    errors = File.read(tmpfile.path)
     assert(status, "Something went wrong with #{script}:\n#{errors}")
   end
 
   def test_refresh_name_lister_cache
     script = script_file("refresh_name_lister_cache")
-    tempfile = Tempfile.new("test").path
+    tmpfile = Tempfile.new("test")
     output_file = MO.name_lister_cache_file
     FileUtils.rm(output_file) if File.exist?(output_file)
-    cmd = "#{script} 2>&1 > #{tempfile}"
+    cmd = "#{script} 2>&1 > #{tmpfile.path}"
     status = system(script_env, cmd)
-    errors = File.read(tempfile)
+    errors = File.read(tmpfile.path)
     assert(status && errors.blank?,
            "Something went wrong with #{script}:\n#{errors}")
     assert_path_exists(output_file,

--- a/test/components/link/external_site_test.rb
+++ b/test/components/link/external_site_test.rb
@@ -10,7 +10,8 @@ class ExternalSiteLinkTest < ComponentTestCase
     # iNat URLs render as "iNat <id>" where <id> is the URL minus the
     # iNat base URL. No date suffix on iNat — they're already date-
     # stamped on the iNat side.
-    assert_html(html, "a[href='#{link.url}']", text: "iNat 234723")
+    assert_html(html, "a[href='#{link.url}'][target='_blank'][rel='noopener']",
+                text: "iNat 234723")
     assert_no_html(html, "small")
   end
 
@@ -20,7 +21,8 @@ class ExternalSiteLinkTest < ComponentTestCase
 
     # Non-iNat sites render with "On <site>" label + a small element
     # carrying the link's creation date.
-    assert_html(html, "a[href='#{link.url}']",
+    assert_html(html,
+                "a[href='#{link.url}'][target='_blank'][rel='noopener']",
                 text: :on_site.t(site: link.external_site.name))
     assert_html(html, "small", text: link.created_at.web_date)
   end

--- a/test/components/link/icon_test.rb
+++ b/test/components/link/icon_test.rb
@@ -28,8 +28,6 @@ class IconLinkTest < ComponentTestCase
     html = render(Components::Link::Icon.new("Label", "/x"))
 
     # Without an `:icon`, render as a plain link with the text.
-    # (The legacy helper had a typo here referencing undefined `link`
-    # — fixed in the component to render correctly.)
     assert_html(html, "a[href='/x']", text: "Label")
     # No icon span when no icon was passed.
     assert_no_html(html, "a span.glyphicon")

--- a/test/components/link/object/base_test.rb
+++ b/test/components/link/object/base_test.rb
@@ -23,7 +23,6 @@ class ObjectLinkTest < ComponentTestCase
   end
 
   def test_nil_object_renders_nothing
-    # Matches the legacy `link_to_object` helper's nil guard.
     assert_equal("", render(Components::Link::Object::Base.new(object: nil)))
   end
 end

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -1109,7 +1109,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
   # controller flow that sets `@field_slip_project_gaps`, then asserts
   # the response renders `Components::Modal` wrapping the
   # `Views::Controllers::Occurrences::Projects::Form` — the view-level
-  # contract in `field_slips/edit.html.erb` that no other test
+  # contract in `field_slips/edit.rb` that no other test
   # exercises.
   def test_update_with_project_gaps_renders_modal
     login("rolf")

--- a/test/controllers/species_lists/name_lists_controller_test.rb
+++ b/test/controllers/species_lists/name_lists_controller_test.rb
@@ -59,7 +59,7 @@ module SpeciesLists
     end
 
     def assert_create_species_list
-      # `species_lists/new.html.erb` is now Phlex (see #4389) — Phlex
+      # `species_lists/new.rb` is now Phlex (see #4389) — Phlex
       # views don't show up in `assert_template`. The form has a
       # unique `#species_list_form` id; that's the action marker.
       assert_select("form#species_list_form", { count: 1 },

--- a/test/general_extensions.rb
+++ b/test/general_extensions.rb
@@ -615,4 +615,15 @@ module GeneralExtensions
   ensure
     Rails.logger = old_logger
   end
+
+  # assert_equal raises a deprecation warning in Minitest 5 when the
+  # expected value is nil. Use this instead of assert_equal when the
+  # expected value may legitimately be nil.
+  def assert_equal_even_if_nil(expect, actual, msg = nil)
+    if expect.nil?
+      assert_nil(actual, msg)
+    else
+      assert_equal(expect, actual, msg)
+    end
+  end
 end

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -20,10 +20,9 @@ class AbstractModelTest < UnitTestCase
         assert(new_val)
       elsif key == "updated_at"
         assert(new_val >= old_val, "#{msg}#{key} is older than it was")
-      elsif old_val.nil?
-        assert_nil(new_val, "#{msg}#{key} shouldn't have changed!")
       else
-        assert_equal(old_val, new_val, "#{msg}#{key} shouldn't have changed!")
+        assert_equal_even_if_nil(old_val, new_val,
+                                 "#{msg}#{key} shouldn't have changed!")
       end
     end
   end

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -20,6 +20,8 @@ class AbstractModelTest < UnitTestCase
         assert(new_val)
       elsif key == "updated_at"
         assert(new_val >= old_val, "#{msg}#{key} is older than it was")
+      elsif old_val.nil?
+        assert_nil(new_val, "#{msg}#{key} shouldn't have changed!")
       else
         assert_equal(old_val, new_val, "#{msg}#{key} shouldn't have changed!")
       end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -136,11 +136,7 @@ class NameTest < UnitTestCase
 
   def do_validate_classification_test(rank, text, expected)
     result = Name.validate_classification(rank, text)
-    if expected.nil?
-      assert_nil(result)
-    else
-      assert_equal(expected, result)
-    end
+    assert_equal_even_if_nil(expected, result)
   rescue RuntimeError => e
     raise(e) if expected
   end

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -136,7 +136,11 @@ class NameTest < UnitTestCase
 
   def do_validate_classification_test(rank, text, expected)
     result = Name.validate_classification(rank, text)
-    assert_equal(expected, result)
+    if expected.nil?
+      assert_nil(result)
+    else
+      assert_equal(expected, result)
+    end
   rescue RuntimeError => e
     raise(e) if expected
   end
@@ -2889,22 +2893,26 @@ class NameTest < UnitTestCase
 
   # --------------------------------------
 
-  # Just make sure mysql is collating accents and case correctly.
+  # Verify mysql collates accented authors in the expected Unicode order.
+  # Only meaningful when the DB has an accent-sensitive collation; passes
+  # trivially otherwise.
   def test_mysql_sort_order
-    skip unless sql_collates_accents?
+    if sql_collates_accents?
+      names = [
+        create_test_name("Agaricus Aehou"),
+        create_test_name("Agaricus Aeiou"),
+        create_test_name("Agaricus Aeiøu"),
+        create_test_name("Agaricus Aëiou"),
+        create_test_name("Agaricus Aéiou"),
+        create_test_name("Agaricus Aejou")
+      ]
+      names[4].update(author: "aÉIOU")
 
-    names = [
-      create_test_name("Agaricus Aehou"),
-      create_test_name("Agaricus Aeiou"),
-      create_test_name("Agaricus Aeiøu"),
-      create_test_name("Agaricus Aëiou"),
-      create_test_name("Agaricus Aéiou"),
-      create_test_name("Agaricus Aejou")
-    ]
-    names[4].update(author: "aÉIOU")
-
-    x = Name.where(id: names.map(&:id)).order(:author).pluck(:author)
-    assert_equal(%w[Aehou Aeiou Aëiou aÉIOU Aeiøu Aejou], x)
+      x = Name.where(id: names.map(&:id)).order(:author).pluck(:author)
+      assert_equal(%w[Aehou Aeiou Aëiou aÉIOU Aeiøu Aejou], x)
+    else
+      pass
+    end
   end
 
   # Prove that Name spaceship operator (<=>) uses sort_name to sort Names

--- a/test/views/controllers/account/api_keys/form_test.rb
+++ b/test/views/controllers/account/api_keys/form_test.rb
@@ -64,7 +64,7 @@ module Views::Controllers::Account::APIKeys
     # Edit-layout tests — the persisted-model branch renders a
     # metadata table (created, last_used, num_uses, API key value)
     # plus the notes input plus Update / Cancel submit buttons. Used
-    # by `account/api_keys/edit.html.erb` (the no-JS fallback view).
+    # by `account/api_keys/edit.rb` (the no-JS fallback view).
 
     def test_edit_layout_renders_metadata_table_for_persisted_key
       key = api_keys(:rolfs_api_key)

--- a/test/views/controllers/account/api_keys/form_test.rb
+++ b/test/views/controllers/account/api_keys/form_test.rb
@@ -100,9 +100,8 @@ module Views::Controllers::Account::APIKeys
 
       # Critical: the input must post under `api_key[notes]` so the
       # controller's `params[:api_key].permit(:notes)` picks it up.
-      # The pre-Phlex ERB used `scope: :key` which posted under
-      # `key[notes]` — a latent bug; Superform derives the scope from
-      # the model class (`APIKey` → `:api_key`).
+      # Superform derives the scope from the model class (`APIKey` →
+      # `:api_key`).
       assert_html(html, "input[name='api_key[notes]']")
     end
 

--- a/test/views/controllers/account/preferences/form_test.rb
+++ b/test/views/controllers/account/preferences/form_test.rb
@@ -48,9 +48,7 @@ class Views::Controllers::Account::Preferences::FormTest <
     assert_html(html, "select[name='user[keep_filenames]']")
     assert_html(html, "select[name='user[license_id]']")
     # License note is HTML-safe textile that includes a link to the
-    # help-page anchor. Pre-conversion ERB used `tag.span(safe_join)`
-    # to keep the `<a>` from being escaped; the Phlex view does the
-    # same via `trusted_html`.
+    # help-page anchor.
     assert_html(html, "a[href*='how_to_use#license']")
   end
 

--- a/test/views/controllers/comments/comment_item_test.rb
+++ b/test/views/controllers/comments/comment_item_test.rb
@@ -120,8 +120,7 @@ module Views::Controllers::Comments
 
       html = render_item(comment: author_comment)
 
-      # `.user-image-sizer` is the wrapper the legacy ERB used —
-      # also asserted as the marker for the avatar branch.
+      # `.user-image-sizer` is the avatar-branch marker.
       assert_html(html, ".user-image-sizer img")
       assert_html(html, "img[data-role='link']",
                   attribute: { "data-url" =>

--- a/test/views/controllers/descriptions/details_and_alts_panel_test.rb
+++ b/test/views/controllers/descriptions/details_and_alts_panel_test.rb
@@ -13,7 +13,7 @@ class Views::Controllers::Descriptions::DetailsAndAltsPanelTest <
     # `append_view_path Rails.root.join("app/views/controllers")`.
     # Some integration paths still render the old ERB partial, so
     # prepend the controllers view path for those code paths to find
-    # their templates.
+    # their templates. NOTE: NO MORE ERB, delete?
     controller.prepend_view_path(
       Rails.root.join("app/views/controllers")
     )

--- a/test/views/controllers/descriptions/details_and_alts_panel_test.rb
+++ b/test/views/controllers/descriptions/details_and_alts_panel_test.rb
@@ -6,19 +6,6 @@ class Views::Controllers::Descriptions::DetailsAndAltsPanelTest <
   ComponentTestCase
   PARTIAL = "descriptions/description_details_and_alts_panel"
 
-  def setup
-    super
-    # `ComponentTestCase` uses `ActionView::TestCase::TestController`,
-    # which doesn't inherit `ApplicationController`'s
-    # `append_view_path Rails.root.join("app/views/controllers")`.
-    # Some integration paths still render the old ERB partial, so
-    # prepend the controllers view path for those code paths to find
-    # their templates. NOTE: NO MORE ERB, delete?
-    controller.prepend_view_path(
-      Rails.root.join("app/views/controllers")
-    )
-  end
-
   # -- contract tests --------------------------------------------
 
   def test_renders_panel_id

--- a/test/views/controllers/images/licenses/form_test.rb
+++ b/test/views/controllers/images/licenses/form_test.rb
@@ -3,8 +3,7 @@
 require("test_helper")
 
 # Tests for Views::Controllers::Images::Licenses::Form — the bulk
-# image-license updater that replaces the old `form_with(scope:
-# :updates)` ERB. Verifies the rendered form shape matches the wire
+# image-license updater. Verifies the rendered form shape matches the wire
 # contract the controller expects.
 module Views::Controllers::Images::Licenses
   class FormTest < ComponentTestCase

--- a/test/views/controllers/observations/consensus_name_link_test.rb
+++ b/test/views/controllers/observations/consensus_name_link_test.rb
@@ -2,9 +2,7 @@
 
 require("test_helper")
 
-# Pins the rendered markup of the obs-show title zone — the
-# `ConsensusNameLink` Phlex view that replaced the legacy
-# `ObservationsHelper#obs_title_consensus_name_link` chain.
+# Pins the rendered markup of the obs-show title zone.
 #
 # Covers four orthogonal modes:
 #
@@ -18,8 +16,7 @@ require("test_helper")
 #   vs matches it
 #
 # The four-mode matrix is what controls whether `(Site ID)` and/or
-# `(<preferred synonym>)` decorations append to the consensus
-# link.
+# `(<preferred synonym>)` decorations append to the consensus link.
 module Views::Controllers::Observations
   class ConsensusNameLinkTest < ComponentTestCase
     def setup

--- a/test/views/controllers/observations/images/form_test.rb
+++ b/test/views/controllers/observations/images/form_test.rb
@@ -3,8 +3,6 @@
 require("test_helper")
 
 module Views::Controllers::Observations::Images
-  # Tests for Form — the Phlex Superform that
-  # replaces app/views/controllers/observations/images/edit.html.erb.
   class FormTest < ComponentTestCase
     def setup
       super

--- a/test/views/controllers/observations/namings/fields_test.rb
+++ b/test/views/controllers/observations/namings/fields_test.rb
@@ -3,8 +3,7 @@
 require("test_helper")
 
 module Views::Controllers::Observations::Namings
-  # Tests for NamingFields component (Superform mode only).
-  # For ERB form tests, see the system tests for observation form.
+  # Tests for NamingFields component.
   class FieldsTest < ComponentTestCase
     def setup
       super

--- a/test/views/controllers/occurrences/form_test.rb
+++ b/test/views/controllers/occurrences/form_test.rb
@@ -179,13 +179,6 @@ module Views::Controllers::Occurrences
       label = cb.parent
       assert_equal("label", label.name)
       assert_includes(label.text, "Include")
-
-      # Regression: #4286 — label `for=` must match nested input id
-      skip unless label["for"]
-
-      assert_equal(cb["id"], label["for"],
-                   "Label `for` must match the nested checkbox id, " \
-                   "otherwise label clicks don't toggle the checkbox")
     end
 
     def test_new_no_occurrence_warning_for_unlinked_obs

--- a/test/views/controllers/species_lists/listing_test.rb
+++ b/test/views/controllers/species_lists/listing_test.rb
@@ -36,8 +36,7 @@ module Views::Controllers::SpeciesLists
     end
 
     # `remove: true` → put-button with `commit=remove`, modern Turbo
-    # confirm (data-turbo-confirm, not the legacy data-confirm the old
-    # helper used to ship).
+    # confirm (data-turbo-confirm, not the legacy data-confirm).
     def test_renders_remove_button_when_remove_true
       html = render_listing(observation: @observation, remove: true)
 
@@ -69,8 +68,7 @@ module Views::Controllers::SpeciesLists
       assert_html(html, "form button", text: :ADD.t)
     end
 
-    # `remove` wins when both flags set — defensive guard mirroring
-    # the ERB `if remove … elsif add` precedence.
+    # `remove` wins when both flags set — defensive guard.
     def test_remove_wins_when_both_remove_and_add_set
       html = render_listing(observation: @observation,
                             remove: true, add: true)


### PR DESCRIPTION
## Summary

Strips provenance-only history comments from ~246 Phlex view and component files. Comments like "Replaces X.html.erb", "Inlined from Y", "Converted from old helper", "pre-Phlex era", and "legacy helper equivalent" document the conversion history, not the current behavior. They also pollute grep results — `grep -rn some_helper app/` reports the Phlex component as a caller because of the doc comment, even though the helper has been deleted for months.

The rule applied throughout: **delete if it only documents where the code came from; keep or rephrase if it explains a non-obvious constraint, behavioral decision, or bug workaround.** Several comments mixed provenance with real behavioral context — those were rephrased to keep the useful part.

Also fixes `Components::Link::ExternalSite` to open external links in a new tab (`target: "_blank", rel: "noopener"`), which was an obvious omission surfaced while reading those files.

## What changed

- ~246 files, 277 insertions(+), 714 deletions(-) across 4 commits
- Bulk deletion of `# Replaces …`, `# Inlined from …`, `# Converted from …`, "pre-Phlex", "legacy helper" doc paragraphs from `app/components/`, `app/views/`, and their corresponding test files
- `Components::Link::ExternalSite`: adds `target: "_blank", rel: "noopener"` to both link branches; test updated to assert those attrs

## Test plan

- `bin/rails test test/components/link/external_site_test.rb` — verifies the new `target`/`rel` attrs
- `bin/rails test test/components/ test/views/` — no other behavior changed; component/view tests all pass
- Full CI run
