### PR TITLE
Add production-log route analysis scripts

### DIFF
--- a/script/route_examples.rb
+++ b/script/route_examples.rb
@@ -1,0 +1,209 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Extract the most recent N requests for a given route (controller + action)
+# from the (gzipped) production logs, with full params and timing.
+#
+# Production logs at :info with the default Logger::Formatter, so each request
+# is a block of lines sharing one "[timestamp #pid]". Puma runs one request
+# per worker at a time (threads 1,1), so a given PID's lines are sequential:
+#
+#   I, [...#pid]  INFO -- : Started PATCH "/..." for 1.2.3.4 at ...
+#   I, [...#pid]  INFO -- : Processing by Foo::BarController#edit as HTML
+#   I, [...#pid]  INFO -- :   Parameters: {"id"=>"5", ...}
+#   I, [...#pid]  INFO -- : Completed 200 OK in 523ms (Views: ... | AR: ...)
+#   W, [...#pid]  WARN -- : TIME: 0.523 200 foo/bar edit user 1.2.3.4\turl\tUA
+#
+# We anchor on the TIME line (it carries the route + the canonical timing) and
+# attach that PID's most recent Started / Parameters / Completed lines.
+#
+# Scans newest file first and stops once N matches are found, so it usually
+# only reads the live log plus a file or two.
+#
+# Usage:
+#   ruby script/route_examples.rb CONTROLLER ACTION [-n N] [--logdir DIR]
+# e.g.
+#   ruby script/route_examples.rb observations/species_lists edit -n 20
+
+require "date"
+require "zlib"
+require "optparse"
+
+class RouteExamples
+  HEAD_RE = /\A[A-Z], \[([\d\-T:.+]+) \#(\d+)\][^:]*:\s?(.*)/
+  STARTED_RE = /\AStarted (\S+) "([^"]*)"/
+  PARAMS_RE = /\AParameters:\s*(.*)/m
+
+  def initialize(controller:, action:, count:, logdir:)
+    @controller = controller
+    @action = action
+    @count = count
+    @logdir = logdir
+  end
+
+  def run
+    records = collect
+    print_records(records.sort_by { |r| r[:ts] }.last(@count).reverse)
+  end
+
+  private
+
+  # Newest file first, stopping once we have enough matches.
+  def collect
+    files = candidate_files
+    records = []
+    files.each_with_index do |path, i|
+      warn(format("[%d/%d] %s (have %d/%d)", i + 1, files.size,
+                  File.basename(path), records.size, @count))
+      records.concat(scan(path))
+      break if records.size >= @count
+    end
+    records
+  end
+
+  # --- file discovery (newest first) ---
+
+  def candidate_files
+    files = []
+    live = File.join(@logdir, "production.log")
+    files << live if File.exist?(live)
+    dated = Dir.glob(File.join(@logdir, "production.log-[0-9]*")) +
+            Dir.glob(File.join(@logdir, "old", "production.log-[0-9]*.gz"))
+    files + dated.sort_by { |p| filename_date(p) || Date.new(1900) }.reverse
+  end
+
+  def filename_date(path)
+    m = /production\.log-(\d{8})/.match(path)
+    m && Date.strptime(m[1], "%Y%m%d")
+  rescue Date::Error
+    nil
+  end
+
+  # --- scan one file ---
+
+  def scan(path)
+    @pending = Hash.new { |h, k| h[k] = {} }
+    records = []
+    each_line(path) do |line|
+      parsed = parse_line(line)
+      next unless parsed
+
+      record = absorb(parsed)
+      records << record if record
+    end
+    records
+  rescue Zlib::GzipFile::Error, IOError, SystemCallError => e
+    warn("  skip #{path}: #{e.class}: #{e.message}")
+    records || []
+  end
+
+  def each_line(path, &block)
+    if path.end_with?(".gz")
+      Zlib::GzipReader.open(path) { |gz| gz.each_line(&block) }
+    else
+      File.open(path, "rb") { |f| f.each_line(&block) }
+    end
+  end
+
+  # Update per-PID pending state; on a matching TIME line, emit the record.
+  def absorb(parsed)
+    pid, ts, kind, payload = parsed
+    if kind == :time
+      finish(pid, ts, payload)
+    else
+      @pending[pid][kind] = payload
+      nil
+    end
+  end
+
+  def finish(pid, timestamp, fields)
+    pending = @pending.delete(pid) || {}
+    return nil unless fields[:controller] == @controller &&
+                      fields[:action] == @action
+
+    build_record(timestamp, fields, pending)
+  end
+
+  def build_record(timestamp, fields, pending)
+    started = pending[:started] || {}
+    { ts: timestamp, elapsed: fields[:elapsed], status: fields[:status],
+      ip: fields[:ip], url: fields[:url],
+      method: started[:method], path: started[:path],
+      params: pending[:params], completed: pending[:completed] }
+  end
+
+  # --- line parsing ---
+
+  def parse_line(line)
+    line = line.scrub unless line.valid_encoding?
+    m = HEAD_RE.match(line)
+    return nil unless m
+
+    kind, payload = classify(m[3].strip)
+    kind && [m[2], m[1], kind, payload]
+  end
+
+  def classify(msg)
+    return [:time, parse_time(msg)] if msg.start_with?("TIME:")
+    if (m = STARTED_RE.match(msg))
+      return [:started, { method: m[1], path: m[2] }]
+    end
+    if (m = PARAMS_RE.match(msg))
+      return [:params, m[1]]
+    end
+    return [:completed, msg] if msg.start_with?("Completed ")
+
+    nil
+  end
+
+  # "TIME: elapsed status controller action robot ip\turl\tua"
+  def parse_time(msg)
+    head, url, = msg.split("\t")
+    parts = head.split(/\s+/)
+    { elapsed: parts[1], status: parts[2], controller: parts[3],
+      action: parts[4], robot: parts[5], ip: parts[6], url: url }
+  end
+
+  # --- output ---
+
+  def print_records(records)
+    if records.empty?
+      warn("No requests found for '#{@controller} #{@action}'")
+      return
+    end
+    records.each { |r| print_one(r) }
+  end
+
+  def print_one(record)
+    puts(record_header(record))
+    puts("  params:    #{record[:params] || "(none logged)"}")
+    puts("  url:       #{record[:url]}")
+    puts("  ip:        #{record[:ip]}")
+    puts("  completed: #{record[:completed]}") if record[:completed]
+    puts
+  end
+
+  def record_header(record)
+    format("=== %s  %ss  %s  %s %s", record[:ts], record[:elapsed],
+           record[:status], record[:method], record[:path])
+  end
+end
+
+def parse_options(argv)
+  opts = { count: 10, logdir: "/var/web/mo/log" }
+  parser = OptionParser.new do |o|
+    o.banner = "Usage: ruby script/route_examples.rb CONTROLLER ACTION [opts]"
+    o.on("-n", "--count N", Integer, "Examples to show (default 10)") do |v|
+      opts[:count] = v
+    end
+    o.on("--logdir DIR", "Log directory (default /var/web/mo/log)") do |v|
+      opts[:logdir] = v
+    end
+  end
+  parser.parse!(argv)
+  controller, action = argv
+  abort(parser.help) unless controller && action
+  opts.merge(controller: controller, action: action)
+end
+
+RouteExamples.new(**parse_options(ARGV)).run if $PROGRAM_NAME == __FILE__

--- a/script/route_runtimes.rb
+++ b/script/route_runtimes.rb
@@ -1,0 +1,296 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Scan (gzipped) production logs and report, per route, the total time spent
+# and the median runtime over a date window. Standalone Ruby — no Rails boot,
+# streams each file line-by-line, so it's light on the server. Still, prefer
+# running off-peak / niced (`nice -n19 ruby script/route_runtimes.rb ...`).
+#
+# A route is controller + action (e.g. "rss_logs show",
+# "observations/maps index"), parsed from the request-stats TIME line that
+# app/controllers/application_controller.rb logs:
+#
+#   W, [2026-06-21T18:03:22.316401 #2379965]  WARN -- : \
+#     TIME: 0.00348845 302 rss_logs show user 201.227.43.116  https://...  UA
+#         elapsed^      status^  ctrl^  action^ robot^
+#
+# Counts SUCCESSFUL (2xx), non-robot requests only. Each line is included by
+# its own timestamp (not the filename date), so the log-rotation naming
+# scheme doesn't matter for correctness; filename dates are only a coarse
+# skip (±2 day margin) to avoid reading files clearly outside the window.
+#
+# Usage:
+#   ruby script/route_runtimes.rb [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+#                                 [--logdir DIR] [--out FILE] [--top N]
+#
+# Defaults: window = trailing 30 days (today-30 .. today, inclusive);
+# logdir = /var/web/mo/log; out = route_runtimes_<start>_to_<end>.csv;
+# top = 30 (rows printed to stdout). Writes the full sorted CSV AND prints a
+# top-N table.
+
+require "date"
+require "zlib"
+require "optparse"
+require "csv"
+
+class RouteRuntimes
+  # date, elapsed, status, controller, action, robot
+  LINE_RE = /
+    \[(\d{4}-\d{2}-\d{2})T[\d:.]+[^\]]*\]   # [2026-06-21T18:03:22.316401 #pid]
+    .*?\bTIME:\s+
+    (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)
+  /x
+
+  PROGRESS_EVERY = 1_000_000
+
+  def initialize(opts)
+    @start = opts.fetch(:start)
+    @end = opts.fetch(:end)
+    @logdir = opts.fetch(:logdir)
+    @out = opts.fetch(:out)
+    @top = opts.fetch(:top)
+    @durations = Hash.new { |h, k| h[k] = [] }
+    @lines = 0
+    @scanned = 0
+    @counted = 0
+    @bytes_done = 0   # on-disk bytes of fully-scanned files
+    @total_bytes = 0
+    @current_io = nil # stream of the file being scanned (for ETA)
+  end
+
+  def run
+    files = discover_files
+    @total_bytes = files.sum { |path| file_size(path) }
+    @started = clock
+    warn("Scanning #{files.size} file(s) for #{@start}..#{@end} " \
+         "(2xx, non-robot)")
+    files.each_with_index { |path, i| scan_file(path, i + 1, files.size) }
+    rows = summarize
+    write_csv(rows)
+    print_table(rows)
+    report_done(rows.size)
+  end
+
+  private
+
+  def report_done(route_count)
+    warn(format("Done in %s: %d lines, %d counted, %d routes -> %s",
+                hms(clock - @started), @scanned, @counted, route_count, @out))
+  end
+
+  def clock
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def hms(secs)
+    s = secs.round
+    format("%d:%02d:%02d", s / 3600, (s % 3600) / 60, s % 60)
+  end
+
+  # --- file discovery ---
+
+  # Current live log + rotated (plain) + archived (.gz). Bare production.log
+  # has no date so it's always scanned; dated files are skipped only when
+  # clearly outside the window (±2 days, since the rotation date can lag the
+  # content date by ~1 day).
+  def discover_files
+    files = []
+    live = File.join(@logdir, "production.log")
+    files << live if File.exist?(live)
+    files.concat(dated_files(File.join(@logdir, "production.log-[0-9]*")))
+    files.concat(dated_files(File.join(@logdir, "old",
+                                       "production.log-[0-9]*.gz")))
+    files
+  end
+
+  def dated_files(glob)
+    lo = @start - 2
+    hi = @end + 2
+    Dir.glob(glob).select { |path| keep_dated_file?(path, lo, hi) }
+  end
+
+  # Skip files clearly outside the window. An undateable name is skipped
+  # (with a warning) rather than scanned — these globs only match dated
+  # files, and the bare production.log is added separately.
+  def keep_dated_file?(path, low, high)
+    date = filename_date(path)
+    if date.nil?
+      warn("  skip #{File.basename(path)}: no parseable YYYYMMDD in name")
+      return false
+    end
+    date.between?(low, high)
+  end
+
+  # Date from production.log-YYYYMMDD, with or without a -N rotation suffix
+  # and/or .gz (e.g. production.log-20250427-2.gz -> 2025-04-27).
+  def filename_date(path)
+    m = /production\.log-(\d{8})/.match(path)
+    m && Date.strptime(m[1], "%Y%m%d")
+  rescue Date::Error
+    nil
+  end
+
+  # --- scanning ---
+
+  def scan_file(path, idx, total)
+    warn(format("[%d/%d] %s (%s) %s", idx, total, File.basename(path),
+                human_size(path), eta_text))
+    each_line(path) do |line|
+      @lines += 1
+      consume(line)
+      report_progress if (@lines % PROGRESS_EVERY).zero?
+    end
+  rescue Zlib::GzipFile::Error, IOError, SystemCallError => e
+    warn("  skip #{path}: #{e.class}: #{e.message}")
+  ensure
+    @bytes_done += file_size(path)
+  end
+
+  def report_progress
+    elapsed = clock - @started
+    rate = elapsed.positive? ? (@lines / elapsed).round : 0
+    warn(format("  %s | %d lines | %d counted | %d lines/s | %s",
+                hms(elapsed), @lines, @counted, rate, eta_text))
+  end
+
+  # ETA from the fraction of total on-disk bytes processed (completed files
+  # plus the current file's stream position). Plain bytes process faster than
+  # .gz bytes (no decompression), so the estimate is roughest while the two
+  # uncompressed production.log files are scanned and tightens over the .gz
+  # set.
+  def eta_text
+    cur = processed_bytes
+    elapsed = clock - @started
+    return "ETA --" unless @total_bytes.positive? && cur.positive? &&
+                           elapsed.positive?
+
+    frac = cur.to_f / @total_bytes
+    remaining = elapsed * (1.0 - frac) / frac
+    format("%d%% done, ETA %s", (frac * 100).round, hms(remaining))
+  end
+
+  def processed_bytes
+    @bytes_done + (@current_io&.pos || 0)
+  end
+
+  def file_size(path)
+    File.size(path)
+  rescue SystemCallError
+    0
+  end
+
+  def human_size(path)
+    format("%.1f MB", file_size(path).to_f / (1024 * 1024))
+  end
+
+  def each_line(path, &block)
+    @current_io = File.open(path, "rb")
+    reader = if path.end_with?(".gz")
+               Zlib::GzipReader.new(@current_io)
+             else
+               @current_io
+             end
+    reader.each_line(&block)
+  ensure
+    @current_io&.close
+    @current_io = nil
+  end
+
+  def consume(line)
+    line = line.scrub unless line.valid_encoding?
+    m = LINE_RE.match(line)
+    return unless m
+
+    @scanned += 1
+    fields = m.captures # date, elapsed, status, controller, action, robot
+    return unless countable?(fields)
+
+    secs = fields[1].to_f
+    return unless secs.finite? && secs >= 0
+
+    @durations["#{fields[3]} #{fields[4]}"] << secs
+    @counted += 1
+  end
+
+  # 2xx, non-robot, in the date window. Lexicographic date compare is
+  # correct for YYYY-MM-DD strings.
+  def countable?(fields)
+    date, _elapsed, status, = fields
+    robot = fields[5]
+    date.between?(@start.to_s, @end.to_s) &&
+      status.start_with?("2") && robot != "robot"
+  end
+
+  # --- summarize / output ---
+
+  def summarize
+    rows = @durations.map do |route, secs|
+      { route: route, count: secs.size,
+        total_seconds: secs.sum.round(3),
+        median_seconds: median(secs).round(6) }
+    end
+    rows.sort_by { |r| -r[:total_seconds] }
+  end
+
+  def median(values)
+    sorted = values.sort
+    n = sorted.size
+    mid = n / 2
+    n.odd? ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0
+  end
+
+  def write_csv(rows)
+    CSV.open(@out, "w") do |csv|
+      csv << %w[route count total_seconds median_seconds]
+      rows.each do |r|
+        csv << [r[:route], r[:count], r[:total_seconds], r[:median_seconds]]
+      end
+    end
+  end
+
+  def print_table(rows)
+    puts(format("\nTop %d routes by total time (%s..%s):", @top, @start, @end))
+    puts("route                                  count      total_s   median_s")
+    rows.first(@top).each do |r|
+      puts(format("%-34s %9d %12.3f %10.6f",
+                  r[:route], r[:count], r[:total_seconds], r[:median_seconds]))
+    end
+  end
+end
+
+# Standalone script (no Rails/ActiveSupport), so plain Date is correct here.
+def parse_options(argv)
+  today = Date.today # rubocop:disable Rails/Date
+  opts = { start: today - 30, end: today, logdir: "/var/web/mo/log",
+           out: nil, top: 30 }
+  option_parser(opts).parse!(argv)
+  opts[:start] = to_date(opts[:start])
+  opts[:end] = to_date(opts[:end])
+  opts[:out] ||= "route_runtimes_#{opts[:start]}_to_#{opts[:end]}.csv"
+  opts
+end
+
+def to_date(value)
+  value.is_a?(Date) ? value : Date.parse(value)
+end
+
+def option_parser(opts)
+  OptionParser.new do |o|
+    o.banner = "Usage: ruby script/route_runtimes.rb [options]"
+    o.on("--start DATE", "First day (YYYY-MM-DD), inclusive") do |v|
+      opts[:start] = v
+    end
+    o.on("--end DATE", "Last day (YYYY-MM-DD), inclusive") do |v|
+      opts[:end] = v
+    end
+    o.on("--logdir DIR", "Log directory (default /var/web/mo/log)") do |v|
+      opts[:logdir] = v
+    end
+    o.on("--out FILE", "CSV output path") { |v| opts[:out] = v }
+    o.on("--top N", Integer, "Rows to print (default 30)") do |v|
+      opts[:top] = v
+    end
+  end
+end
+
+RouteRuntimes.new(parse_options(ARGV)).run if $PROGRAM_NAME == __FILE__

--- a/script/route_runtimes.rb
+++ b/script/route_runtimes.rb
@@ -74,8 +74,9 @@ class RouteRuntimes
   private
 
   def report_done(route_count)
-    warn(format("Done in %s: %d lines, %d counted, %d routes -> %s",
-                hms(clock - @started), @scanned, @counted, route_count, @out))
+    warn(format("Done in %s: %d lines (%d TIME), %d counted, %d routes -> %s",
+                hms(clock - @started), @lines, @scanned, @counted,
+                route_count, @out))
   end
 
   def clock
@@ -192,6 +193,10 @@ class RouteRuntimes
              end
     reader.each_line(&block)
   ensure
+    # Closing the GzipReader closes the underlying file too; @current_io&.close
+    # is then a no-op (idempotent) and also covers the case where GzipReader
+    # construction raised and left the file open.
+    reader&.close
     @current_io&.close
     @current_io = nil
   end


### PR DESCRIPTION
## Summary

Two standalone Ruby scripts (no Rails boot — they stream the gzipped logs line-by-line, so they're light on the server) for analyzing MO's production request-stats logs. Both parse the `TIME:` line that `app/controllers/application_controller.rb` logs per request:

```
W, [2026-06-21T18:03:22.316401 #2379965]  WARN -- : TIME: 0.00348845 302 rss_logs show user 201.227.43.116  https://...  UA
        elapsed^         status^  ctrl^    action^ robot^
```

### `script/route_runtimes.rb`
Per-route **total time** and **median runtime** over a date window.
- Keys by `controller action`; counts **successful (2xx), non-robot** requests.
- Windows by each line's **own timestamp** (robust to the log-rotation naming, including `-N` same-day suffixes), with a coarse ±2-day filename-date skip so it doesn't read files clearly outside the window.
- Writes a CSV (`route,count,total_seconds,median_seconds`, sorted by total desc) **and** prints a top-N table.
- Mid-run progress: per-file banner + a line every 1M rows with elapsed, count, rate, and a **byte-based ETA**.

```bash
nice -n19 ruby script/route_runtimes.rb                       # trailing 30 days
nice -n19 ruby script/route_runtimes.rb --start 2026-05-21 --end 2026-06-21 \
  --logdir /var/web/mo/log --out /tmp/routes.csv --top 50
```

### `script/route_examples.rb`
The most recent **N** requests for a given route, with **full params and timing**.
- Production logs at `:info`, so each request is a block of lines sharing one `[timestamp #pid]` (Puma serves one request per worker at a time). The script anchors on the `TIME:` line and attaches that PID's `Started` (method+path), `Parameters:`, and `Completed` (Views/AR breakdown) lines.
- Scans **newest file first and stops** once N are found — normally just the live log plus a file or two.

```bash
ruby script/route_examples.rb observations/species_lists edit -n 20
ruby script/route_examples.rb observations index -n 5 --logdir /var/web/mo/log
```

Both default `--logdir` to `/var/web/mo/log` and discover `production.log`, `production.log-YYYYMMDD` (incl. `-N` rotation suffixes), and `old/production.log-YYYYMMDD.gz`.

## Notes

- Pure stdlib (`zlib`, `date`, `optparse`, `csv`); no Rails, no new gems.
- RuboCop clean. These are operational/diagnostic tools, validated with synthetic-log fixtures (route keying, 2xx + robot filtering, gz reading, date windowing, per-PID params correlation, last-N ordering).

## Test plan

- [x] RuboCop clean on both files.
- [x] `ruby -c` syntax check passes.
- [x] Verified against synthetic logs: filtering, gz handling, `-N`-suffix dating, per-line window, median math, ETA, and per-PID params correlation.
