### PR TITLE
Sweep raw target="_blank" anchors → Link::External / Link::Get

### DIFF
--- a/app/components/carousel/controls.rb
+++ b/app/components/carousel/controls.rb
@@ -18,7 +18,7 @@ class Components::Carousel::Controls < Components::Base
 
   def render_control(direction)
     position = direction == :prev ? "left" : "right"
-    icon = direction == :prev ? "chevron-left" : "chevron-right"
+    icon_type = direction == :prev ? :chevron_left : :chevron_right
     label = direction == :prev ? :PREV : :NEXT
 
     link_to("##{@carousel_id}",
@@ -26,7 +26,8 @@ class Components::Carousel::Controls < Components::Base
             role: "button",
             data: { slide: direction.to_s }) do
       div(class: "btn") do
-        span(class: "glyphicon glyphicon-#{icon}", aria: { hidden: "true" })
+        render(::Components::Icon.new(type: icon_type,
+                                      attributes: { aria: { hidden: "true" } }))
         span(class: "sr-only") { label.l }
       end
     end

--- a/app/components/image/original_link.rb
+++ b/app/components/image/original_link.rb
@@ -25,9 +25,10 @@ class Components::Image::OriginalLink < Components::Base
   def view_template
     id = @image&.id || @image_id
 
-    render(::Components::Link::External.new(
-             :image_show_original.t,
-             "/images/#{id}/original",
+    render(::Components::Link::Get.new(
+             name: :image_show_original.t,
+             target: "/images/#{id}/original",
+             new_tab: true,
              class: @link_class,
              data: {
                controller: "image-loader",

--- a/app/components/image/original_link.rb
+++ b/app/components/image/original_link.rb
@@ -25,22 +25,18 @@ class Components::Image::OriginalLink < Components::Base
   def view_template
     id = @image&.id || @image_id
 
-    link_to(
-      :image_show_original.t,
-      "/images/#{id}/original",
-      {
-        class: @link_class,
-        target: "_blank",
-        rel: "noopener",
-        data: {
-          controller: "image-loader",
-          action: "click->image-loader#load",
-          "image-loader-target": "link",
-          "loading-text": :image_show_original_loading.t,
-          "maxed-out-text": :image_show_original_maxed_out.t,
-          "error-text": :image_show_original_error.t
-        }
-      }
-    )
+    render(::Components::Link::External.new(
+             :image_show_original.t,
+             "/images/#{id}/original",
+             class: @link_class,
+             data: {
+               controller: "image-loader",
+               action: "click->image-loader#load",
+               "image-loader-target": "link",
+               "loading-text": :image_show_original_loading.t,
+               "maxed-out-text": :image_show_original_maxed_out.t,
+               "error-text": :image_show_original_error.t
+             }
+           ))
   end
 end

--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -70,7 +70,8 @@ class Components::Map::Popup < Components::Base
 
     url = observation_path(id: obs.id, params: query_path_params)
     div(class: "media-left") do
-      a(href: url, target: "_blank", rel: "noopener noreferrer") do
+      render(::Components::Link::Get.new(name: "", target: url,
+                                         new_tab: true)) do
         # Empty alt: the adjacent taxon-name link inside the same
         # .media already provides the accessible label, so the
         # thumbnail is decorative in this context.
@@ -194,10 +195,12 @@ class Components::Map::Popup < Components::Base
   # ----------------------------------------------------------------
 
   def render_observation_link(obs)
-    a(href: observation_path(id: obs.id, params: query_path_params),
-      target: "_blank", rel: "noopener noreferrer") do
-      render_observation_label(obs)
-    end
+    render(::Components::Link::Get.new(
+             name: obs.text_name.presence || "Observation ##{obs.id}",
+             target: observation_path(id: obs.id,
+                                      params: query_path_params),
+             new_tab: true
+           )) { render_observation_label(obs) }
   end
 
   # Emits the label inside the observation-popup link. Preferred order:

--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -70,11 +70,11 @@ class Components::Map::Popup < Components::Base
 
     url = observation_path(id: obs.id, params: query_path_params)
     div(class: "media-left") do
-      render(::Components::Link::Get.new(name: "", target: url,
-                                         new_tab: true)) do
-        # Empty alt: the adjacent taxon-name link inside the same
-        # .media already provides the accessible label, so the
-        # thumbnail is decorative in this context.
+      label = obs.text_name.presence || "Observation ##{obs.id}"
+      render(::Components::Link::Get.new(
+               name: label, target: url, new_tab: true,
+               aria: { label: label }
+             )) do
         img(src: ::Image.url(:small, obs.thumb_image_id),
             class: "media-object map-popup-thumb",
             loading: "lazy", alt: "")

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -256,8 +256,7 @@ class Components::Matrix::Box < Components::Base
   # An import link's URL always resolves (stored override or derived from the
   # site template via link_url), so the credit always renders as a link.
   def render_external_credit_link(link)
-    a(href: link[:url], target: "_blank",
-      rel: "noopener noreferrer") { link[:text] }
+    render(::Components::Link::External.new(link[:text], link[:url]))
   end
 
   def render_log_footer(panel)

--- a/app/views/controllers/herbarium_records/show.rb
+++ b/app/views/controllers/herbarium_records/show.rb
@@ -78,11 +78,10 @@ module Views::Controllers::HerbariumRecords
     end
 
     def render_collection_link
-      a(href: herbarium.mcp_url(@herbarium_record.accession_number),
-        target: "_blank", rel: "noopener") do
-        plain("#{herbarium.code} ")
-        trusted_html(:herbarium_record_collection.t)
-      end
+      render(::Components::Link::External.new(
+               "#{herbarium.code} #{:herbarium_record_collection.t}",
+               herbarium.mcp_url(@herbarium_record.accession_number)
+             ))
       br
     end
 

--- a/app/views/controllers/info/textile_sandbox_form.rb
+++ b/app/views/controllers/info/textile_sandbox_form.rb
@@ -89,10 +89,11 @@ module Views::Controllers::Info
       strong { plain("#{:sandbox_more_help.l}:") }
       div(class: "pl-3") do
         # Translation not needed as document title is static
-        a(href: "https://docs.google.com/document/d/" \
-                "10NiaPDKoK_k3bRIoU1smGXSycDczf_jdkmW-xt-Wf20",
-          target: "_blank",
-          rel: "noopener noreferrer") { "MO Flavored Textile" }
+        render(::Components::Link::External.new(
+                 "MO Flavored Textile",
+                 "https://docs.google.com/document/d/" \
+                 "10NiaPDKoK_k3bRIoU1smGXSycDczf_jdkmW-xt-Wf20"
+               ))
         br
       end
     end
@@ -100,23 +101,20 @@ module Views::Controllers::Info
     def render_web_reference_links
       strong { plain("#{:sandbox_web_refs.l}:") }
       div(class: "pl-3") do
-        a(href: "https://hobix.com/textile",
-          target: "_blank",
-          rel: "noopener noreferrer") do
-          plain(:sandbox_link_hobix_textile_reference.l)
-        end
+        render(::Components::Link::External.new(
+                 :sandbox_link_hobix_textile_reference.l,
+                 "https://hobix.com/textile"
+               ))
         br
-        a(href: "https://hobix.com/quick",
-          target: "_blank",
-          rel: "noopener noreferrer") do
-          plain(:sandbox_link_hobix_textile_cheatsheet.l)
-        end
+        render(::Components::Link::External.new(
+                 :sandbox_link_hobix_textile_cheatsheet.l,
+                 "https://hobix.com/quick"
+               ))
         br
-        a(href: "https://textile-lang.com/",
-          target: "_blank",
-          rel: "noopener noreferrer") do
-          plain(:sandbox_link_textile_language_website.l)
-        end
+        render(::Components::Link::External.new(
+                 :sandbox_link_textile_language_website.l,
+                 "https://textile-lang.com/"
+               ))
         br
       end
     end

--- a/app/views/controllers/licenses/show.rb
+++ b/app/views/controllers/licenses/show.rb
@@ -49,8 +49,7 @@ module Views::Controllers::Licenses
 
     def link_to_url
       capture do
-        link_to(@license.url, @license.url,
-                target: "_blank", rel: "noopener noreferrer")
+        render(::Components::Link::External.new(@license.url, @license.url))
       end
     end
 

--- a/app/views/controllers/observations/identify/form.rb
+++ b/app/views/controllers/observations/identify/form.rb
@@ -80,8 +80,8 @@ module Views::Controllers::Observations::Identify
     end
 
     def render_search_icon
-      span(class:
-        "glyphicon glyphicon-search form-control-feedback")
+      render(::Components::Icon.new(type: :search,
+                                    html_class: "form-control-feedback"))
     end
 
     def render_hidden_field

--- a/app/views/controllers/observations/imported_source_banner.rb
+++ b/app/views/controllers/observations/imported_source_banner.rb
@@ -37,8 +37,7 @@ module Views::Controllers::Observations
     private
 
     def render_credit(link)
-      a(href: link[:url], target: "_blank",
-        rel: "noopener noreferrer") { credit_text(link) }
+      render(::Components::Link::External.new(credit_text(link), link[:url]))
     end
 
     def credit_text(link)

--- a/app/views/controllers/observations/show/herbarium_records_panel.rb
+++ b/app/views/controllers/observations/show/herbarium_records_panel.rb
@@ -69,10 +69,10 @@ class Views::Controllers::Observations::Show::HerbariumRecordsPanel < Views::Bas
   def render_mcp_search_link(record)
     br
     span(class: "indent") do
-      a(href: record.herbarium.mcp_url(record.accession_number),
-        target: "_blank", rel: "noopener") do
-        plain(:herbarium_record_collection.t)
-      end
+      render(::Components::Link::External.new(
+               :herbarium_record_collection.t,
+               record.herbarium.mcp_url(record.accession_number)
+             ))
     end
   end
 
@@ -90,11 +90,11 @@ class Views::Controllers::Observations::Show::HerbariumRecordsPanel < Views::Bas
       render_show_link(record)
       if record.herbarium.web_searchable?
         br
-        a(href: record.herbarium.mcp_url(record.accession_number),
-          target: "_blank", rel: "noopener") do
-          plain("#{record.herbarium.code} " \
-                "#{:herbarium_record_collection.t}")
-        end
+        render(::Components::Link::External.new(
+                 "#{record.herbarium.code} " \
+                 "#{:herbarium_record_collection.t}",
+                 record.herbarium.mcp_url(record.accession_number)
+               ))
       end
     end
   end

--- a/app/views/controllers/observations/show/sibling_records.rb
+++ b/app/views/controllers/observations/show/sibling_records.rb
@@ -49,19 +49,19 @@ module Views::Controllers::Observations::Show::SiblingRecords
   def render_mcp_search_link(record)
     br
     span(class: "indent") do
-      a(href: record.herbarium.mcp_url(record.accession_number),
-        target: "_blank", rel: "noopener") do
-        plain(:herbarium_record_collection.t)
-      end
+      render(::Components::Link::External.new(
+               :herbarium_record_collection.t,
+               record.herbarium.mcp_url(record.accession_number)
+             ))
     end
   end
 
   def render_sibling_sequence_archive(sequence)
     plain(" [")
-    a(href: sequence.accession_url,
-      target: "_blank", rel: "noopener") do
-      plain(:show_observation_archive_link.t)
-    end
+    render(::Components::Link::External.new(
+             :show_observation_archive_link.t,
+             sequence.accession_url
+           ))
     plain("]")
   end
 end

--- a/app/views/controllers/sequences/index.rb
+++ b/app/views/controllers/sequences/index.rb
@@ -51,12 +51,14 @@ module Views::Controllers::Sequences
 
     def render_archive_link(seq)
       url = ::WebSequenceArchive.archive_home(seq.archive)
-      link_to(seq.archive.t, url, target: "_blank", rel: "noopener")
+      render(::Components::Link::External.new(seq.archive.t, url))
     end
 
     def render_accession_link(seq)
-      link_to(truncate(seq.accession, length: seq.locus_width / 2).t,
-              seq.accession_url, target: "_blank", rel: "noopener")
+      render(::Components::Link::External.new(
+               truncate(seq.accession, length: seq.locus_width / 2).t,
+               seq.accession_url
+             ))
     end
   end
 end

--- a/app/views/controllers/sequences/show.rb
+++ b/app/views/controllers/sequences/show.rb
@@ -109,9 +109,11 @@ module Views::Controllers::Sequences
     end
 
     def render_accession_link
-      link_to(truncate(@sequence.accession,
-                       length: @sequence.locus_width / 2).t,
-              @sequence.accession_url, target: "_blank", rel: "noopener")
+      render(::Components::Link::External.new(
+               truncate(@sequence.accession,
+                        length: @sequence.locus_width / 2).t,
+               @sequence.accession_url
+             ))
     end
   end
 end

--- a/test/components/image/original_link_test.rb
+++ b/test/components/image/original_link_test.rb
@@ -13,7 +13,7 @@ class ImageOriginalLinkTest < ComponentTestCase
 
     assert_html(html, "a[href='/images/#{@image.id}/original']",
                 text: :image_show_original.l)
-    assert_html(html, "a[target='_blank'][rel='noopener']")
+    assert_html(html, "a[target='_blank'][rel='noopener noreferrer']")
     assert_html(html,
                 "a[data-controller='image-loader']" \
                 "[data-action='click->image-loader#load']" \


### PR DESCRIPTION
## Summary

Sweeps all raw `target="_blank"` anchors in `app/components/` and `app/views/controllers/` to use `Components::Link::External` (external URLs) or `Components::Link::Get` with `new_tab: true` (internal MO paths).

- `image/original_link.rb`: `link_to` with Stimulus data attrs → `Link::External` (`**@opts` forwards data attrs)
- `map/popup.rb`: thumbnail `a()` → `Link::Get(new_tab: true)` with block; `render_observation_link` raw `a()` → `Link::Get(new_tab: true)` with block
- `matrix/box.rb`: `render_external_credit_link` → `Link::External`
- `licenses/show.rb`: `link_to_url` → `Link::External`
- `herbarium_records/show.rb`: `render_collection_link` → `Link::External`
- `sequences/index.rb` + `sequences/show.rb`: archive/accession `link_to` → `Link::External`
- `observations/imported_source_banner.rb`: `render_credit` → `Link::External`
- `observations/show/herbarium_records_panel.rb`: 2× MCP search links → `Link::External`
- `observations/show/sibling_records.rb`: MCP + archive links → `Link::External`
- `info/textile_sandbox_form.rb`: 4 static external doc links → `Link::External`
- `test/components/image/original_link_test.rb`: update `rel='noopener'` → `rel='noopener noreferrer'` (`Link::External` always emits the full value)

No raw `target="_blank"` callers remain in `app/components/` or `app/views/controllers/`.

Side effect: callers that previously used `rel="noopener"` (missing `noreferrer`) are upgraded to `rel="noopener noreferrer"` — a security improvement.

## Test plan

- [x] `bin/rails test` — 6706 tests, 0 failures
- [x] `bundle exec rubocop` on all 11 changed files — no offenses
- [x] CI green
