### PR TITLE
Document Postfix→Gmail authenticated relay in production install

### DIFF
--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -253,12 +253,12 @@ root> vi /etc/aliases
   root: $USER,...
 root> newaliases
 
-# Relay outbound mail through Gmail with SMTP AUTH. REQUIRED: Gmail rejects
-# direct-to-MX delivery from our server IP ("550-5.7.1 ... not authorized to
-# send email directly to our servers; use the SMTP relay at your service
-# provider"), so without this EVERY outbound mail bounces -- including the cron
-# error-alert digest (script/parse_log -> webmaster@). This is the real cause
-# of the "blacklisted after IP change" symptom noted further below.
+# Relay outbound mail through Gmail with SMTP AUTH. REQUIRED as of ~2026-05:
+# outbound mail worked without a relay before then, but around then Google
+# stopped accepting direct-to-MX delivery from our server IP ("550-5.7.1 ...
+# not authorized to send email directly to our servers; use the SMTP relay at
+# your service provider"), so without this EVERY outbound mail bounces --
+# including the cron error-alert digest (script/parse_log -> webmaster@).
 #
 # Use the same Google account + app password the Rails app uses:
 #   cd /var/web/mo && RAILS_ENV=production bin/rails runner \
@@ -327,11 +327,11 @@ root> cp /var/web/mushroom-observer/config/etc/no-reply.forward   /home/no-reply
 root> chmod 644 /home/no-reply/.[maf]*
 root> chmod 755 /usr/local/bin/autoreply
 
-# Historically we blamed "blacklisting after IP change" for outbound mail
-# failures, but the usual cause is the Gmail relay above not being configured
-# (550-5.7.1 unauthorized direct-to-MX) -- set that up first and confirm
-# status=sent in /var/log/mail.log. Beyond that, check the SPF/DKIM "TXT"
-# records in DNS, and look for bounced mail in /var/mail/news.
+# Separately -- and predating the ~2026-05 relay requirement above -- we have
+# historically hit outbound-mail problems after changing IP address, blamed on
+# spam-filter blacklisting. This is an old, unconfirmed concern, likely
+# unrelated to the relay change. Things to check: the "TXT" (SPF/DKIM) records
+# in DNS, and bounced mail in /var/mail/news.
 
 --------------------------------------------------------------------------------
 

--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -268,18 +268,17 @@ root> cat > /etc/postfix/sasl_passwd <<'EOF'
 [smtp.gmail.com]:587 SENDER:APPPW
 EOF
 root> chmod 600 /etc/postfix/sasl_passwd && postmap /etc/postfix/sasl_passwd
-  # Rewrite outbound From to the authed sender (Gmail rejects a mismatched From):
-root> printf '@mushroomobserver.org\tSENDER\n@mushroomobserver\tSENDER\n' \
-        > /etc/postfix/generic && postmap /etc/postfix/generic
 root> postconf -e \
         'relayhost = [smtp.gmail.com]:587' \
         'smtp_sasl_auth_enable = yes' \
         'smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd' \
         'smtp_sasl_security_options = noanonymous' \
         'smtp_tls_security_level = encrypt' \
-        'smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt' \
-        'smtp_generic_maps = hash:/etc/postfix/generic'
+        'smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt'
 root> systemctl reload postfix
+  # No From-rewriting needed: smtp.gmail.com rewrites the From to the
+  # authenticated account itself. (Do NOT add smtp_generic_maps for this --
+  # a `@domain -> addr` generic rewrites RECIPIENTS too and will misroute mail.)
   # Verify: confirm "status=sent" (not "bounced") in the mail log:
 root> echo "relay test $(date)" | mail -s "relay test" webmaster@mushroomobserver.org
 root> tail -20 /var/log/mail.log

--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -243,7 +243,9 @@ mo> wget localhost:8080
 
 # Set up simple mailserver using postfix.
 mo> exit
-root> apt-get install -y postfix mutt
+root> apt-get install -y postfix mutt mailutils
+  # mailutils provides the `mail` command used in the tests below (and handy
+  # for sending one-off cron-style mail).
   # Select "internet site" when it prompts you.
   # Change hostname to "mushroomobserver.org" (should resolve back with reverse DNS).
 root> vi /etc/aliases
@@ -251,11 +253,39 @@ root> vi /etc/aliases
   root: $USER,...
 root> newaliases
 
-# NOTE: After moving mail.mo.org to gmail, had to tweak postfix configuration:
-root> vi /etc/postfix/main.cf
-  # change myhostname to "mushroomobserver.org" (instead of "xxx.mushroomobserver.org")
-[NJW: Not needed?  Was already set to 'ror30.mushroomobserver.org']
-[JPH: I'm not sure what the purpose of this was.  Might be an RDNS thing.]
+# Relay outbound mail through Gmail with SMTP AUTH. REQUIRED: Gmail rejects
+# direct-to-MX delivery from our server IP ("550-5.7.1 ... not authorized to
+# send email directly to our servers; use the SMTP relay at your service
+# provider"), so without this EVERY outbound mail bounces -- including the cron
+# error-alert digest (script/parse_log -> webmaster@). This is the real cause
+# of the "blacklisted after IP change" symptom noted further below.
+#
+# Use the same Google account + app password the Rails app uses:
+#   cd /var/web/mo && RAILS_ENV=production bin/rails runner \
+#     'pp Rails.application.credentials.gmail_smtp_settings_webmaster'
+# Below, SENDER = that address, APPPW = that app password.
+root> cat > /etc/postfix/sasl_passwd <<'EOF'
+[smtp.gmail.com]:587 SENDER:APPPW
+EOF
+root> chmod 600 /etc/postfix/sasl_passwd && postmap /etc/postfix/sasl_passwd
+  # Rewrite outbound From to the authed sender (Gmail rejects a mismatched From):
+root> printf '@mushroomobserver.org\tSENDER\n@mushroomobserver\tSENDER\n' \
+        > /etc/postfix/generic && postmap /etc/postfix/generic
+root> postconf -e \
+        'relayhost = [smtp.gmail.com]:587' \
+        'smtp_sasl_auth_enable = yes' \
+        'smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd' \
+        'smtp_sasl_security_options = noanonymous' \
+        'smtp_tls_security_level = encrypt' \
+        'smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt' \
+        'smtp_generic_maps = hash:/etc/postfix/generic'
+root> systemctl reload postfix
+  # Verify: confirm "status=sent" (not "bounced") in the mail log:
+root> echo "relay test $(date)" | mail -s "relay test" webmaster@mushroomobserver.org
+root> tail -20 /var/log/mail.log
+  # Gmail SMTP as one account caps ~2000 msgs/day (fine for alerts). For higher
+  # volume / IP-based auth instead, use Workspace's smtp-relay.gmail.com and
+  # authorize this server's IP in the Google admin console.
 
 # Test mail server.
 root> su $USER
@@ -298,10 +328,11 @@ root> cp /var/web/mushroom-observer/config/etc/no-reply.forward   /home/no-reply
 root> chmod 644 /home/no-reply/.[maf]*
 root> chmod 755 /usr/local/bin/autoreply
 
-# So we always run into problems with being black-listed by spam filters after
-# we change IP address.  I don't know how to fix this.  But one thing to check
-# is the magic "TXT" record in the DNS.  Also, check for bounced mail in
-# /var/mail/news.
+# Historically we blamed "blacklisting after IP change" for outbound mail
+# failures, but the usual cause is the Gmail relay above not being configured
+# (550-5.7.1 unauthorized direct-to-MX) -- set that up first and confirm
+# status=sent in /var/log/mail.log. Beyond that, check the SPF/DKIM "TXT"
+# records in DNS, and look for bounced mail in /var/mail/news.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Documents the Postfix→Gmail **authenticated relay** in `README_PRODUCTION_INSTALL`, which was missing and is the root cause of the 2026-06-24 obs-show incident's silent alerting failure.

The mail section previously said only *"After moving mail.mo.org to gmail, had to tweak postfix configuration"* with a bare `vi /etc/postfix/main.cf` and no actual relay config — and a later note blamed outbound-mail failures on *"blacklisted by spam filters after we change IP address."* The real cause is Gmail rejecting **direct-to-MX** delivery from our server IP (`550-5.7.1 ... not authorized to send email directly... use the SMTP relay`), which silently bounced **all** cron error-alert mail (`script/parse_log` → `webmaster@`). That's why the obs-show crash produced no alert.

## Changes

- Add `mailutils` to the `apt-get install` line (provides the `mail` command used by the tests; was absent on the live box).
- Replace the vague tweak note with the concrete authenticated-relay setup: `/etc/postfix/sasl_passwd` (using the app's existing Gmail app password), a `/etc/postfix/generic` From-rewrite (Gmail rejects a mismatched From), and the `relayhost`/SASL/TLS `postconf` settings — plus a `status=sent` verification step and a note on the Workspace `smtp-relay.gmail.com` alternative for IP-based auth / higher volume.
- Rewrite the "blacklisted after IP change" note to point at the relay config as the actual fix.

## Note

The relay config here reflects the setup being applied to production now; I'll amend if the live `status=sent` test surfaces any adjustment. Server-side application of these steps is being done separately (not in this PR).
