### PR TITLE
Close 3 coverage gaps (1 dead branch removed, 2 tested)

### DIFF
--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -130,18 +130,13 @@ class Inat
       nil
     end
 
-    # Stamp the MO observation's URL onto the source iNat observation. Skipped
-    # by default in development, so a local import never annotates a real iNat
-    # observation; production writes back (the test suite is isolated from
-    # iNat by WebMock). Admins can override this per import via a checkbox on
-    # the import form (InatImport#writeback); when they haven't, the policy is
-    # `default` and the environment decides.
+    # Stamp the MO observation's URL onto the source iNat observation. Only
+    # called when writing back: `finalize_import` gates this on
+    # `skip_inat_writeback?` (skipped by default in development so a local
+    # import never annotates a real iNat observation; production writes back,
+    # and the test suite is isolated from iNat by WebMock). Admins can override
+    # per import via a checkbox on the import form (InatImport#writeback).
     def update_inat_observation
-      if skip_inat_writeback?
-        log("Skipped iNat write-back for #{@inat_obs[:id]}")
-        return
-      end
-
       update_mushroom_observer_url_field
       sleep(1) # Avoid hitting iNat API rate limits
     end

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -657,6 +657,16 @@ class ApplicationFormTest < ComponentTestCase
     assert_includes(form, "my-3")
   end
 
+  # `as:` other than :button delegates to Superform's submit, which renders an
+  # <input type="submit"> rather than MO's Button::Submit <button>.
+  def test_submit_as_non_button_uses_superform_input
+    form = render_form do
+      submit("Save", as: :input)
+    end
+
+    assert_html(form, "input[type='submit'][value='Save']")
+  end
+
   def test_submit_with_custom_submits_with
     form = render_form do
       submit("Save", submits_with: "Saving...")

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -1508,6 +1508,12 @@ class InatImportsControllerTest < FunctionalTestCase
                   "Form should be reloaded, not the confirm page")
   end
 
+  # URI.parse raises URI::InvalidURIError on a malformed URL (e.g. a space);
+  # taxon_ids_from_url rescues it and returns no ids rather than 500ing.
+  def test_taxon_ids_from_url_handles_malformed_url
+    assert_equal([], @controller.send(:taxon_ids_from_url, "http://foo bar"))
+  end
+
   ########## Utilities
 
   def authorization_denial_callback_params

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -1511,7 +1511,12 @@ class InatImportsControllerTest < FunctionalTestCase
   # URI.parse raises URI::InvalidURIError on a malformed URL (e.g. a space);
   # taxon_ids_from_url rescues it and returns no ids rather than 500ing.
   def test_taxon_ids_from_url_handles_malformed_url
-    assert_equal([], @controller.send(:taxon_ids_from_url, "http://foo bar"))
+    malformed = "http://foo bar"
+    # Guard: confirm the input really triggers the rescue, so this test
+    # keeps covering the rescue branch (not the empty-query happy path,
+    # which also returns []) across Ruby/URI changes.
+    assert_raises(URI::InvalidURIError) { URI.parse(malformed) }
+    assert_equal([], @controller.send(:taxon_ids_from_url, malformed))
   end
 
   ########## Utilities


### PR DESCRIPTION
## Summary

Closes the 3 files whose uncovered-line count increased between `deploy-2026-06-21-13-54` and `main` (the net +3 from the coverage comparison). Each gap was triaged as dead-code-to-remove or reachable-and-tested.

| File:line | Verdict | Action |
| --- | --- | --- |
| `app/classes/inat/observation_importer.rb:141-142` | dead | removed |
| `app/components/application_form/field_helpers.rb:431` | reachable | tested |
| `app/controllers/inat_imports_controller.rb:199` | reachable | tested |

### 1. observation_importer.rb — dead code, removed

`update_inat_observation` re-checked `if skip_inat_writeback?` and returned early. But its only caller, `finalize_import`, already invokes it `unless skip_inat_writeback?` — so the inner branch was unreachable. Removed the guard; the method now just writes back, and the comment notes the caller does the gating.

### 2. field_helpers.rb — reachable, tested

`submit` takes `as:` (default `:button`). The `else` branch (`as` ≠ `:button`) delegates to Superform's `submit`, which renders an `<input type="submit">` instead of MO's `Button::Submit` `<button>`. It's a real (if currently unused-by-views) API param with a working fallback — not dead — so I added a test exercising it rather than removing a parameter used by 7 call sites.

### 3. inat_imports_controller.rb — reachable, tested

`taxon_ids_from_url` rescues `URI::InvalidURIError` and returns `[]`. `URI.parse` raises on a malformed `inat_url` (e.g. one containing a space), so the rescue is reachable; added a test.

## Test plan

- [x] `bin/rails test test/components/application_form_test.rb` — new `test_submit_as_non_button_uses_superform_input`
- [x] `bin/rails test test/controllers/inat_imports_controller_test.rb` — new `test_taxon_ids_from_url_handles_malformed_url`
- [x] `bin/rails test test/controllers/inat_imports_controller_test.rb test/jobs/inat_import_job_test.rb` (123 runs, 0 failures) — confirms the dead-code removal didn't affect the import flow
- [x] RuboCop clean
