### PR TITLE
Fix nil observation_id in add_missing_views_corresponding_to_votes

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -240,7 +240,8 @@ class Vote < AbstractModel
     # (user 0 is used for anonymous votes, ignore those)
     Vote.where.not(user_id: 0).joins(join).
       where(observation_views: { id: nil }).
-      select(:observation_id, :user_id, :updated_at).map do |vote|
+      select("votes.observation_id, votes.user_id, votes.updated_at").
+      map do |vote|
       unless dry_run
         ObservationView.create!(
           observation_id: vote.observation_id,

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -242,17 +242,17 @@ class Vote < AbstractModel
       where(observation_views: { id: nil }).
       select("votes.observation_id, votes.user_id, votes.updated_at").
       map do |vote|
-      unless dry_run
-        ObservationView.create!(
-          observation_id: vote.observation_id,
-          user_id: vote.user_id,
-          last_view: vote.updated_at,
-          reviewed: 1
-        )
+        unless dry_run
+          ObservationView.create!(
+            observation_id: vote.observation_id,
+            user_id: vote.user_id,
+            last_view: vote.updated_at,
+            reviewed: 1
+          )
+        end
+        "User #{vote.user_id} has reviewed observation #{vote.observation_id} " \
+          "(insert)."
       end
-      "User #{vote.user_id} has reviewed observation #{vote.observation_id} " \
-        "(insert)."
-    end
   end
 
   def self.votes_views_join_condition

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -240,7 +240,9 @@ class Vote < AbstractModel
     # (user 0 is used for anonymous votes, ignore those)
     Vote.where.not(user_id: 0).joins(join).
       where(observation_views: { id: nil }).
-      select("votes.observation_id, votes.user_id, votes.updated_at").
+      select(arel_table[:observation_id],
+             arel_table[:user_id],
+             arel_table[:updated_at]).
       map do |vote|
         unless dry_run
           ObservationView.create!(

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -252,8 +252,8 @@ class Vote < AbstractModel
             reviewed: 1
           )
         end
-        "User #{vote.user_id} has reviewed observation #{vote.observation_id} " \
-          "(insert)."
+        "User #{vote.user_id} has reviewed observation " \
+        "#{vote.observation_id} (insert)."
       end
   end
 

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -86,6 +86,30 @@ class VoteTest < UnitTestCase
     end
   end
 
+  def test_add_missing_views_populates_observation_id
+    assert_equal(0, ObservationView.count,
+                 "Expected no ObservationView records at start")
+
+    msgs = Vote.add_missing_views_corresponding_to_votes
+
+    assert_operator(ObservationView.count, :>, 0,
+                    "Should have created ObservationView records")
+    ObservationView.find_each do |ov|
+      assert_not_nil(ov.observation_id,
+                     "nil observation_id for user #{ov.user_id}")
+      assert(
+        Vote.exists?(observation_id: ov.observation_id,
+                     user_id: ov.user_id),
+        "ObservationView (obs #{ov.observation_id}, " \
+        "user #{ov.user_id}) should match a Vote"
+      )
+    end
+    msgs.each do |msg|
+      assert_match(/reviewed observation \d+/, msg,
+                   "Message missing numeric observation_id: #{msg.inspect}")
+    end
+  end
+
   def test_confidence_returns_no_opinion_for_zero
     # Bug: Vote.confidence(0) was returning "Doubtful" instead of "No Opinion"
     assert_equal("No Opinion", Vote.confidence(0))


### PR DESCRIPTION
Fixes `refresh_caches` output which omitted Observation id. Example bad output:

>User 38275 has reviewed observation  (insert).
