### PR TITLE
Return message without throwing Error for bad /api2 root requests

### DIFF
--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -21,8 +21,20 @@ class API2Controller < ApplicationController
   wrap_parameters false
 
   def index
-    render(json: { errors: ["Use /api2/{resource} — e.g. /api2/images"] },
-           status: :bad_request)
+    @start_time = Time.zone.now
+    @api = API2.execute(method: "GET", action: "index")
+    set_cors_headers
+    request.format = "json" if request.format == "html"
+    respond_to do |format|
+      format.xml  do
+        render(layout: false, template: "/api2/results",
+               status: :bad_request)
+      end
+      format.json do
+        render(layout: false, template: "/api2/results",
+               status: :bad_request)
+      end
+    end
   end
 
   # Standard entry point for REST requests.

--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -22,19 +22,12 @@ class API2Controller < ApplicationController
 
   def index
     @start_time = Time.zone.now
-    @api = API2.execute(method: "GET", action: "index")
-    set_cors_headers
-    request.format = "json" if request.format == "html"
-    respond_to do |format|
-      format.xml  do
-        render(layout: false, template: "/api2/results",
-               status: :bad_request)
-      end
-      format.json do
-        render(layout: false, template: "/api2/results",
-               status: :bad_request)
-      end
-    end
+    @api = API2.execute(method: request.method, action: "index")
+    do_render_bad_request
+  rescue StandardError => e
+    @api ||= API2.new
+    @api.errors << API2::RenderFailed.new(e)
+    do_render_bad_request
   end
 
   # Standard entry point for REST requests.
@@ -196,6 +189,21 @@ class API2Controller < ApplicationController
 
   def do_render_json
     render(layout: false, template: "/api2/results")
+  end
+
+  def do_render_bad_request
+    set_cors_headers
+    request.format = "json" if request.format == "html"
+    respond_to do |format|
+      format.xml  do
+        render(layout: false, template: "/api2/results",
+               status: :bad_request)
+      end
+      format.json do
+        render(layout: false, template: "/api2/results",
+               status: :bad_request)
+      end
+    end
   end
 
   def set_cors_headers

--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -20,6 +20,11 @@ class API2Controller < ApplicationController
   # wrapped parameters break JSON requests in the unit tests.
   wrap_parameters false
 
+  def index
+    render(json: { errors: ["Use /api2/{resource} — e.g. /api2/images"] },
+           status: :bad_request)
+  end
+
   # Standard entry point for REST requests.
   def api_keys
     rest_query(:api_key)

--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -23,9 +23,11 @@ class API2Controller < ApplicationController
   def index
     @start_time = Time.zone.now
     @api = API2.execute(method: request.method, action: "index")
+    @api.version ||= API2.version
     do_render_bad_request
   rescue StandardError => e
     @api ||= API2.new
+    @api.version ||= API2.version
     @api.errors << API2::RenderFailed.new(e)
     do_render_bad_request
   end

--- a/app/controllers/api2_controller.rb
+++ b/app/controllers/api2_controller.rb
@@ -193,7 +193,7 @@ class API2Controller < ApplicationController
 
   def do_render_bad_request
     set_cors_headers
-    request.format = "json" if request.format == "html"
+    request.format = "json" unless request.format.json? || request.format.xml?
     respond_to do |format|
       format.xml  do
         render(layout: false, template: "/api2/results",

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -655,6 +655,20 @@ class API2ControllerTest < FunctionalTestCase
                  "RenderFailed error should be fatal")
   end
 
+  def test_index_rescue_wraps_unexpected_errors
+    boom = RuntimeError.new("unexpected")
+    API2.stub(:execute, ->(_) { raise(boom) }) do
+      get(:index, params: { format: :json })
+    end
+    assert_equal(400, @response.status,
+                 "Rescued index should still return 400")
+    error = @response.parsed_body["errors"].first
+    assert_equal("API2::RenderFailed", error["code"],
+                 "Unexpected error in index should be wrapped in RenderFailed")
+    assert_equal("true", error["fatal"],
+                 "RenderFailed error should be fatal")
+  end
+
   def test_routing
     assert_routing({ path: "/api2/comments", method: :delete },
                    { controller: "api2", action: "comments" })

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -58,12 +58,24 @@ class API2ControllerTest < FunctionalTestCase
   end
 
   def test_index_returns_bad_request
-    get(:index, params: { action: "images", format: :json })
+    get(:index, params: { format: :json })
     assert_equal(400, @response.status,
                  "GET /api2 without a resource path should return 400")
-    json = @response.parsed_body
-    assert(json["errors"].any? { |e| e.include?("/api2/") },
-           "Error message should hint at the correct URL format")
+    error = @response.parsed_body["errors"].first
+    assert_equal("API2::BadAction", error["code"],
+                 "Error code should identify the bad action")
+    assert_equal("true", error["fatal"],
+                 "Error should be fatal")
+
+    get(:index, params: { format: :xml })
+    assert_equal(400, @response.status,
+                 "XML: GET /api2 without a resource path should return 400")
+    doc = REXML::Document.new(@response.body)
+    xml_error = doc.root.elements["errors/error"]
+    assert_equal("API2::BadAction", xml_error.elements["code"].text,
+                 "XML error code should identify the bad action")
+    assert_equal("true", xml_error.elements["fatal"].text,
+                 "XML error should be fatal")
   end
 
   def test_basic_collection_number_get_request

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -54,7 +54,16 @@ class API2ControllerTest < FunctionalTestCase
     @request.user_agent = "Googlebot"
     obs = Observation.first
     get(:observations, params: { id: obs.id })
-    assert_equal(200, @response.status)
+    assert_equal(200, @response.status, "Robot GET should succeed")
+  end
+
+  def test_index_returns_bad_request
+    get(:index, params: { action: "images", format: :json })
+    assert_equal(400, @response.status,
+                 "GET /api2 without a resource path should return 400")
+    json = @response.parsed_body
+    assert(json["errors"].any? { |e| e.include?("/api2/") },
+           "Error message should hint at the correct URL format")
   end
 
   def test_basic_collection_number_get_request

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -641,6 +641,20 @@ class API2ControllerTest < FunctionalTestCase
     get(:observations, params: params.merge(format: :xml, detail: :high))
   end
 
+  def test_render_api_results_rescue_wraps_unexpected_errors
+    boom = RuntimeError.new("unexpected")
+    API2.stub(:execute, ->(_) { raise(boom) }) do
+      get(:observations, params: { format: :json })
+    end
+    assert_equal(200, @response.status,
+                 "Rescued render should still return a response")
+    error = @response.parsed_body["errors"].first
+    assert_equal("API2::RenderFailed", error["code"],
+                 "Unexpected error should be wrapped in RenderFailed")
+    assert_equal("true", error["fatal"],
+                 "RenderFailed error should be fatal")
+  end
+
   def test_routing
     assert_routing({ path: "/api2/comments", method: :delete },
                    { controller: "api2", action: "comments" })

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -58,7 +58,7 @@ class API2ControllerTest < FunctionalTestCase
   end
 
   def test_index_returns_bad_request
-    get(:index, params: { format: :json })
+    get(:index)
     assert_equal(400, @response.status,
                  "GET /api2 without a resource path should return 400")
     error = @response.parsed_body["errors"].first


### PR DESCRIPTION
See [Copilot Request Overview](https://github.com/MushroomObserver/mushroom-observer/pull/4612#pullrequestreview-4585486114)