### PR TITLE
Fix 500 on unauthenticated request to  engine controller 

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -12,7 +12,7 @@ class AdminController < ApplicationController
     if session[:user_id]
       redirect_to("/")
     else
-      redirect_to(new_account_login_path)
+      redirect_to(main_app.new_account_login_path)
     end
   end
 

--- a/test/integration/rails-dom-testing/redirects_integration_test.rb
+++ b/test/integration/rails-dom-testing/redirects_integration_test.rb
@@ -202,7 +202,7 @@ class RedirectsIntegrationTest < IntegrationTestCase
     )
   end
 
-  # SpecisList/show  ---------------------------------
+  # SpeciesList/show  ---------------------------------
   def test_show_species_list
     spl = species_lists(:first_species_list)
     login

--- a/test/integration/rails-dom-testing/redirects_integration_test.rb
+++ b/test/integration/rails-dom-testing/redirects_integration_test.rb
@@ -188,6 +188,20 @@ class RedirectsIntegrationTest < IntegrationTestCase
     )
   end
 
+  # Mission Control Jobs engine  ---------------------------------------------
+
+  # Regression: unauthenticated GET /jobs was returning 500 because
+  # AdminController#access_denied called `new_account_login_path`, which is
+  # not in scope inside a mounted engine without the `main_app.` prefix.
+  def test_unauthenticated_get_jobs_redirects_to_login
+    get("/jobs")
+    assert_equal(
+      new_account_login_path,
+      @response.request.fullpath,
+      "Unauthenticated GET /jobs should redirect to login, not raise a 500"
+    )
+  end
+
   # SpecisList/show  ---------------------------------
   def test_show_species_list
     spl = species_lists(:first_species_list)


### PR DESCRIPTION
Resolves #4621

An alert was created when an error was thrown by a robot requesting
```ruby
GET “/jobs”
```

This was handled by MissionControl, which redirected to the unqualified "new_account_login_path" which eventually threw a 500 Internal Server Error.
CC explains:

> Rails engines have their own isolated routing namespace. When MissionControl::Jobs::QueuesController handles a request, its routing context is the engine's — not the main app's. Route helpers like new_account_login_path are defined on the main app's router, so calling one bare inside an engine controller raises `NoMethodError`, which Rails catches and converts to a 500.
> 
> `main_app` is a proxy object Rails provides in any controller (engine or not) that delegates to the main application's routes. So `main_app.new_account_login_path` resolves correctly from inside the engine's context, while bare `new_account_login_path` does not.
> 
> The reason this only surfaced with Mission Control and not with regular admin controllers (e.g. Admin::DonationsController) is that those live in the main app and already inherit the main app's routing context — bare helpers work fine there. Mission Control's controllers are the only ones that inherit from AdminController while living inside an engine.