### PR TITLE
Fix header icon/sorter regressions + flaky herbarium system test

### DIFF
--- a/test/system/herbarium_form_system_test.rb
+++ b/test/system/herbarium_form_system_test.rb
@@ -150,12 +150,12 @@ class HerbariumFormSystemTest < ApplicationSystemTestCase
       # Verify autocompleter switched to location_google mode
       assert_selector("[data-type='location_google']", wait: 5)
 
-      # In a real browser the user's focus/click sequence fires
-      # `ourClick` on the place-name input after the mode swap,
-      # which triggers `scheduleGoogleRefresh` → geocoding. The
-      # JS-driven `execute_script("...click()")` above bypasses
-      # those events, so we have to fire one manually here.
-      find_field("herbarium_place_name").click
+      # Trigger geocoding: `ourClick` on the input → `scheduleRefresh`
+      # → `scheduleGoogleRefresh`. Capybara's `.click` doesn't reliably
+      # fire the event to Stimulus after the JS-driven mode swap above,
+      # so dispatch via JS — same pattern as the create-button click.
+      execute_script("arguments[0].click()",
+                     find_field("herbarium_place_name"))
 
       # Wait for hidden ID to be set (proves geocoding worked)
       assert_field("herbarium_location_id", with: "-1", type: :hidden, wait: 10)


### PR DESCRIPTION
## Summary

- `InterestIcons`: make `user` nilable; component owns the `<ul>` wrap and emits it even when empty (no user) so the parent flex layout is always consistent — fixes the double-`<ul>` regression from the Phlex sweep
- `EditDeleteIcons` (renamed from `EditDestroyIcons`): component now owns its own `<ul>` wrap; emits empty `<ul>` when viewer has no permissions, so layout is consistent without PageTitle having to know about it
- `PageTitle`: drop own `<ul>` wrappers for both icon slots — components own the wrap now, PageTitle just injects `content_for` directly
- `Sorter`: restore missing `list-unstyled` on the outer `<ul>` (got dropped in the Phlex sweep, causing browser-default bullet points)
- `add_interest_icons`: remove the `return unless user` guard — component handles nil user by emitting an empty `<ul>`
- Herbarium form system test: fix the flaky geocoding trigger — `Capybara.click` on the place-name input doesn't reliably fire the Stimulus listener after a JS-driven mode switch; switch to `execute_script("arguments[0].click()")`, the same pattern already used for the create-button click above it

## Test plan

- [x] `bin/rails test test/views/layouts/header/` — 72 tests, 0 failures
- [x] `bin/rails test test/system/herbarium_form_system_test.rb` — previously flaky test now passes reliably
- [x] `bin/rails test` — 6560 tests, 0 failures (3 pre-existing i18n failures in `external_link.rb`, unrelated to this branch)
- [x] `bin/rails test test/system/` — 60 tests, 0 failures
- [x] `bundle exec rubocop` — 2485 files, no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
