### PR TITLE
Ignore invalid q[model] params instead of 500ing

### DIFF
--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -261,6 +261,10 @@ module ApplicationController::Queries
   def query_from_q_param_hash
     q_param = params[:q]
     return query_from_session if q_param.is_a?(String)
+    # `q` can arrive as an Array (`?q[]=x`) or other non-hash from crafted
+    # requests; only a Parameters hash carries a model + the lookup fields,
+    # and `q_param[:model]` on an Array would raise a TypeError -> 500.
+    return nil unless q_param.is_a?(ActionController::Parameters)
 
     return nil if q_param[:model].blank?
     # `model` is attacker-reachable and gets constantized in
@@ -271,11 +275,6 @@ module ApplicationController::Queries
 
     Query.lookup(q_param[:model].to_sym,
                  **q_param.except(:model).to_unsafe_hash.symbolize_keys)
-  end
-
-  def valid_query_model?(model)
-    klass = "Query::#{model.to_s.pluralize}".safe_constantize
-    klass.is_a?(Class) && klass < Query
   end
 
   # Add a :q param to a path helper like `names_path`,
@@ -295,6 +294,12 @@ module ApplicationController::Queries
   # helper_method :add_q_param
 
   private
+
+  # Internal to query_from_q_param_hash: true only for a real Query subclass.
+  def valid_query_model?(model)
+    klass = "Query::#{model.to_s.pluralize}".safe_constantize
+    klass.is_a?(Class) && klass < Query
+  end
 
   def append_q_param_to_path(path, q_param)
     return path unless q_param

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -263,9 +263,19 @@ module ApplicationController::Queries
     return query_from_session if q_param.is_a?(String)
 
     return nil if q_param[:model].blank?
+    # `model` is attacker-reachable and gets constantized in
+    # Query.create_query, so ignore anything that isn't a real Query subclass.
+    # Scanners probe this param with injection payloads, which otherwise raise
+    # `NameError: wrong constant name ...` and 500.
+    return nil unless valid_query_model?(q_param[:model])
 
     Query.lookup(q_param[:model].to_sym,
                  **q_param.except(:model).to_unsafe_hash.symbolize_keys)
+  end
+
+  def valid_query_model?(model)
+    klass = "Query::#{model.to_s.pluralize}".safe_constantize
+    klass.is_a?(Class) && klass < Query
   end
 
   # Add a :q param to a path helper like `names_path`,

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -40,6 +40,19 @@ class ArticlesControllerTest < FunctionalTestCase
     assert_flash_error(:runtime_no_matches.t(type: :article))
   end
 
+  # A scanner probing q[model] with an injection payload used to 500
+  # (NameError: wrong constant name) in Query.create_query. The bad model is
+  # now ignored and the index renders normally.
+  def test_index_ignores_invalid_q_model
+    get(:index, params: { q: { model: %q{Article',).)"(,,,},
+                               order_by: "created_at" } })
+    assert_response(:success)
+
+    # an unknown but syntactically-valid model name is ignored too
+    get(:index, params: { q: { model: "Bogus", order_by: "created_at" } })
+    assert_response(:success)
+  end
+
   def test_index_links_to_create
     login(users(:article_writer).login)
     get(:index)

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -51,6 +51,10 @@ class ArticlesControllerTest < FunctionalTestCase
     # an unknown but syntactically-valid model name is ignored too
     get(:index, params: { q: { model: "Bogus", order_by: "created_at" } })
     assert_response(:success)
+
+    # a non-hash q (e.g. ?q[]=x) is ignored rather than raising a TypeError
+    get(:index, params: { q: ["x"] })
+    assert_response(:success)
   end
 
   def test_index_links_to_create


### PR DESCRIPTION
## Summary

Fixes the `NameError: wrong constant name …` 500s reported in #alerts (two this evening, from a vulnerability scanner probing `/articles?...&q[model]=…`).

The `model` of a `q` hash param is attacker-reachable and gets constantized in `Query.create_query`:

```ruby
"Query::#{model.to_s.pluralize}".constantize
```

A scanner sending an injection payload — e.g. `q[model]=Article',).)"(,,,` (SQLi-style) or `q[model]=Article'nEOtRZ<'">ntXcDq` (XSS-style) — turns that into `"Query::Article',).)\"(,,,s".constantize`, which raises `NameError: wrong constant name …`. It's uncaught, so each probe is a 500 plus an exception-notification post. No data is exposed (nothing reaches SQL/HTML — it blows up at `constantize`); it's just noise + a 500 where a normal render is correct, and it affects **every** index that accepts a `q[model]` hash.

## Fix

`query_from_q_param_hash` now ignores a `q[model]` that doesn't resolve to a real `Query` subclass:

```ruby
return nil unless valid_query_model?(q_param[:model])

def valid_query_model?(model)
  klass = "Query::#{model.to_s.pluralize}".safe_constantize
  klass.is_a?(Class) && klass < Query
end
```

`safe_constantize` returns `nil` for both the injection garbage ("wrong constant name") and an unknown-but-valid name ("uninitialized constant"), so the bad param is simply dropped and the index renders its default listing. This is the boundary where the param enters the app, so the one change covers all `q[model]`-accepting indexes. Legitimate `q` params are unaffected (`model: "Article"` → `Query::Articles < Query` → kept).

## Test plan

- [x] New `ArticlesControllerTest#test_index_ignores_invalid_q_model` — both an injection payload and an unknown-but-valid model name return 200 instead of raising.
- [x] `bin/rails test test/controllers/articles_controller_test.rb` (11 runs, 0 failures); `test_index_filtered` still confirms real `q` params work.

## Follow-up (optional, not in this PR)

Could also filter `NameError: wrong constant name` out of exception_notification so any future constantize path doesn't spam #alerts — but the boundary fix is the real fix.
