### PR TITLE
Add Grid constants for Bootstrap 3→4 column class migration

### DIFF
--- a/app/classes/grid.rb
+++ b/app/classes/grid.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Bootstrap grid column class constants for responsive layout.
+# All values use Bootstrap 3 syntax. When migrating to Bootstrap 4:
+#   col-xs-N → col-N, col-xs-offset-N → offset-N
+# Update this file and all callers update automatically.
+module Grid
+  FULL           = "col-xs-12"
+  HALF           = "col-xs-6"
+  THIRD          = "col-xs-4"
+  QUARTER        = "col-xs-3"
+  CENTERED_THIRD = "col-xs-4 col-xs-offset-4"
+
+  SM3 = "col-xs-12 col-sm-3"
+  SM4 = "col-xs-12 col-sm-4"
+  SM5 = "col-xs-12 col-sm-5"
+  SM7 = "col-xs-12 col-sm-7"
+  SM8 = "col-xs-12 col-sm-8"
+  SM9 = "col-xs-12 col-sm-9"
+
+  MD6  = "col-xs-12 col-md-6"
+  MD10 = "col-xs-12 col-md-10"
+
+  # Full → half → third → quarter across xs/sm/md/lg.
+  # Default tile size for Components::Matrix::Box.
+  TILE = "col-xs-12 col-sm-6 col-md-4 col-lg-3"
+
+  # Full on xs, half on sm, full on md, half on lg.
+  # Used by search/lookup field groups.
+  FORM_COLS = "col-xs-12 col-sm-6 col-md-12 col-lg-6"
+end

--- a/app/components/form/compass_fields.rb
+++ b/app/components/form/compass_fields.rb
@@ -21,7 +21,7 @@ class Components::Form::CompassFields < Components::Base
 
   def render_north_row
     div(class: "row vcenter") do
-      div(class: "col-xs-4 col-xs-offset-4 text-center") do
+      div(class: "#{Grid::CENTERED_THIRD} text-center") do
         compass_input(:north)
       end
     end
@@ -29,17 +29,17 @@ class Components::Form::CompassFields < Components::Base
 
   def render_east_west_row
     div(class: "row vcenter mt-3") do
-      div(class: "col-xs-4 text-center") { compass_input(:west) }
-      div(class: "col-xs-4 small text-center p-0") do
+      div(class: "#{Grid::THIRD} text-center") { compass_input(:west) }
+      div(class: "#{Grid::THIRD} small text-center p-0") do
         plain(:form_locations_lat_long_help.l)
       end
-      div(class: "col-xs-4 text-center") { compass_input(:east) }
+      div(class: "#{Grid::THIRD} text-center") { compass_input(:east) }
     end
   end
 
   def render_south_row
     div(class: "row vcenter mt-3") do
-      div(class: "col-xs-4 col-xs-offset-4 text-center") do
+      div(class: "#{Grid::CENTERED_THIRD} text-center") do
         compass_input(:south)
       end
     end

--- a/app/components/form/names_lookup_field_group.rb
+++ b/app/components/form/names_lookup_field_group.rb
@@ -167,6 +167,6 @@ class Components::Form::NamesLookupFieldGroup < Components::Base
   end
 
   def column_classes
-    "col-xs-12 col-sm-6 col-md-12 col-lg-6"
+    Grid::FORM_COLS
   end
 end

--- a/app/components/form/region_with_box_fields.rb
+++ b/app/components/form/region_with_box_fields.rb
@@ -77,13 +77,13 @@ class Components::Form::RegionWithBoxFields < Components::Base
   end
 
   def render_east_west_row(directions, in_box_ns)
-    render_compass_input(directions[0], in_box_ns, "col-xs-4")
+    render_compass_input(directions[0], in_box_ns, Grid::THIRD)
     render_compass_help
-    render_compass_input(directions[1], in_box_ns, "col-xs-4")
+    render_compass_input(directions[1], in_box_ns, Grid::THIRD)
   end
 
   def render_single_compass_input(direction, in_box_ns)
-    render_compass_input(direction, in_box_ns, "col-xs-4 col-xs-offset-4")
+    render_compass_input(direction, in_box_ns, Grid::CENTERED_THIRD)
   end
 
   def render_compass_input(direction, in_box_ns, col_classes)
@@ -104,7 +104,7 @@ class Components::Form::RegionWithBoxFields < Components::Base
   end
 
   def render_compass_help
-    div(class: "col-xs-4 small text-center p-0") do
+    div(class: "#{Grid::THIRD} small text-center p-0") do
       plain(:form_locations_lat_long_help.l)
     end
   end

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -122,7 +122,7 @@ class Components::Form::Search < Components::ApplicationForm
   def render_form_columns
     div(class: "row") do
       field_columns.each do |panels|
-        div(class: "col-xs-12 col-md-6") do
+        div(class: Grid::MD6) do
           panels.each do |heading, sections|
             render_panel(heading:, sections:)
           end
@@ -206,7 +206,7 @@ class Components::Form::Search < Components::ApplicationForm
   end
 
   def column_classes
-    "col-xs-12 col-sm-6 col-md-12 col-lg-6"
+    Grid::FORM_COLS
   end
 
   # Helper to check if a field is a date field

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -16,7 +16,7 @@
 #     user: @user,
 #     object: @observation,
 #     identify: true,
-#     columns: "col-xs-12 col-sm-6"
+#     columns: Grid::FULL
 #   )
 #
 # @example Custom block content
@@ -31,7 +31,7 @@ class Components::Matrix::Box < Components::Base
   prop :user, _Nilable(User), default: nil
   prop :object, _Nilable(AbstractModel), default: nil
   prop :id, _Nilable(_Union(Integer, String)), default: nil
-  prop :columns, String, default: "col-xs-12 col-sm-6 col-md-4 col-lg-3"
+  prop :columns, String, default: Grid::TILE
   prop :extra_class, String, default: ""
   prop :identify, _Boolean, default: false
   prop :votes, _Boolean, default: true

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -9,10 +9,10 @@
 # 2. With a block - renders a simple <li> wrapper for custom content
 #
 # @example Standard object rendering
-#   render MatrixBox.new(user: @user, object: @observation)
+#   render Components::Matrix::Box.new(user: @user, object: @observation)
 #
 # @example With custom options
-#   render MatrixBox.new(
+#   render Components::Matrix::Box.new(
 #     user: @user,
 #     object: @observation,
 #     identify: true,

--- a/app/views/controllers/collection_numbers/edit.rb
+++ b/app/views/controllers/collection_numbers/edit.rb
@@ -22,8 +22,8 @@ module Views::Controllers::CollectionNumbers
       )
 
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-7") { render_form }
-        div(class: "col-xs-12 col-sm-5") { render_observation_boxes }
+        div(class: Grid::SM7) { render_form }
+        div(class: Grid::SM5) { render_observation_boxes }
       end
     end
 
@@ -39,7 +39,7 @@ module Views::Controllers::CollectionNumbers
           render(Components::Matrix::Box.new(
                    user: @user,
                    object: obs.rss_log || obs,
-                   columns: "col-xs-12"
+                   columns: Grid::FULL
                  ))
         end
       end

--- a/app/views/controllers/collection_numbers/new.rb
+++ b/app/views/controllers/collection_numbers/new.rb
@@ -17,8 +17,8 @@ module Views::Controllers::CollectionNumbers
       )
 
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-7") { render_form }
-        div(class: "col-xs-12 col-sm-5") { render_observation_box }
+        div(class: Grid::SM7) { render_form }
+        div(class: Grid::SM5) { render_observation_box }
       end
     end
 
@@ -33,7 +33,7 @@ module Views::Controllers::CollectionNumbers
         render(Components::Matrix::Box.new(
                  user: @user,
                  object: @observation.rss_log || @observation,
-                 columns: "col-xs-12"
+                 columns: Grid::FULL
                ))
       end
     end

--- a/app/views/controllers/comments/new.rb
+++ b/app/views/controllers/comments/new.rb
@@ -29,7 +29,7 @@ module Views::Controllers::Comments
     private
 
     def render_form_column
-      div(class: "col-xs-12 col-sm-8") do
+      div(class: Grid::SM8) do
         comment { "[form:comment]" }
         render(Form.new(@comment, local: true))
         comment { "[eoform:comment]" }
@@ -46,7 +46,7 @@ module Views::Controllers::Comments
     end
 
     def render_images_column
-      div(class: "col-xs-12 col-sm-4") do
+      div(class: Grid::SM4) do
         render(::Views::Controllers::Observations::Show::ImagesPanel.new(
                  obs: @target, images: @target.images_sorted, user: @user
                ))

--- a/app/views/controllers/descriptions/details_and_alts_panel.rb
+++ b/app/views/controllers/descriptions/details_and_alts_panel.rb
@@ -43,8 +43,8 @@ module Views::Controllers::Descriptions
 
     def render_two_columns
       div(class: "row") do
-        div(class: "col-xs-12 col-md-6") { render_details_column }
-        div(class: "col-xs-12 col-md-6") { render_alts_column }
+        div(class: Grid::MD6) { render_details_column }
+        div(class: Grid::MD6) { render_alts_column }
       end
     end
 

--- a/app/views/controllers/glossary_terms/index/item.rb
+++ b/app/views/controllers/glossary_terms/index/item.rb
@@ -10,8 +10,8 @@ module Views::Controllers::GlossaryTerms
 
       def view_template
         div(class: "row") do
-          div(class: "col-xs-12 col-sm-9") { render_left }
-          div(class: "col-xs-12 col-sm-3") { render_right }
+          div(class: Grid::SM9) { render_left }
+          div(class: Grid::SM3) { render_right }
         end
       end
 

--- a/app/views/controllers/herbarium_records/edit.rb
+++ b/app/views/controllers/herbarium_records/edit.rb
@@ -20,8 +20,8 @@ module Views::Controllers::HerbariumRecords
       )
 
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-7") { render_form }
-        div(class: "col-xs-12 col-sm-5") { render_observation_boxes }
+        div(class: Grid::SM7) { render_form }
+        div(class: Grid::SM5) { render_observation_boxes }
       end
     end
 
@@ -37,7 +37,7 @@ module Views::Controllers::HerbariumRecords
           render(Components::Matrix::Box.new(
                    user: @user,
                    object: obs.rss_log || obs,
-                   columns: "col-xs-12"
+                   columns: Grid::FULL
                  ))
         end
       end

--- a/app/views/controllers/herbarium_records/new.rb
+++ b/app/views/controllers/herbarium_records/new.rb
@@ -19,8 +19,8 @@ module Views::Controllers::HerbariumRecords
       )
 
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-7") { render_form_column }
-        div(class: "col-xs-12 col-sm-5") { render_observation_box }
+        div(class: Grid::SM7) { render_form_column }
+        div(class: Grid::SM5) { render_observation_box }
       end
     end
 
@@ -39,7 +39,7 @@ module Views::Controllers::HerbariumRecords
         render(Components::Matrix::Box.new(
                  user: @user,
                  object: @observation.rss_log || @observation,
-                 columns: "col-xs-12"
+                 columns: Grid::FULL
                ))
       end
     end

--- a/app/views/controllers/locations/show/coordinates.rb
+++ b/app/views/controllers/locations/show/coordinates.rb
@@ -85,14 +85,14 @@ module Views::Controllers::Locations
 
       def render_east_west
         div(class: "row") do
-          div(class: "col-xs-6") do
+          div(class: Grid::HALF) do
             span(class: "pull-left") do
               b { "#{:WEST.l}:" }
               plain(" ")
               plain("#{@location.west}°")
             end
           end
-          div(class: "col-xs-6") do
+          div(class: Grid::HALF) do
             span(class: "pull-right") do
               b { "#{:EAST.l}:" }
               plain(" ")

--- a/app/views/controllers/observations/external_links/edit.rb
+++ b/app/views/controllers/observations/external_links/edit.rb
@@ -16,8 +16,8 @@ module Views::Controllers::Observations::ExternalLinks
       add_edit_title(@external_link)
 
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-7") { render_form }
-        div(class: "col-xs-12 col-sm-5") { render_matrix_box }
+        div(class: Grid::SM7) { render_form }
+        div(class: Grid::SM5) { render_matrix_box }
       end
     end
 
@@ -39,7 +39,7 @@ module Views::Controllers::Observations::ExternalLinks
         render(::Components::Matrix::Box.new(
                  user: @user,
                  object: @observation,
-                 columns: "col-xs-12"
+                 columns: Grid::FULL
                ))
       end
     end

--- a/app/views/controllers/observations/external_links/new.rb
+++ b/app/views/controllers/observations/external_links/new.rb
@@ -17,8 +17,8 @@ module Views::Controllers::Observations::ExternalLinks
       add_new_title(:add_object, :EXTERNAL_LINK)
 
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-7") { render_form }
-        div(class: "col-xs-12 col-sm-5") { render_matrix_box }
+        div(class: Grid::SM7) { render_form }
+        div(class: Grid::SM5) { render_matrix_box }
       end
     end
 
@@ -39,7 +39,7 @@ module Views::Controllers::Observations::ExternalLinks
         render(::Components::Matrix::Box.new(
                  user: @user,
                  object: @observation.rss_log || @observation,
-                 columns: "col-xs-12"
+                 columns: Grid::FULL
                ))
       end
     end

--- a/app/views/controllers/observations/form.rb
+++ b/app/views/controllers/observations/form.rb
@@ -223,7 +223,7 @@ module Views::Controllers::Observations
     end
 
     def render_naming_column
-      div(class: "col-xs-12 col-md-6") do
+      div(class: Grid::MD6) do
         render(Views::Controllers::Observations::Namings::Fields.new(
                  form: self,
                  vote: @vote,
@@ -240,7 +240,7 @@ module Views::Controllers::Observations
 
     def render_specimen_column
       code = @field_code_locked ? @field_code : editable_field_code
-      div(class: "col-xs-12 col-md-6") do
+      div(class: Grid::MD6) do
         render(Specimen.new(
                  form: self,
                  observation: model,

--- a/app/views/controllers/observations/form/details.rb
+++ b/app/views/controllers/observations/form/details.rb
@@ -22,8 +22,8 @@ class Views::Controllers::Observations::Form::Details < Views::Base
 
   def view_template
     div(class: "row") do
-      div(class: "col-xs-12 col-md-6") { render_left_column }
-      div(class: "col-xs-12 col-md-6") { render_map }
+      div(class: Grid::MD6) { render_left_column }
+      div(class: Grid::MD6) { render_map }
     end
   end
 
@@ -187,7 +187,7 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   end
 
   def render_coordinate_field(field, abbr_key, full_key, addon)
-    div(class: "col-xs-4") do
+    div(class: Grid::THIRD) do
       label_html = coordinate_label(abbr_key, full_key)
       @form.text_field(
         field,

--- a/app/views/controllers/observations/namings/edit.rb
+++ b/app/views/controllers/observations/namings/edit.rb
@@ -23,11 +23,11 @@ module Views::Controllers::Observations::Namings
     def view_template
       add_chrome
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-8") do
+        div(class: Grid::SM8) do
           div(class: "mt-3") { render_observation_details }
           div(class: "mt-3") { render_naming_form }
         end
-        div(class: "col-xs-12 col-sm-4") { render_images }
+        div(class: Grid::SM4) { render_images }
       end
     end
 

--- a/app/views/controllers/observations/namings/new.rb
+++ b/app/views/controllers/observations/namings/new.rb
@@ -26,11 +26,11 @@ module Views::Controllers::Observations::Namings
     def view_template
       add_chrome
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-8") do
+        div(class: Grid::SM8) do
           div(class: "mt-3") { render_observation_details }
           div(class: "mt-3") { render_naming_form }
         end
-        div(class: "col-xs-12 col-sm-4") { render_images }
+        div(class: Grid::SM4) { render_images }
       end
     end
 

--- a/app/views/controllers/observations/show/name_info_panel.rb
+++ b/app/views/controllers/observations/show/name_info_panel.rb
@@ -22,11 +22,11 @@ class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
 
   def render_body
     div(class: "row") do
-      div(class: "col-xs-6") do
+      div(class: Grid::HALF) do
         div(class: "font-weight-bold") { plain("#{:on_mo.l}:") }
         render_links_on_mo
       end
-      div(class: "col-xs-6") do
+      div(class: Grid::HALF) do
         div(class: "font-weight-bold") { plain("#{:on_the_web.l}:") }
         render_links_on_web
       end

--- a/app/views/controllers/observations/show/namings/footer_legend.rb
+++ b/app/views/controllers/observations/show/namings/footer_legend.rb
@@ -13,10 +13,10 @@ class Views::Controllers::Observations::Show::Namings::FooterLegend < Views::Bas
     div(class: "row") do
       div(class: "col-sm-11") do
         div(class: "row") do
-          div(class: "col-xs-4 col-xs-offset-4") do
+          div(class: Grid::CENTERED_THIRD) do
             render_legend("vote-icon-yours", :show_namings_eye_help.t)
           end
-          div(class: "col-xs-4") do
+          div(class: Grid::THIRD) do
             render_legend("vote-icon-consensus",
                           :show_namings_eyes_help.t)
           end

--- a/app/views/controllers/projects/banner.rb
+++ b/app/views/controllers/projects/banner.rb
@@ -28,7 +28,7 @@ module Views::Controllers::Projects
       end
 
       div(class: "row") do
-        div(class: "col-xs-12", id: "project_tabs") do
+        div(class: Grid::FULL, id: "project_tabs") do
           render(Components::NavTabs.new(
                    current: @current_tab, link_class: "mt-3",
                    tabs: ::Tab::Project::Banner.new(
@@ -43,7 +43,7 @@ module Views::Controllers::Projects
 
     def render_banner_with_image
       div(class: "row") do
-        div(class: "col-xs-12", id: "project_banner") do
+        div(class: Grid::FULL, id: "project_banner") do
           img(src: @project.image.large_url, class: "banner-image")
           div(class: "bottom-left ml-3 mb-3 p-2") do
             render_banner_title(with_overlay_styling: true)
@@ -56,7 +56,7 @@ module Views::Controllers::Projects
 
     def render_banner_without_image
       div(class: "row") do
-        div(class: "col-xs-12", id: "project_banner") do
+        div(class: Grid::FULL, id: "project_banner") do
           div(class: "pl-3 mt-3") do
             render_banner_title(with_overlay_styling: false)
           end

--- a/app/views/controllers/sequences/edit.rb
+++ b/app/views/controllers/sequences/edit.rb
@@ -16,8 +16,8 @@ module Views::Controllers::Sequences
 
       obs = @sequence.observation
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-7") { render_form_column(obs) }
-        div(class: "col-xs-12 col-sm-5") { render_matrix_column(obs) }
+        div(class: Grid::SM7) { render_form_column(obs) }
+        div(class: Grid::SM5) { render_matrix_column(obs) }
       end
     end
 
@@ -41,7 +41,7 @@ module Views::Controllers::Sequences
         render(::Components::Matrix::Box.new(
                  user: current_user,
                  object: obs.rss_log || obs,
-                 columns: "col-xs-12"
+                 columns: Grid::FULL
                ))
       end
     end

--- a/app/views/controllers/sequences/new.rb
+++ b/app/views/controllers/sequences/new.rb
@@ -12,8 +12,8 @@ module Views::Controllers::Sequences
       add_context_nav(::Tab::Sequence::Form.new(back_object: @observation))
 
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-7") { render_form_column }
-        div(class: "col-xs-12 col-sm-5") { render_matrix_column }
+        div(class: Grid::SM7) { render_form_column }
+        div(class: Grid::SM5) { render_matrix_column }
       end
     end
 
@@ -29,7 +29,7 @@ module Views::Controllers::Sequences
         render(::Components::Matrix::Box.new(
                  user: current_user,
                  object: @observation.rss_log || @observation,
-                 columns: "col-xs-12"
+                 columns: Grid::FULL
                ))
       end
     end

--- a/app/views/controllers/support/form.rb
+++ b/app/views/controllers/support/form.rb
@@ -33,7 +33,7 @@ module Views::Controllers::Support
     def render_amount_row
       div(class: "row") do
         PRESET_AMOUNTS.each do |amount|
-          div(class: "col-xs-3") do
+          div(class: Grid::QUARTER) do
             radio_field(:amount, [amount, "$#{amount.to_i}"])
           end
         end

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -110,7 +110,7 @@ module Views::Layouts
     end
 
     def render_right_side(content_classes, &block)
-      div(id: "right_side", class: "col-xs-12 col-md-10") do
+      div(id: "right_side", class: Grid::MD10) do
         render(Views::Layouts::TopNav.new(user: current_user,
                                           query: current_query))
         render(Views::Layouts::App::PageFlash.new)

--- a/test/classes/grid_test.rb
+++ b/test/classes/grid_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Pins the Bootstrap 3 column class strings in Grid so that a future
+# Bootstrap 4 migration (col-xs-N → col-N, col-xs-offset-N → offset-N)
+# shows up as deliberate test failures rather than silent drift.
+class GridTest < UnitTestCase
+  def test_simple_widths
+    assert_equal("col-xs-12", Grid::FULL)
+    assert_equal("col-xs-6",  Grid::HALF)
+    assert_equal("col-xs-4",  Grid::THIRD)
+    assert_equal("col-xs-3",  Grid::QUARTER)
+    assert_equal("col-xs-4 col-xs-offset-4", Grid::CENTERED_THIRD)
+  end
+
+  def test_sm_responsive
+    assert_equal("col-xs-12 col-sm-3", Grid::SM3)
+    assert_equal("col-xs-12 col-sm-4", Grid::SM4)
+    assert_equal("col-xs-12 col-sm-5", Grid::SM5)
+    assert_equal("col-xs-12 col-sm-7", Grid::SM7)
+    assert_equal("col-xs-12 col-sm-8", Grid::SM8)
+    assert_equal("col-xs-12 col-sm-9", Grid::SM9)
+  end
+
+  def test_md_responsive
+    assert_equal("col-xs-12 col-md-6",  Grid::MD6)
+    assert_equal("col-xs-12 col-md-10", Grid::MD10)
+  end
+
+  def test_complex_responsive
+    assert_equal("col-xs-12 col-sm-6 col-md-4 col-lg-3", Grid::TILE)
+    assert_equal("col-xs-12 col-sm-6 col-md-12 col-lg-6", Grid::FORM_COLS)
+  end
+end


### PR DESCRIPTION
## Summary

Extracts Bootstrap 3 responsive column class strings into a `Grid` module (`app/classes/grid.rb`) so the Bootstrap 4 migration reduces to updating one file.

- Adds `Grid::FULL`, `HALF`, `THIRD`, `QUARTER`, `CENTERED_THIRD`, `SM3–SM9`, `MD6`, `MD10`, `TILE`, and `FORM_COLS` — covering the 15 most-used column combos across components and views.
- Updates 26 callers across `app/components/`, `app/views/controllers/`, and `app/views/layouts/` to use constants instead of raw strings.
- When Bootstrap 4 ships, `col-xs-N → col-N` and `col-xs-offset-N → offset-N` is a one-file change; all callers update automatically.
- Adds `test/classes/grid_test.rb` that pins all constant values — the tests will deliberately fail when the BS4 values are installed, making the migration auditable rather than invisible.

## What's NOT changed

Strings that mix non-grid classes (e.g. `"col-xs-4 text-center"`) use interpolation (`"#{Grid::THIRD} text-center"`) so only the grid part is centralized. Single-use or one-off combos (`col-xs-12 col-sm-9 col-lg-10`, `col-xs-12 col-sm-8 col-md-6 col-lg-4`) are left as raw strings — no value in naming them.

## Test plan

- [x] `bin/rails test test/classes/grid_test.rb` — 4 tests, 19 assertions, 0 failures
- [x] `bundle exec rubocop` on all 28 changed files — no offenses

Fixes part of #3797

🤖 Generated with [Claude Code](https://claude.com/claude-code)
