### PR TITLE
Fix description show-page OOM: stop preloading all_users on public descriptions

### DIFF
--- a/app/controllers/concerns/descriptions/permissions.rb
+++ b/app/controllers/concerns/descriptions/permissions.rb
@@ -86,7 +86,8 @@ module Descriptions::Permissions
   included do
     # Form to adjust permissions on a description.
     def edit
-      return unless (@description = find_description!(params[:id].to_s))
+      return unless (@description = find_description!(params[:id].to_s,
+                                                      for_permissions: true))
 
       done = false
       # Doesn't have permission.
@@ -114,7 +115,8 @@ module Descriptions::Permissions
     end
 
     def update
-      return unless (@description = find_description!(params[:id].to_s))
+      return unless (@description = find_description!(params[:id].to_s,
+                                                      for_permissions: true))
 
       done = false
       # Doesn't have permission.

--- a/app/controllers/locations/descriptions/shared_private_methods.rb
+++ b/app/controllers/locations/descriptions/shared_private_methods.rb
@@ -5,16 +5,11 @@ module Locations::Descriptions
     private
 
     # This either finds a description by id, or sets the ivar from the param.
-    # The permissions form needs the non-strict `permissions_includes` (it
-    # lazily reads `group.users.first`); everything else uses `show_includes`.
-    def find_description!(id = nil, for_permissions: false)
+    # (Location descriptions have no permissions form, so there is no
+    # `for_permissions` variant here — unlike name descriptions.)
+    def find_description!(id = nil)
       desc_id = id || params[:id]
-      scope = if for_permissions
-                LocationDescription.permissions_includes
-              else
-                LocationDescription.show_includes
-              end
-      @description = scope.safe_find(desc_id) ||
+      @description = LocationDescription.show_includes.safe_find(desc_id) ||
                      flash_error_and_goto_index(LocationDescription, desc_id)
     end
   end

--- a/app/controllers/locations/descriptions/shared_private_methods.rb
+++ b/app/controllers/locations/descriptions/shared_private_methods.rb
@@ -5,9 +5,16 @@ module Locations::Descriptions
     private
 
     # This either finds a description by id, or sets the ivar from the param.
-    def find_description!(id = nil)
+    # The permissions form needs the non-strict `permissions_includes` (it
+    # lazily reads `group.users.first`); everything else uses `show_includes`.
+    def find_description!(id = nil, for_permissions: false)
       desc_id = id || params[:id]
-      @description = LocationDescription.show_includes.safe_find(desc_id) ||
+      scope = if for_permissions
+                LocationDescription.permissions_includes
+              else
+                LocationDescription.show_includes
+              end
+      @description = scope.safe_find(desc_id) ||
                      flash_error_and_goto_index(LocationDescription, desc_id)
     end
   end

--- a/app/controllers/names/descriptions/shared_private_methods.rb
+++ b/app/controllers/names/descriptions/shared_private_methods.rb
@@ -5,9 +5,16 @@ module Names::Descriptions
     private
 
     # This either finds a description by id, or sets the ivar from the param.
-    def find_description!(id = nil)
+    # The permissions form needs the non-strict `permissions_includes` (it
+    # lazily reads `group.users.first`); everything else uses `show_includes`.
+    def find_description!(id = nil, for_permissions: false)
       desc_id = id || params[:id]
-      @description = NameDescription.show_includes.safe_find(desc_id) ||
+      scope = if for_permissions
+                NameDescription.permissions_includes
+              else
+                NameDescription.show_includes
+              end
+      @description = scope.safe_find(desc_id) ||
                      flash_error_and_goto_index(NameDescription, desc_id)
     end
   end

--- a/app/models/description/scopes.rb
+++ b/app/models/description/scopes.rb
@@ -38,18 +38,22 @@ module Description::Scopes
     # The admin/reader/writer join records belong_to `:user_group`
     # (preloaded for `update_groups` in the permissions concern); the
     # author/editor join records belong_to `:user`. The
-    # admin/reader/writer through groups preload `users: :user_groups`
-    # so the permissions form can render personal-group user rows
-    # (`group.users.first`) and check `user.in_group?("reviewers")`
-    # without lazy-loading.
+    # admin/reader/writer through groups are preloaded for their names /
+    # `include?(all_users)` checks, but their `users` are NOT: the
+    # permissions form reads `group.users.first` only on small personal
+    # groups (a LIMIT 1 lazy query) and renders standard groups
+    # ("all users" / "reviewers") by name. Preloading group `users` would
+    # materialize the entire ~90k-member `all_users` group on every public
+    # description show page — a multi-second render + OOM. The permissions
+    # form uses the non-strict `permissions_includes` and lazy-loads instead.
     def permissions_subtree
       prefix = name.underscore # "name_description" / "location_description"
       [
-        { admin_groups: { users: :user_groups } },
+        :admin_groups,
         :authors,
         :editors,
-        { reader_groups: { users: :user_groups } },
-        { writer_groups: { users: :user_groups } },
+        :reader_groups,
+        :writer_groups,
         { "#{prefix}_admins": :user_group },
         { "#{prefix}_authors": :user },
         { "#{prefix}_editors": :user },

--- a/app/models/description/scopes.rb
+++ b/app/models/description/scopes.rb
@@ -39,10 +39,11 @@ module Description::Scopes
     # (preloaded for `update_groups` in the permissions concern); the
     # author/editor join records belong_to `:user`. The
     # admin/reader/writer through groups are preloaded for their names /
-    # `include?(all_users)` checks, but their `users` are NOT: the
-    # permissions form reads `group.users.first` only on small personal
-    # groups (a LIMIT 1 lazy query) and renders standard groups
-    # ("all users" / "reviewers") by name. Preloading group `users` would
+    # `include?(all_users)` checks, but their `users` are NOT: only the
+    # permissions form reads group `users`, lazily and only on small groups
+    # (`group.users.first` on personal groups, `group.users.include?(user)`
+    # on named project groups). The `all_users` group is always skipped or
+    # rendered by name, never enumerated. Preloading group `users` would
     # materialize the entire ~90k-member `all_users` group on every public
     # description show page — a multi-second render + OOM. The permissions
     # form uses the non-strict `permissions_includes` and lazy-loads instead.

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -123,12 +123,6 @@ class LocationDescription < Description
     )
   }
 
-  # Load path for the permissions form. Unlike show_includes it is NOT
-  # strict_loading: the form lazily reads `group.users.first` on personal
-  # groups (a LIMIT 1) and `user.in_group?`. It deliberately does NOT preload
-  # group users, so it never materializes the ~90k-member all_users group.
-  scope :permissions_includes, -> { includes(*permissions_subtree) }
-
   ALL_NOTE_FIELDS = [:gen_desc, :ecology, :species, :notes, :refs].freeze
   SEARCHABLE_FIELDS = ALL_NOTE_FIELDS
 

--- a/app/models/location_description.rb
+++ b/app/models/location_description.rb
@@ -123,6 +123,12 @@ class LocationDescription < Description
     )
   }
 
+  # Load path for the permissions form. Unlike show_includes it is NOT
+  # strict_loading: the form lazily reads `group.users.first` on personal
+  # groups (a LIMIT 1) and `user.in_group?`. It deliberately does NOT preload
+  # group users, so it never materializes the ~90k-member all_users group.
+  scope :permissions_includes, -> { includes(*permissions_subtree) }
+
   ALL_NOTE_FIELDS = [:gen_desc, :ecology, :species, :notes, :refs].freeze
   SEARCHABLE_FIELDS = ALL_NOTE_FIELDS
 

--- a/app/models/name_description.rb
+++ b/app/models/name_description.rb
@@ -163,6 +163,12 @@ class NameDescription < Description
     )
   }
 
+  # Load path for the permissions form. Unlike show_includes it is NOT
+  # strict_loading: the form lazily reads `group.users.first` on personal
+  # groups (a LIMIT 1) and `user.in_group?`. It deliberately does NOT preload
+  # group users, so it never materializes the ~90k-member all_users group.
+  scope :permissions_includes, -> { includes(*permissions_subtree) }
+
   EOL_NOTE_FIELDS = [
     :gen_desc, :diag_desc, :distribution, :habitat, :look_alikes, :uses
   ].freeze

--- a/test/models/description_test.rb
+++ b/test/models/description_test.rb
@@ -31,6 +31,24 @@ class DescriptionTest < UnitTestCase
   #  Make sure all the author/editor-related magic is working right.
   # ------------------------------------------------------------------
 
+  # Guards the public-description show-page OOM: show_includes must preload the
+  # permission groups but NOT their users. A public description's `all_users`
+  # reader group has ~90k members on production; preloading them turned the
+  # show page into a multi-second, OOM-prone render.
+  def test_show_includes_does_not_preload_group_users
+    desc = name_descriptions(:peltigera_desc)
+    desc.add_reader(UserGroup.all_users)
+
+    loaded = NameDescription.show_includes.find(desc.id)
+
+    assert(loaded.association(:reader_groups).loaded?,
+           "reader_groups should be preloaded for include?(all_users)")
+    group = loaded.reader_groups.detect { |g| g == UserGroup.all_users }
+    assert_not_nil(group, "expected the all_users reader group")
+    assert_not(group.association(:users).loaded?,
+               "reader group users must NOT be preloaded (loads all_users)")
+  end
+
   def test_authors_and_editors
     [LocationDescription, NameDescription].each do |model|
       case model.name


### PR DESCRIPTION
## Summary

Fixes the 2026-06-26 production OOM outages. Public **description show pages** (`/names/descriptions/:id`, `/locations/descriptions/:id`) eager-loaded `reader_groups`/`writer_groups → users → user_groups` via `permissions_subtree`/`show_includes`. For a **public** description those groups are the `all_users` group (~90k members), so the show page materialized **the entire user base plus every member's group memberships** on each render.

Measured on the offending page (`NameDescription 5422`, public): **`show_includes` 10.41s → 0.53s**, eliminating the ~7s Ruby + 2.4s GC + memory balloon. Under concurrent retries (users re-hitting the apparently-hung page) that balloon OOM'd the box.

It scales with the user count, which is why it newly went bad as the base grew past ~90k, and it affected *every* public Name/Location description show page, not just 5422.

## Diagnosis (from the production + a reproduced local log)

`Completed 200 OK in 11210ms (Views: 301ms | ActiveRecord: 1133ms | GC: 2394ms)` — the view was fast; the cost was a controller-phase `User Load (508ms) WHERE id IN (…90k…)` then per-member `UserGroupUser`/`UserGroup` preloads, traced to `Description::Scopes#permissions_subtree`.

## Fix

- **`permissions_subtree`** now preloads the permission groups **without** their users — the show page only needs `reader_groups.include?(all_users)` (an identity check on the still-preloaded groups).
- The **permissions edit form** genuinely needs `group.users` (it renders personal-group rows via `group.users.first`). It now loads via a new **non-strict** `permissions_includes` scope: lazy `group.users.first` is a `LIMIT 1` on tiny personal groups, and the `all_users` group is rendered by name — so it never materializes 90k users. `find_description!(for_permissions: true)` selects this scope; everything else keeps strict `show_includes`.
- **Regression guard**: a test asserting `show_includes` preloads the reader groups but **not** their users.

## Test plan

- [x] New regression test in `test/models/description_test.rb`.
- [x] `bin/rails test test/models/description_test.rb test/controllers/names/descriptions/permissions_controller_test.rb test/controllers/names/descriptions_controller_test.rb` (68 runs, 0 failures).
- [x] `bin/rails test test/controllers/locations/descriptions/ test/controllers/locations/descriptions_controller_test.rb` (44 runs, 0 failures).

## Follow-ups (separate, recommended)

- **`Rack::Timeout`** (~20–30s) + a per-worker memory cap (PumaWorkerKiller) so no single request can OOM the box and the retry-amplification is cut — defense in depth for any future O(user-count) regression.
