### PR TITLE
Allow iNat import to match misspelled MO names by text_name

### DIFF
--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -74,7 +74,8 @@ class Inat
 
     # The MO name for the iNat provisional-name observation field, or nil.
     # iNat can't use a provisional name as its own identification, so it is a
-    # separate proposal from the Observation Taxon. Creates the MO name if absent.
+    # separate proposal from the Observation Taxon. Creates the MO name if
+    # absent.
     # NOTE: iNat users seem to add a prov name only when there's a sequence.
     def prov_name
       return nil if inat_obs.provisional_name.blank?
@@ -87,9 +88,9 @@ class Inat
     end
 
     # The MO name for the iNat "Species Name Override" obs field, or nil. The
-    # override outranks the provisional name and the Observation Taxon as the lead
-    # (#4533). Returns nil - falling back to the provisional/Community lead -
-    # when the override value can't be parsed or created as an MO Name.
+    # override outranks the provisional name and the Observation Taxon as the
+    # lead (#4533). Returns nil - falling back to the provisional/Community
+    # lead - when the override value can't be parsed or created as an MO Name.
     def override_name
       return @override_name if defined?(@override_name)
 
@@ -140,9 +141,10 @@ class Inat
       name.best_preferred_synonym.presence || name
     end
 
-    # Pure: the namings to create as [name, vote] for the given Observation Taxon
-    # name, provisional name (or nil), override name (or nil), and the lead's
-    # confidence vote. The lead (override, else provisional, else Observation Taxon)
+    # Pure: the namings to create as [name, vote] for the given Observation
+    # Taxon name, provisional name (or nil), override name (or nil), and the
+    # lead's confidence vote. The lead (override, else provisional, else
+    # Observation Taxon)
     # leads at lead_vote; every other name and the preferred synonym of any
     # deprecated name follow at Could Be. Lead is first so it wins
     # calc_consensus ties. (#4212, #4533)

--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -67,14 +67,14 @@ class Inat
                                                         match_inat: true)
     end
 
-    # The MO name for the iNat Community ID, creating it if needed.
+    # The MO name for the iNat Observation Taxon, creating it if needed.
     def community_name
       resolved_obs_name
     end
 
     # The MO name for the iNat provisional-name observation field, or nil.
     # iNat can't use a provisional name as its own identification, so it is a
-    # separate proposal from the Community ID. Creates the MO name if absent.
+    # separate proposal from the Observation Taxon. Creates the MO name if absent.
     # NOTE: iNat users seem to add a prov name only when there's a sequence.
     def prov_name
       return nil if inat_obs.provisional_name.blank?
@@ -87,7 +87,7 @@ class Inat
     end
 
     # The MO name for the iNat "Species Name Override" obs field, or nil. The
-    # override outranks the provisional name and the Community ID as the lead
+    # override outranks the provisional name and the Observation Taxon as the lead
     # (#4533). Returns nil - falling back to the provisional/Community lead -
     # when the override value can't be parsed or created as an MO Name.
     def override_name
@@ -125,7 +125,7 @@ class Inat
     end
 
     # The name proposed as the obs's consensus: the override name when present,
-    # else the provisional name, else the Community ID, corrected to its
+    # else the provisional name, else the Observation Taxon, corrected to its
     # preferred synonym when deprecated in MO. calc_consensus confirms it from
     # the votes, where it carries the highest weight. (#4212, #4533)
     def lead_name
@@ -140,9 +140,9 @@ class Inat
       name.best_preferred_synonym.presence || name
     end
 
-    # Pure: the namings to create as [name, vote] for the given Community ID
+    # Pure: the namings to create as [name, vote] for the given Observation Taxon
     # name, provisional name (or nil), override name (or nil), and the lead's
-    # confidence vote. The lead (override, else provisional, else Community ID)
+    # confidence vote. The lead (override, else provisional, else Observation Taxon)
     # leads at lead_vote; every other name and the preferred synonym of any
     # deprecated name follow at Could Be. Lead is first so it wins
     # calc_consensus ties. (#4212, #4533)

--- a/app/classes/inat/mo_observation_builder/naming_reasons.rb
+++ b/app/classes/inat/mo_observation_builder/naming_reasons.rb
@@ -17,7 +17,7 @@ class Inat
         elsif suggested?(name)
           suggester_with_date(name)
         else
-          "iNat `Observation Taxon` #{Time.zone.today.strftime("%Y-%m-%d")}"
+          "#{:inat_observation_taxon.l} #{Time.zone.today.strftime("%Y-%m-%d")}"
         end
       end
 

--- a/app/classes/inat/mo_observation_builder/naming_reasons.rb
+++ b/app/classes/inat/mo_observation_builder/naming_reasons.rb
@@ -4,7 +4,7 @@ class Inat
   class MoObservationBuilder
     # How the importer explains each naming it creates (the reasons[2] text):
     # Species Name Override (#4533), Provisional Species Name, an iNat
-    # suggester, or the Community ID. Mixed into MoObservationBuilder.
+    # suggester, or the Observation Taxon. Mixed into MoObservationBuilder.
     module NamingReasons
       private
 
@@ -17,7 +17,7 @@ class Inat
         elsif suggested?(name)
           suggester_with_date(name)
         else
-          "iNat `Community ID` #{Time.zone.today.strftime("%Y-%m-%d")}"
+          "iNat `Observation Taxon` #{Time.zone.today.strftime("%Y-%m-%d")}"
         end
       end
 

--- a/app/classes/inat/mo_observation_builder/naming_reasons.rb
+++ b/app/classes/inat/mo_observation_builder/naming_reasons.rb
@@ -15,14 +15,22 @@ class Inat
         elsif same_name?(name, prov_name)
           provisional_explanation
         elsif suggested?(name)
-          suggester_with_date(name)
+          "#{suggester_with_date(name)}#{corrected_spelling_note(name)}"
         else
-          "#{:inat_observation_taxon.l} #{Time.zone.today.strftime("%Y-%m-%d")}"
+          "#{:inat_observation_taxon.l} " \
+          "#{Time.zone.today.strftime("%Y-%m-%d")}" \
+          "#{corrected_spelling_note(name)}"
         end
       end
 
       def same_name?(name, other)
         other && name.id == other.id
+      end
+
+      def corrected_spelling_note(name)
+        return "" unless community_name.correct_spelling == name
+
+        " #{:inat_corrected_spelling.l}"
       end
 
       def provisional_explanation

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -268,7 +268,7 @@ class Inat
     end
 
     # The value of the iNat "Species Name Override" observation field, or nil.
-    # When present it outranks the provisional name and the Community ID as the
+    # When present it outranks the provisional name and the Observation Taxon as the
     # lead naming. (#4533)
     def name_override
       return nil if inat_obs_fields.blank?

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -268,8 +268,8 @@ class Inat
     end
 
     # The value of the iNat "Species Name Override" observation field, or nil.
-    # When present it outranks the provisional name and the Observation Taxon as the
-    # lead naming. (#4533)
+    # When present it outranks the provisional name and the Observation Taxon
+    # as the lead naming. (#4533)
     def name_override
       return nil if inat_obs_fields.blank?
 

--- a/app/classes/inat/taxon.rb
+++ b/app/classes/inat/taxon.rb
@@ -98,8 +98,7 @@ class Inat
         # parse it to get MO's text_name rank abbreviation
         # E.g. "sect." instead of "section"
         text_name: ::Name.parse_name(full_name_string).text_name,
-        rank: @taxon[:rank].titleize,
-        correct_spelling_id: nil
+        rank: @taxon[:rank].titleize
       ).
         # iNat lacks taxa "sensu xxx", so ignore MO Names sensu xxx
         where.not(::Name[:author] =~ /^sensu /).

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3254,6 +3254,7 @@
   inat_wrong_user: "[inat_logged_in_user] is logged into iNat. To import iNat observations of [inat_username] make sure that [inat_username] is logged into iNat on your device"
   inat_page_of_obs_failed: Failed to get page of observations from iNat API
 
+  inat_observation_taxon: iNat Observation Taxon
   inat_snapshot_caption: iNat imported data
   inat_dqa_casual: Casual
   inat_dqa_needs_id: Needs ID

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3255,6 +3255,7 @@
   inat_page_of_obs_failed: Failed to get page of observations from iNat API
 
   inat_observation_taxon: iNat Observation Taxon
+  inat_corrected_spelling: (corrected spelling)
   inat_snapshot_caption: iNat imported data
   inat_dqa_casual: Casual
   inat_dqa_needs_id: Needs ID

--- a/test/classes/inat_mo_observation_builder_test.rb
+++ b/test/classes/inat_mo_observation_builder_test.rb
@@ -65,13 +65,13 @@ class InatMoObservationBuilderTest < UnitTestCase
   # Pluteus petasatus (deprecated) has no approved synonym; Peltigera is a
   # second approved name. (See test_best_preferred_synonym in name_test.rb.)
 
-  # An accepted Community ID with no provisional name: a single naming.
+  # An accepted Observation Taxon with no provisional name: a single naming.
   def test_proposed_namings_single_accepted
     assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE]],
                  proposed(community: names(:lactarius_alpinus)))
   end
 
-  # A deprecated Community ID is corrected: its preferred synonym leads, the
+  # A deprecated Observation Taxon is corrected: its preferred synonym leads, the
   # deprecated name follows at Could Be. (Applies to all imports.)
   def test_proposed_namings_deprecated_community_adds_preferred_synonym
     assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE],
@@ -79,7 +79,7 @@ class InatMoObservationBuilderTest < UnitTestCase
                  proposed(community: names(:lactarius_alpigenes)))
   end
 
-  # A provisional name (not deprecated) leads; the Community ID follows.
+  # A provisional name (not deprecated) leads; the Observation Taxon follows.
   def test_proposed_namings_provisional_leads
     assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE],
                   ["Peltigera", Vote::MIN_POS_VOTE]],
@@ -87,9 +87,9 @@ class InatMoObservationBuilderTest < UnitTestCase
                           provisional: names(:lactarius_alpinus)))
   end
 
-  # The provisional is deprecated in favor of the Community ID (the Leccinum
+  # The provisional is deprecated in favor of the Observation Taxon (the Leccinum
   # scenario): the accepted name leads, the deprecated provisional follows,
-  # and the synonym-of-the-provisional dedups with the Community ID.
+  # and the synonym-of-the-provisional dedups with the Observation Taxon.
   def test_proposed_namings_deprecated_provisional_prefers_accepted
     assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE],
                   ["Lactarius alpigenes", Vote::MIN_POS_VOTE]],
@@ -103,7 +103,7 @@ class InatMoObservationBuilderTest < UnitTestCase
                  proposed(community: names(:pluteus_petasatus_deprecated)))
   end
 
-  # Provisional equal to the Community ID collapses to a single naming.
+  # Provisional equal to the Observation Taxon collapses to a single naming.
   def test_proposed_namings_provisional_equals_community
     assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE]],
                  proposed(community: names(:lactarius_alpinus),
@@ -112,7 +112,7 @@ class InatMoObservationBuilderTest < UnitTestCase
 
   # --- Species Name Override (#4533) ---
 
-  # The override leads ahead of the Community ID.
+  # The override leads ahead of the Observation Taxon.
   def test_proposed_namings_override_leads_over_community
     assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE],
                   ["Peltigera", Vote::MIN_POS_VOTE]],
@@ -120,7 +120,7 @@ class InatMoObservationBuilderTest < UnitTestCase
                           override: names(:lactarius_alpinus)))
   end
 
-  # The override outranks BOTH the provisional name and the Community ID;
+  # The override outranks BOTH the provisional name and the Observation Taxon;
   # the other two follow at Could Be.
   def test_proposed_namings_override_outranks_provisional_and_community
     assert_equal([["Coprinus comatus", Vote::MAXIMUM_VOTE],

--- a/test/classes/inat_mo_observation_builder_test.rb
+++ b/test/classes/inat_mo_observation_builder_test.rb
@@ -22,7 +22,8 @@ class InatMoObservationBuilderTest < UnitTestCase
     attr_reader :sequences, :provisional_name, :name_override
 
     def [](key)
-      { quality_grade: @quality_grade, license_code: "cc-by" }[key]
+      { quality_grade: @quality_grade, license_code: "cc-by",
+        identifications: [] }[key]
     end
   end
 
@@ -71,8 +72,8 @@ class InatMoObservationBuilderTest < UnitTestCase
                  proposed(community: names(:lactarius_alpinus)))
   end
 
-  # A deprecated Observation Taxon is corrected: its preferred synonym leads, the
-  # deprecated name follows at Could Be. (Applies to all imports.)
+  # A deprecated Observation Taxon is corrected: its preferred synonym leads,
+  # the deprecated name follows at Could Be. (Applies to all imports.)
   def test_proposed_namings_deprecated_community_adds_preferred_synonym
     assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE],
                   ["Lactarius alpigenes", Vote::MIN_POS_VOTE]],
@@ -87,9 +88,10 @@ class InatMoObservationBuilderTest < UnitTestCase
                           provisional: names(:lactarius_alpinus)))
   end
 
-  # The provisional is deprecated in favor of the Observation Taxon (the Leccinum
-  # scenario): the accepted name leads, the deprecated provisional follows,
-  # and the synonym-of-the-provisional dedups with the Observation Taxon.
+  # The provisional is deprecated in favor of the Observation Taxon (the
+  # Leccinum scenario): the accepted name leads, the deprecated provisional
+  # follows, and the synonym-of-the-provisional dedups with the Observation
+  # Taxon.
   def test_proposed_namings_deprecated_provisional_prefers_accepted
     assert_equal([["Lactarius alpinus", Vote::MAXIMUM_VOTE],
                   ["Lactarius alpigenes", Vote::MIN_POS_VOTE]],
@@ -189,6 +191,18 @@ class InatMoObservationBuilderTest < UnitTestCase
     builder = builder_for(name_override: existing.text_name)
     assert_equal("Following Species Name Override from iNat",
                  builder.send(:used_references_explanation, existing))
+  end
+
+  # The observation taxon explanation uses the inat_observation_taxon
+  # translation string plus today's date.
+  def test_observation_taxon_naming_reason
+    name = names(:peltigera)
+    expected = "#{:inat_observation_taxon.l} " \
+               "#{Time.zone.today.strftime("%Y-%m-%d")}"
+    assert_equal(expected,
+                 builder_for.send(:used_references_explanation, name),
+                 "Observation taxon explanation should use " \
+                 "inat_observation_taxon translation key")
   end
 
   private

--- a/test/classes/inat_mo_observation_builder_test.rb
+++ b/test/classes/inat_mo_observation_builder_test.rb
@@ -12,14 +12,19 @@ class InatMoObservationBuilderTest < UnitTestCase
   # Minimal stand-in for an ::Inat::Obs, exposing only what naming_vote reads.
   class FakeInatObs
     def initialize(sequences:, provisional_name:, quality_grade:,
-                   name_override: nil)
+                   name_override: nil, obs_taxon_name: nil)
       @sequences = sequences
       @provisional_name = provisional_name
       @quality_grade = quality_grade
       @name_override = name_override
+      @obs_taxon_name = obs_taxon_name
     end
 
     attr_reader :sequences, :provisional_name, :name_override
+
+    def name
+      @obs_taxon_name
+    end
 
     def [](key)
       { quality_grade: @quality_grade, license_code: "cc-by",
@@ -200,17 +205,37 @@ class InatMoObservationBuilderTest < UnitTestCase
     expected = "#{:inat_observation_taxon.l} " \
                "#{Time.zone.today.strftime("%Y-%m-%d")}"
     assert_equal(expected,
-                 builder_for.send(:used_references_explanation, name),
+                 builder_for(obs_taxon_name: name).
+                   send(:used_references_explanation, name),
                  "Observation taxon explanation should use " \
                  "inat_observation_taxon translation key")
   end
 
+  # When the obs taxon is a misspelling and the proposed name is its correct
+  # spelling, the observation taxon explanation appends the corrected spelling
+  # note.
+  def test_observation_taxon_naming_reason_corrected_spelling
+    misspelling = names(:petigera)
+    correct = misspelling.correct_spelling
+    assert(correct, "Test requires a name fixture with correct_spelling set")
+    expected = "#{:inat_observation_taxon.l} " \
+               "#{Time.zone.today.strftime("%Y-%m-%d")} " \
+               "#{:inat_corrected_spelling.l}"
+    assert_equal(expected,
+                 builder_for(obs_taxon_name: misspelling).
+                   send(:used_references_explanation, correct),
+                 "Observation taxon explanation should append corrected " \
+                 "spelling note when proposed name corrects the obs taxon")
+  end
+
   private
 
-  def builder_for(provisional_name: nil, name_override: nil)
+  def builder_for(provisional_name: nil, name_override: nil,
+                  obs_taxon_name: nil)
     fake = FakeInatObs.new(sequences: [], quality_grade: "needs_id",
                            provisional_name: provisional_name,
-                           name_override: name_override)
+                           name_override: name_override,
+                           obs_taxon_name: obs_taxon_name)
     Inat::MoObservationBuilder.new(inat_obs: fake, user: users(:rolf),
                                    external_site: :stub)
   end

--- a/test/classes/inat_taxon_test.rb
+++ b/test/classes/inat_taxon_test.rb
@@ -247,6 +247,38 @@ class InatTaxonTest < UnitTestCase
                "Plant identification taxon should not be importable")
   end
 
+  def test_maps_inat_infrageneric_to_mo_misspelled_name
+    correct = Name.create(
+      user: rolf, rank: "Subsection",
+      text_name: "Leccinum subsect. Scabri",
+      search_name: "Leccinum subsect. Scabri",
+      display_name: "**__Leccinum__** subsect. **__Scabri__**",
+      sort_name: "Leccinum  {3subsect.  Scabri",
+      author: ""
+    )
+    misspelling = Name.create(
+      user: rolf, rank: "Subsection",
+      text_name: "Leccinum subsect. Scabra",
+      search_name: "Leccinum subsect. Scabra",
+      display_name: "__Leccinum__ subsect. __Scabra__",
+      sort_name: "Leccinum  {3subsect.  Scabra",
+      author: "", deprecated: true, correct_spelling: correct
+    )
+
+    ancestor_ids = [Inat::Constants::FUNGI_TAXON_ID]
+    inat_taxon = Inat::Taxon.new(
+      rank: "subsection", name: "Scabra", ancestor_ids: ancestor_ids
+    )
+    stub_genus_lookup(
+      ancestor_ids: ancestor_ids.join(","),
+      body: { results: [{ name: "Leccinum" }] }
+    )
+
+    assert_equal(misspelling, inat_taxon.name,
+                 "iNat subsection should map to misspelled MO Name " \
+                 "when only a misspelling has that text_name")
+  end
+
   def test_returns_nil_when_no_mo_match
     assert_not(Name.exists?(text_name: "Calostoma lutescens"),
                "Test needs iNat taxon without an MO matching Name")

--- a/test/classes/inat_taxon_test.rb
+++ b/test/classes/inat_taxon_test.rb
@@ -248,7 +248,7 @@ class InatTaxonTest < UnitTestCase
   end
 
   def test_maps_inat_infrageneric_to_mo_misspelled_name
-    correct = Name.create(
+    correct = Name.create!(
       user: rolf, rank: "Subsection",
       text_name: "Leccinum subsect. Scabri",
       search_name: "Leccinum subsect. Scabri",
@@ -256,7 +256,7 @@ class InatTaxonTest < UnitTestCase
       sort_name: "Leccinum  {3subsect.  Scabri",
       author: ""
     )
-    misspelling = Name.create(
+    misspelling = Name.create!(
       user: rolf, rank: "Subsection",
       text_name: "Leccinum subsect. Scabra",
       search_name: "Leccinum subsect. Scabra",

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -429,7 +429,7 @@ class InatImportJobTest < ActiveJob::TestCase
     assert(name.rss_log_id.present?,
            "Failed to log creation of provisional name")
 
-    # iNat Community ID + the provisional name (lead) -> two namings.
+    # iNat Observation Taxon + the provisional name (lead) -> two namings.
     standard_assertions(obs: obs, name: name, naming_count: 2)
 
     proposed_name = obs.namings.first
@@ -532,7 +532,7 @@ class InatImportJobTest < ActiveJob::TestCase
       "It should create only 3 names: provisional, its genus, suggested ID"
     )
 
-    # iNat Community ID + the provisional name (lead) -> two namings.
+    # iNat Observation Taxon + the provisional name (lead) -> two namings.
     standard_assertions(obs: obs, name: expected_consensus, naming_count: 2)
 
     assert(obs.sequences.one?, "Obs should have one sequence")


### PR DESCRIPTION
Resolves #4578, a bug exposed by @dwmccheyne's recent bulk import. 

Removes `correct_spelling_id: nil` from `Inat::Taxon#matching_names_at_regular_ranks` so that a misspelled Name is returned when it is the only MO Name whose `text_name` matches the parsed iNat taxon name. Previously the lookup excluded misspellings, found nothing, then tried to create a new Name — which failed because `API2::NameAlreadyExists` fires on any existing Name with that `text_name`, misspelling or not.

The Naming now faithfully records the iNat identification (the misspelled name), while `ConsensusCalculator` automatically follows `correct_spelling` to set the observation's consensus name to the MO-preferred spelling.

###  Manual Test

- [x] Import an iNat obs whose leading ID is misspelt 
(I only know of one misspelt name, https://www.inaturalist.org/taxa/1397470-Scabra)
Example obs iwth that name: https://www.inaturalist.org/observations/135189450)
- Expected result: 
  - MO Consensus is the correct spelling.
  - MO Proposed Names include the misspelling
  - MO Proposed Names include the correct spelling with an indication that it's a correction.

> [!NOTE]
> It's possible that iNat will correct the spelling (an orthographic variant) while this PR is pending.