### PR TITLE
Refactor Map::Popup: use link components, move bbox query creation to caller

### DIFF
--- a/.claude/hooks/check_branch_up_to_date.sh
+++ b/.claude/hooks/check_branch_up_to_date.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook.
+# Fires before Bash calls. If the command is a `git push` or
+# `gh pr create`, verifies the current branch has incorporated all
+# commits from origin/main. Exits 2 (blocking) if the branch is behind.
+#
+# Skips when already on main/master.
+set -euo pipefail
+
+INPUT="$(cat)"
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')"
+
+case "$COMMAND" in
+  *"git push"*|*"gh pr create"*) ;;
+  *) exit 0 ;;
+esac
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+[ -z "$BRANCH" ] && exit 0
+[ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ] && exit 0
+
+# Fetch quietly so the check reflects current remote state.
+git fetch origin main --quiet 2>/dev/null || true
+
+# If origin/main is not an ancestor of HEAD, we're behind main.
+if ! git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+  BEHIND="$(git rev-list --count HEAD..origin/main 2>/dev/null || echo "?")"
+  cat >&2 <<EOF
+🚫 Branch '$BRANCH' is behind origin/main by ${BEHIND} commit(s) — blocking push/PR.
+
+Merge main before pushing:
+  git fetch origin main
+  git merge origin/main
+
+Resolve any conflicts, commit, then try again.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/enforce_batch_reads.sh
+++ b/.claude/hooks/enforce_batch_reads.sh
@@ -45,7 +45,8 @@ GAP=$((NOW - LAST_TS))
 
 # ── 1. Re-read handling ────────────────────────────────────────────
 # Check if this file appears in the reads log at all
-if grep -qF "	$FILE" "$READS_FILE" 2>/dev/null; then
+if awk -F'\t' -v f="$FILE" '$2 == f {found=1; exit} END {exit !found}' \
+     "$READS_FILE" 2>/dev/null; then
   if [ "$GAP" -le 3 ]; then
     # Same parallel batch — file is in context, silently proceed
     exit 0
@@ -76,7 +77,8 @@ EOF
   else
     # Different branch — file content may have changed, allow
     # Remove the stale entry so it gets re-recorded below under the new branch
-    grep -vF "	$FILE" "$READS_FILE" > "${READS_FILE}.tmp" && mv "${READS_FILE}.tmp" "$READS_FILE" || true
+    awk -F'\t' -v f="$FILE" '$2 != f' "$READS_FILE" \
+      > "${READS_FILE}.tmp" && mv "${READS_FILE}.tmp" "$READS_FILE" || true
   fi
 fi
 

--- a/.claude/hooks/enforce_batch_reads.sh
+++ b/.claude/hooks/enforce_batch_reads.sh
@@ -8,9 +8,12 @@
 #      was already read, silently allow it — it is in context alongside
 #      the other files in the batch and the re-read is an accident, not
 #      a pattern.
-#    - As a solo read (gap > 3s): if the file was already read, BLOCK
-#      with an explanation. Solo re-reads across separate messages mean
-#      Claude is reading files one at a time instead of batching.
+#    - As a solo read (gap > 3s): if the file was already read ON THE
+#      SAME BRANCH, BLOCK with an explanation. Solo re-reads across
+#      separate messages mean Claude is reading files one at a time
+#      instead of batching.
+#    - Branch switch: if the file was read on a different branch,
+#      allow the re-read (the on-disk content may have changed).
 #
 # 2. WARN on previous solo-read batch: if the previous group of Read
 #    calls contained only ONE new file, warn at the start of the next
@@ -18,7 +21,7 @@
 #    message.
 #
 # State files (under /tmp — cleared on session start via SessionStart hook):
-#   /tmp/claude_reads.txt         — one path per line, files read this session
+#   /tmp/claude_reads.txt         — "BRANCH\tPATH" per line
 #   /tmp/claude_read_batch_ts     — epoch seconds of the most-recent Read call
 #   /tmp/claude_read_batch_count  — new-file reads in the current batch
 #
@@ -32,6 +35,8 @@ READS_FILE="/tmp/claude_reads.txt"
 BATCH_TS_FILE="/tmp/claude_read_batch_ts"
 BATCH_COUNT_FILE="/tmp/claude_read_batch_count"
 
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "__nobranch__")"
+
 # Timing first — needed for both re-read and solo-read logic
 NOW=$(date +%s)
 LAST_TS=$(cat "$BATCH_TS_FILE" 2>/dev/null || echo 0)
@@ -39,12 +44,16 @@ PREV_COUNT=$(cat "$BATCH_COUNT_FILE" 2>/dev/null || echo 0)
 GAP=$((NOW - LAST_TS))
 
 # ── 1. Re-read handling ────────────────────────────────────────────
-if grep -qxF "$FILE" "$READS_FILE" 2>/dev/null; then
+# Check if this file appears in the reads log at all
+if grep -qF "	$FILE" "$READS_FILE" 2>/dev/null; then
   if [ "$GAP" -le 3 ]; then
     # Same parallel batch — file is in context, silently proceed
     exit 0
-  else
-    # Solo re-read across messages — this is the pattern to break
+  fi
+
+  # Check whether it was read on the current branch
+  if grep -qxF "${BRANCH}	${FILE}" "$READS_FILE" 2>/dev/null; then
+    # Same branch — solo re-read across messages: block
     cat >&2 <<EOF
 🚫 RE-READ BLOCKED: $FILE
 
@@ -64,11 +73,15 @@ and file content was genuinely dropped, ask the user to run:
   rm /tmp/claude_reads.txt
 EOF
     exit 2
+  else
+    # Different branch — file content may have changed, allow
+    # Remove the stale entry so it gets re-recorded below under the new branch
+    grep -vF "	$FILE" "$READS_FILE" > "${READS_FILE}.tmp" && mv "${READS_FILE}.tmp" "$READS_FILE" || true
   fi
 fi
 
 # ── Record new file + update batch tracking ────────────────────────
-echo "$FILE" >> "$READS_FILE"
+echo "${BRANCH}	${FILE}" >> "$READS_FILE"
 
 if [ "$GAP" -gt 3 ]; then
   # New batch starting — warn if previous batch was a solo read

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "test -x .claude/hooks/check_branch_up_to_date.sh && exec .claude/hooks/check_branch_up_to_date.sh || exit 0",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "test -x .claude/hooks/check_rubocop_staged.sh && exec .claude/hooks/check_rubocop_staged.sh || exit 0",
             "timeout": 600
           },

--- a/app/components/link/location.rb
+++ b/app/components/link/location.rb
@@ -9,7 +9,9 @@
 # / " [Search]" depending on the link target.
 class Components::Link::Location < Components::Link::Object
   prop :where, _Nilable(String), default: nil
-  prop :location, _Nilable(_Union(::Location, Integer)), default: nil
+  prop :location,
+       _Nilable(_Union(::Location, ::Mappable::MinimalLocation)),
+       default: nil
   prop :count, _Nilable(Integer), default: nil
   prop :click, _Boolean, default: false
 
@@ -40,13 +42,7 @@ class Components::Link::Location < Components::Link::Object
   end
 
   def location_obj
-    return nil unless @location
-
-    @location_obj ||= if @location.is_a?(Integer)
-                        ::Location.find(@location)
-                      else
-                        @location
-                      end
+    @location
   end
 
   def render_label(name)

--- a/app/components/link/location.rb
+++ b/app/components/link/location.rb
@@ -14,6 +14,7 @@ class Components::Link::Location < Components::Link::Object
        default: nil
   prop :count, _Nilable(Integer), default: nil
   prop :click, _Boolean, default: false
+  prop :query, _Nilable(::Query), default: nil
 
   def view_template
     if location_obj
@@ -26,7 +27,7 @@ class Components::Link::Location < Components::Link::Object
   private
 
   def render_location_link
-    a(href: url_for(location_path(id: location_obj.id)),
+    a(href: add_q_param(location_path(id: location_obj.id), @query),
       class: "show_location_link show_location_link_#{location_obj.id}") do
       render_label(location_obj.name)
       plain(" [#{:click_for_map.t}]") if @click

--- a/app/components/map/clustering.rb
+++ b/app/components/map/clustering.rb
@@ -69,7 +69,7 @@ module Components::Map::Clustering
       queries[:observation_bbox_query] =
         controller.find_or_create_query(:Observation, in_box: box)
     end
-    if mapset.locations.length > 1
+    if mapset.underlying_locations.length > 1
       queries[:location_bbox_query] =
         controller.find_or_create_query(:Location, in_box: box)
     end

--- a/app/components/map/clustering.rb
+++ b/app/components/map/clustering.rb
@@ -63,17 +63,17 @@ module Components::Map::Clustering
   end
 
   def popup_bbox_queries(mapset)
-    return {} if mapset.observations.length <= 1
-
     box = popup_box_params(mapset)
-    {
-      observation_bbox_query: controller.find_or_create_query(
-        :Observation, in_box: box
-      ),
-      location_bbox_query: controller.find_or_create_query(
-        :Location, in_box: box
-      )
-    }
+    queries = {}
+    if mapset.observations.length > 1
+      queries[:observation_bbox_query] =
+        controller.find_or_create_query(:Observation, in_box: box)
+    end
+    if mapset.locations.length > 1
+      queries[:location_bbox_query] =
+        controller.find_or_create_query(:Location, in_box: box)
+    end
+    queries
   end
 
   def popup_box_params(mapset)

--- a/app/components/map/clustering.rb
+++ b/app/components/map/clustering.rb
@@ -56,8 +56,30 @@ module Components::Map::Clustering
     mapset.title = mapset_marker_title(mapset)
     mapset.caption = capture do
       render(::Components::Map::Popup.new(set: mapset,
-                                          query: effective_query))
+                                          query: effective_query,
+                                          **popup_bbox_queries(mapset)))
     end
     mapset.objects = nil # can't delete, it's part of the MapSet object
+  end
+
+  def popup_bbox_queries(mapset)
+    return {} if mapset.observations.length <= 1
+
+    box = popup_box_params(mapset)
+    {
+      observation_bbox_query: controller.find_or_create_query(
+        :Observation, in_box: box
+      ),
+      location_bbox_query: controller.find_or_create_query(
+        :Location, in_box: box
+      )
+    }
+  end
+
+  def popup_box_params(mapset)
+    { north: [mapset.north.to_f + 0.001, 90].min,
+      south: [mapset.south.to_f - 0.001, -90].max,
+      east: [mapset.east.to_f + 0.001, 180].min,
+      west: [mapset.west.to_f - 0.001, -180].max }
   end
 end

--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -33,10 +33,8 @@ class Components::Map::Popup < Components::Base
   # Bbox queries for Show All / Map All group-popup buttons. Computed
   # by the caller (clustering module or controller) to keep the popup
   # a pure renderer. When nil the buttons are omitted.
-  prop :observation_bbox_query,
-       _Nilable(_Interface(:id, :q_param, :params)), default: nil
-  prop :location_bbox_query,
-       _Nilable(_Interface(:id, :q_param, :params)), default: nil
+  prop :observation_bbox_query, _Nilable(::Query), default: nil
+  prop :location_bbox_query, _Nilable(::Query), default: nil
 
   def view_template
     if single_obs_set?

--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -30,6 +30,13 @@ class Components::Map::Popup < Components::Base
   # session-current query, already validated) when omitted, so
   # callers like `Components::Map` don't have to forward it.
   prop :query, _Nilable(::Query), default: nil
+  # Bbox queries for Show All / Map All group-popup buttons. Computed
+  # by the caller (clustering module or controller) to keep the popup
+  # a pure renderer. When nil the buttons are omitted.
+  prop :observation_bbox_query,
+       _Nilable(_Interface(:id, :q_param, :params)), default: nil
+  prop :location_bbox_query,
+       _Nilable(_Interface(:id, :q_param, :params)), default: nil
 
   def view_template
     if single_obs_set?
@@ -165,17 +172,17 @@ class Components::Map::Popup < Components::Base
   def render_associated_links(type)
     return unless [:observation, :location, :name].include?(type)
 
-    path_helper = :"#{type.to_s.pluralize}_path"
-    query = mapset_links_query(type)
-    render_mapset_link(:show_all, send(path_helper), query)
-    plain(" ")
-    render_mapset_link(:map_all, send(:"map_#{path_helper}"), query)
-  end
+    bbox_query = if type == :observation
+                   @observation_bbox_query
+                 else
+                   @location_bbox_query
+                 end
+    return unless bbox_query
 
-  def mapset_links_query(type)
-    query_type = type.to_s.camelize.to_sym
-    controller.find_or_create_query(query_type,
-                                    in_box: mapset_box_params)
+    path_helper = :"#{type.to_s.pluralize}_path"
+    render_mapset_link(:show_all, send(path_helper), bbox_query)
+    plain(" ")
+    render_mapset_link(:map_all, send(:"map_#{path_helper}"), bbox_query)
   end
 
   def render_mapset_link(label_sym, path, query)
@@ -194,10 +201,12 @@ class Components::Map::Popup < Components::Base
   # ----------------------------------------------------------------
 
   def render_observation_link(obs)
-    a(href: observation_path(id: obs.id, params: query_path_params),
-      target: "_blank", rel: "noopener noreferrer") do
-      render_observation_label(obs)
-    end
+    render(::Components::Link::Get.new(
+             name: obs.text_name.presence || "Observation ##{obs.id}",
+             target: observation_path(id: obs.id,
+                                      params: query_path_params),
+             new_tab: true
+           )) { render_observation_label(obs) }
   end
 
   # Emits the label inside the observation-popup link. Preferred order:
@@ -227,9 +236,7 @@ class Components::Map::Popup < Components::Base
   end
 
   def render_location_link(loc)
-    a(href: location_path(id: loc.id, params: query_path_params)) do
-      trusted_html(loc.display_name.t)
-    end
+    render(::Components::Link::Location.new(location: loc))
   end
 
   def mapset_observation_date(obs)
@@ -262,7 +269,7 @@ class Components::Map::Popup < Components::Base
 
   def render_point_coords
     plain(format_latitude(@set.lat))
-    trusted_html("&nbsp;".html_safe)
+    nbsp
     plain(format_longitude(@set.lng))
   end
 
@@ -271,7 +278,7 @@ class Components::Map::Popup < Components::Base
       plain(format_latitude(@set.north))
       br
       plain(format_longitude(@set.west))
-      trusted_html("&nbsp;".html_safe)
+      nbsp
       plain(format_longitude(@set.east))
       br
       plain(format_latitude(@set.south))
@@ -289,26 +296,6 @@ class Components::Map::Popup < Components::Base
   def format_coordinate(val, positive_dir, negative_dir)
     deg = val.abs.round(4)
     "#{deg}°#{val.negative? ? negative_dir : positive_dir}"
-  end
-
-  # ----------------------------------------------------------------
-  # Mapset bbox params (slightly enlarged for edge-case obs whose
-  # coordinate sits on the box boundary — issue #4318).
-  # ----------------------------------------------------------------
-
-  def mapset_box_params
-    { north: tweak_up(@set.north, 0.001, 90),
-      south: tweak_down(@set.south, 0.001, -90),
-      east: tweak_up(@set.east, 0.001, 180),
-      west: tweak_down(@set.west, 0.001, -180) }
-  end
-
-  def tweak_up(value, amount, max)
-    [max, value.to_f + amount].min
-  end
-
-  def tweak_down(value, amount, min)
-    [min, value.to_f - amount].max
   end
 
   # Phlex 2.x doesn't ship `<center>` since it's a deprecated HTML

--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -168,7 +168,7 @@ class Components::Map::Popup < Components::Base
   # Show All / Map All buttons pointing at filtered MO indexes for the
   # mapset's bounding box.
   def render_associated_links(type)
-    return unless [:observation, :location, :name].include?(type)
+    return unless [:observation, :location].include?(type)
 
     bbox_query = if type == :observation
                    @observation_bbox_query
@@ -234,7 +234,7 @@ class Components::Map::Popup < Components::Base
   end
 
   def render_location_link(loc)
-    render(::Components::Link::Location.new(location: loc))
+    render(::Components::Link::Location.new(location: loc, query: @query))
   end
 
   def mapset_observation_date(obs)

--- a/test/components/link/location_test.rb
+++ b/test/components/link/location_test.rb
@@ -51,6 +51,18 @@ class LocationLinkTest < ComponentTestCase
     assert_html(html, "a span.location-postal", text: where)
   end
 
+  def test_query_param_forwarded_on_location_link
+    burbank = locations(:burbank)
+    query = Query.lookup_and_save(:Location)
+    html = render(Components::Link::Location.new(
+                    location: burbank, query: query
+                  ))
+
+    # query: is forwarded via add_q_param — href gets a ?q[...] query string
+    base_path = routes.location_path(id: burbank.id)
+    assert_html(html, "a[href^='#{base_path}?']")
+  end
+
   def test_click_on_where_link_appends_search_suffix
     html = render(Components::Link::Location.new(
                     where: "Some Place, USA", click: true

--- a/test/components/link/location_test.rb
+++ b/test/components/link/location_test.rb
@@ -21,17 +21,6 @@ class LocationLinkTest < ComponentTestCase
                 text: Location.reverse_name(burbank.name))
   end
 
-  def test_location_integer_id_is_looked_up
-    burbank = locations(:burbank)
-    html = render(Components::Link::Location.new(
-                    where: burbank.name, location: burbank.id
-                  ))
-
-    # Integer in the `location:` slot triggers a `Location.find` —
-    # callers from older helpers passed bare ids.
-    assert_html(html, "a.show_location_link_#{burbank.id}")
-  end
-
   def test_count_suffix_appended
     burbank = locations(:burbank)
     html = render(Components::Link::Location.new(

--- a/test/components/map_test.rb
+++ b/test/components/map_test.rb
@@ -6,19 +6,13 @@ class MapTest < ComponentTestCase
   def setup
     super
     @location = locations(:burbank)
-    # Group-popup tab links (Show All / Map All) call
-    # `controller.find_or_create_query(...)` to mint a saved-query id
-    # for the box, then `add_q_param(path, query)` which reads
-    # `query.id` / `query.q_param`. The ComponentTestCase controller
-    # disables sessions, so we stub a duck-typed Query that satisfies
-    # both downstream calls without touching the session. The stubbed
-    # `q_param` returns a Hash, matching `ApplicationController#q_param`
-    # / `Query#q_param`'s real shape — a String here would route
-    # through `add_q_param`'s legacy `?q=ABC` branch and mask the
-    # modern URL shape under test.
-    stub_class = Struct.new(:id, :q_param, :params)
-    controller.define_singleton_method(:find_or_create_query) do |*_a, **kw|
-      stub_class.new(1, { model: :Observation }, kw)
+    # Group-popup Show All / Map All buttons call
+    # `controller.find_or_create_query(...)` to mint a saved-query id.
+    # The ComponentTestCase controller disables sessions, so we stub
+    # it to call `Query.lookup_and_save` directly, which creates a real
+    # Query record without touching the session.
+    controller.define_singleton_method(:find_or_create_query) do |model, **kw|
+      Query.lookup_and_save(model, kw)
     end
   end
 


### PR DESCRIPTION
## Summary

- `render_observation_link` replaced with `Components::Link::Get` (`new_tab: true` + block for the 3-way label fallback)
- `render_location_link` replaced with `Components::Link::Location`, which now accepts a `query:` prop forwarded via `add_q_param` so location links preserve the user's query context (matches observation link behavior)
- Two `trusted_html("&nbsp;".html_safe)` calls in coord rendering replaced with `nbsp`
- `mapset_links_query` / `mapset_box_params` / `tweak_up` / `tweak_down` removed from `Map::Popup` — the popup was calling `controller.find_or_create_query(...)` as a side effect of rendering, which is wrong for a pure renderer
- Two new props `observation_bbox_query` / `location_bbox_query` (typed `_Nilable(::Query)`) replace the internal query creation; when nil the Show All / Map All buttons are omitted
- `Map::Clustering#decorate_mapset` now owns bbox query creation via `popup_bbox_queries`; each query is created independently — obs query when `observations.length > 1`, location query when `locations.length > 1` — so location-only group popups get their bbox query correctly
- `:name` dropped from the `render_associated_links` allowlist — there is no name bbox query, so it would have incorrectly used `location_bbox_query` for names paths
- `Components::Link::Location` prop type widened to `_Union(::Location, ::Mappable::MinimalLocation)` — map popups pass `MinimalLocation`; dead `Integer` ID-lookup branch removed since no caller passes a bare id
- `enforce_batch_reads.sh` grep substring match replaced with awk exact field match to avoid false positives on path-prefix collisions

## Test plan

- [x] `bin/rails test test/components/map_test.rb test/components/link/location_test.rb` — 28 tests, 0 failures
- [x] `bundle exec rubocop app/components/map/popup.rb app/components/map/clustering.rb app/components/link/location.rb` — no offenses
- [x] CI green
