### PR TITLE
Fix obs-show crash on iNat import links (nil url)

### DIFF
--- a/app/components/link/external.rb
+++ b/app/components/link/external.rb
@@ -54,7 +54,7 @@ class Components::Link::External < Components::Base
   # off it to get the bare iNat id either way.
   def link_content
     if inaturalist?
-      "iNat #{@link.link_url.sub(@link.external_site.base_url, "")}"
+      "iNat #{@link.link_url.delete_prefix(@link.external_site.base_url)}"
     else
       :on_site.t(site: @link.external_site.name)
     end

--- a/app/components/link/external.rb
+++ b/app/components/link/external.rb
@@ -28,7 +28,7 @@ class Components::Link::External < Components::Base
       @opts = tab.html_options.except(*NON_HTML_OPTS).merge(opts)
     elsif link
       @content = link_content
-      @path = link.url
+      @path = link.link_url
       @opts = opts
     else
       @content = content
@@ -49,9 +49,12 @@ class Components::Link::External < Components::Base
 
   private
 
+  # Import links store external_id with a nil url (the url is derived), while
+  # manual links store the url. link_url resolves both, so strip the base_url
+  # off it to get the bare iNat id either way.
   def link_content
     if inaturalist?
-      "iNat #{@link.url.sub(@link.external_site.base_url, "")}"
+      "iNat #{@link.link_url.sub(@link.external_site.base_url, "")}"
     else
       :on_site.t(site: @link.external_site.name)
     end

--- a/test/components/link/external_test.rb
+++ b/test/components/link/external_test.rb
@@ -73,7 +73,7 @@ class Components::Link::ExternalTest < ComponentTestCase
     html = render(Components::Link::External.new(link: link))
 
     assert_html(html, "a[href='#{site.observation_url("372490529")}']" \
-                      "[target='_blank']",
+                      "[target='_blank'][rel='noopener noreferrer']",
                 text: "iNat 372490529")
   end
 

--- a/test/components/link/external_test.rb
+++ b/test/components/link/external_test.rb
@@ -62,6 +62,21 @@ class Components::Link::ExternalTest < ComponentTestCase
     assert_no_html(html, "small")
   end
 
+  # Regression: import links store external_id with a nil url (url is derived).
+  # The component used to call link.url.sub(...) -> NoMethodError on nil.
+  def test_inat_import_link_with_nil_url_renders_derived_id
+    site = external_sites(:inaturalist)
+    link = ExternalLink.new(external_site: site, relationship: :import,
+                            external_id: "372490529")
+    assert_nil(link.url, "Import links store external_id, not url")
+
+    html = render(Components::Link::External.new(link: link))
+
+    assert_html(html, "a[href='#{site.observation_url("372490529")}']" \
+                      "[target='_blank']",
+                text: "iNat 372490529")
+  end
+
   def test_other_site_renders_on_site_label_and_date
     link = external_links(:coprinus_comatus_obs_mycoportal_link)
     html = render(Components::Link::External.new(link: link))


### PR DESCRIPTION
## Summary

`ObservationsController#show` raised `NoMethodError: undefined method 'sub' for nil` for any observation with an iNaturalist **import** link (reported on obs 646274).

`Components::Link::External`, in its `link:` form, set the anchor href to `@link.url` and built the label as `"iNat #{@link.url.sub(@link.external_site.base_url, "")}"`. But iNat **import** links (created by #4299 / #4529) store `external_id` with a **nil `url`** — the url is derived on display via `ExternalLink#link_url`. So `@link.url.sub(...)` blew up on nil.

Fix: use `@link.link_url` for both the href and the label. `link_url` returns the stored url for manual links and the derived `base_url + external_id` for import links, so `iNat <id>` and the href are correct for both kinds.

## Why it surfaced now

Pre-#4299, every external link was a manually-added link with a populated `url`. #4299 / #4529 introduced import links carrying `external_id` with a nil `url`; the obs-show external-links panel renders them through this component, so any observation with an iNat import link hit the nil.

## Test

Adds `test_inat_import_link_with_nil_url_renders_derived_id`, which builds an import link (`external_id` set, `url` nil) and asserts it renders `iNat <id>` with the derived href. The existing iNat test only covered a manual link (url present) — that was the gap that let this reach production.

- [x] `bin/rails test test/components/link/external_test.rb test/views/controllers/observations/show/external_links_panel_test.rb` (12 runs, 0 failures)

## Out of scope

The API2 external_link serializers (`_external_link.xml.builder`, `_external_link.json.jbuilder`, `api2_inline_helper`) also read `link.url` directly. They guard with `.to_s` / nil-tolerant XML so they don't crash, but they emit an empty url for import links instead of the derived one. Worth a follow-up to switch them to `link_url`; not a crash, so not included here.
