### PR TITLE
Add ignored iNat IDs report

### DIFF
--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -64,6 +64,10 @@ class Inat
       without_field: "Mushroom Observer URL"
     }.freeze
 
+    # A work-around because iNat has no "has a date" filter;
+    # an arbitrarily early d1 approximates it.
+    EARLIEST_DATE_FILTER = "1000-01-01"
+
     # Added when importing others' observations (superimporter, not own).
     # Own-observation imports accept unlicensed obs and apply the user's
     # default MO license to any unlicensed images.

--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -67,14 +67,7 @@ class Inat
     # Added when importing others' observations (superimporter, not own).
     # Own-observation imports accept unlicensed obs and apply the user's
     # default MO license to any unlicensed images.
-    #
-    # The iNat API `licensed` param returns true if the observation
-    # license_code is null. So we have to use this filter to get the count of
-    # observations that are licensed, and subtract from total to get the
-    # unlicensed count.
-    LICENSED_FILTER =
-      { license: "cc0,cc-by,cc-by-nc,cc-by-nd,cc-by-nc-nd," \
-                 "cc-by-sa,cc-by-nc-sa" }.freeze
+    LICENSED_FILTER = { licensed: true }.freeze
 
     # Kept for backwards compatibility; some callers may still reference this.
     IMPORT_FILTER_PARAMS = BASE_FILTER_PARAMS.merge(LICENSED_FILTER).freeze

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -46,6 +46,7 @@ class Inat
       return false if @inat_obs.taxon_importable?
 
       log_with_response_error("Skipped #{@inat_obs[:id]} not importable")
+      inat_import.add_ignored_obs(:not_importable)
       true
     end
 
@@ -55,6 +56,7 @@ class Inat
       log_with_response_error(
         "Skipped #{@inat_obs[:id]} #{:inat_observed_missing_date.l}"
       )
+      inat_import.add_ignored_obs(:date_missing)
       true
     end
 
@@ -74,6 +76,7 @@ class Inat
       )
 
       log("Skipped #{@inat_obs[:id]} already imported")
+      inat_import.add_ignored_obs(:already_imported)
       true
     end
 

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -106,16 +106,16 @@ class InatImportsController < ApplicationController
   private
 
   def confirm_import
-    @estimate = fetch_import_estimate
-    return inat_unreachable if @estimate.nil?
-    return reload_form if @estimate == false
+    @expected = fetch_expected_count
+    return inat_unreachable if @expected.nil?
+    return reload_form if @expected == false
 
     fetch_confirm_counts
     warn_about_listed_previous_imports
     @inat_import = InatImport.find_or_create_by(user: @user)
     @confirm_form = build_confirm_form
     render(Views::Controllers::InatImports::Confirm.new(
-             confirm_form: @confirm_form, estimate: @estimate,
+             confirm_form: @confirm_form, expected: @expected,
              unlicensed_obs: @unlicensed_obs, inat_import: @inat_import,
              requested: @requested, after_taxon: @after_taxon,
              estimate_with_date: @estimate_with_date

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -110,18 +110,27 @@ class InatImportsController < ApplicationController
     return inat_unreachable if @estimate.nil?
     return reload_form if @estimate == false
 
-    @unlicensed_obs = if import_others?
-                        fetch_unlicensed_others_count
-                      else
-                        fetch_unlicensed_obs_count
-                      end
+    fetch_confirm_counts
     warn_about_listed_previous_imports
     @inat_import = InatImport.find_or_create_by(user: @user)
     @confirm_form = build_confirm_form
     render(Views::Controllers::InatImports::Confirm.new(
              confirm_form: @confirm_form, estimate: @estimate,
-             unlicensed_obs: @unlicensed_obs, inat_import: @inat_import
+             unlicensed_obs: @unlicensed_obs, inat_import: @inat_import,
+             requested: @requested, after_taxon: @after_taxon,
+             estimate_with_date: @estimate_with_date
            ))
+  end
+
+  def fetch_confirm_counts
+    @unlicensed_obs = if import_others?
+                        fetch_unlicensed_others_count
+                      else
+                        fetch_unlicensed_obs_count
+                      end
+    @requested = fetch_raw_requested_count
+    @after_taxon = fetch_after_taxon_count
+    @estimate_with_date = fetch_estimate_with_date_count
   end
 
   def inat_unreachable

--- a/app/controllers/inat_imports_controller/estimators.rb
+++ b/app/controllers/inat_imports_controller/estimators.rb
@@ -28,29 +28,28 @@ module InatImportsController::Estimators
   end
 
   # Counts unlicensed observations for the own-observations case.
-  # Total minus licensed gives the unlicensed count via two fast
-  # only_id queries.
   def fetch_unlicensed_obs_count
-    licensed = RestClient.get(
-      "#{API_BASE}/observations?#{licensed_estimate_query_args.to_query}",
+    response = RestClient.get(
+      "#{API_BASE}/observations?" \
+      "#{import_estimate_query_args.merge(licensed: false).to_query}",
       { accept: :json, open_timeout: 5, timeout: 10 }
     )
-    @expected - JSON.parse(licensed.body)["total_results"]
+    JSON.parse(response.body)["total_results"]
   rescue RestClient::Exception, JSON::ParserError => e
     Rails.logger.warn(
-      "iNat licensed count request failed: #{e.class}: #{e.message}"
+      "iNat unlicensed count request failed: #{e.class}: #{e.message}"
     )
     nil
   end
 
   # Counts unlicensed observations that will be skipped for import-others.
-  # @expected is already licensed-only; total minus @expected = unlicensed.
   def fetch_unlicensed_others_count
-    total = RestClient.get(
-      "#{API_BASE}/observations?#{total_others_estimate_query_args.to_query}",
+    response = RestClient.get(
+      "#{API_BASE}/observations?" \
+      "#{total_others_estimate_query_args.merge(licensed: false).to_query}",
       { accept: :json, open_timeout: 5, timeout: 10 }
     )
-    JSON.parse(total.body)["total_results"] - @expected
+    JSON.parse(response.body)["total_results"]
   rescue RestClient::Exception, JSON::ParserError => e
     Rails.logger.warn(
       "iNat unlicensed-others count request failed: #{e.class}: #{e.message}"
@@ -89,12 +88,14 @@ module InatImportsController::Estimators
     nil
   end
 
-  # Count of importable observations that HAVE a date (estimate query +
-  # d1=1800-01-01). Diff vs @expected gives the no-date count.
+  # Count of importable observations that HAVE a date
+  # Diff vs @expected gives the no-date count.
   def fetch_estimate_with_date_count
     RestClient.get(
+      # iNat API does not support a without_observation_date filter,
+      # so use an arbitrarily early date to get a workable estimate.
       "#{API_BASE}/observations?" \
-      "#{import_estimate_query_args.merge(d1: "1800-01-01").to_query}",
+      "#{import_estimate_query_args.merge(d1: "1000-01-01").to_query}",
       { accept: :json, open_timeout: 5, timeout: 10 }
     ).then { |r| JSON.parse(r.body)["total_results"] }
   rescue RestClient::Exception, JSON::ParserError => e
@@ -125,10 +126,6 @@ module InatImportsController::Estimators
     end
     args[:id] = params[:inat_ids] if listing_ids?
     args
-  end
-
-  def licensed_estimate_query_args
-    import_estimate_query_args.merge(LICENSED_FILTER)
   end
 
   # Strip MO-controlled params so estimates match actual import behavior.

--- a/app/controllers/inat_imports_controller/estimators.rb
+++ b/app/controllers/inat_imports_controller/estimators.rb
@@ -91,11 +91,12 @@ module InatImportsController::Estimators
   # Count of importable observations that HAVE a date
   # Diff vs @expected gives the no-date count.
   def fetch_estimate_with_date_count
+    # iNat has no "without date" filter; EARLIEST_DATE_FILTER approximates it.
+    # Preserve a user-supplied d1 — it already excludes undated obs.
+    args = import_estimate_query_args
+    args[:d1] ||= EARLIEST_DATE_FILTER
     RestClient.get(
-      # iNat API does not support a without_observation_date filter,
-      # so use an arbitrarily early date to get a workable estimate.
-      "#{API_BASE}/observations?" \
-      "#{import_estimate_query_args.merge(d1: "1000-01-01").to_query}",
+      "#{API_BASE}/observations?#{args.to_query}",
       { accept: :json, open_timeout: 5, timeout: 10 }
     ).then { |r| JSON.parse(r.body)["total_results"] }
   rescue RestClient::Exception, JSON::ParserError => e

--- a/app/controllers/inat_imports_controller/estimators.rb
+++ b/app/controllers/inat_imports_controller/estimators.rb
@@ -56,6 +56,52 @@ module InatImportsController::Estimators
     nil
   end
 
+  # Count without any MO-added filters — just the user's own scope
+  # (ownership + their IDs/URL). Used to compute "Requested Observations"
+  # and derive the ignored-obs breakdown on the confirmation page.
+  def fetch_raw_requested_count
+    RestClient.get(
+      "#{API_BASE}/observations?#{raw_requested_query_args.to_query}",
+      { accept: :json, open_timeout: 5, timeout: 10 }
+    ).then { |r| JSON.parse(r.body)["total_results"] }
+  rescue RestClient::Exception, JSON::ParserError => e
+    Rails.logger.warn(
+      "iNat raw-requested count failed: #{e.class}: #{e.message}"
+    )
+    nil
+  end
+
+  # Count after applying MO's fungi/myxo taxon filter but before
+  # `without_field` (already-imported filter) or license filter.
+  # Together with @estimate and @unlicensed_obs this lets us derive
+  # the already-imported and not-importable sub-counts.
+  def fetch_after_taxon_count
+    RestClient.get(
+      "#{API_BASE}/observations?#{after_taxon_query_args.to_query}",
+      { accept: :json, open_timeout: 5, timeout: 10 }
+    ).then { |r| JSON.parse(r.body)["total_results"] }
+  rescue RestClient::Exception, JSON::ParserError => e
+    Rails.logger.warn(
+      "iNat after-taxon count failed: #{e.class}: #{e.message}"
+    )
+    nil
+  end
+
+  # Count of importable observations that HAVE a date (estimate query +
+  # d1=1800-01-01). Diff vs @estimate gives the no-date count.
+  def fetch_estimate_with_date_count
+    RestClient.get(
+      "#{API_BASE}/observations?" \
+      "#{import_estimate_query_args.merge(d1: "1800-01-01").to_query}",
+      { accept: :json, open_timeout: 5, timeout: 10 }
+    ).then { |r| JSON.parse(r.body)["total_results"] }
+  rescue RestClient::Exception, JSON::ParserError => e
+    Rails.logger.warn(
+      "iNat date-estimate count failed: #{e.class}: #{e.message}"
+    )
+    nil
+  end
+
   # Total obs count for import-others without a license filter,
   # used to derive how many will be skipped.
   def total_others_estimate_query_args
@@ -89,5 +135,26 @@ module InatImportsController::Estimators
   def url_query_args
     strip = Inat::URLNormalizer::STRIP_PARAMS.map(&:to_sym)
     Rack::Utils.parse_query(params[:inat_url].to_s).symbolize_keys.except(*strip)
+  end
+
+  # No MO-added filters: just the user's scope (IDs/URL + ownership).
+  # Used for the "Requested Observations" count on the confirm page.
+  def raw_requested_query_args
+    args = listing_url? ? url_query_args : {}
+    args[:only_id] = true
+    args[:id] = params[:inat_ids] if listing_ids?
+    args[:user_login] = params[:inat_username]&.strip unless import_others?
+    args
+  end
+
+  # Taxon filter applied but no `without_field` or license filter.
+  # Used to derive not-importable and already-imported sub-counts.
+  def after_taxon_query_args
+    args = listing_url? ? url_query_args : {}
+    args[:only_id] = true
+    args[:taxon_id] ||= IMPORTABLE_TAXON_IDS_ARG
+    args[:id] = params[:inat_ids] if listing_ids?
+    args[:user_login] = params[:inat_username]&.strip unless import_others?
+    args
   end
 end

--- a/app/controllers/inat_imports_controller/estimators.rb
+++ b/app/controllers/inat_imports_controller/estimators.rb
@@ -5,7 +5,7 @@ module InatImportsController::Estimators
 
   private
 
-  def fetch_import_estimate
+  def fetch_expected_count
     response = RestClient.get(
       "#{API_BASE}/observations?#{import_estimate_query_args.to_query}",
       { accept: :json, open_timeout: 5, timeout: 10 }
@@ -15,7 +15,9 @@ module InatImportsController::Estimators
     flash_warning(:inat_unknown_param.t(error: inat_error_text(e)))
     false
   rescue RestClient::Exception, JSON::ParserError => e
-    Rails.logger.warn("iNat estimate request failed: #{e.class}: #{e.message}")
+    Rails.logger.warn(
+      "iNat expected count request failed: #{e.class}: #{e.message}"
+    )
     nil
   end
 
@@ -33,25 +35,25 @@ module InatImportsController::Estimators
       "#{API_BASE}/observations?#{licensed_estimate_query_args.to_query}",
       { accept: :json, open_timeout: 5, timeout: 10 }
     )
-    @estimate - JSON.parse(licensed.body)["total_results"]
+    @expected - JSON.parse(licensed.body)["total_results"]
   rescue RestClient::Exception, JSON::ParserError => e
     Rails.logger.warn(
-      "iNat licensed estimate request failed: #{e.class}: #{e.message}"
+      "iNat licensed count request failed: #{e.class}: #{e.message}"
     )
     nil
   end
 
   # Counts unlicensed observations that will be skipped for import-others.
-  # @estimate is already licensed-only; total minus @estimate = unlicensed.
+  # @expected is already licensed-only; total minus @expected = unlicensed.
   def fetch_unlicensed_others_count
     total = RestClient.get(
       "#{API_BASE}/observations?#{total_others_estimate_query_args.to_query}",
       { accept: :json, open_timeout: 5, timeout: 10 }
     )
-    JSON.parse(total.body)["total_results"] - @estimate
+    JSON.parse(total.body)["total_results"] - @expected
   rescue RestClient::Exception, JSON::ParserError => e
     Rails.logger.warn(
-      "iNat unlicensed-others estimate request failed: #{e.class}: #{e.message}"
+      "iNat unlicensed-others count request failed: #{e.class}: #{e.message}"
     )
     nil
   end
@@ -73,7 +75,7 @@ module InatImportsController::Estimators
 
   # Count after applying MO's fungi/myxo taxon filter but before
   # `without_field` (already-imported filter) or license filter.
-  # Together with @estimate and @unlicensed_obs this lets us derive
+  # Together with @expected and @unlicensed_obs this lets us derive
   # the already-imported and not-importable sub-counts.
   def fetch_after_taxon_count
     RestClient.get(
@@ -88,7 +90,7 @@ module InatImportsController::Estimators
   end
 
   # Count of importable observations that HAVE a date (estimate query +
-  # d1=1800-01-01). Diff vs @estimate gives the no-date count.
+  # d1=1800-01-01). Diff vs @expected gives the no-date count.
   def fetch_estimate_with_date_count
     RestClient.get(
       "#{API_BASE}/observations?" \

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -104,6 +104,20 @@ class InatImport < ApplicationRecord
     Importing? && ended_at.nil? && updated_at < STUCK_THRESHOLD.ago
   end
 
+  def add_ignored_obs(reason)
+    case reason
+    when :not_importable then increment!(:ignored_not_importable_count)
+    when :date_missing   then increment!(:ignored_date_missing_count)
+    when :already_imported then increment!(:ignored_already_imported_count)
+    end
+  end
+
+  def ignored_total_count
+    ignored_not_importable_count.to_i +
+      ignored_date_missing_count.to_i +
+      ignored_already_imported_count.to_i
+  end
+
   def add_response_error(error)
     msg = if error.is_a?(::RestClient::Response)
             error.body

--- a/app/models/inat_import_job_tracker.rb
+++ b/app/models/inat_import_job_tracker.rb
@@ -17,6 +17,13 @@ class InatImportJobTracker < ApplicationRecord
   delegate :imported_count, to: :import
   delegate :avg_import_time, to: :import
   delegate :response_errors, to: :import
+  delegate :ignored_not_importable_count, to: :import
+  delegate :ignored_date_missing_count, to: :import
+  delegate :ignored_already_imported_count, to: :import
+  delegate :ignored_total_count, to: :import
+  delegate :inat_ids, to: :import
+  delegate :inat_url, to: :import
+  delegate :inat_username, to: :import
 
   def status
     import.state

--- a/app/views/controllers/inat_imports/confirm.rb
+++ b/app/views/controllers/inat_imports/confirm.rb
@@ -11,6 +11,9 @@ module Views::Controllers::InatImports
     # estimate call errors; ConfirmForm handles nil.
     prop :unlicensed_obs, _Nilable(::Integer), default: nil
     prop :inat_import, ::InatImport
+    prop :requested, _Nilable(::Integer), default: nil
+    prop :after_taxon, _Nilable(::Integer), default: nil
+    prop :estimate_with_date, _Nilable(::Integer), default: nil
 
     def view_template
       add_page_title(:inat_import_confirm_title.l)
@@ -19,7 +22,11 @@ module Views::Controllers::InatImports
       render(ConfirmForm.new(@confirm_form,
                              estimate: @estimate,
                              unlicensed_obs: @unlicensed_obs,
-                             inat_import: @inat_import))
+                             breakdown: { inat_import: @inat_import,
+                                          requested: @requested,
+                                          after_taxon: @after_taxon,
+                                          estimate_with_date:
+                                            @estimate_with_date }))
     end
   end
 end

--- a/app/views/controllers/inat_imports/confirm.rb
+++ b/app/views/controllers/inat_imports/confirm.rb
@@ -2,13 +2,13 @@
 
 module Views::Controllers::InatImports
   # iNat import-confirmation page. Renders the form (already a
-  # Phlex `ConfirmForm`) with import estimate + unlicensed-obs
+  # Phlex `ConfirmForm`) with expected import count + unlicensed-obs
   # numbers passed through.
   class Confirm < Views::FullPageBase
     prop :confirm_form, ::FormObject::InatImportConfirm
-    prop :estimate, ::Integer
+    prop :expected, ::Integer
     # `fetch_unlicensed_*_count` returns nil when the iNat licensed-
-    # estimate call errors; ConfirmForm handles nil.
+    # count call errors; ConfirmForm handles nil.
     prop :unlicensed_obs, _Nilable(::Integer), default: nil
     prop :inat_import, ::InatImport
     prop :requested, _Nilable(::Integer), default: nil
@@ -20,7 +20,7 @@ module Views::Controllers::InatImports
       add_context_nav(::Tab::InatImport::FormNew.new)
 
       render(ConfirmForm.new(@confirm_form,
-                             estimate: @estimate,
+                             expected: @expected,
                              unlicensed_obs: @unlicensed_obs,
                              breakdown: { inat_import: @inat_import,
                                           requested: @requested,

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -7,8 +7,6 @@ module Views::Controllers::InatImports
   class ConfirmForm < ::Components::ApplicationForm
     include ::Inat::Constants
 
-    # breakdown: hash with :inat_import, :requested, :after_taxon,
-    # :estimate_with_date — iNat API counts from the confirm step.
     def initialize(model, expected: nil, unlicensed_obs: nil,
                    breakdown: {}, **)
       @expected = expected
@@ -17,6 +15,7 @@ module Views::Controllers::InatImports
       @requested = breakdown[:requested]
       @after_taxon = breakdown[:after_taxon]
       @estimate_with_date = breakdown[:estimate_with_date]
+      @estimated_at = Time.current
       super(model, **)
     end
 
@@ -28,9 +27,7 @@ module Views::Controllers::InatImports
       render_buttons
     end
 
-    def form_action
-      inat_imports_path
-    end
+    def form_action = inat_imports_path
 
     private
 
@@ -58,7 +55,7 @@ module Views::Controllers::InatImports
       return if rows.empty?
 
       br
-      render_ignored_total(rows)
+      render_ignored_total
       render_ignored_overlap_note if rows.size > 1
       div(class: "ml-3") do
         rows.each do |row|
@@ -68,17 +65,20 @@ module Views::Controllers::InatImports
       br
     end
 
-    def render_ignored_total(rows)
+    def render_ignored_total
+      return unless @requested && (@estimate_with_date || @expected)
+
+      total = @requested.to_i - (@estimate_with_date || @expected).to_i
       b { plain(:inat_import_confirm_ignored_total_caption.l) }
       plain(": ")
-      span(id: "total_ignored_count") do
-        plain(rows.sum { |r| r[:count] }.to_s)
-      end
+      span(id: "total_ignored_count") { plain(total.to_s) }
     end
 
     def render_ignored_overlap_note
-      div { small { plain(:inat_import_confirm_ignored_overlap_note.l) } }
+      div { small(class: "overlap-note") { plain(overlap_note) } }
     end
+
+    def overlap_note = :inat_import_confirm_ignored_overlap_note.l
 
     def ignored_row_data
       [not_importable_row, already_imported_row,
@@ -149,6 +149,17 @@ module Views::Controllers::InatImports
           plain((@estimate_with_date || @expected).to_s)
         end
       end
+      render_expected_count_note
+    end
+
+    def render_expected_count_note
+      return unless @expected
+
+      t = @estimated_at.strftime("%Y-%m-%d %H:%M:%S %Z")
+      plain(" ")
+      small { plain(:inat_import_confirm_expected_as_of.t(time: t)) }
+      br
+      small { plain(:inat_import_confirm_expected_staleness.l) }
     end
 
     def expected_obs_url
@@ -163,7 +174,7 @@ module Views::Controllers::InatImports
       args = Rack::Utils.parse_query(query_str.to_s)
       args["iconic_taxa"] ||= "Fungi,Protozoa" unless args.key?("taxon_id")
       args["without_field"] = BASE_FILTER_PARAMS[:without_field]
-      args["d1"] = "1000-01-01"
+      args["d1"] ||= EARLIEST_DATE_FILTER
       filter = LICENSED_FILTER.stringify_keys.transform_values(&:to_s)
       args.merge!(filter) if import_others?
       args
@@ -186,8 +197,7 @@ module Views::Controllers::InatImports
     end
 
     def estimated_time
-      seconds = (@estimate_with_date || @expected) * avg_import_seconds
-      format_hms(seconds)
+      format_hms((@estimate_with_date || @expected) * avg_import_seconds)
     end
 
     def avg_import_seconds
@@ -283,14 +293,10 @@ module Views::Controllers::InatImports
     end
 
     def render_hidden_fields
-      hidden_field(:inat_username)
-      hidden_field(:inat_ids)
-      hidden_field(:import_all)
-      hidden_field(:consent)
-      hidden_field(:import_others)
-      hidden_field(:inat_url)
-      hidden_field(:original_inat_url)
-      hidden_field(:skip_inat_writeback)
+      [:inat_username, :inat_ids, :import_all, :consent, :import_others,
+       :inat_url, :original_inat_url, :skip_inat_writeback].each do |f|
+        hidden_field(f)
+      end
     end
 
     def render_buttons
@@ -311,8 +317,6 @@ module Views::Controllers::InatImports
                                              name: "go_back", value: "1")
     end
 
-    def import_others?
-      model.import_others == "1"
-    end
+    def import_others? = model.import_others == "1"
   end
 end

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -20,7 +20,6 @@ module Views::Controllers::InatImports
 
     def view_template
       render_expected
-      render_ignored_section if show_ignored_section?
       render_explanation
       render_prompt
       render_hidden_fields
@@ -40,6 +39,10 @@ module Views::Controllers::InatImports
             requested_obs_line
             br
           end
+          render_ignored_not_importable_row
+          render_ignored_already_imported_row
+          render_ignored_no_date_row
+          render_ignored_unlicensed_row if import_others?
           count_expected_line
           unless import_others?
             br
@@ -107,23 +110,6 @@ module Views::Controllers::InatImports
       minutes = (total_seconds % 3600) / 60
       remaining = total_seconds % 60
       Kernel.format("%02d:%02d:%02d", hours, minutes, remaining)
-    end
-
-    def show_ignored_section?
-      @requested && @estimate_with_date &&
-        @requested.to_i > @estimate_with_date.to_i
-    end
-
-    def render_ignored_section
-      render(Components::Panel.new) do |panel|
-        panel.with_body do
-          h5 { plain(:inat_import_confirm_ignored_heading.l) }
-          render_ignored_not_importable_row
-          render_ignored_already_imported_row
-          render_ignored_no_date_row
-          render_ignored_unlicensed_row if import_others?
-        end
-      end
     end
 
     def render_ignored_not_importable_row

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -138,7 +138,30 @@ module Views::Controllers::InatImports
     def count_expected_line
       b { plain(:inat_import_confirm_expected_caption.l) }
       plain(": ")
-      span(id: "expected_count") { plain(expected_count) }
+      span(id: "expected_count") do
+        url = expected_obs_url
+        if url
+          link_to(expected_count, url,
+                  target: "_blank", rel: "noopener noreferrer")
+        else
+          plain(expected_count)
+        end
+      end
+    end
+
+    def expected_obs_url
+      base = requested_obs_url
+      return nil unless base
+
+      uri, query_str = base.split("?", 2)
+      args = Rack::Utils.parse_query(query_str.to_s)
+      args["taxon_id"] ||= ::Inat::Constants::IMPORTABLE_TAXON_IDS_ARG
+      args["without_field"] =
+        ::Inat::Constants::BASE_FILTER_PARAMS[:without_field]
+      if import_others?
+        args["license"] = ::Inat::Constants::LICENSED_FILTER[:license]
+      end
+      "#{uri}?#{args.to_query}"
     end
 
     def expected_count

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -5,16 +5,22 @@ module Views::Controllers::InatImports
   # and Proceed/Go Back buttons. Hidden fields carry form data
   # through the confirmation step. Rendered by `confirm.rb`.
   class ConfirmForm < ::Components::ApplicationForm
+    # breakdown: hash with :inat_import, :requested, :after_taxon,
+    # :estimate_with_date — iNat API counts from the confirm step.
     def initialize(model, estimate: nil, unlicensed_obs: nil,
-                   inat_import: nil, **)
+                   breakdown: {}, **)
       @estimate = estimate
       @unlicensed_obs = unlicensed_obs
-      @inat_import = inat_import
+      @inat_import = breakdown[:inat_import]
+      @requested = breakdown[:requested]
+      @after_taxon = breakdown[:after_taxon]
+      @estimate_with_date = breakdown[:estimate_with_date]
       super(model, **)
     end
 
     def view_template
       render_estimate
+      render_ignored_section if show_ignored_section?
       render_explanation
       render_prompt
       render_hidden_fields
@@ -30,11 +36,31 @@ module Views::Controllers::InatImports
     def render_estimate
       render(Components::Panel.new) do |panel|
         panel.with_body do
+          if @requested
+            requested_obs_line
+            br
+          end
           count_estimate_line
-          br
-          unlicensed_obs_line
+          unless import_others?
+            br
+            unlicensed_obs_line
+          end
           br
           time_estimate_line
+        end
+      end
+    end
+
+    def requested_obs_line
+      b { plain(:inat_import_confirm_requested_caption.l) }
+      plain(": ")
+      span(id: "requested_count") do
+        url = requested_obs_url
+        if url
+          link_to(@requested.to_s, url,
+                  target: "_blank", rel: "noopener noreferrer")
+        else
+          plain(@requested.to_s)
         end
       end
     end
@@ -56,15 +82,7 @@ module Views::Controllers::InatImports
       return unless @unlicensed_obs.to_i.positive?
 
       plain(" ")
-      plain(unlicensed_obs_note)
-    end
-
-    def unlicensed_obs_note
-      if import_others?
-        :inat_import_confirm_unlicensed_others_note.l
-      else
-        :inat_import_confirm_unlicensed_obs_note.l
-      end
+      plain(:inat_import_confirm_unlicensed_obs_note.l)
     end
 
     def time_estimate_line
@@ -89,6 +107,112 @@ module Views::Controllers::InatImports
       minutes = (total_seconds % 3600) / 60
       remaining = total_seconds % 60
       Kernel.format("%02d:%02d:%02d", hours, minutes, remaining)
+    end
+
+    def show_ignored_section?
+      @requested && @estimate_with_date &&
+        @requested.to_i > @estimate_with_date.to_i
+    end
+
+    def render_ignored_section
+      render(Components::Panel.new) do |panel|
+        panel.with_body do
+          h5 { plain(:inat_import_confirm_ignored_heading.l) }
+          render_ignored_not_importable_row
+          render_ignored_already_imported_row
+          render_ignored_no_date_row
+          render_ignored_unlicensed_row if import_others?
+        end
+      end
+    end
+
+    def render_ignored_not_importable_row
+      return unless @requested && @after_taxon
+
+      count = @requested.to_i - @after_taxon.to_i
+      return unless count.positive?
+
+      render_ignored_row(:inat_import_confirm_not_importable_caption,
+                         count, nil)
+    end
+
+    def render_ignored_already_imported_row
+      count = already_imported_count
+      return unless count&.positive?
+
+      render_ignored_row(:inat_import_confirm_already_imported_caption,
+                         count, already_imported_url)
+    end
+
+    def render_ignored_no_date_row
+      return unless @estimate && @estimate_with_date
+
+      count = @estimate.to_i - @estimate_with_date.to_i
+      return unless count.positive?
+
+      render_ignored_row(:inat_import_confirm_no_date_caption, count, nil)
+    end
+
+    def render_ignored_unlicensed_row
+      count = @unlicensed_obs.to_i
+      return unless count.positive?
+
+      div(class: "mb-1") do
+        b { plain("#{:inat_import_confirm_unlicensed_obs_caption.l}: ") }
+        span(id: "ignored_unlicensed_count") { plain(count.to_s) }
+      end
+    end
+
+    def render_ignored_row(caption_key, count, url)
+      div(class: "mb-1") do
+        b { plain("#{caption_key.l}: ") }
+        if url
+          link_to(count.to_s, url,
+                  target: "_blank", rel: "noopener noreferrer")
+        else
+          plain(count.to_s)
+        end
+      end
+    end
+
+    def already_imported_count
+      return unless @after_taxon && @estimate
+
+      if import_others?
+        @after_taxon.to_i - @estimate.to_i - @unlicensed_obs.to_i
+      else
+        @after_taxon.to_i - @estimate.to_i
+      end
+    end
+
+    def requested_obs_url
+      query = requested_obs_query
+      return nil unless query
+      return query if query.start_with?("http")
+
+      inat_obs_search_url(query)
+    end
+
+    # Returns a full URL (for original_inat_url) or a query string
+    # fragment that inat_obs_search_url will prepend the base to.
+    def requested_obs_query
+      m = model
+      return "id=#{m.inat_ids}" if m.inat_ids.present?
+      return m.original_inat_url if m.original_inat_url.present?
+      return m.inat_url if m.inat_url.present?
+
+      "user_id=#{m.inat_username}" if m.inat_username.present?
+    end
+
+    def already_imported_url
+      base = requested_obs_url
+      return nil unless base
+
+      "#{base}&with_field=Mushroom+Observer+URL"
+    end
+
+    def inat_obs_search_url(query_string)
+      "#{::Inat::Constants::SITE}/observations?#{query_string}"
     end
 
     def render_explanation

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -155,7 +155,9 @@ module Views::Controllers::InatImports
 
       uri, query_str = base.split("?", 2)
       args = Rack::Utils.parse_query(query_str.to_s)
-      args["taxon_id"] ||= ::Inat::Constants::IMPORTABLE_TAXON_IDS_ARG
+      unless args.key?("taxon_id") || args.key?("iconic_taxa")
+        args["iconic_taxa"] = "Fungi,Protozoa"
+      end
       args["without_field"] =
         ::Inat::Constants::BASE_FILTER_PARAMS[:without_field]
       if import_others?
@@ -227,9 +229,23 @@ module Views::Controllers::InatImports
     def requested_obs_url
       query = requested_obs_query
       return nil unless query
-      return query if query.start_with?("http")
+      return normalize_inat_ui_url(query) if query.start_with?("http")
 
-      inat_obs_search_url(query)
+      inat_obs_search_url(translate_api_to_ui_params(query))
+    end
+
+    # iNat UI does not support comma-separated taxon_id values; replace
+    # with iconic_taxa when more than one taxon ID is present.
+    def translate_api_to_ui_params(query_str)
+      args = Rack::Utils.parse_query(query_str.to_s)
+      return args.to_query unless args["taxon_id"]&.include?(",")
+
+      args.except("taxon_id").merge("iconic_taxa" => "Fungi,Protozoa").to_query
+    end
+
+    def normalize_inat_ui_url(url)
+      uri, query_str = url.split("?", 2)
+      "#{uri}?#{translate_api_to_ui_params(query_str.to_s)}"
     end
 
     # Returns a full URL (for original_inat_url) or a query string

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -143,10 +143,10 @@ module Views::Controllers::InatImports
       span(id: "expected_count") do
         url = expected_obs_url
         if url
-          link_to(@expected.to_s, url,
+          link_to((@estimate_with_date || @expected).to_s, url,
                   target: "_blank", rel: "noopener noreferrer")
         else
-          plain(@expected.to_s)
+          plain((@estimate_with_date || @expected).to_s)
         end
       end
     end
@@ -156,18 +156,17 @@ module Views::Controllers::InatImports
       return nil unless base
 
       uri, query_str = base.split("?", 2)
+      "#{uri}?#{expected_obs_args(query_str).to_query}"
+    end
+
+    def expected_obs_args(query_str)
       args = Rack::Utils.parse_query(query_str.to_s)
-      unless args.key?("taxon_id") || args.key?("iconic_taxa")
-        args["iconic_taxa"] = "Fungi,Protozoa"
-      end
-      args["without_field"] =
-        BASE_FILTER_PARAMS[:without_field]
-      if import_others?
-        args.merge!(
-          LICENSED_FILTER.transform_keys(&:to_s).transform_values(&:to_s)
-        )
-      end
-      "#{uri}?#{args.to_query}"
+      args["iconic_taxa"] ||= "Fungi,Protozoa" unless args.key?("taxon_id")
+      args["without_field"] = BASE_FILTER_PARAMS[:without_field]
+      args["d1"] = "1000-01-01"
+      filter = LICENSED_FILTER.stringify_keys.transform_values(&:to_s)
+      args.merge!(filter) if import_others?
+      args
     end
 
     def unlicensed_obs_line
@@ -187,7 +186,7 @@ module Views::Controllers::InatImports
     end
 
     def estimated_time
-      seconds = @expected * avg_import_seconds
+      seconds = (@estimate_with_date || @expected) * avg_import_seconds
       format_hms(seconds)
     end
 

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -263,7 +263,8 @@ module Views::Controllers::InatImports
       base = requested_obs_url
       return nil unless base
 
-      "#{base}&with_field=Mushroom+Observer+URL"
+      # https://forum.inaturalist.org/t/how-to-use-inaturalists-search-urls-wiki-part-2-of-2/18792#heading--obs--field
+      "#{base}&field:Mushroom%20Observer%20URL"
     end
 
     def inat_obs_search_url(query_string)

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -156,6 +156,9 @@ module Views::Controllers::InatImports
       uri, query_str = base.split("?", 2)
       args = Rack::Utils.parse_query(query_str.to_s)
       unless args.key?("taxon_id") || args.key?("iconic_taxa")
+        # iNat UI does not support comma-separated taxon_id values;
+        # Instead, use iconic_taxa, which reasonably approximates
+        # IMPORTABLE_TAXON_IDS
         args["iconic_taxa"] = "Fungi,Protozoa"
       end
       args["without_field"] =

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module Views::Controllers::InatImports
-  # Confirmation form for iNat import. Shows estimated import count
+  # Confirmation form for iNat import. Shows expected import count
   # and Proceed/Go Back buttons. Hidden fields carry form data
   # through the confirmation step. Rendered by `confirm.rb`.
   class ConfirmForm < ::Components::ApplicationForm
     # breakdown: hash with :inat_import, :requested, :after_taxon,
     # :estimate_with_date — iNat API counts from the confirm step.
-    def initialize(model, estimate: nil, unlicensed_obs: nil,
+    def initialize(model, expected: nil, unlicensed_obs: nil,
                    breakdown: {}, **)
-      @estimate = estimate
+      @expected = expected
       @unlicensed_obs = unlicensed_obs
       @inat_import = breakdown[:inat_import]
       @requested = breakdown[:requested]
@@ -19,7 +19,7 @@ module Views::Controllers::InatImports
     end
 
     def view_template
-      render_estimate
+      render_expected
       render_ignored_section if show_ignored_section?
       render_explanation
       render_prompt
@@ -33,14 +33,14 @@ module Views::Controllers::InatImports
 
     private
 
-    def render_estimate
+    def render_expected
       render(Components::Panel.new) do |panel|
         panel.with_body do
           if @requested
             requested_obs_line
             br
           end
-          count_estimate_line
+          count_expected_line
           unless import_others?
             br
             unlicensed_obs_line
@@ -65,14 +65,14 @@ module Views::Controllers::InatImports
       end
     end
 
-    def count_estimate_line
-      b { plain(:inat_import_confirm_estimate_caption.l) }
+    def count_expected_line
+      b { plain(:inat_import_confirm_expected_caption.l) }
       plain(": ")
-      span(id: "estimated_count") { plain(estimated_count) }
+      span(id: "expected_count") { plain(expected_count) }
     end
 
-    def estimated_count
-      @estimate.to_s
+    def expected_count
+      @expected.to_s
     end
 
     def unlicensed_obs_line
@@ -92,7 +92,7 @@ module Views::Controllers::InatImports
     end
 
     def estimated_time
-      seconds = @estimate * avg_import_seconds
+      seconds = @expected * avg_import_seconds
       format_hms(seconds)
     end
 
@@ -145,9 +145,9 @@ module Views::Controllers::InatImports
     end
 
     def render_ignored_no_date_row
-      return unless @estimate && @estimate_with_date
+      return unless @expected && @estimate_with_date
 
-      count = @estimate.to_i - @estimate_with_date.to_i
+      count = @expected.to_i - @estimate_with_date.to_i
       return unless count.positive?
 
       render_ignored_row(:inat_import_confirm_no_date_caption, count, nil)
@@ -176,12 +176,12 @@ module Views::Controllers::InatImports
     end
 
     def already_imported_count
-      return unless @after_taxon && @estimate
+      return unless @after_taxon && @expected
 
       if import_others?
-        @after_taxon.to_i - @estimate.to_i - @unlicensed_obs.to_i
+        @after_taxon.to_i - @expected.to_i - @unlicensed_obs.to_i
       else
-        @after_taxon.to_i - @estimate.to_i
+        @after_taxon.to_i - @expected.to_i
       end
     end
 

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -5,6 +5,8 @@ module Views::Controllers::InatImports
   # and Proceed/Go Back buttons. Hidden fields carry form data
   # through the confirmation step. Rendered by `confirm.rb`.
   class ConfirmForm < ::Components::ApplicationForm
+    include ::Inat::Constants
+
     # breakdown: hash with :inat_import, :requested, :after_taxon,
     # :estimate_with_date — iNat API counts from the confirm step.
     def initialize(model, expected: nil, unlicensed_obs: nil,
@@ -106,7 +108,7 @@ module Views::Controllers::InatImports
       return unless import_others? && @unlicensed_obs.to_i.positive?
 
       { key: :inat_import_confirm_unlicensed_obs_caption,
-        count: @unlicensed_obs.to_i, url: nil }
+        count: @unlicensed_obs.to_i, url: unlicensed_obs_url }
     end
 
     def not_importable_count
@@ -141,10 +143,10 @@ module Views::Controllers::InatImports
       span(id: "expected_count") do
         url = expected_obs_url
         if url
-          link_to(expected_count, url,
+          link_to(@expected.to_s, url,
                   target: "_blank", rel: "noopener noreferrer")
         else
-          plain(expected_count)
+          plain(@expected.to_s)
         end
       end
     end
@@ -156,21 +158,16 @@ module Views::Controllers::InatImports
       uri, query_str = base.split("?", 2)
       args = Rack::Utils.parse_query(query_str.to_s)
       unless args.key?("taxon_id") || args.key?("iconic_taxa")
-        # iNat UI does not support comma-separated taxon_id values;
-        # Instead, use iconic_taxa, which reasonably approximates
-        # IMPORTABLE_TAXON_IDS
         args["iconic_taxa"] = "Fungi,Protozoa"
       end
       args["without_field"] =
-        ::Inat::Constants::BASE_FILTER_PARAMS[:without_field]
+        BASE_FILTER_PARAMS[:without_field]
       if import_others?
-        args["license"] = ::Inat::Constants::LICENSED_FILTER[:license]
+        args.merge!(
+          LICENSED_FILTER.transform_keys(&:to_s).transform_values(&:to_s)
+        )
       end
       "#{uri}?#{args.to_query}"
-    end
-
-    def expected_count
-      @expected.to_s
     end
 
     def unlicensed_obs_line
@@ -270,8 +267,12 @@ module Views::Controllers::InatImports
       "#{base}&field:Mushroom%20Observer%20URL"
     end
 
+    def unlicensed_obs_url
+      requested_obs_url&.then { |u| "#{u}&licensed=false" }
+    end
+
     def inat_obs_search_url(query_string)
-      "#{::Inat::Constants::SITE}/observations?#{query_string}"
+      "#{SITE}/observations?#{query_string}"
     end
 
     def render_explanation

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -34,6 +34,7 @@ module Views::Controllers::InatImports
     def render_expected
       render(Components::Panel.new) do |panel|
         panel.with_body do
+          render_timestamp_note
           if @requested
             requested_obs_line
             br
@@ -112,9 +113,7 @@ module Views::Controllers::InatImports
     end
 
     def not_importable_count
-      return unless @requested && @after_taxon
-
-      @requested.to_i - @after_taxon.to_i
+      @requested.to_i - @after_taxon.to_i if @requested && @after_taxon
     end
 
     def no_date_count
@@ -149,17 +148,45 @@ module Views::Controllers::InatImports
           plain((@estimate_with_date || @expected).to_s)
         end
       end
-      render_expected_count_note
     end
 
-    def render_expected_count_note
+    def render_timestamp_note
       return unless @expected
 
       t = @estimated_at.strftime("%Y-%m-%d %H:%M:%S %Z")
-      plain(" ")
-      small { plain(:inat_import_confirm_expected_as_of.t(time: t)) }
-      br
-      small { plain(:inat_import_confirm_expected_staleness.l) }
+      p(id: "as_of") { plain(:inat_import_confirm_expected_as_of.t(time: t)) }
+      return unless show_staleness_note?
+
+      stale = :inat_import_confirm_expected_staleness.l
+      p(class: "staleness-note") { plain(stale) }
+    end
+
+    def show_staleness_note? = !stable_result_set?
+
+    def stable_result_set?
+      return true if model.inat_ids.present?
+      return false unless (query = requested_obs_query)
+
+      qs = query.start_with?("http") ? query.split("?", 2)[1].to_s : query
+      args = Rack::Utils.parse_query(qs)
+      args["id"].present? || date_filtered_before_estimated_at?(args)
+    end
+
+    def date_filtered_before_estimated_at?(args)
+      date = d2_date(args) || year_end_date(args)
+      date && date < @estimated_at.to_date
+    rescue ArgumentError
+      false
+    end
+
+    def d2_date(args)
+      Date.parse(args["d2"]) if args["d2"].present?
+    end
+
+    def year_end_date(args)
+      return unless (year = args["year"]&.to_i)
+
+      Date.new(year, args["month"]&.to_i || 12, args["day"]&.to_i || -1)
     end
 
     def expected_obs_url
@@ -206,33 +233,23 @@ module Views::Controllers::InatImports
     end
 
     def format_hms(seconds)
-      total_seconds = seconds.to_i
-      hours = total_seconds / 3600
-      minutes = (total_seconds % 3600) / 60
-      remaining = total_seconds % 60
-      Kernel.format("%02d:%02d:%02d", hours, minutes, remaining)
+      s = seconds.to_i
+      Kernel.format("%02d:%02d:%02d", s / 3600, s % 3600 / 60, s % 60)
     end
 
     def render_ignored_row(caption_key, count, url)
+      link_opts = { target: "_blank", rel: "noopener noreferrer" }
       div(class: "mb-1") do
         b { plain("#{caption_key.l}: ") }
-        if url
-          link_to(count.to_s, url,
-                  target: "_blank", rel: "noopener noreferrer")
-        else
-          plain(count.to_s)
-        end
+        url ? link_to(count.to_s, url, **link_opts) : plain(count.to_s)
       end
     end
 
     def already_imported_count
       return unless @after_taxon && @expected
 
-      if import_others?
-        @after_taxon.to_i - @expected.to_i - @unlicensed_obs.to_i
-      else
-        @after_taxon.to_i - @expected.to_i
-      end
+      diff = @after_taxon.to_i - @expected.to_i
+      import_others? ? diff - @unlicensed_obs.to_i : diff
     end
 
     def requested_obs_url
@@ -284,13 +301,9 @@ module Views::Controllers::InatImports
       "#{SITE}/observations?#{query_string}"
     end
 
-    def render_explanation
-      p { plain(:inat_import_confirm_explanation.l) }
-    end
+    def render_explanation = p { plain(:inat_import_confirm_explanation.l) }
 
-    def render_prompt
-      p { plain(:inat_import_confirm_prompt.l) }
-    end
+    def render_prompt = p { plain(:inat_import_confirm_prompt.l) }
 
     def render_hidden_fields
       [:inat_username, :inat_ids, :import_all, :consent, :import_others,
@@ -301,20 +314,12 @@ module Views::Controllers::InatImports
 
     def render_buttons
       div(class: "mt-3") do
-        proceed_button
+        submit(:inat_import_confirm_proceed.l, as: :button,
+                                               name: "confirmed", value: "1")
         whitespace
-        go_back_button
+        submit(:inat_import_confirm_go_back.l, as: :button,
+                                               name: "go_back", value: "1")
       end
-    end
-
-    def proceed_button
-      submit(:inat_import_confirm_proceed.l, as: :button,
-                                             name: "confirmed", value: "1")
-    end
-
-    def go_back_button
-      submit(:inat_import_confirm_go_back.l, as: :button,
-                                             name: "go_back", value: "1")
     end
 
     def import_others? = model.import_others == "1"

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -39,10 +39,7 @@ module Views::Controllers::InatImports
             requested_obs_line
             br
           end
-          render_ignored_not_importable_row
-          render_ignored_already_imported_row
-          render_ignored_no_date_row
-          render_ignored_unlicensed_row if import_others?
+          render_ignored_section
           count_expected_line
           unless import_others?
             br
@@ -52,6 +49,76 @@ module Views::Controllers::InatImports
           time_estimate_line
         end
       end
+    end
+
+    def render_ignored_section
+      rows = ignored_row_data
+      return if rows.empty?
+
+      br
+      render_ignored_total(rows)
+      render_ignored_overlap_note if rows.size > 1
+      div(class: "ml-3") do
+        rows.each do |row|
+          render_ignored_row(row[:key], row[:count], row[:url])
+        end
+      end
+      br
+    end
+
+    def render_ignored_total(rows)
+      b { plain(:inat_import_confirm_ignored_total_caption.l) }
+      plain(": ")
+      span(id: "total_ignored_count") do
+        plain(rows.sum { |r| r[:count] }.to_s)
+      end
+    end
+
+    def render_ignored_overlap_note
+      div { small { plain(:inat_import_confirm_ignored_overlap_note.l) } }
+    end
+
+    def ignored_row_data
+      [not_importable_row, already_imported_row,
+       no_date_row, unlicensed_row].compact
+    end
+
+    def not_importable_row
+      return unless (c = not_importable_count)&.positive?
+
+      { key: :inat_import_confirm_not_importable_caption, count: c, url: nil }
+    end
+
+    def already_imported_row
+      return unless (c = already_imported_count)&.positive?
+
+      { key: :inat_import_confirm_already_imported_caption,
+        count: c, url: already_imported_url }
+    end
+
+    def no_date_row
+      return unless (c = no_date_count)&.positive?
+
+      { key: :inat_import_confirm_no_date_caption, count: c, url: nil }
+    end
+
+    def unlicensed_row
+      return unless import_others? && @unlicensed_obs.to_i.positive?
+
+      { key: :inat_import_confirm_unlicensed_obs_caption,
+        count: @unlicensed_obs.to_i, url: nil }
+    end
+
+    def not_importable_count
+      return unless @requested && @after_taxon
+
+      @requested.to_i - @after_taxon.to_i
+    end
+
+    def no_date_count
+      return unless @expected && @estimate_with_date
+
+      @expected.to_i - @estimate_with_date.to_i
     end
 
     def requested_obs_line
@@ -110,43 +177,6 @@ module Views::Controllers::InatImports
       minutes = (total_seconds % 3600) / 60
       remaining = total_seconds % 60
       Kernel.format("%02d:%02d:%02d", hours, minutes, remaining)
-    end
-
-    def render_ignored_not_importable_row
-      return unless @requested && @after_taxon
-
-      count = @requested.to_i - @after_taxon.to_i
-      return unless count.positive?
-
-      render_ignored_row(:inat_import_confirm_not_importable_caption,
-                         count, nil)
-    end
-
-    def render_ignored_already_imported_row
-      count = already_imported_count
-      return unless count&.positive?
-
-      render_ignored_row(:inat_import_confirm_already_imported_caption,
-                         count, already_imported_url)
-    end
-
-    def render_ignored_no_date_row
-      return unless @expected && @estimate_with_date
-
-      count = @expected.to_i - @estimate_with_date.to_i
-      return unless count.positive?
-
-      render_ignored_row(:inat_import_confirm_no_date_caption, count, nil)
-    end
-
-    def render_ignored_unlicensed_row
-      count = @unlicensed_obs.to_i
-      return unless count.positive?
-
-      div(class: "mb-1") do
-        b { plain("#{:inat_import_confirm_unlicensed_obs_caption.l}: ") }
-        span(id: "ignored_unlicensed_count") { plain(count.to_s) }
-      end
     end
 
     def render_ignored_row(caption_key, count, url)

--- a/app/views/controllers/inat_imports/job_trackers/current.rb
+++ b/app/views/controllers/inat_imports/job_trackers/current.rb
@@ -15,6 +15,7 @@ module Views::Controllers::InatImports::JobTrackers
         render_remaining_line
         render_ended_line
         render_error_line
+        render_ignored_section if show_ignored_section?
         render(::Components::Alert.new(
                  message: @tracker.help, level: :warning, class: "mt-3"
                ))
@@ -85,6 +86,31 @@ module Views::Controllers::InatImports::JobTrackers
         plain(@tracker.response_errors.to_s)
       end
       br
+    end
+
+    def show_ignored_section?
+      @tracker.status == "Done" && @tracker.ignored_total_count.positive?
+    end
+
+    def render_ignored_section
+      div(class: "mt-3") do
+        h5 { plain(:inat_import_tracker_ignored_heading.l) }
+        render_ignored_row(:inat_import_tracker_ignored_not_importable,
+                           @tracker.ignored_not_importable_count)
+        render_ignored_row(:inat_import_tracker_ignored_already_imported,
+                           @tracker.ignored_already_imported_count)
+        render_ignored_row(:inat_import_tracker_ignored_date_missing,
+                           @tracker.ignored_date_missing_count)
+      end
+    end
+
+    def render_ignored_row(caption_key, count)
+      return unless count.positive?
+
+      div(class: "mb-1") do
+        b { plain("#{caption_key.l}: ") }
+        plain(count.to_s)
+      end
     end
 
     def remaining_time_in_hours_minutes_seconds(tracker)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3267,7 +3267,6 @@
   inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
   inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
   inat_import_confirm_time_estimate_caption: Estimated time
-  inat_import_confirm_ignored_heading: Ignored Observations
   inat_import_confirm_not_importable_caption: Not fungi or slime molds
   inat_import_confirm_already_imported_caption: Already imported
   inat_import_confirm_no_date_caption: No observation date

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3272,6 +3272,8 @@
   inat_import_confirm_not_importable_caption: Not fungi or slime molds
   inat_import_confirm_already_imported_caption: Already imported
   inat_import_confirm_no_date_caption: No observation date
+  inat_import_confirm_expected_as_of: "as of [time]"
+  inat_import_confirm_expected_staleness: Actual imports may be higher.
   inat_import_confirm_explanation: "MO will import your iNat observations that are identified as a fungus or slime mold and that were neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script. Unlicensed images will be imported with your default MO license. You can work on other things while the import is proceeding."
   inat_import_confirm_prompt: Would you like to proceed with the import?
   inat_import_confirm_proceed: Proceed

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3272,8 +3272,8 @@
   inat_import_confirm_not_importable_caption: Not fungi or slime molds
   inat_import_confirm_already_imported_caption: Already imported
   inat_import_confirm_no_date_caption: No observation date
-  inat_import_confirm_expected_as_of: "as of [time]"
-  inat_import_confirm_expected_staleness: Actual imports may be higher.
+  inat_import_confirm_expected_as_of: "As of [time]"
+  inat_import_confirm_expected_staleness: Actual counts may change after that time.
   inat_import_confirm_explanation: "MO will import your iNat observations that are identified as a fungus or slime mold and that were neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script. Unlicensed images will be imported with your default MO license. You can work on other things while the import is proceeding."
   inat_import_confirm_prompt: Would you like to proceed with the import?
   inat_import_confirm_proceed: Proceed

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3261,11 +3261,16 @@
   inat_not_imported: Not Imported
 
   inat_import_confirm_title: Confirm iNat Import
+  inat_import_confirm_requested_caption: Requested Observations
   inat_import_confirm_estimate_caption: Estimated number of imports
   inat_import_confirm_unlicensed_obs_caption: Unlicensed observations
   inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
   inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
   inat_import_confirm_time_estimate_caption: Estimated time
+  inat_import_confirm_ignored_heading: Ignored Observations
+  inat_import_confirm_not_importable_caption: Not fungi or slime molds
+  inat_import_confirm_already_imported_caption: Already imported
+  inat_import_confirm_no_date_caption: No observation date
   inat_import_confirm_explanation: "MO will import your iNat observations that are identified as a fungus or slime mold and that were neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script. Unlicensed images will be imported with your default MO license. You can work on other things while the import is proceeding."
   inat_import_confirm_prompt: Would you like to proceed with the import?
   inat_import_confirm_proceed: Proceed
@@ -3293,6 +3298,10 @@
   inat_import_tracker_imported_count: Number Imported
   inat_import_tracker_leave_page: You may continue working in MO by opening another tab, or by leaving this page. To return to this page, you can (a) go back in your browser, or (b) click Create Observation, iNat Import; if the import is in progress, this page will be redisplayed.
   inat_import_tracker_pending: Please wait until your pending iNat Import is Done before starting a new one.
+  inat_import_tracker_ignored_heading: Ignored Observations
+  inat_import_tracker_ignored_not_importable: Not importable (not fungi or slime molds)
+  inat_import_tracker_ignored_already_imported: Already imported
+  inat_import_tracker_ignored_date_missing: No observation date
   inat_importables_explanation: "An ??importable?? observation is an iNat observation which: you created, whose iNat identity is a fungus or slime mold, and which was neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script."
 
   # observer/list_notifications

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3267,6 +3267,8 @@
   inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
   inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
   inat_import_confirm_time_estimate_caption: Estimated time
+  inat_import_confirm_ignored_total_caption: Total Ignored Observations
+  inat_import_confirm_ignored_overlap_note: "(following categories may overlap)"
   inat_import_confirm_not_importable_caption: Not fungi or slime molds
   inat_import_confirm_already_imported_caption: Already imported
   inat_import_confirm_no_date_caption: No observation date

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3262,7 +3262,7 @@
 
   inat_import_confirm_title: Confirm iNat Import
   inat_import_confirm_requested_caption: Requested Observations
-  inat_import_confirm_estimate_caption: Estimated number of imports
+  inat_import_confirm_expected_caption: Expected imports
   inat_import_confirm_unlicensed_obs_caption: Unlicensed observations
   inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
   inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"

--- a/db/migrate/20260627000000_add_ignored_counts_to_inat_imports.rb
+++ b/db/migrate/20260627000000_add_ignored_counts_to_inat_imports.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddIgnoredCountsToInatImports < ActiveRecord::Migration[7.2]
+  def change
+    change_table(:inat_imports, bulk: true) do |t|
+      t.integer(:ignored_not_importable_count, default: 0, null: false)
+      t.integer(:ignored_date_missing_count, default: 0, null: false)
+      t.integer(:ignored_already_imported_count, default: 0, null: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_20_175348) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_27_000000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -89,7 +89,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_20_175348) do
     t.string "external_id", limit: 64
     t.integer "relationship", default: 0, null: false
     t.datetime "last_synced_at"
-    t.virtual "import_target", type: :string, as: "(case when (`relationship` = 1) then concat(`target_type`,_utf8mb4':',`target_id`) end)", stored: true
+    t.virtual "import_target", type: :string, as: "(case when (`relationship` = 1) then concat(`target_type`,_utf8mb3':',`target_id`) end)", stored: true
     t.index ["external_site_id", "relationship", "target_type", "external_id"], name: "index_external_links_on_site_rel_target_extid"
     t.index ["import_target"], name: "index_external_links_on_import_target", unique: true
     t.index ["target_type", "target_id"], name: "index_external_links_on_target"
@@ -235,8 +235,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_20_175348) do
     t.datetime "last_obs_start"
     t.boolean "cancel"
     t.boolean "import_others", default: false, null: false
-    t.text "inat_url"
     t.integer "writeback", default: 0, null: false
+    t.text "inat_url"
+    t.boolean "skip_inat_update", default: false, null: false
+    t.integer "ignored_not_importable_count", default: 0, null: false
+    t.integer "ignored_date_missing_count", default: 0, null: false
+    t.integer "ignored_already_imported_count", default: 0, null: false
   end
 
   create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -646,13 +646,13 @@ class InatImportsControllerTest < FunctionalTestCase
     user = users(:rolf)
     inat_ids = "12345"
 
-    # Total query (no licensed filter) returns 1 (the unlicensed obs)
+    # General query returns 1 (expected count, which includes unlicensed obs)
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       to_return(status: 200, body: { total_results: 1 }.to_json)
-    # Licensed query returns 0 (unlicensed obs excluded)
+    # licensed=false query returns 1 directly — registered last, matched first
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including("license" => Inat::Constants::LICENSED_FILTER[:license])).
-      to_return(status: 200, body: { total_results: 0 }.to_json)
+      with(query: hash_including("licensed" => "false")).
+      to_return(status: 200, body: { total_results: 1 }.to_json)
 
     login(user.login)
     post(:create,
@@ -667,7 +667,7 @@ class InatImportsControllerTest < FunctionalTestCase
     )
     assert_select(
       "#unlicensed_obs_count", "1",
-      "Confirm form should report unlicensed obs count (total - licensed)"
+      "Unlicensed obs count comes directly from licensed=false query"
     )
   end
 
@@ -676,13 +676,13 @@ class InatImportsControllerTest < FunctionalTestCase
     assert(InatImport.super_importer?(user),
            "Test requires user to be a super_importer")
 
-    # Total (no license filter) returns 5: 2 unlicensed will be skipped
+    # General query returns 3 for expected count and other requests
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      to_return(status: 200, body: { total_results: 5 }.to_json)
-    # Licensed query (the estimate) returns 3 — registered last, matched first
-    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including("license" => Inat::Constants::LICENSED_FILTER[:license])).
       to_return(status: 200, body: { total_results: 3 }.to_json)
+    # licensed=false returns 2 unlicensed obs — registered last, matched first
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including("licensed" => "false")).
+      to_return(status: 200, body: { total_results: 2 }.to_json)
 
     login(user.login)
     post(:create,
@@ -701,11 +701,11 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
-  def test_confirm_renders_gracefully_when_licensed_estimate_fails
+  def test_confirm_renders_gracefully_when_unlicensed_estimate_fails
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       to_return(status: 200, body: { total_results: 3 }.to_json)
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including("license" => Inat::Constants::LICENSED_FILTER[:license])).
+      with(query: hash_including("licensed" => "false")).
       to_return(status: 500, body: "error")
 
     login(users(:rolf).login)
@@ -716,7 +716,7 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_select("#expected_count")
     assert_select(
       "#unlicensed_obs_count", "",
-      "Unlicensed count should be blank when licensed estimate fails"
+      "Unlicensed count should be blank when licensed=false request fails"
     )
   end
 
@@ -725,16 +725,14 @@ class InatImportsControllerTest < FunctionalTestCase
     assert(InatImport.super_importer?(user),
            "Test requires user to be a super_importer")
 
-    # Total-others request (no license filter) returns 200 with invalid JSON,
-    # triggers JSON::ParserError and the rescue in fetch_unlicensed_others_count
+    # General query returns 3 for expected count and other requests
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      to_return(status: 200, body: "not json")
-    # Licensed estimate returns valid JSON — registered last, matched first.
-    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including(
-        "license" => Inat::Constants::LICENSED_FILTER[:license]
-      )).
       to_return(status: 200, body: { total_results: 3 }.to_json)
+    # licensed=false returns invalid JSON — triggers rescue in
+    # fetch_unlicensed_others_count; registered last, matched first
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including("licensed" => "false")).
+      to_return(status: 200, body: "not json")
 
     login(user.login)
     post(:create,
@@ -747,8 +745,8 @@ class InatImportsControllerTest < FunctionalTestCase
       "Expected count should still show when unlicensed-others request fails"
     )
     assert_select(
-      "#ignored_unlicensed_count", { count: 0 },
-      "Unlicensed count should not appear when total-others estimate fails"
+      "#total_ignored_count", { count: 0 },
+      "Unlicensed count should not appear when unlicensed-others estimate fails"
     )
   end
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -696,7 +696,7 @@ class InatImportsControllerTest < FunctionalTestCase
       "Estimate for import-others should be licensed obs count"
     )
     assert_select(
-      "#unlicensed_obs_count", "2",
+      "#ignored_unlicensed_count", "2",
       "Confirm form should report unlicensed obs that will be skipped"
     )
   end
@@ -747,8 +747,8 @@ class InatImportsControllerTest < FunctionalTestCase
       "Estimate should still show when only unlicensed-others request fails"
     )
     assert_select(
-      "#unlicensed_obs_count", "",
-      "Unlicensed count should be blank when total-others estimate fails"
+      "#ignored_unlicensed_count", { count: 0 },
+      "Unlicensed count should not appear when total-others estimate fails"
     )
   end
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -752,6 +752,28 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
+  # estimators.rb lines 99-102: rescue block of fetch_estimate_with_date_count
+  def test_confirm_renders_gracefully_when_date_estimate_fails
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      to_return(status: 200, body: { total_results: 3 }.to_json)
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including("d1" => "1800-01-01")).
+      to_return(status: 500, body: "error")
+
+    login(users(:rolf).login)
+    post(:create,
+         params: { inat_ids: "1,2,3", inat_username: "rolf", consent: 1 })
+
+    assert_response(
+      :success,
+      "Confirm page should render when date-estimate request fails"
+    )
+    assert_select(
+      "#estimated_count", "3",
+      "Estimate count still shows when date-estimate request fails"
+    )
+  end
+
   def test_create_go_back_with_superform_params
     login(users(:rolf).login)
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -332,11 +332,11 @@ class InatImportsControllerTest < FunctionalTestCase
       relationship: :import, external_id: inat_id,
       url: "#{site.base_url}#{inat_id}"
     )
-    estimate_response = { total_results: 1 }.to_json
+    { total_results: 1 }.to_json
 
     stub_request(
       :get, %r{api\.inaturalist\.org/v1/observations}
-    ).to_return(status: 200, body: estimate_response)
+    ).to_return(status: 200, body: expected_response)
     login(user.login)
 
     post(:create,
@@ -448,14 +448,14 @@ class InatImportsControllerTest < FunctionalTestCase
                  "Failed to save InatImport.inat_username")
   end
 
-  def test_create_shows_confirmation_with_estimate
+  def test_create_shows_confirmation_with_expected_count
     user = users(:rolf)
     inat_username = "rolf"
     inat_ids = "123,456"
-    estimate_response = { total_results: 2 }.to_json
+    { total_results: 2 }.to_json
 
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      to_return(status: 200, body: estimate_response)
+      to_return(status: 200, body: expected_response)
     login(user.login)
 
     post(:create,
@@ -463,15 +463,15 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1 })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     body = @response.body
-    assert_match(:inat_import_confirm_estimate_caption.l, body)
-    assert_select("#estimated_count", "2")
+    assert_match(:inat_import_confirm_expected_caption.l, body)
+    assert_select("#expected_count", "2")
     assert_match(:inat_import_confirm_time_estimate_caption.l, body)
     assert_select("#estimated_time", "00:00:24")
   end
 
-  def test_superimporter_import_listed_observations_estimate_excludes_user_login
+  def test_superimporter_import_listed_observations_expected_excludes_user_login
     user = users(:dick) # Dick is a super_importer
     assert(InatImport.super_importer?(user),
            "Test requires user to be a super_importer")
@@ -479,7 +479,7 @@ class InatImportsControllerTest < FunctionalTestCase
     inat_ids = "339315928"
     assert_nil(Observation.find_by(inat_id: inat_ids.to_i))
 
-    # Make the request for estimated # of imports return one result
+    # Make the request for expected count return one result
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       to_return(status: 200, body: { total_results: 1 }.to_json)
 
@@ -495,10 +495,10 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1, import_others: "1" })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
-      "#estimated_count", "1",
-      "Estimate should not filter by user_login if a super_importer " \
+      "#expected_count", "1",
+      "Expected count should not filter by user_login if a super_importer " \
       "imports listed observations"
     )
   end
@@ -611,7 +611,7 @@ class InatImportsControllerTest < FunctionalTestCase
                  "importer applies its environment default")
   end
 
-  def test_superimporter_own_import_all_estimate_filters_by_user
+  def test_superimporter_own_import_all_expected_filters_by_user
     user = users(:dick) # Dick is a super_importer with inat_username "dick"
     assert(InatImport.super_importer?(user),
            "Test requires user to be a super_importer")
@@ -634,10 +634,10 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_username: user.inat_username, all: 1, consent: 1 })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
-      "#estimated_count", "1",
-      "Estimate for a super_importer's own import-all should filter " \
+      "#expected_count", "1",
+      "Expected count for a super_importer's own import-all should filter " \
       "by user_login, not return a global count"
     )
   end
@@ -660,10 +660,10 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1 })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
-      "#estimated_count", "1",
-      "Estimate should include unlicensed own observations"
+      "#expected_count", "1",
+      "Expected count should include unlicensed own observations"
     )
     assert_select(
       "#unlicensed_obs_count", "1",
@@ -690,10 +690,10 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1, import_others: "1" })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
-      "#estimated_count", "3",
-      "Estimate for import-others should be licensed obs count"
+      "#expected_count", "3",
+      "Expected count for import-others should be licensed obs count"
     )
     assert_select(
       "#ignored_unlicensed_count", "2",
@@ -713,7 +713,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_ids: "1,2,3", inat_username: "rolf", consent: 1 })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
       "#unlicensed_obs_count", "",
       "Unlicensed count should be blank when licensed estimate fails"
@@ -743,8 +743,8 @@ class InatImportsControllerTest < FunctionalTestCase
 
     assert_response(:success)
     assert_select(
-      "#estimated_count", "3",
-      "Estimate should still show when only unlicensed-others request fails"
+      "#expected_count", "3",
+      "Expected count should still show when unlicensed-others request fails"
     )
     assert_select(
       "#ignored_unlicensed_count", { count: 0 },
@@ -769,8 +769,8 @@ class InatImportsControllerTest < FunctionalTestCase
       "Confirm page should render when date-estimate request fails"
     )
     assert_select(
-      "#estimated_count", "3",
-      "Estimate count still shows when date-estimate request fails"
+      "#expected_count", "3",
+      "Expected count still shows when date-estimate request fails"
     )
   end
 
@@ -851,7 +851,7 @@ class InatImportsControllerTest < FunctionalTestCase
                  "normalized query string")
   end
 
-  def test_create_confirmation_estimate_unavailable
+  def test_create_confirmation_expected_unavailable
     user = users(:rolf)
     inat_username = "rolf"
     inat_ids = "123"
@@ -929,7 +929,7 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1, all: 1, import_others: "1" })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
   end
 
   def test_superimporter_not_own_import_all_without_username_blocked
@@ -1068,8 +1068,8 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: inat_username, consent: 1 })
 
     assert_response(:success, "Valid URL should proceed to confirmation")
-    assert_select("#estimated_count", "5",
-                  "Confirmation should show estimate from URL query")
+    assert_select("#expected_count", "5",
+                  "Confirmation should show expected count from URL query")
   end
 
   def test_importable_taxon_id_preserved_in_normalized_url
@@ -1284,7 +1284,7 @@ class InatImportsControllerTest < FunctionalTestCase
       "Confirm page must show the ignored-params warning for user_login " \
       "stripped from the URL for a non-superimporter"
     )
-    assert_select("#estimated_count", "3",
+    assert_select("#expected_count", "3",
                   "Confirm page should render with the estimate")
   end
 
@@ -1352,11 +1352,11 @@ class InatImportsControllerTest < FunctionalTestCase
     post(:create,
          params: { inat_url: url, import_others: "1", consent: 1 })
 
-    assert_select("#estimated_count", true,
+    assert_select("#expected_count", true,
                   "Superimporter URL import without username should confirm")
   end
 
-  def test_url_mode_estimate_merges_url_params
+  def test_url_mode_expected_merges_url_params
     user = users(:rolf)
     url = "#{INAT_SITE_OBS_URL}?project_id=291058"
 
@@ -1373,11 +1373,11 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "7",
-                  "Estimate should include project_id from user URL")
+    assert_select("#expected_count", "7",
+                  "Expected count should include project_id from user URL")
   end
 
-  def test_url_mode_estimate_mo_params_win_over_url_params
+  def test_url_mode_expected_mo_params_win_over_url_params
     user = users(:rolf)
     # URL supplies conflicting taxon_id and only_id; MO's values must win.
     # taxon_id=9999 is non-importable so it is stripped; MO's IMPORTABLE_IDS
@@ -1402,11 +1402,11 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "5",
+    assert_select("#expected_count", "5",
                   "MO taxon_id and only_id must override user-supplied values")
   end
 
-  def test_url_mode_estimate_uses_user_supplied_importable_taxon_id
+  def test_url_mode_expected_uses_user_supplied_importable_taxon_id
     user = users(:rolf)
     # taxon_id=54134 is a Fungi child — importable. The estimate must send
     # taxon_id=54134, not MO's IMPORTABLE_TAXON_IDS_ARG (47170,47685).
@@ -1430,12 +1430,13 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "3",
+    assert_select("#expected_count", "3",
                   "Importable user-supplied taxon_id should be used " \
-                  "in the estimate, not replaced by IMPORTABLE_TAXON_IDS_ARG")
+                  "in the expected count, not replaced " \
+                  "by IMPORTABLE_TAXON_IDS_ARG")
   end
 
-  def test_url_mode_estimate_excludes_id_param
+  def test_url_mode_expected_excludes_id_param
     user = users(:rolf)
     # URL supplies id=12345; PageParser drops it in URL mode, estimate must too.
     url = "#{INAT_API_OBS_URL}?project_id=291058&id=12345"
@@ -1453,11 +1454,11 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "9",
-                  "id param from URL must be excluded from the estimate")
+    assert_select("#expected_count", "9",
+                  "id param from URL must be excluded from the expected count")
   end
 
-  def test_non_superuser_url_with_foreign_user_id_strips_user_id_from_estimate
+  def test_non_superuser_url_with_foreign_user_id_strips_user_id_from_expected
     user = users(:rolf)
     # user_id is stripped for non-superimporters — iNat ORs user_id and
     # user_login, so a user-supplied user_id alongside the injected user_login
@@ -1478,8 +1479,8 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "5",
-                  "user_id must be stripped from the estimate request")
+    assert_select("#expected_count", "5",
+                  "user_id must be stripped from the expected count request")
   end
 
   def test_url_params_preserved_through_confirm_round_trip
@@ -1506,7 +1507,7 @@ class InatImportsControllerTest < FunctionalTestCase
                  "inat_url should be saved from superform hidden field")
   end
 
-  def test_estimate_422_surfaces_inat_error_message
+  def test_expected_422_surfaces_inat_error_message
     user = users(:rolf)
     url = "#{INAT_API_OBS_URL}?place_id=678910"
     inat_error = "Unknown place_id 678910"

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -750,12 +750,72 @@ class InatImportsControllerTest < FunctionalTestCase
     )
   end
 
-  # estimators.rb lines 99-102: rescue block of fetch_estimate_with_date_count
+  def test_confirm_renders_gracefully_when_raw_requested_count_fails
+    # raw_requested_query_args has no taxon_id; general stub catches it
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      to_return(status: 200, body: "not json")
+    # Requests with taxon_id (all other count queries) succeed
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including(
+        "taxon_id" => Inat::Constants::IMPORTABLE_TAXON_IDS_ARG
+      )).
+      to_return(status: 200, body: { total_results: 3 }.to_json)
+
+    login(users(:rolf).login)
+    post(:create,
+         params: { inat_ids: "1,2,3", inat_username: "rolf", consent: 1 })
+
+    assert_response(
+      :success,
+      "Confirm page should render when raw-requested count fails"
+    )
+    assert_select(
+      "#requested_count", { count: 0 },
+      "Requested count should not appear when raw-requested count fails"
+    )
+    assert_select(
+      "#expected_count", "3",
+      "Expected count should still show when raw-requested count fails"
+    )
+  end
+
+  def test_confirm_renders_gracefully_when_after_taxon_count_fails
+    taxon_ids = Inat::Constants::IMPORTABLE_TAXON_IDS_ARG
+    without_field = Inat::Constants::BASE_FILTER_PARAMS[:without_field]
+
+    # General stub succeeds for requests without taxon_id (raw_requested)
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      to_return(status: 200, body: { total_results: 3 }.to_json)
+    # after_taxon has taxon_id but not without_field — matches this failure stub
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including("taxon_id" => taxon_ids)).
+      to_return(status: 200, body: "not json")
+    # expected/unlicensed/date-estimate have both — matched first (LIFO)
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including("taxon_id" => taxon_ids,
+                                 "without_field" => without_field)).
+      to_return(status: 200, body: { total_results: 3 }.to_json)
+
+    login(users(:rolf).login)
+    post(:create,
+         params: { inat_ids: "1,2,3", inat_username: "rolf", consent: 1 })
+
+    assert_response(
+      :success,
+      "Confirm page should render when after-taxon count fails"
+    )
+    assert_select(
+      "#expected_count", "3",
+      "Expected count should still show when after-taxon count fails"
+    )
+  end
+
+  # estimators.rb rescue block of fetch_estimate_with_date_count
   def test_confirm_renders_gracefully_when_date_estimate_fails
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       to_return(status: 200, body: { total_results: 3 }.to_json)
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including("d1" => "1800-01-01")).
+      with(query: hash_including("d1" => "1000-01-01")).
       to_return(status: 500, body: "error")
 
     login(users(:rolf).login)

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -676,8 +676,15 @@ class InatImportsControllerTest < FunctionalTestCase
     assert(InatImport.super_importer?(user),
            "Test requires user to be a super_importer")
 
-    # General query returns 3 for expected count and other requests
+    licensed_filter =
+      Inat::Constants::LICENSED_FILTER.transform_keys(&:to_s).
+      transform_values(&:to_s)
+    # General stub returns 5 for unfiltered counts (raw_requested, after_taxon)
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      to_return(status: 200, body: { total_results: 5 }.to_json)
+    # licensed=true returns 3 (expected + date-estimate counts)
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including(licensed_filter)).
       to_return(status: 200, body: { total_results: 3 }.to_json)
     # licensed=false returns 2 unlicensed obs — registered last, matched first
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
@@ -697,7 +704,7 @@ class InatImportsControllerTest < FunctionalTestCase
     )
     assert_select(
       "#total_ignored_count", "2",
-      "Confirm form should report unlicensed obs that will be skipped"
+      "Total ignored = requested(5) - expected(3)"
     )
   end
 
@@ -815,7 +822,7 @@ class InatImportsControllerTest < FunctionalTestCase
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       to_return(status: 200, body: { total_results: 3 }.to_json)
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including("d1" => "1000-01-01")).
+      with(query: hash_including("d1" => Inat::Constants::EARLIEST_DATE_FILTER)).
       to_return(status: 500, body: "error")
 
     login(users(:rolf).login)

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -332,7 +332,7 @@ class InatImportsControllerTest < FunctionalTestCase
       relationship: :import, external_id: inat_id,
       url: "#{site.base_url}#{inat_id}"
     )
-    { total_results: 1 }.to_json
+    expected_response = { total_results: 1 }.to_json
 
     stub_request(
       :get, %r{api\.inaturalist\.org/v1/observations}
@@ -452,7 +452,7 @@ class InatImportsControllerTest < FunctionalTestCase
     user = users(:rolf)
     inat_username = "rolf"
     inat_ids = "123,456"
-    { total_results: 2 }.to_json
+    expected_response = { total_results: 2 }.to_json
 
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       to_return(status: 200, body: expected_response)
@@ -696,7 +696,7 @@ class InatImportsControllerTest < FunctionalTestCase
       "Expected count for import-others should be licensed obs count"
     )
     assert_select(
-      "#ignored_unlicensed_count", "2",
+      "#total_ignored_count", "2",
       "Confirm form should report unlicensed obs that will be skipped"
     )
   end

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -22,30 +22,34 @@ module Views::Controllers::InatImports
                      "No link when URL cannot be constructed")
     end
 
-    # Lines 135-136, 153, 173: not_importable and no_date rows (plain text)
     def test_ignored_section_not_importable_and_no_date_rows
       # requested(10) - after_taxon(8) = 2 not-importable
-      # estimate(8) - estimate_with_date(6) = 2 no-date
+      # expected(8) - estimate_with_date(6) = 2 no-date; total = 4, 2 rows
       html = render_form(expected: 8,
                          breakdown: { requested: 10, after_taxon: 8,
                                       estimate_with_date: 6 })
 
+      assert_html(html, "#total_ignored_count", text: "4")
+      assert_html(html, "small",
+                  text: :inat_import_confirm_ignored_overlap_note.l.
+                        as_displayed)
       assert_html(html, "b",
                   text: :inat_import_confirm_not_importable_caption.l)
       assert_html(html, "b",
                   text: :inat_import_confirm_no_date_caption.l)
     end
 
-    # Lines 143-144, 167-170, 184, 208, 210-211:
-    # already_imported row with a live already_imported_url
     def test_ignored_section_already_imported_row_with_link
-      # after_taxon(10) - estimate(8) = 2 already-imported (own import)
+      # after_taxon(10) - expected(8) = 2 already-imported; total = 2, 1 row
       # inat_ids set → already_imported_url returns a URL → link rendered
       html = render_form(model_attrs: { inat_ids: "1,2,3" },
                          expected: 8,
                          breakdown: { requested: 10, after_taxon: 10,
                                       estimate_with_date: 8 })
 
+      assert_html(html, "#total_ignored_count", text: "2")
+      assert_no_html(html, "small",
+                     "Overlap note absent with only one ignored row")
       assert_html(html, "a[href*='with_field=Mushroom+Observer+URL']")
     end
 

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Views::Controllers::InatImports
+  class ConfirmFormTest < ComponentTestCase
+    def setup
+      super
+      @inat_import = inat_imports(:rolf_inat_import)
+    end
+
+    # Line 63: plain(@requested.to_s) — when requested_obs_url is nil
+    # (no inat_ids, original_inat_url, inat_url, or inat_username set)
+    def test_requested_count_plain_when_no_url_constructable
+      html = render_form(model_attrs: { inat_ids: nil, inat_username: nil },
+                         estimate: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_html(html, "#requested_count", text: "5")
+      assert_no_html(html, "#requested_count a",
+                     "No link when URL cannot be constructed")
+    end
+
+    # Lines 135-136, 153, 173: not_importable and no_date rows (plain text)
+    def test_ignored_section_not_importable_and_no_date_rows
+      # requested(10) - after_taxon(8) = 2 not-importable
+      # estimate(8) - estimate_with_date(6) = 2 no-date
+      html = render_form(estimate: 8,
+                         breakdown: { requested: 10, after_taxon: 8,
+                                      estimate_with_date: 6 })
+
+      assert_html(html, "h5",
+                  text: :inat_import_confirm_ignored_heading.l.as_displayed)
+      assert_html(html, "b",
+                  text: :inat_import_confirm_not_importable_caption.l)
+      assert_html(html, "b",
+                  text: :inat_import_confirm_no_date_caption.l)
+    end
+
+    # Lines 143-144, 167-170, 184, 208, 210-211:
+    # already_imported row with a live already_imported_url
+    def test_ignored_section_already_imported_row_with_link
+      # after_taxon(10) - estimate(8) = 2 already-imported (own import)
+      # inat_ids set → already_imported_url returns a URL → link rendered
+      html = render_form(model_attrs: { inat_ids: "1,2,3" },
+                         estimate: 8,
+                         breakdown: { requested: 10, after_taxon: 10,
+                                      estimate_with_date: 8 })
+
+      assert_html(html, "a[href*='with_field=Mushroom+Observer+URL']")
+    end
+
+    # Lines 63, 143-144, 184, 208-209, 173:
+    # already_imported row without URL (already_imported_url → nil)
+    def test_ignored_section_already_imported_row_no_link_when_no_url
+      # No ids/url/username → requested_obs_url nil → already_imported_url nil
+      html = render_form(model_attrs: { inat_ids: nil, inat_username: nil },
+                         estimate: 8,
+                         breakdown: { requested: 10, after_taxon: 10,
+                                      estimate_with_date: 8 })
+
+      assert_html(html, "#requested_count")
+      assert_no_html(html, "a[href*='with_field']",
+                     "No already-imported link when URL cannot be constructed")
+    end
+
+    private
+
+    def render_form(model_attrs: {}, estimate: 5, unlicensed_obs: nil,
+                    breakdown: {})
+      defaults = { inat_username: "joe" }
+      model = FormObject::InatImportConfirm.new(defaults.merge(model_attrs))
+      render(ConfirmForm.new(
+               model,
+               estimate: estimate,
+               unlicensed_obs: unlicensed_obs,
+               breakdown: { inat_import: @inat_import }.merge(breakdown)
+             ))
+    end
+  end
+end

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -13,7 +13,7 @@ module Views::Controllers::InatImports
     # (no inat_ids, original_inat_url, inat_url, or inat_username set)
     def test_requested_count_plain_when_no_url_constructable
       html = render_form(model_attrs: { inat_ids: nil, inat_username: nil },
-                         estimate: 5,
+                         expected: 5,
                          breakdown: { requested: 5, after_taxon: 5,
                                       estimate_with_date: 5 })
 
@@ -26,7 +26,7 @@ module Views::Controllers::InatImports
     def test_ignored_section_not_importable_and_no_date_rows
       # requested(10) - after_taxon(8) = 2 not-importable
       # estimate(8) - estimate_with_date(6) = 2 no-date
-      html = render_form(estimate: 8,
+      html = render_form(expected: 8,
                          breakdown: { requested: 10, after_taxon: 8,
                                       estimate_with_date: 6 })
 
@@ -44,7 +44,7 @@ module Views::Controllers::InatImports
       # after_taxon(10) - estimate(8) = 2 already-imported (own import)
       # inat_ids set → already_imported_url returns a URL → link rendered
       html = render_form(model_attrs: { inat_ids: "1,2,3" },
-                         estimate: 8,
+                         expected: 8,
                          breakdown: { requested: 10, after_taxon: 10,
                                       estimate_with_date: 8 })
 
@@ -56,7 +56,7 @@ module Views::Controllers::InatImports
     def test_ignored_section_already_imported_row_no_link_when_no_url
       # No ids/url/username → requested_obs_url nil → already_imported_url nil
       html = render_form(model_attrs: { inat_ids: nil, inat_username: nil },
-                         estimate: 8,
+                         expected: 8,
                          breakdown: { requested: 10, after_taxon: 10,
                                       estimate_with_date: 8 })
 
@@ -67,13 +67,13 @@ module Views::Controllers::InatImports
 
     private
 
-    def render_form(model_attrs: {}, estimate: 5, unlicensed_obs: nil,
+    def render_form(model_attrs: {}, expected: 5, unlicensed_obs: nil,
                     breakdown: {})
       defaults = { inat_username: "joe" }
       model = FormObject::InatImportConfirm.new(defaults.merge(model_attrs))
       render(ConfirmForm.new(
                model,
-               estimate: estimate,
+               expected: expected,
                unlicensed_obs: unlicensed_obs,
                breakdown: { inat_import: @inat_import }.merge(breakdown)
              ))

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -73,6 +73,18 @@ module Views::Controllers::InatImports
       assert_html(html, "a[href*='field:Mushroom']")
     end
 
+    def test_ignored_section_unlicensed_row_links_to_inat
+      # import_others: "1" + inat_ids set → unlicensed_obs_url returns a URL
+      html = render_form(model_attrs: { inat_ids: "1,2,3",
+                                        import_others: "1" },
+                         unlicensed_obs: 2,
+                         expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_html(html, "a[href*='licensed=false']")
+    end
+
     # Lines 63, 143-144, 184, 208-209, 173:
     # already_imported row without URL (already_imported_url → nil)
     def test_ignored_section_already_imported_row_no_link_when_no_url

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -77,8 +77,10 @@ module Views::Controllers::InatImports
                          breakdown: { requested: 5, after_taxon: 5,
                                       estimate_with_date: 5 })
 
-      assert_html(html, "small",
-                  text: :inat_import_confirm_expected_staleness.l)
+      assert_html(html, "#as_of")
+      assert_html(html, ".staleness-note",
+                  text: :inat_import_confirm_expected_staleness.l.
+                        as_displayed)
     end
 
     def test_expected_count_omits_note_when_no_expected
@@ -86,8 +88,52 @@ module Views::Controllers::InatImports
                          breakdown: { requested: 5, after_taxon: 5,
                                       estimate_with_date: 5 })
 
-      assert_no_html(html, "small",
+      assert_no_html(html, "#as_of",
                      "Timestamp note absent when expected count is nil")
+    end
+
+    def test_staleness_note_suppressed_when_importing_inat_ids
+      html = render_form(model_attrs: { inat_ids: "1,2,3" },
+                         expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_html(html, "#as_of")
+      assert_no_html(html, ".staleness-note",
+                     "Staleness note absent when importing specific iNat IDs")
+    end
+
+    def test_staleness_note_suppressed_when_url_has_id_param
+      url = "#{Inat::Constants::SITE}/observations?id=12345"
+      html = render_form(model_attrs: { inat_ids: nil, inat_url: url },
+                         expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_no_html(html, ".staleness-note",
+                     "Staleness note absent when URL has id param")
+    end
+
+    def test_staleness_note_suppressed_when_url_has_past_d2
+      url = "#{Inat::Constants::SITE}/observations?user_id=joe&d2=2020-01-01"
+      html = render_form(model_attrs: { inat_ids: nil, inat_url: url },
+                         expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_no_html(html, ".staleness-note",
+                     "Staleness note absent when URL has past d2")
+    end
+
+    def test_staleness_note_suppressed_when_url_has_past_year
+      url = "#{Inat::Constants::SITE}/observations?user_id=joe&year=2020"
+      html = render_form(model_attrs: { inat_ids: nil, inat_url: url },
+                         expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_no_html(html, ".staleness-note",
+                     "Staleness note absent when URL filtered to past year")
     end
 
     def test_expected_count_plain_when_no_url_constructable

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -23,14 +23,13 @@ module Views::Controllers::InatImports
     end
 
     def test_ignored_section_not_importable_and_no_date_rows
-      # requested(10) - after_taxon(8) = 2 not-importable
-      # expected(8) - estimate_with_date(6) = 2 no-date; total = 4, 2 rows
+      # requested(10) - estimate_with_date(6) = 4 total ignored; 2 rows → note
       html = render_form(expected: 8,
                          breakdown: { requested: 10, after_taxon: 8,
                                       estimate_with_date: 6 })
 
       assert_html(html, "#total_ignored_count", text: "4")
-      assert_html(html, "small",
+      assert_html(html, "small.overlap-note",
                   text: :inat_import_confirm_ignored_overlap_note.l.
                         as_displayed)
       assert_html(html, "b",
@@ -46,6 +45,49 @@ module Views::Controllers::InatImports
 
       assert_html(html, "#expected_count a[href*='iconic_taxa']" \
                         "[target='_blank']")
+    end
+
+    def test_expected_obs_url_adds_date_filter_when_none_present
+      html = render_form(expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_html(html, "#expected_count " \
+                        "a[href*='d1=#{Inat::Constants::EARLIEST_DATE_FILTER}']")
+    end
+
+    def test_expected_obs_url_preserves_user_supplied_date
+      url = "#{Inat::Constants::SITE}/observations?user_id=joe&d1=2020-01-01"
+      html = render_form(model_attrs: { inat_ids: nil, inat_url: url },
+                         expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_html(html, "#expected_count a[href*='d1=2020-01-01']")
+      assert_no_html(
+        html,
+        "#expected_count " \
+        "a[href*='d1=#{Inat::Constants::EARLIEST_DATE_FILTER}']",
+        "User-supplied d1 should not be replaced with the default"
+      )
+    end
+
+    def test_expected_count_shows_timestamp_note
+      html = render_form(expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_html(html, "small",
+                  text: :inat_import_confirm_expected_staleness.l)
+    end
+
+    def test_expected_count_omits_note_when_no_expected
+      html = render_form(expected: nil,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_no_html(html, "small",
+                     "Timestamp note absent when expected count is nil")
     end
 
     def test_expected_count_plain_when_no_url_constructable
@@ -68,7 +110,7 @@ module Views::Controllers::InatImports
                                       estimate_with_date: 8 })
 
       assert_html(html, "#total_ignored_count", text: "2")
-      assert_no_html(html, "small",
+      assert_no_html(html, "small.overlap-note",
                      "Overlap note absent with only one ignored row")
       assert_html(html, "a[href*='field:Mushroom']")
     end

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -73,6 +73,18 @@ module Views::Controllers::InatImports
       assert_html(html, "a[href*='field:Mushroom']")
     end
 
+    def test_requested_count_translates_multi_taxon_id_to_iconic_taxa
+      url = "https://www.inaturalist.org/observations?taxon_id=47170,47685"
+      html = render_form(model_attrs: { inat_ids: nil, inat_url: url },
+                         expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_html(html, "#requested_count a[href*='iconic_taxa']")
+      assert_no_html(html, "#requested_count a[href*='taxon_id']",
+                     "Multi-value taxon_id replaced with iconic_taxa in link")
+    end
+
     def test_ignored_section_unlicensed_row_links_to_inat
       # import_others: "1" + inat_ids set → unlicensed_obs_url returns a URL
       html = render_form(model_attrs: { inat_ids: "1,2,3",

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -70,7 +70,7 @@ module Views::Controllers::InatImports
       assert_html(html, "#total_ignored_count", text: "2")
       assert_no_html(html, "small",
                      "Overlap note absent with only one ignored row")
-      assert_html(html, "a[href*='with_field=Mushroom+Observer+URL']")
+      assert_html(html, "a[href*='field:Mushroom']")
     end
 
     # Lines 63, 143-144, 184, 208-209, 173:

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -39,6 +39,26 @@ module Views::Controllers::InatImports
                   text: :inat_import_confirm_no_date_caption.l)
     end
 
+    def test_expected_count_links_to_inat_when_url_constructable
+      html = render_form(expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_html(html, "#expected_count a[href*='without_field']" \
+                        "[target='_blank']")
+    end
+
+    def test_expected_count_plain_when_no_url_constructable
+      html = render_form(model_attrs: { inat_ids: nil, inat_username: nil },
+                         expected: 5,
+                         breakdown: { requested: 5, after_taxon: 5,
+                                      estimate_with_date: 5 })
+
+      assert_html(html, "#expected_count", text: "5")
+      assert_no_html(html, "#expected_count a",
+                     "No link when URL cannot be constructed")
+    end
+
     def test_ignored_section_already_imported_row_with_link
       # after_taxon(10) - expected(8) = 2 already-imported; total = 2, 1 row
       # inat_ids set → already_imported_url returns a URL → link rendered

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -30,8 +30,6 @@ module Views::Controllers::InatImports
                          breakdown: { requested: 10, after_taxon: 8,
                                       estimate_with_date: 6 })
 
-      assert_html(html, "h5",
-                  text: :inat_import_confirm_ignored_heading.l.as_displayed)
       assert_html(html, "b",
                   text: :inat_import_confirm_not_importable_caption.l)
       assert_html(html, "b",

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -44,7 +44,7 @@ module Views::Controllers::InatImports
                          breakdown: { requested: 5, after_taxon: 5,
                                       estimate_with_date: 5 })
 
-      assert_html(html, "#expected_count a[href*='without_field']" \
+      assert_html(html, "#expected_count a[href*='iconic_taxa']" \
                         "[target='_blank']")
     end
 

--- a/test/views/controllers/inat_imports/job_trackers/current_test.rb
+++ b/test/views/controllers/inat_imports/job_trackers/current_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Views::Controllers::InatImports::JobTrackers
+  class CurrentTest < ComponentTestCase
+    def setup
+      super
+      @import = inat_imports(:lone_wolf_import)
+      @tracker = inat_import_job_trackers(:lone_wolf_tracker)
+    end
+
+    # Lines 96-102, 108-112: render_ignored_section and render_ignored_row
+    def test_ignored_section_shown_when_done_with_ignored_counts
+      @import.update!(ignored_not_importable_count: 3,
+                      ignored_already_imported_count: 2)
+
+      html = render(Current.new(tracker: @tracker))
+
+      assert_html(html, "h5",
+                  text: :inat_import_tracker_ignored_heading.l.as_displayed)
+      assert_html(html, "b",
+                  text: :inat_import_tracker_ignored_not_importable.l)
+      assert_html(html, "b",
+                  text: :inat_import_tracker_ignored_already_imported.l)
+      assert_no_html(html, "b",
+                     "Zero-count date_missing row should not render",
+                     text: :inat_import_tracker_ignored_date_missing.l)
+    end
+
+    def test_ignored_section_absent_when_no_ignored_obs
+      html = render(Current.new(tracker: @tracker))
+
+      assert_no_html(html, "h5",
+                     "Ignored heading absent when all counts are zero")
+    end
+  end
+end


### PR DESCRIPTION
Resolves #4597

## Manual tests — iNat import confirm form

### Types of requests
  - [x] already imported/mirrored
  - [x] neither fungi nor myxo
  - [x] unlicensed when importing others' observations
  - [x] Observed date missing

  - [ ] list of iNat ids
  - [x] import all
  - [x] import other's observations
  - [ ] variety of iNat search URLs

### Caveats 
  - [ ] Time stamp appears at top of form (above Requested Observations)
  - [ ] Includes "may change" caveat if importing all or a URL which is not filtered to specific IDs.
  - [ ] Omits "may change" caveat if importing listed IDs or a URL filtered to specific IDs. 

### Requested Observations
  - [ ] Always appears
  - [ ] Count is reasonable and linked to iNat 
  - [ ] Linked iNat page opens in new tab,  shows observations **without** any MO-added filters
  (no taxon, no field filter), count on iNat page == Requested Observations count

### Total Ignored Observations
  - [ ] Always appears
  - [ ] Count == Requested Observations - Expected, is not linked
  - [ ] "(following categories may overlap)" note appears when 2+ detail ignored rows are shown
  - [ ] Note is absent when only one ignored row is shown

### Ignored Observations detailed rows
- [ ] Below Total Ignored Observations, Indented
- [ ] Row order is reasonable

### Already imported row
- [ ] Appears if any requested observation already imported
- [ ] Does not appear if no requested observations already imported
- [ ] Count is reasonable and linked to iNat 
- [ ] Link should contain `field:Mushroom%20Observer%20URL`
- [ ] Linked iNat page opens in new tab,  count on iNat page == Already imported count, shows only observations with "Mushroom Observer URL" observation field

#### Unlicensed observations
- [ ] Appears if any requested observation is unlicensed (All Rights Reserved)
- [ ] Does not appear if no requested observations unlicensed 
- [ ] Count is reasonable and linked to iNat 
- [ ] Link should contain `field:Mushroom%20Observer%20URL`
- [ ] Linked iNat page opens in new tab,  count on iNat page == Unlicensed count, shows only unlicensed observations 

#### Not fungi or slime molds
- [ ] Appears if any requested observation is neither fungus or slime mold
- [ ] Does not appear if all requested observations are fungi or slime molds
- [ ] Count is reasonable and NOT linked to iNat 

#### No observation date
- [ ] Appears if any requested observation has observation date missing
- [ ] Does not appear if all requested observations have an observation date 
- [ ] Count is reasonable and NOT linked to iNat 

### Expected imports
- [ ] Always appears, below Ignored Observations stuff 
- [ ] Is a link that opens iNat in a new tab
- [ ] Linked iNat page opens in new tab,  count on iNat page == expected imports count, is a plausible Requested Observations (fungi/myxo only, not already imported). 
- [ ] iNat count should = Expected Imports count
- [ ] link URL contains `iconic_taxa=Fungi,Protozoa`, `without_field` (or equivalent)
- [ ] link URL contains a `license=` parameter if Importing others
