### PR TITLE
Fix stale data-target assertions after collapse-trigger change

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -423,3 +423,6 @@ MushroomObserver/NoUserCurrentInViews:
     - "app/controllers/application_controller.rb"
     - "app/controllers/account/login_controller.rb"
     - "app/controllers/admin/session_controller.rb"
+
+Capybara/SpecificActions:
+  Enabled: true

--- a/test/integration/capybara/search_integration_test.rb
+++ b/test/integration/capybara/search_integration_test.rb
@@ -129,7 +129,7 @@ class SearchIntegrationTest < CapybaraIntegrationTestCase
 
     within("#observations_search_form") do |form|
       # Expand the "connected" panel to reveal species_lists field
-      find("a[href='#observations_connected']").click
+      click_link(href: "#observations_connected")
 
       # Wait for the panel to expand
       assert_selector("#query_observations_species_lists", visible: true)
@@ -163,7 +163,7 @@ class SearchIntegrationTest < CapybaraIntegrationTestCase
 
     within("#observations_search_form") do |form|
       # Expand the "connected" panel to reveal project_lists field
-      find("a[href='#observations_connected']").click
+      click_link(href: "#observations_connected")
 
       # Wait for the panel to expand
       assert_selector("#query_observations_project_lists", visible: true)
@@ -193,7 +193,7 @@ class SearchIntegrationTest < CapybaraIntegrationTestCase
 
     within("#observations_search_form") do |form|
       # Expand the "connected" panel to reveal herbaria field
-      find("a[href='#observations_connected']").click
+      click_link(href: "#observations_connected")
 
       # Wait for the panel to expand
       assert_selector("#query_observations_herbaria", visible: true)

--- a/test/integration/capybara/search_integration_test.rb
+++ b/test/integration/capybara/search_integration_test.rb
@@ -129,7 +129,7 @@ class SearchIntegrationTest < CapybaraIntegrationTestCase
 
     within("#observations_search_form") do |form|
       # Expand the "connected" panel to reveal species_lists field
-      find("[data-target='#observations_connected']").click
+      find("a[href='#observations_connected']").click
 
       # Wait for the panel to expand
       assert_selector("#query_observations_species_lists", visible: true)
@@ -163,7 +163,7 @@ class SearchIntegrationTest < CapybaraIntegrationTestCase
 
     within("#observations_search_form") do |form|
       # Expand the "connected" panel to reveal project_lists field
-      find("[data-target='#observations_connected']").click
+      find("a[href='#observations_connected']").click
 
       # Wait for the panel to expand
       assert_selector("#query_observations_project_lists", visible: true)
@@ -193,7 +193,7 @@ class SearchIntegrationTest < CapybaraIntegrationTestCase
 
     within("#observations_search_form") do |form|
       # Expand the "connected" panel to reveal herbaria field
-      find("[data-target='#observations_connected']").click
+      find("a[href='#observations_connected']").click
 
       # Wait for the panel to expand
       assert_selector("#query_observations_herbaria", visible: true)

--- a/test/views/controllers/admin/blocked_ips/manager_test.rb
+++ b/test/views/controllers/admin/blocked_ips/manager_test.rb
@@ -97,7 +97,7 @@ module Views::Controllers::Admin::BlockedIps
       # Has collapse trigger
       assert_html(html, ".panel-collapse-trigger")
       assert_html(html, "[data-toggle='collapse']")
-      assert_html(html, "[data-target='#blocked_ips_body']")
+      assert_html(html, "a[href='#blocked_ips_body']")
 
       # Body is expanded by default (has "in" class)
       assert_html(html, ".panel-collapse.collapse.in")

--- a/test/views/controllers/admin/blocked_ips/manager_test.rb
+++ b/test/views/controllers/admin/blocked_ips/manager_test.rb
@@ -94,10 +94,12 @@ module Views::Controllers::Admin::BlockedIps
     def test_panel_is_collapsible_and_expanded
       html = render_manager(type: :blocked, ips: ["1.2.3.4"])
 
-      # Has collapse trigger
-      assert_html(html, ".panel-collapse-trigger")
-      assert_html(html, "[data-toggle='collapse']")
-      assert_html(html, "a[href='#blocked_ips_body']")
+      # Has collapse trigger — all on the same <a>
+      assert_html(
+        html,
+        "a.panel-collapse-trigger[data-toggle='collapse']" \
+        "[href='#blocked_ips_body']"
+      )
 
       # Body is expanded by default (has "in" class)
       assert_html(html, ".panel-collapse.collapse.in")


### PR DESCRIPTION
## Summary

Two test files were still asserting `[data-target='#...']` on collapse triggers after PR #4594 changed `Link::CollapseToggle` for ID-based targets to emit `href="#..."` instead. This caused `test` CI to fail on any PR that CI-tested against a post-#4594 main merge commit.

- `test/views/controllers/admin/blocked_ips/manager_test.rb` — component test asserting `[data-target='#blocked_ips_body']`
- `test/integration/capybara/search_integration_test.rb` — three Capybara `find("[data-target='#observations_connected']").click` calls

Updated to `a[href='#...']` in both files.

## Test plan

- [x] `bin/rails test test/views/controllers/admin/blocked_ips/manager_test.rb -n test_panel_is_collapsible_and_expanded` — passes
- [ ] CI green (search_integration_test runs in system/integration workers)
