### PR TITLE
Extract Matrix::Box footer rendering into Footer module

### DIFF
--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -23,9 +23,9 @@
 #   render MatrixBox.new(id: 123, extra_class: "text-center") do
 #     tag.div(class: "panel panel-default") { "Custom content" }
 #   end
-# rubocop:disable Metrics/ClassLength
 class Components::Matrix::Box < Components::Base
   include Components::Matrix::Box::RenderData
+  include Components::Matrix::Box::Footer
 
   # Properties
   prop :user, _Nilable(User), default: nil
@@ -258,85 +258,4 @@ class Components::Matrix::Box < Components::Base
   def render_external_credit_link(link)
     render(::Components::Link::External.new(link[:text], link[:url]))
   end
-
-  def render_log_footer(panel)
-    return unless @data[:detail].present? || @data[:time].present?
-
-    panel.with_footer(classes: "log-footer") do
-      render_footer_detail(@data[:detail])
-      render_footer_time(@data[:time])
-    end
-  end
-
-  def render_footer_detail(detail)
-    return if detail.blank?
-
-    if detail.is_a?(User)
-      render_user_detail(detail)
-    else
-      div(class: "rss-detail small") { detail }
-    end
-  end
-
-  def render_footer_time(time)
-    return unless time
-
-    div(
-      class: "rss-what rss-updated-at small",
-      data: { controller: "local-time", local_time_utc_value: time.utc.iso8601 }
-    ) do
-      # Server-rendered fallback for no-JS clients; replaced by Stimulus
-      time.display_time
-    end
-  end
-
-  def render_user_detail(user)
-    div(class: "rss-detail small") do
-      plain("#{:list_users_joined.l}: #{user.created_at.web_date}")
-      br
-      plain("#{:list_users_contribution.l}: #{user.contribution}")
-      br
-      link_to(
-        :OBSERVATIONS.l,
-        observations_path(by_user: user.id)
-      )
-    end
-  end
-
-  def render_identify_footer(panel)
-    return unless @observation_view
-
-    panel.with_footer(classes: "panel-active text-center position-relative") do
-      render(Components::Image::MarkAsReviewedToggle.new(
-               observation_view: @observation_view,
-               selector: "box_reviewed",
-               label_class: "stretched-link"
-             ))
-    end
-  end
-
-  def render_custom_footer(panel, &block)
-    panel.with_footer(classes: "text-center", &block)
-  end
-
-  def render_project_admin_footer(panel)
-    return unless show_project_exclude_button?
-
-    panel.with_footer(classes: "text-center") do
-      render(Components::Button.new(
-               type: :post,
-               name: :EXCLUDE.t,
-               target: exclude_observation_project_update_path(
-                 project_id: @project.id, id: @data[:what].id
-               ),
-               size: :sm
-             ))
-    end
-  end
-
-  def show_project_exclude_button?
-    @project && @data && @data[:type] == :observation &&
-      @project.is_admin?(@user)
-  end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/components/matrix/box/footer.rb
+++ b/app/components/matrix/box/footer.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class Components::Matrix::Box
+  # Footer rendering methods for Components::Matrix::Box.
+  #
+  # Included by Box to keep the footer slot logic in its own file.
+  # Methods here call `panel.with_footer(classes:) { ... }` on the
+  # Panel passed in from `render_object_layout`.
+  module Footer
+    private
+
+    def render_log_footer(panel)
+      return unless @data[:detail].present? || @data[:time].present?
+
+      panel.with_footer(classes: "log-footer") do
+        render_footer_detail(@data[:detail])
+        render_footer_time(@data[:time])
+      end
+    end
+
+    def render_footer_detail(detail)
+      return if detail.blank?
+
+      if detail.is_a?(User)
+        render_user_detail(detail)
+      else
+        div(class: "rss-detail small") { detail }
+      end
+    end
+
+    def render_footer_time(time)
+      return unless time
+
+      div(
+        class: "rss-what rss-updated-at small",
+        data: { controller: "local-time",
+                local_time_utc_value: time.utc.iso8601 }
+      ) do
+        time.display_time
+      end
+    end
+
+    def render_user_detail(user)
+      div(class: "rss-detail small") do
+        plain("#{:list_users_joined.l}: #{user.created_at.web_date}")
+        br
+        plain("#{:list_users_contribution.l}: #{user.contribution}")
+        br
+        link_to(:OBSERVATIONS.l, observations_path(by_user: user.id))
+      end
+    end
+
+    def render_identify_footer(panel)
+      return unless @observation_view
+
+      panel.with_footer(
+        classes: "panel-active text-center position-relative"
+      ) do
+        render(Components::Image::MarkAsReviewedToggle.new(
+                 observation_view: @observation_view,
+                 selector: "box_reviewed",
+                 label_class: "stretched-link"
+               ))
+      end
+    end
+
+    def render_project_admin_footer(panel)
+      return unless show_project_exclude_button?
+
+      panel.with_footer(classes: "text-center") do
+        render(Components::Button.new(
+                 type: :post,
+                 name: :EXCLUDE.t,
+                 target: exclude_observation_project_update_path(
+                   project_id: @project.id, id: @data[:what].id
+                 ),
+                 size: :sm
+               ))
+      end
+    end
+
+    def render_custom_footer(panel, &block)
+      panel.with_footer(classes: "text-center", &block)
+    end
+
+    def show_project_exclude_button?
+      @project && @data && @data[:type] == :observation &&
+        @project.is_admin?(@user)
+    end
+  end
+end

--- a/test/components/matrix/box/footer_test.rb
+++ b/test/components/matrix/box/footer_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Tests for Components::Matrix::Box::Footer, the mixin included by
+# Components::Matrix::Box that owns all footer slot rendering.
+#
+# Content methods (render_footer_detail, render_footer_time,
+# render_user_detail) are tested by creating a minimal anonymous
+# Phlex component that includes the module and calls the method
+# directly in view_template — same technique as collapse_div_test.rb.
+#
+# Slot-level methods (render_log_footer, render_identify_footer,
+# render_project_admin_footer) are tested through a full Box render
+# so the Panel slot machinery is exercised.
+class MatrixBoxFooterTest < ComponentTestCase
+  def setup
+    super
+    @user = users(:rolf)
+  end
+
+  # ---------------------------------------------------------------
+  # render_footer_detail
+  # ---------------------------------------------------------------
+
+  def test_footer_detail_nil_renders_nothing
+    assert_equal("", render_detail(nil))
+  end
+
+  def test_footer_detail_empty_string_renders_nothing
+    assert_equal("", render_detail(""))
+  end
+
+  def test_footer_detail_string_renders_detail_div
+    html = render_detail("Some log detail text")
+
+    assert_html(html, "div.rss-detail.small", text: "Some log detail text")
+  end
+
+  def test_footer_detail_user_renders_user_info
+    user = users(:rolf)
+    html = render_detail(user)
+
+    assert_html(html, "div.rss-detail.small")
+    assert_html(html,
+                "a[href='#{routes.observations_path(by_user: user.id)}']",
+                text: :OBSERVATIONS.l.as_displayed)
+  end
+
+  # ---------------------------------------------------------------
+  # render_footer_time
+  # ---------------------------------------------------------------
+
+  def test_footer_time_nil_renders_nothing
+    assert_equal("", render_time(nil))
+  end
+
+  def test_footer_time_renders_local_time_div
+    time = Time.zone.parse("2024-06-01 12:00:00 UTC")
+    html = render_time(time)
+
+    assert_html(html,
+                "div[data-controller='local-time']" \
+                "[data-local-time-utc-value='#{time.utc.iso8601}']")
+  end
+
+  # ---------------------------------------------------------------
+  # render_project_admin_footer (via full Box render)
+  # ---------------------------------------------------------------
+
+  def test_project_admin_footer_shown_for_admin
+    project = projects(:bolete_project)
+    obs = observations(:coprinus_comatus_obs)
+    dick = users(:dick) # member of bolete_admins
+    html = render(
+      Components::Matrix::Box.new(user: dick, object: obs, project: project)
+    )
+
+    expected_path = routes.exclude_observation_project_update_path(
+      project_id: project.id, id: obs.id
+    )
+    assert_html(html, "form[action='#{expected_path}']")
+  end
+
+  def test_project_admin_footer_hidden_for_non_admin
+    project = projects(:bolete_project)
+    obs = observations(:coprinus_comatus_obs)
+    html = render(
+      Components::Matrix::Box.new(user: @user, object: obs, project: project)
+    )
+
+    expected_path = routes.exclude_observation_project_update_path(
+      project_id: project.id, id: obs.id
+    )
+    assert_no_html(html, "form[action='#{expected_path}']")
+  end
+
+  def test_project_admin_footer_hidden_without_project
+    obs = observations(:coprinus_comatus_obs)
+    html = render(
+      Components::Matrix::Box.new(user: @user, object: obs)
+    )
+
+    assert_no_html(html, "div.panel-footer.text-center")
+  end
+
+  private
+
+  # Renders render_footer_detail(detail) in a Phlex context.
+  def render_detail(detail)
+    render(Class.new(Components::Base) do
+      include Components::Matrix::Box::Footer
+
+      define_method(:view_template) { render_footer_detail(detail) }
+    end.new)
+  end
+
+  # Renders render_footer_time(time) in a Phlex context.
+  def render_time(time)
+    render(Class.new(Components::Base) do
+      include Components::Matrix::Box::Footer
+
+      define_method(:view_template) { render_footer_time(time) }
+    end.new)
+  end
+end


### PR DESCRIPTION
## Summary

Extracts the seven footer-rendering methods from `Components::Matrix::Box` into a new `Components::Matrix::Box::Footer` module, following the same included-module pattern as the existing `RenderData` module in the same directory.

The moved methods: `render_log_footer`, `render_footer_detail`, `render_footer_time`, `render_user_detail`, `render_identify_footer`, `render_project_admin_footer`, `render_custom_footer`, and the `show_project_exclude_button?` predicate.

`Components::Matrix::Box` adds `include Components::Matrix::Box::Footer` and the class drops from ~340 lines to 262, removing the `# rubocop:disable Metrics/ClassLength` annotation.

## Test plan

- [x] New `test/components/matrix/box/footer_test.rb` — 10 tests covering `render_footer_detail` (nil, empty string, string, User), `render_footer_time` (nil, present), and `render_project_admin_footer` gate (admin user shows button, non-admin hides it, no project hides it)
- [x] Existing `test/components/matrix/box_test.rb` — all 19 tests continue to pass, including the log-footer and identify-footer integration paths
- [x] RuboCop clean on both new files
