### PR TITLE
Fix N+1 on observations/species_lists edit page

### DIFF
--- a/app/controllers/observations/species_lists_controller.rb
+++ b/app/controllers/observations/species_lists_controller.rb
@@ -68,15 +68,15 @@ module Observations
         :SpeciesList, editable_by_user: @user, order_by:
       )
 
-      @obs_lists = []
-      @other_lists = []
-      @all_lists.results.each do |list|
-        if list.observations.member?(@observation)
-          @obs_lists << list
-        else
-          @other_lists << list
-        end
-      end
+      # Which of these lists already contain the observation, in ONE query
+      # (its species_list_ids) instead of a per-list `observations.member?`
+      # check — that was an N+1 across all the user's editable lists. Eager-
+      # load :user and :location so the listing view doesn't reload them
+      # per row (place_name -> location, the user link).
+      member_ids = @observation.species_list_ids.to_set
+      @obs_lists, @other_lists =
+        @all_lists.results(include: [:user, :location]).
+        partition { |list| member_ids.include?(list.id) }
     end
 
     def find_observation!

--- a/test/controllers/observations/species_lists_controller_test.rb
+++ b/test/controllers/observations/species_lists_controller_test.rb
@@ -20,6 +20,34 @@ module Observations
       assert(assigns_exist, "Missing species_lists!")
     end
 
+    # The edit page partitions the user's editable lists into those that
+    # already contain the observation (obs_lists) and those that don't
+    # (other_lists). Guards the membership refactor (species_list_ids in one
+    # query, replacing a per-list observations.member? N+1).
+    def test_edit_partitions_lists_by_membership
+      obs = observations(:minimal_unknown_obs)
+      member_list = species_lists(:unknown_species_list)
+      assert(member_list.observations.member?(obs))
+      login(member_list.user.login)
+
+      get(:edit, params: { id: obs.id })
+      assert_response(:success)
+
+      obs_ids = assigns(:obs_lists).map(&:id)
+      other_ids = assigns(:other_lists).map(&:id)
+      assert_includes(obs_ids, member_list.id,
+                      "List containing the obs belongs in obs_lists")
+      assert_not_includes(other_ids, member_list.id)
+      # Every editable list lands in exactly one bucket.
+      assert_equal(assigns(:all_lists).results.map(&:id).sort,
+                   (obs_ids + other_ids).sort)
+      # The partition matches actual membership.
+      assigns(:other_lists).each do |list|
+        assert_not(list.observations.member?(obs),
+                   "other_lists must exclude the observation")
+      end
+    end
+
     def test_add_observation_to_species_list
       spl = species_lists(:first_species_list)
       obs = observations(:coprinus_comatus_obs)

--- a/test/controllers/observations/species_lists_controller_test.rb
+++ b/test/controllers/observations/species_lists_controller_test.rb
@@ -41,11 +41,13 @@ module Observations
       # Every editable list lands in exactly one bucket.
       assert_equal(assigns(:all_lists).results.map(&:id).sort,
                    (obs_ids + other_ids).sort)
-      # The partition matches actual membership.
-      assigns(:other_lists).each do |list|
-        assert_not(list.observations.member?(obs),
-                   "other_lists must exclude the observation")
-      end
+      # The partition matches actual membership (one query for the truth set,
+      # not a per-list check).
+      member_ids = obs.species_list_ids.to_set
+      assert(obs_ids.all? { |id| member_ids.include?(id) },
+             "obs_lists must all contain the observation")
+      assert(other_ids.none? { |id| member_ids.include?(id) },
+             "other_lists must exclude the observation")
     end
 
     def test_add_observation_to_species_list


### PR DESCRIPTION
## Summary

The `observations/species_lists#edit` page (the "add/remove this observation to/from one of my species lists" table) was extremely slow for users with many lists — a reported request took **6.2s (ActiveRecord 4964ms, 1176 queries / 750 cached)**.

## Diagnosis

The N+1 visible in the log (repeated `User`/`Location` loads from `species_lists/listing.rb` and `SpeciesList#place_name`) turned out to be a **minor symptom**: those are query-**cache** hits (~0ms each), because all the lists share the same owner and a small set of repeated locations.

The real cost is in `Observations::SpeciesListsController#set_list_ivars`, which partitioned the user's editable lists with a **per-list query**:

```ruby
@all_lists.results.each do |list|
  if list.observations.member?(@observation)  # one query per list
```

Measured on a production-copy DB for the reported user (**372 editable species lists**):

| | uncached queries | cached |
|---|---:|---:|
| **before** | 377 | 746 |
| **after** | 8 | 2 |

That matches the reported ~1176/750 total and accounts for the ~5s of ActiveRecord time.

## Fix

- Determine membership in **one query** via `@observation.species_list_ids`, then partition the lists in Ruby — no per-list query.
- Eager-load `:user` and `:location` (`results(include: [:user, :location])`) so the listing view doesn't reload them per row.

`@all_lists` stays the `Query` object (the Edit view still uses it for sort options); only the per-list membership loop changed.

## Test plan

- [x] Added a regression test asserting the `obs_lists` / `other_lists` partition matches actual membership and covers every editable list.
- [x] `bin/rails test test/controllers/observations/species_lists_controller_test.rb` — 8 runs, 0 failures (the edit render returns 200 with the eager-loaded associations).
- [x] RuboCop clean.
- [x] Query-count reduction (377 → 8 uncached) verified on a prod-copy DB for the reported 372-list user.
