### PR TITLE
Extract paginated_results into Components::PaginatedResults

### DIFF
--- a/app/components/paginated_results.rb
+++ b/app/components/paginated_results.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Wraps an index result-set block in the `<div id="results">` shell with
+# the pre-rendered pagination strips from `content_for(:index_pagination_*)`
+# woven around it.
+#
+# The matching setter (`add_pagination`) lives on
+# `Views::FullPageBase::IndexNav` — only action views set chrome;
+# any view can read it via this component.
+class Components::PaginatedResults < Components::Base
+  prop :html_id, String, default: "results"
+
+  def view_template(&block)
+    encoded_q = URI.parse(observations_path(q: q_param)).query
+
+    div(id: @html_id, data: { q: encoded_q }) do
+      trusted_html(content_for(:index_pagination_top)) if
+        content_for?(:index_pagination_top)
+      yield
+      trusted_html(content_for(:index_pagination_bottom)) if
+        content_for?(:index_pagination_bottom)
+    end
+  end
+end

--- a/app/views/base.rb
+++ b/app/views/base.rb
@@ -6,42 +6,10 @@
 # `Components::Base` so view classes get the same Phlex/Rails wiring
 # as generic UI components.
 #
-# Things that belong here, not on `Components::Base`: view-layer
-# state assumptions — `paginated_results` reads
-# `content_for(:index_pagination_*)` slots only set on index pages;
-# `reload_with_args` reads `request.url` and is meaningful only
-# inside a request lifecycle. Pure UI components (modals, dropdowns,
-# buttons) don't need either.
-#
-# Per-concern setters that pair with these readers (e.g.
-# `add_pagination` for `paginated_results`) live on
+# Per-concern setters (e.g. `add_pagination`) live on
 # `Views::FullPageBase::*` modules — action views set; sub-partials
-# read.
+# read via `Components::PaginatedResults`.
 class Views::Base < Components::Base
-  # `paginated_results { render_results }` — wraps the supplied result-set
-  # block in the `<div id="results" data-q="...">` shell with the
-  # pre-rendered `:index_pagination_top` / `:index_pagination_bottom`
-  # strips woven around it. Action templates and sub-partials that own
-  # the results body (e.g. `Shared::ImagesToReuseForm`,
-  # `VisualGroups::ImageMatrix`) both call it. The matching
-  # `add_pagination` SETTER (which fills the content_for slots this
-  # method reads) lives on `Views::FullPageBase::IndexNav` because only
-  # action views set chrome.
-  def paginated_results(args = {})
-    html_id = args[:html_id] || "results"
-    encoded_q = URI.parse(observations_path(q: q_param)).query
-
-    div(id: html_id, data: { q: encoded_q }) do
-      if content_for?(:index_pagination_top)
-        trusted_html(content_for(:index_pagination_top))
-      end
-      yield
-      if content_for?(:index_pagination_bottom)
-        trusted_html(content_for(:index_pagination_bottom))
-      end
-    end
-  end
-
   # Rebuilds the current request URL with the given args merged /
   # cleared (e.g. `reload_with_args(merge: nil)` strips the `?merge=`
   # param). Used by the herbaria index merge-mode Alert + language

--- a/app/views/controllers/articles/index.rb
+++ b/app/views/controllers/articles/index.rb
@@ -16,7 +16,7 @@ module Views::Controllers::Articles
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      paginated_results { render_list }
+      render(::Components::PaginatedResults.new) { render_list }
     end
 
     private

--- a/app/views/controllers/collection_numbers/index.rb
+++ b/app/views/controllers/collection_numbers/index.rb
@@ -22,7 +22,7 @@ module Views::Controllers::CollectionNumbers
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      paginated_results { render_rows_table if @objects.any? }
+      render(::Components::PaginatedResults.new) { render_rows_table if @objects.any? }
     end
 
     private

--- a/app/views/controllers/collection_numbers/index.rb
+++ b/app/views/controllers/collection_numbers/index.rb
@@ -22,7 +22,9 @@ module Views::Controllers::CollectionNumbers
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      render(::Components::PaginatedResults.new) { render_rows_table if @objects.any? }
+      render(::Components::PaginatedResults.new) do
+        render_rows_table if @objects.any?
+      end
     end
 
     private

--- a/app/views/controllers/comments/index.rb
+++ b/app/views/controllers/comments/index.rb
@@ -20,7 +20,7 @@ module Views::Controllers::Comments
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      paginated_results { render_list }
+      render(::Components::PaginatedResults.new) { render_list }
     end
 
     private

--- a/app/views/controllers/contributors/index.rb
+++ b/app/views/controllers/contributors/index.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Contributors
       add_pagination(@pagination_data)
 
       render_legend_row
-      paginated_results do
+      render(::Components::PaginatedResults.new) do
         render(::Components::Matrix::Table.new(objects: @objects))
       end
     end

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -96,7 +96,7 @@ module Views::Controllers::FieldSlips
     end
 
     def render_list
-      paginated_results do
+      render(::Components::PaginatedResults.new) do
         render(Components::ListGroup::Base.new) do |list|
           @objects.each do |fs|
             list.item do

--- a/app/views/controllers/glossary_terms/index.rb
+++ b/app/views/controllers/glossary_terms/index.rb
@@ -15,7 +15,7 @@ module Views::Controllers::GlossaryTerms
 
       content_for(:filters) { documentation_link }
 
-      paginated_results { render_list }
+      render(::Components::PaginatedResults.new) { render_list }
     end
 
     private

--- a/app/views/controllers/herbaria/index.rb
+++ b/app/views/controllers/herbaria/index.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Herbaria
 
       render_merge_alert if @merge
 
-      paginated_results { render_table if @objects.any? }
+      render(::Components::PaginatedResults.new) { render_table if @objects.any? }
     end
 
     private

--- a/app/views/controllers/herbaria/index.rb
+++ b/app/views/controllers/herbaria/index.rb
@@ -18,7 +18,9 @@ module Views::Controllers::Herbaria
 
       render_merge_alert if @merge
 
-      render(::Components::PaginatedResults.new) { render_table if @objects.any? }
+      render(::Components::PaginatedResults.new) do
+        render_table if @objects.any?
+      end
     end
 
     private

--- a/app/views/controllers/herbarium_records/index.rb
+++ b/app/views/controllers/herbarium_records/index.rb
@@ -24,7 +24,7 @@ module Views::Controllers::HerbariumRecords
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      paginated_results { render_rows_table if @objects.any? }
+      render(::Components::PaginatedResults.new) { render_rows_table if @objects.any? }
     end
 
     private

--- a/app/views/controllers/herbarium_records/index.rb
+++ b/app/views/controllers/herbarium_records/index.rb
@@ -24,7 +24,9 @@ module Views::Controllers::HerbariumRecords
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      render(::Components::PaginatedResults.new) { render_rows_table if @objects.any? }
+      render(::Components::PaginatedResults.new) do
+        render_rows_table if @objects.any?
+      end
     end
 
     private

--- a/app/views/controllers/images/index.rb
+++ b/app/views/controllers/images/index.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Images
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      paginated_results do
+      render(::Components::PaginatedResults.new) do
         render(::Components::Matrix::Table.new(
                  objects: @objects, user: current_user
                ))

--- a/app/views/controllers/interests/index.rb
+++ b/app/views/controllers/interests/index.rb
@@ -15,7 +15,9 @@ module Views::Controllers::Interests
       container_class(:wide)
 
       render_type_filter if show_type_filter?
-      render(::Components::PaginatedResults.new) { render_interests_table if @interests.any?(&:target) }
+      render(::Components::PaginatedResults.new) do
+        render_interests_table if @interests.any?(&:target)
+      end
     end
 
     private

--- a/app/views/controllers/interests/index.rb
+++ b/app/views/controllers/interests/index.rb
@@ -15,7 +15,7 @@ module Views::Controllers::Interests
       container_class(:wide)
 
       render_type_filter if show_type_filter?
-      paginated_results { render_interests_table if @interests.any?(&:target) }
+      render(::Components::PaginatedResults.new) { render_interests_table if @interests.any?(&:target) }
     end
 
     private

--- a/app/views/controllers/locations/descriptions/index.rb
+++ b/app/views/controllers/locations/descriptions/index.rb
@@ -12,7 +12,7 @@ module Views::Controllers::Locations
       def view_template
         register_chrome
 
-        paginated_results { render_list if @descriptions.any? }
+        render(::Components::PaginatedResults.new) { render_list if @descriptions.any? }
       end
 
       private

--- a/app/views/controllers/locations/descriptions/index.rb
+++ b/app/views/controllers/locations/descriptions/index.rb
@@ -12,7 +12,9 @@ module Views::Controllers::Locations
       def view_template
         register_chrome
 
-        render(::Components::PaginatedResults.new) { render_list if @descriptions.any? }
+        render(::Components::PaginatedResults.new) do
+          render_list if @descriptions.any?
+        end
       end
 
       private

--- a/app/views/controllers/locations/index.rb
+++ b/app/views/controllers/locations/index.rb
@@ -63,7 +63,7 @@ module Views::Controllers::Locations
       render(::Components::ContentPadded.new) do
         small { plain(:list_place_names_parenthetical.l) }
       end
-      paginated_results { render_known_list(counts) }
+      render(::Components::PaginatedResults.new) { render_known_list(counts) }
     end
 
     def render_known_list(counts)

--- a/app/views/controllers/names/descriptions/index.rb
+++ b/app/views/controllers/names/descriptions/index.rb
@@ -11,7 +11,9 @@ module Views::Controllers::Names::Descriptions
     def view_template
       register_chrome
 
-      render(::Components::PaginatedResults.new) { render_table if @descriptions.any? }
+      render(::Components::PaginatedResults.new) do
+        render_table if @descriptions.any?
+      end
     end
 
     private

--- a/app/views/controllers/names/descriptions/index.rb
+++ b/app/views/controllers/names/descriptions/index.rb
@@ -11,7 +11,7 @@ module Views::Controllers::Names::Descriptions
     def view_template
       register_chrome
 
-      paginated_results { render_table if @descriptions.any? }
+      render(::Components::PaginatedResults.new) { render_table if @descriptions.any? }
     end
 
     private

--- a/app/views/controllers/names/index.rb
+++ b/app/views/controllers/names/index.rb
@@ -48,7 +48,7 @@ module Views::Controllers::Names
       render_suggestions_alert if suggest_alternates?
       render_help_blurb if @help
 
-      paginated_results { render_name_rows }
+      render(::Components::PaginatedResults.new) { render_name_rows }
     end
 
     private

--- a/app/views/controllers/observations/identify/index.rb
+++ b/app/views/controllers/observations/identify/index.rb
@@ -28,7 +28,7 @@ module Views::Controllers::Observations::Identify
         p { trusted_html(:obs_needing_id_intro.tp) }
       end
 
-      paginated_results { render_matrix }
+      render(::Components::PaginatedResults.new) { render_matrix }
     end
 
     private

--- a/app/views/controllers/observations/index.rb
+++ b/app/views/controllers/observations/index.rb
@@ -36,7 +36,7 @@ module Views::Controllers::Observations
 
       render_suggestions_alert if suggest_alternates?
 
-      paginated_results { render_matrix }
+      render(::Components::PaginatedResults.new) { render_matrix }
     end
 
     private

--- a/app/views/controllers/observations/locations/edit.rb
+++ b/app/views/controllers/observations/locations/edit.rb
@@ -27,7 +27,7 @@ module Views::Controllers::Observations::Locations
 
     def render_matches
       div(class: "h4") { plain(:list_merge_options_near_matches.t) }
-      paginated_results do
+      render(::Components::PaginatedResults.new) do
         render(::Components::ListGroup::Base.new) do |list|
           @matches.each { |location| render_match(list, location) }
         end

--- a/app/views/controllers/projects/index.rb
+++ b/app/views/controllers/projects/index.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Projects
       add_pagination(@pagination_data)
       container_class(:text_image)
 
-      paginated_results { render_list_group }
+      render(::Components::PaginatedResults.new) { render_list_group }
     end
 
     private

--- a/app/views/controllers/rss_logs/index.rb
+++ b/app/views/controllers/rss_logs/index.rb
@@ -13,7 +13,7 @@ module Views::Controllers::RssLogs
     def view_template
       register_chrome
 
-      paginated_results do
+      render(::Components::PaginatedResults.new) do
         render(::Components::Matrix::Table.new(
                  objects: @rss_logs, user: current_user, cached: true
                ))

--- a/app/views/controllers/sequences/index.rb
+++ b/app/views/controllers/sequences/index.rb
@@ -14,7 +14,7 @@ module Views::Controllers::Sequences
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      paginated_results { render_list }
+      render(::Components::PaginatedResults.new) { render_list }
     end
 
     private

--- a/app/views/controllers/shared/images_to_reuse_form.rb
+++ b/app/views/controllers/shared/images_to_reuse_form.rb
@@ -35,7 +35,7 @@ module Views::Controllers::Shared
     private
 
     def render_image_matrix
-      paginated_results do
+      render(::Components::PaginatedResults.new) do
         render(::Components::Matrix::Table.new) do
           @objects.each { |image| render_image_card(image) }
         end

--- a/app/views/controllers/species_lists/index.rb
+++ b/app/views/controllers/species_lists/index.rb
@@ -21,7 +21,7 @@ module Views::Controllers::SpeciesLists
       add_pagination(@pagination_data)
       container_class(:wide)
 
-      paginated_results { render_list }
+      render(::Components::PaginatedResults.new) { render_list }
     end
 
     private

--- a/app/views/controllers/species_lists/show.rb
+++ b/app/views/controllers/species_lists/show.rb
@@ -60,7 +60,7 @@ module Views::Controllers::SpeciesLists
              ))
       render_project_buttons
       render_list_search
-      paginated_results { render_observations }
+      render(::Components::PaginatedResults.new) { render_observations }
       render_comments
       render(Views::Layouts::ObjectFooter.new(
                user: @user, obj: @species_list

--- a/app/views/controllers/users/index.rb
+++ b/app/views/controllers/users/index.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Users
       if in_admin_mode?
         render_admin_table
       else
-        paginated_results do
+        render(::Components::PaginatedResults.new) do
           render(::Components::Matrix::Table.new(objects: @users))
         end
       end
@@ -27,7 +27,7 @@ module Views::Controllers::Users
 
     def render_admin_table
       style { ".permissions td { padding: 3px 5px 3px 5px }" }
-      paginated_results do
+      render(::Components::PaginatedResults.new) do
         table(align: "center",
               class: "table table-striped permissions",
               cellspacing: "2") do

--- a/app/views/controllers/visual_groups/image_matrix.rb
+++ b/app/views/controllers/visual_groups/image_matrix.rb
@@ -13,11 +13,9 @@ module Views::Controllers::VisualGroups
     prop :pagination_data, _Nilable(PaginationData)
 
     def view_template
-      div(id: "results") do
-        render(::Components::PaginatedResults.new) do
-          render(Components::Matrix::Table.new) do
-            @subset.each { |row| render_matrix_box(row) }
-          end
+      render(::Components::PaginatedResults.new) do
+        render(Components::Matrix::Table.new) do
+          @subset.each { |row| render_matrix_box(row) }
         end
       end
     end

--- a/app/views/controllers/visual_groups/image_matrix.rb
+++ b/app/views/controllers/visual_groups/image_matrix.rb
@@ -14,7 +14,7 @@ module Views::Controllers::VisualGroups
 
     def view_template
       div(id: "results") do
-        paginated_results do
+        render(::Components::PaginatedResults.new) do
           render(Components::Matrix::Table.new) do
             @subset.each { |row| render_matrix_box(row) }
           end

--- a/test/components/paginated_results_test.rb
+++ b/test/components/paginated_results_test.rb
@@ -30,6 +30,13 @@ class PaginatedResultsTest < ComponentTestCase
     assert_html(html, "div#results", text: "content")
   end
 
+  def test_data_q_encodes_q_param
+    controller.define_singleton_method(:q_param) { "42" }
+    html = render_it
+
+    assert_html(html, "div#results[data-q='q=42']")
+  end
+
   private
 
   def render_it(html_id: "results")

--- a/test/components/paginated_results_test.rb
+++ b/test/components/paginated_results_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class PaginatedResultsTest < ComponentTestCase
+  def setup
+    super
+    controller.define_singleton_method(:q_param) { nil }
+    controller.define_singleton_method(:observations_path) do |**|
+      "/observations"
+    end
+  end
+
+  def test_wraps_block_in_results_div
+    html = render_it
+
+    assert_html(html, "div#results")
+  end
+
+  def test_custom_html_id
+    html = render_it(html_id: "my-results")
+
+    assert_html(html, "div#my-results")
+    assert_no_html(html, "div#results")
+  end
+
+  def test_renders_block_content
+    html = render_it
+
+    assert_html(html, "div#results", text: "content")
+  end
+
+  private
+
+  def render_it(html_id: "results")
+    render(
+      Class.new(Components::Base) do
+        define_method(:_html_id) { html_id }
+
+        def view_template
+          render(::Components::PaginatedResults.new(html_id: _html_id)) do
+            plain("content")
+          end
+        end
+      end.new
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- Extracts `paginated_results` off `Views::Base` into `Components::PaginatedResults`, a standalone Phlex component.
- All 25 index view callers (`comments/index`, `observations/index`, `shared/images_to_reuse_form`, etc.) updated from `paginated_results { ... }` to `render(::Components::PaginatedResults.new) { ... }`.
- `Views::Base` loses the method and its associated comment; the class comment is trimmed accordingly.
- The component accepts an optional `html_id:` prop (default `"results"`) for the one caller that needed a custom id.

## Test plan

- [x] `bin/rails test test/views/controllers/` — 739 tests, 0 failures
- [x] `bin/rails test test/components/paginated_results_test.rb` — 3 tests, 0 failures
- [x] Rubocop clean on all changed files
