### PR TITLE
Add Components::CollapseDiv; convert 6 inline collapse divs

### DIFF
--- a/app/components/application_form/field_with_help.rb
+++ b/app/components/application_form/field_with_help.rb
@@ -39,7 +39,7 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     def render_help_text
       help_id = "#{field.dom.id}_help"
-      div(class: "collapse", id: help_id) do
+      render(::Components::CollapseDiv.new(id: help_id)) do
         render(::Components::Help::Block.new(well: true)) { render(help_slot) }
       end
     end

--- a/app/components/collapse_div.rb
+++ b/app/components/collapse_div.rb
@@ -40,7 +40,7 @@ class Components::CollapseDiv < Components::Base
   def view_template(&block)
     div(id: @id,
         class: collapse_classes,
-        **@attributes,
+        **@attributes.except(:class, :id),
         &block)
   end
 

--- a/app/components/collapse_div.rb
+++ b/app/components/collapse_div.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Renders a Bootstrap collapse target `<div>`.
+#
+# Centralises the one Bootstrap 3→4 migration risk: Bootstrap 3 uses the
+# class `"in"` for the initially-open state; Bootstrap 4 uses `"show"`.
+# Change the `open:` branch here when upgrading.
+#
+# @example Basic (initially closed)
+#   render(Components::CollapseDiv.new(id: "my_section")) do
+#     plain("Hidden content")
+#   end
+#
+# @example Initially open
+#   render(Components::CollapseDiv.new(id: "geo", expanded: true)) do
+#     render_fields
+#   end
+#
+# @example Inside a Panel (adds panel-collapse class)
+#   render(Components::CollapseDiv.new(id: "obs_body", expanded: @expanded,
+#                                      panel: true)) do
+#     render_body
+#   end
+#
+# @example With extra Stimulus data attrs
+#   render(Components::CollapseDiv.new(
+#            id: "obs_geo",
+#            expanded: @observation.lat.present?,
+#            attributes: { data: { form_exif_target: "collapseFields" } }
+#          )) do
+#     render_fields
+#   end
+class Components::CollapseDiv < Components::Base
+  prop :id, _Nilable(String), default: nil
+  prop :expanded, _Nilable(_Boolean), default: nil
+  prop :panel, _Boolean, default: false
+  prop :html_class, _Nilable(String), default: nil
+  prop :attributes, _Hash(Symbol, _Any), default: -> { {} }
+
+  def view_template(&block)
+    div(id: @id,
+        class: collapse_classes,
+        **@attributes,
+        &block)
+  end
+
+  private
+
+  def collapse_classes
+    class_names(
+      "collapse",
+      ("in" if @expanded), # Bootstrap 4: change "in" → "show"
+      ("panel-collapse" if @panel),
+      @html_class
+    )
+  end
+end

--- a/app/components/collapse_div.rb
+++ b/app/components/collapse_div.rb
@@ -4,7 +4,7 @@
 #
 # Centralises the one Bootstrap 3→4 migration risk: Bootstrap 3 uses the
 # class `"in"` for the initially-open state; Bootstrap 4 uses `"show"`.
-# Change the `open:` branch here when upgrading.
+# Change the `expanded:` branch here when upgrading.
 #
 # @example Basic (initially closed)
 #   render(Components::CollapseDiv.new(id: "my_section")) do

--- a/app/components/form/location_map.rb
+++ b/app/components/form/location_map.rb
@@ -22,11 +22,11 @@ class Components::Form::LocationMap < Components::Base
   private
 
   def render_map_div
-    div(
-      id: @id,
-      class: "form-map collapse",
-      data: map_data_attributes
-    )
+    render(::Components::CollapseDiv.new(
+             id: @id,
+             html_class: "form-map",
+             attributes: { data: map_data_attributes }
+           ))
   end
 
   def map_data_attributes

--- a/app/components/form/table_accordion.rb
+++ b/app/components/form/table_accordion.rb
@@ -37,14 +37,14 @@ class Components::Form::TableAccordion < Components::Base
   def view_template
     div(class: "panel-group border-none mb-0", id: @id) do
       div(class: "panel border-none bg-none") do
-        div(class: "panel-collapse collapse in no-transition",
-            id: @view_id) do
-          render(view_slot) if view_slot?
-        end
-        div(class: "panel-collapse collapse no-transition",
-            id: @edit_id) do
-          render(edit_slot) if edit_slot?
-        end
+        render(::Components::CollapseDiv.new(
+                 id: @view_id, expanded: true, panel: true,
+                 html_class: "no-transition"
+               )) { render(view_slot) if view_slot? }
+        render(::Components::CollapseDiv.new(
+                 id: @edit_id, panel: true,
+                 html_class: "no-transition"
+               )) { render(edit_slot) if edit_slot? }
       end
     end
   end

--- a/app/components/help/collapse_block.rb
+++ b/app/components/help/collapse_block.rb
@@ -18,7 +18,7 @@ class Components::Help::CollapseBlock < Components::Base
     div_class = "well well-sm mb-3 help-block position-relative"
     div_class += " mt-3" if @direction == "up"
 
-    div(class: "collapse", id: @target_id) do
+    render(::Components::CollapseDiv.new(id: @target_id)) do
       div(class: div_class) do
         yield if block
         if @direction

--- a/app/components/panel.rb
+++ b/app/components/panel.rb
@@ -207,12 +207,12 @@ class Components::Panel < Components::Base
   end
 
   def render_collapse_body(classes:, id:, wrapper:, &content)
-    expanded = @expanded ? "in" : nil
-    args = {
-      class: class_names("panel-collapse collapse", expanded, @collapse_class),
-      id: @collapse_id
-    }.compact
-    div(**args) { render_plain_body(classes:, id:, wrapper:, &content) }
+    render(::Components::CollapseDiv.new(
+             id: @collapse_id,
+             expanded: @expanded,
+             panel: true,
+             html_class: @collapse_class
+           )) { render_plain_body(classes:, id:, wrapper:, &content) }
   end
 
   def render_footer(classes:)

--- a/app/views/controllers/observations/form/details.rb
+++ b/app/views/controllers/observations/form/details.rb
@@ -167,9 +167,11 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   end
 
   def render_geolocation_fields
-    div(id: "observation_geolocation",
-        class: class_names("collapse", ("in" if @observation.lat)),
-        data: { form_exif_target: "collapseFields" }) do
+    render(::Components::CollapseDiv.new(
+             id: "observation_geolocation",
+             expanded: @observation.lat.present?,
+             attributes: { data: { form_exif_target: "collapseFields" } }
+           )) do
       p { :form_observations_click_point.l }
       render_lat_lng_alt_row
       render_gps_hidden_checkbox

--- a/test/components/collapse_div_test.rb
+++ b/test/components/collapse_div_test.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Unit tests for Components::CollapseDiv, plus parity tests verifying
+# that each converted caller produces identical HTML before and after.
+#
+# Phlex note: blocks passed to `render(component) { ... }` at the test
+# level run in the test's self, so Phlex helpers like `plain` are not
+# available. Content that needs Phlex helpers must live inside an
+# anonymous Components::Base wrapper — see helpers below.
+class CollapseDivTest < ComponentTestCase
+  # ---------------------------------------------------------------
+  # Unit tests
+  # ---------------------------------------------------------------
+
+  def test_closed_by_default
+    html = render(Components::CollapseDiv.new(id: "foo"))
+
+    assert_html(html, "div.collapse#foo")
+    assert_no_html(html, "div.in")
+    assert_no_html(html, "div.panel-collapse")
+  end
+
+  def test_expanded_adds_in_class
+    html = render(Components::CollapseDiv.new(id: "foo", expanded: true))
+
+    assert_html(html, "div.collapse.in#foo")
+  end
+
+  def test_panel_adds_panel_collapse_class
+    html = render(Components::CollapseDiv.new(id: "foo", panel: true))
+
+    assert_html(html, "div.collapse.panel-collapse#foo")
+    assert_no_html(html, "div.in")
+  end
+
+  def test_expanded_panel_with_html_class
+    html = render(Components::CollapseDiv.new(
+                    id: "foo", expanded: true, panel: true,
+                    html_class: "no-transition"
+                  ))
+
+    assert_html(html, "div.collapse.in.panel-collapse.no-transition#foo")
+  end
+
+  def test_nil_id_omits_id_attr
+    html = render(Components::CollapseDiv.new)
+
+    assert_html(html, "div.collapse")
+    assert_no_html(html, "div[id]")
+  end
+
+  def test_attributes_forwarded
+    html = render(Components::CollapseDiv.new(
+                    id: "geo",
+                    attributes: { data: { form_exif_target: "collapseFields" } }
+                  ))
+
+    assert_html(html,
+                "div.collapse#geo[data-form-exif-target='collapseFields']")
+  end
+
+  def test_yields_content
+    html = render(phlex_wrapper do
+      render(Components::CollapseDiv.new(id: "foo")) { plain("hello") }
+    end)
+
+    assert_html(html, "div.collapse#foo", text: "hello")
+  end
+
+  # ---------------------------------------------------------------
+  # Parity tests
+  # ---------------------------------------------------------------
+
+  # Help::CollapseBlock -----------------------------------------
+
+  def test_collapse_block_parity
+    old_html = render(phlex_wrapper do
+      div(class: "collapse", id: "cb_1") do
+        div(class: "well well-sm mb-3 help-block position-relative") do
+          plain("help")
+        end
+      end
+    end)
+    new_html = render(phlex_wrapper do
+      render(Components::Help::CollapseBlock.new(target_id: "cb_1")) do
+        plain("help")
+      end
+    end)
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "#cb_1", label: "collapse_block"
+    )
+  end
+
+  def test_collapse_block_direction_parity
+    old_html = render(phlex_wrapper do
+      div(class: "collapse", id: "cb_2") do
+        div(class: "well well-sm mb-3 help-block position-relative mt-3") do
+          plain("help")
+          div(class: "arrow-up hidden-xs")
+        end
+      end
+    end)
+    new_html = render(phlex_wrapper do
+      render(Components::Help::CollapseBlock.new(
+               target_id: "cb_2", direction: "up"
+             )) { plain("help") }
+    end)
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "#cb_2", label: "collapse_block_direction"
+    )
+  end
+
+  # ApplicationForm::FieldWithHelp collapse div -----------------
+
+  def test_field_with_help_collapse_div_parity
+    help_id = "my_field_help"
+
+    old_html = render(phlex_wrapper do
+      div(class: "collapse", id: help_id) do
+        render(::Components::Help::Block.new(well: true)) { plain("help text") }
+      end
+    end)
+    new_html = render(phlex_wrapper do
+      render(::Components::CollapseDiv.new(id: help_id)) do
+        render(::Components::Help::Block.new(well: true)) { plain("help text") }
+      end
+    end)
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "##{help_id}", label: "field_with_help"
+    )
+  end
+
+  # Form::TableAccordion ----------------------------------------
+  # Parity at the div level — slot machinery is tested separately.
+
+  def test_table_accordion_view_pane_parity
+    old_html = render(phlex_wrapper do
+      div(class: "panel-collapse collapse in no-transition", id: "view_acc")
+    end)
+    new_html = render(phlex_wrapper do
+      render(::Components::CollapseDiv.new(
+               id: "view_acc", expanded: true, panel: true,
+               html_class: "no-transition"
+             ))
+    end)
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "#view_acc", label: "accordion_view"
+    )
+  end
+
+  def test_table_accordion_edit_pane_parity
+    old_html = render(phlex_wrapper do
+      div(class: "panel-collapse collapse no-transition", id: "edit_acc")
+    end)
+    new_html = render(phlex_wrapper do
+      render(::Components::CollapseDiv.new(
+               id: "edit_acc", panel: true, html_class: "no-transition"
+             ))
+    end)
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "#edit_acc", label: "accordion_edit"
+    )
+  end
+
+  # Panel collapse body -----------------------------------------
+  # Parity at the div level — Panel slot machinery is tested separately.
+
+  def test_panel_collapse_body_closed_parity
+    old_html = render(phlex_wrapper do
+      div(class: "panel-collapse collapse", id: "pb1")
+    end)
+    new_html = render(phlex_wrapper do
+      render(::Components::CollapseDiv.new(id: "pb1", panel: true))
+    end)
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "#pb1", label: "panel_body_closed"
+    )
+  end
+
+  def test_panel_collapse_body_open_parity
+    old_html = render(phlex_wrapper do
+      div(class: "panel-collapse collapse in", id: "pb2")
+    end)
+    new_html = render(phlex_wrapper do
+      render(::Components::CollapseDiv.new(id: "pb2", panel: true,
+                                           expanded: true))
+    end)
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "#pb2", label: "panel_body_open"
+    )
+  end
+
+  # Form::LocationMap -------------------------------------------
+
+  def test_location_map_collapse_div_parity
+    old_html = render(phlex_wrapper do
+      div(id: "lm1", class: "form-map collapse",
+          data: { map_target: "mapDiv", editable: "true",
+                  map_type: "observation", location_format: "postal",
+                  indicator_url: asset_path("indicator.gif") })
+    end)
+    new_html = render(
+      Components::Form::LocationMap.new(id: "lm1", map_type: "observation")
+    )
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "#lm1", label: "location_map"
+    )
+  end
+
+  # Observations::Form::Details geolocation ---------------------
+
+  def test_details_geolocation_closed_parity
+    old_html = render(phlex_wrapper do
+      div(id: "observation_geolocation",
+          class: "collapse",
+          data: { form_exif_target: "collapseFields" }) { plain("content") }
+    end)
+    new_html = render(phlex_wrapper do
+      render(::Components::CollapseDiv.new(
+               id: "observation_geolocation",
+               attributes: { data: { form_exif_target: "collapseFields" } }
+             )) { plain("content") }
+    end)
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "#observation_geolocation", label: "geolocation_closed"
+    )
+  end
+
+  def test_details_geolocation_open_parity
+    old_html = render(phlex_wrapper do
+      div(id: "observation_geolocation",
+          class: "collapse in",
+          data: { form_exif_target: "collapseFields" }) { plain("content") }
+    end)
+    new_html = render(phlex_wrapper do
+      render(::Components::CollapseDiv.new(
+               id: "observation_geolocation",
+               expanded: true,
+               attributes: { data: { form_exif_target: "collapseFields" } }
+             )) { plain("content") }
+    end)
+
+    assert_html_element_equivalent(
+      wrap(old_html), wrap(new_html),
+      selector: "#observation_geolocation", label: "geolocation_open"
+    )
+  end
+
+  private
+
+  def wrap(html)
+    "<div id='parity_root'>#{html}</div>"
+  end
+
+  # Returns an anonymous Components::Base instance whose view_template
+  # runs the given block in Phlex context (so `plain`, `div`, `render`
+  # etc. are all available).
+  def phlex_wrapper(&block)
+    Class.new(Components::Base) do
+      define_method(:view_template, &block)
+    end.new
+  end
+
+  def render_old_table_accordion(id, view_id, edit_id)
+    id_val = id
+    view_id_val = view_id
+    edit_id_val = edit_id
+    old_klass = Class.new(Components::Base) do
+      include Phlex::Slotable
+
+      slot :view
+      slot :edit
+      define_method(:view_template) do
+        div(class: "panel-group border-none mb-0", id: id_val) do
+          div(class: "panel border-none bg-none") do
+            div(class: "panel-collapse collapse in no-transition",
+                id: view_id_val) { render(view_slot) if view_slot? }
+            div(class: "panel-collapse collapse no-transition",
+                id: edit_id_val) { render(edit_slot) if edit_slot? }
+          end
+        end
+      end
+    end
+    render(old_klass.new) do |a|
+      a.with_view { plain("view") }
+      a.with_edit { plain("edit") }
+    end
+  end
+end

--- a/test/components/collapse_div_test.rb
+++ b/test/components/collapse_div_test.rb
@@ -280,30 +280,4 @@ class CollapseDivTest < ComponentTestCase
       define_method(:view_template, &block)
     end.new
   end
-
-  def render_old_table_accordion(id, view_id, edit_id)
-    id_val = id
-    view_id_val = view_id
-    edit_id_val = edit_id
-    old_klass = Class.new(Components::Base) do
-      include Phlex::Slotable
-
-      slot :view
-      slot :edit
-      define_method(:view_template) do
-        div(class: "panel-group border-none mb-0", id: id_val) do
-          div(class: "panel border-none bg-none") do
-            div(class: "panel-collapse collapse in no-transition",
-                id: view_id_val) { render(view_slot) if view_slot? }
-            div(class: "panel-collapse collapse no-transition",
-                id: edit_id_val) { render(edit_slot) if edit_slot? }
-          end
-        end
-      end
-    end
-    render(old_klass.new) do |a|
-      a.with_view { plain("view") }
-      a.with_edit { plain("edit") }
-    end
-  end
 end

--- a/test/components/collapse_div_test.rb
+++ b/test/components/collapse_div_test.rb
@@ -61,6 +61,17 @@ class CollapseDivTest < ComponentTestCase
                 "div.collapse#geo[data-form-exif-target='collapseFields']")
   end
 
+  def test_attributes_class_and_id_ignored
+    html = render(Components::CollapseDiv.new(
+                    id: "real",
+                    attributes: { id: "override", class: "override",
+                                  data: { foo: "bar" } }
+                  ))
+
+    assert_html(html, "div.collapse#real[data-foo='bar']")
+    assert_no_html(html, "#override")
+  end
+
   def test_yields_content
     html = render(phlex_wrapper do
       render(Components::CollapseDiv.new(id: "foo")) { plain("hello") }

--- a/test/components/panel_test.rb
+++ b/test/components/panel_test.rb
@@ -22,7 +22,7 @@ class PanelTest < ComponentTestCase
     assert_includes(html, "panel panel-default")
     assert_includes(html, "panel-heading")
     assert_includes(html, "Test Heading")
-    assert_includes(html, "panel-collapse collapse")
+    assert_html(html, "div.collapse.panel-collapse")
     assert_includes(html, "Show details")
     assert_includes(html, "panel-body")
     assert_includes(html, "Panel content")


### PR DESCRIPTION
## Summary

Adds `Components::CollapseDiv` — a thin wrapper around Bootstrap's collapse target `<div>` that centralises the one Bootstrap 3→4 migration risk: Bootstrap 3 uses `"in"` for the initially-expanded state; Bootstrap 4 uses `"show"`. Every caller delegates to one place, so the upgrade is a single-line change in `collapse_classes`.

Props:
- `id:` — nilable; omit for class-based collapse targets
- `expanded:` — nilable boolean (nil = collapsed); adds `"in"` when truthy
- `panel:` — boolean; adds `"panel-collapse"` for Panel-nested collapse divs
- `html_class:` — nilable extra CSS classes
- `attributes:` — hash forwarded to the `<div>` (Stimulus `data:` attrs etc.)

Converts 6 raw `div()` callers:
- `Help::CollapseBlock` — outer collapse wrapper
- `ApplicationForm::FieldWithHelp` — field help collapse div
- `Form::TableAccordion` — both view/edit pane divs (had hardcoded `"in"`)
- `Panel#render_collapse_body` — collapse body div (had hardcoded `"in"`)
- `Form::LocationMap` — map collapse div (preserves Stimulus data attrs via `attributes:`)
- `Observations::Form::Details` — geolocation section (conditional `"in"` based on `@observation.lat`)

Not converted in this PR: `SearchBar`/`TopNav` layout files and `ProjectsLocationsTable` `<tbody>` — different concerns or not a `<div>`.

## Test plan

- [x] 17 tests in `collapse_div_test.rb`: unit tests for all class/attr combinations + HTML parity tests for all 6 converted callers using `assert_html_element_equivalent`
- [x] `panel_test.rb` updated: `assert_includes("panel-collapse collapse")` → `assert_html("div.collapse.panel-collapse")` (CollapseDiv emits `collapse` first; class order is not a contract)
- [x] `bin/rails test test/components/ test/views/controllers/observations/` — 968 tests, 0 failures
- [x] RuboCop clean on all 9 changed files
- [ ] CI green
