### PR TITLE
Track ignored iNat obs counts; show summary on Done

### DIFF
--- a/app/classes/inat/confirm_url_builder.rb
+++ b/app/classes/inat/confirm_url_builder.rb
@@ -59,7 +59,6 @@ class Inat::ConfirmURLBuilder
     args = Rack::Utils.parse_query(query_str.to_s)
     args["iconic_taxa"] ||= "Fungi,Protozoa" unless args.key?("taxon_id")
     args["without_field"] = BASE_FILTER_PARAMS[:without_field]
-    args["d1"] ||= EARLIEST_DATE_FILTER
     filter = LICENSED_FILTER.stringify_keys.transform_values(&:to_s)
     args.merge!(filter) if import_others?
     args

--- a/app/classes/inat/confirm_url_builder.rb
+++ b/app/classes/inat/confirm_url_builder.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+class Inat::ConfirmURLBuilder
+  include Inat::Constants
+
+  def initialize(model, estimated_at:)
+    @model = model
+    @estimated_at = estimated_at
+  end
+
+  def requested_obs_url
+    query = requested_obs_query
+    return nil unless query
+    return normalize_inat_ui_url(query) if query.start_with?("http")
+
+    "#{SITE}/observations?#{translate_api_to_ui_params(query)}"
+  end
+
+  def expected_obs_url
+    base = requested_obs_url
+    return nil unless base
+
+    uri, query_str = base.split("?", 2)
+    "#{uri}?#{expected_obs_args(query_str).to_query}"
+  end
+
+  def already_imported_url
+    base = requested_obs_url
+    return nil unless base
+
+    "#{base}&field:Mushroom%20Observer%20URL"
+  end
+
+  def unlicensed_obs_url
+    requested_obs_url&.then { |u| "#{u}&licensed=false" }
+  end
+
+  def stable_result_set?
+    return true if @model.inat_ids.present?
+    return false unless (query = requested_obs_query)
+
+    qs = query.start_with?("http") ? query.split("?", 2)[1].to_s : query
+    args = Rack::Utils.parse_query(qs)
+    args["id"].present? || date_filtered_before_estimated_at?(args)
+  end
+
+  private
+
+  def requested_obs_query
+    m = @model
+    return "id=#{m.inat_ids}" if m.inat_ids.present?
+    return m.original_inat_url if m.original_inat_url.present?
+    return m.inat_url if m.inat_url.present?
+
+    "user_id=#{m.inat_username}" if m.inat_username.present?
+  end
+
+  def expected_obs_args(query_str)
+    args = Rack::Utils.parse_query(query_str.to_s)
+    args["iconic_taxa"] ||= "Fungi,Protozoa" unless args.key?("taxon_id")
+    args["without_field"] = BASE_FILTER_PARAMS[:without_field]
+    args["d1"] ||= EARLIEST_DATE_FILTER
+    filter = LICENSED_FILTER.stringify_keys.transform_values(&:to_s)
+    args.merge!(filter) if import_others?
+    args
+  end
+
+  def translate_api_to_ui_params(query_str)
+    args = Rack::Utils.parse_query(query_str.to_s)
+    return args.to_query unless args["taxon_id"]&.include?(",")
+
+    args.except("taxon_id").merge("iconic_taxa" => "Fungi,Protozoa").to_query
+  end
+
+  def normalize_inat_ui_url(url)
+    uri, query_str = url.split("?", 2)
+    "#{uri}?#{translate_api_to_ui_params(query_str.to_s)}"
+  end
+
+  def date_filtered_before_estimated_at?(args)
+    date = d2_date(args) || year_end_date(args)
+    date && date < @estimated_at.to_date
+  rescue ArgumentError
+    false
+  end
+
+  def d2_date(args)
+    Date.parse(args["d2"]) if args["d2"].present?
+  end
+
+  def year_end_date(args)
+    return unless (year = args["year"]&.to_i)
+
+    Date.new(year, args["month"]&.to_i || 12, args["day"]&.to_i || -1)
+  end
+
+  def import_others?
+    @model.import_others == "1"
+  end
+end

--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -64,17 +64,14 @@ class Inat
       without_field: "Mushroom Observer URL"
     }.freeze
 
+    # A work-around because iNat has no "has a date" filter;
+    # an arbitrarily early d1 approximates it.
+    EARLIEST_DATE_FILTER = "1000-01-01"
+
     # Added when importing others' observations (superimporter, not own).
     # Own-observation imports accept unlicensed obs and apply the user's
     # default MO license to any unlicensed images.
-    #
-    # The iNat API `licensed` param returns true if the observation
-    # license_code is null. So we have to use this filter to get the count of
-    # observations that are licensed, and subtract from total to get the
-    # unlicensed count.
-    LICENSED_FILTER =
-      { license: "cc0,cc-by,cc-by-nc,cc-by-nd,cc-by-nc-nd," \
-                 "cc-by-sa,cc-by-nc-sa" }.freeze
+    LICENSED_FILTER = { licensed: true }.freeze
 
     # Kept for backwards compatibility; some callers may still reference this.
     IMPORT_FILTER_PARAMS = BASE_FILTER_PARAMS.merge(LICENSED_FILTER).freeze

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -46,6 +46,7 @@ class Inat
       return false if @inat_obs.taxon_importable?
 
       log_with_response_error("Skipped #{@inat_obs[:id]} not importable")
+      inat_import.add_ignored_obs(:not_importable)
       true
     end
 
@@ -55,6 +56,7 @@ class Inat
       log_with_response_error(
         "Skipped #{@inat_obs[:id]} #{:inat_observed_missing_date.l}"
       )
+      inat_import.add_ignored_obs(:date_missing)
       true
     end
 
@@ -74,6 +76,7 @@ class Inat
       )
 
       log("Skipped #{@inat_obs[:id]} already imported")
+      inat_import.add_ignored_obs(:already_imported)
       true
     end
 

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -79,22 +79,33 @@ class InatImportsController < ApplicationController
   private
 
   def confirm_import
-    @estimate = fetch_import_estimate
-    return inat_unreachable if @estimate.nil?
-    return reload_form if @estimate == false
+    @expected = fetch_expected_count
+    return inat_unreachable if @expected.nil?
+    return reload_form if @expected == false
 
     @unlicensed_obs = if import_others?
                         fetch_unlicensed_others_count
                       else
                         fetch_unlicensed_obs_count
                       end
-    warn_about_listed_previous_imports
     @inat_import = InatImport.find_or_create_by(user: @user)
+    warn_about_listed_previous_imports
     @confirm_form = build_confirm_form
     render(Views::Controllers::InatImports::Confirm.new(
-             confirm_form: @confirm_form, estimate: @estimate,
-             unlicensed_obs: @unlicensed_obs, inat_import: @inat_import
+             confirm_form: @confirm_form,
+             expected: @expected,
+             unlicensed_obs: @unlicensed_obs,
+             inat_import: @inat_import,
+             **fetch_confirm_counts
            ))
+  end
+
+  def fetch_confirm_counts
+    {
+      requested: fetch_raw_requested_count,
+      after_taxon: fetch_after_taxon_count,
+      estimate_with_date: fetch_estimate_with_date_count
+    }
   end
 
   def inat_unreachable

--- a/app/controllers/inat_imports_controller/estimators.rb
+++ b/app/controllers/inat_imports_controller/estimators.rb
@@ -5,18 +5,45 @@ module InatImportsController::Estimators
 
   private
 
-  def fetch_import_estimate
-    response = RestClient.get(
-      "#{API_BASE}/observations?#{import_estimate_query_args.to_query}",
-      { accept: :json, open_timeout: 5, timeout: 10 }
-    )
+  def fetch_expected_count
+    response = inat_get(import_estimate_query_args)
     JSON.parse(response.body)["total_results"]
   rescue RestClient::UnprocessableEntity => e
     flash_warning(:inat_unknown_param.t(error: inat_error_text(e)))
     false
   rescue RestClient::Exception, JSON::ParserError => e
-    Rails.logger.warn("iNat estimate request failed: #{e.class}: #{e.message}")
+    Rails.logger.warn(
+      "iNat estimate request failed: #{e.class}: #{e.message}"
+    )
     nil
+  end
+
+  def fetch_raw_requested_count
+    inat_get_count(raw_requested_query_args)
+  end
+
+  def fetch_after_taxon_count
+    inat_get_count(after_taxon_query_args)
+  end
+
+  def fetch_estimate_with_date_count
+    inat_get_count(
+      import_estimate_query_args.merge(d1: EARLIEST_DATE_FILTER)
+    )
+  end
+
+  # Own-imports: count of obs in scope that carry no license.
+  # Informational only — own obs are imported regardless of license.
+  def fetch_unlicensed_obs_count
+    inat_get_count(import_estimate_query_args.merge(licensed: false))
+  end
+
+  # Import-others: count of obs that are importable-taxa but not licensed.
+  # These will be skipped entirely.
+  def fetch_unlicensed_others_count
+    args = import_estimate_query_args.except(:licensed).
+           merge(licensed: false)
+    inat_get_count(args)
   end
 
   def inat_error_text(exception)
@@ -25,47 +52,42 @@ module InatImportsController::Estimators
     exception.message
   end
 
-  # Counts unlicensed observations for the own-observations case.
-  # Total minus licensed gives the unlicensed count via two fast
-  # only_id queries.
-  def fetch_unlicensed_obs_count
-    licensed = RestClient.get(
-      "#{API_BASE}/observations?#{licensed_estimate_query_args.to_query}",
+  def inat_get(args)
+    RestClient.get(
+      "#{API_BASE}/observations?#{args.to_query}",
       { accept: :json, open_timeout: 5, timeout: 10 }
     )
-    @estimate - JSON.parse(licensed.body)["total_results"]
+  end
+
+  def inat_get_count(args)
+    response = inat_get(args)
+    JSON.parse(response.body)["total_results"]
   rescue RestClient::Exception, JSON::ParserError => e
-    Rails.logger.warn(
-      "iNat licensed estimate request failed: #{e.class}: #{e.message}"
-    )
+    Rails.logger.warn("iNat count request failed: #{e.class}: #{e.message}")
     nil
   end
 
-  # Counts unlicensed observations that will be skipped for import-others.
-  # @estimate is already licensed-only; total minus @estimate = unlicensed.
-  def fetch_unlicensed_others_count
-    total = RestClient.get(
-      "#{API_BASE}/observations?#{total_others_estimate_query_args.to_query}",
-      { accept: :json, open_timeout: 5, timeout: 10 }
-    )
-    JSON.parse(total.body)["total_results"] - @estimate
-  rescue RestClient::Exception, JSON::ParserError => e
-    Rails.logger.warn(
-      "iNat unlicensed-others estimate request failed: #{e.class}: #{e.message}"
-    )
-    nil
-  end
-
-  # Total obs count for import-others without a license filter,
-  # used to derive how many will be skipped.
-  def total_others_estimate_query_args
+  # All obs in user scope — no taxon, without_field, or license filter.
+  def raw_requested_query_args
     args = listing_url? ? url_query_args : {}
-    args.merge!(BASE_FILTER_PARAMS, only_id: true)
-    args[:taxon_id] ||= IMPORTABLE_TAXON_IDS_ARG
+    args[:only_id] = true
     args[:id] = params[:inat_ids] if listing_ids?
+    args[:user_login] = params[:inat_username]&.strip unless import_others?
     args
   end
 
+  # Obs in importable taxa — no without_field or license filter.
+  def after_taxon_query_args
+    args = listing_url? ? url_query_args : {}
+    args[:only_id] = true
+    args[:taxon_id] ||= IMPORTABLE_TAXON_IDS_ARG
+    args[:id] = params[:inat_ids] if listing_ids?
+    args[:user_login] = params[:inat_username]&.strip unless import_others?
+    args
+  end
+
+  # Obs that will actually be imported: taxon + without_field
+  # + licensed (for import-others) + user scope.
   def import_estimate_query_args
     args = listing_url? ? url_query_args : {}
     args.merge!(BASE_FILTER_PARAMS, only_id: true)
@@ -79,15 +101,12 @@ module InatImportsController::Estimators
     args
   end
 
-  def licensed_estimate_query_args
-    import_estimate_query_args.merge(LICENSED_FILTER)
-  end
-
   # Strip MO-controlled params so estimates match actual import behavior.
   # Normal URL submissions are cleaned by normalize_inat_url_param! first;
   # this guards against raw query strings (no "://") that bypass it.
   def url_query_args
     strip = Inat::URLNormalizer::STRIP_PARAMS.map(&:to_sym)
-    Rack::Utils.parse_query(params[:inat_url].to_s).symbolize_keys.except(*strip)
+    Rack::Utils.parse_query(params[:inat_url].to_s).
+      symbolize_keys.except(*strip)
   end
 end

--- a/app/controllers/inat_imports_controller/estimators.rb
+++ b/app/controllers/inat_imports_controller/estimators.rb
@@ -27,9 +27,9 @@ module InatImportsController::Estimators
   end
 
   def fetch_estimate_with_date_count
-    inat_get_count(
-      import_estimate_query_args.merge(d1: EARLIEST_DATE_FILTER)
-    )
+    args = import_estimate_query_args
+    args[:d1] ||= EARLIEST_DATE_FILTER
+    inat_get_count(args)
   end
 
   # Own-imports: count of obs in scope that carry no license.

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -104,7 +104,10 @@ class InatImportJob < ApplicationJob
 
   def import_requested_observations(id_above:, continuation:)
     unless continuation
-      inat_import.update(state: "Importing", started_at: Time.zone.now)
+      inat_import.update(state: "Importing", started_at: Time.zone.now,
+                         ignored_not_importable_count: 0,
+                         ignored_date_missing_count: 0,
+                         ignored_already_imported_count: 0)
       return log("No observations requested") unless observations_requested?
     end
 

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -118,6 +118,7 @@ class InatImport < ApplicationRecord
     when :not_importable    then increment!(:ignored_not_importable_count)
     when :date_missing      then increment!(:ignored_date_missing_count)
     when :already_imported  then increment!(:ignored_already_imported_count)
+    else raise(ArgumentError.new("Unknown ignored reason: #{reason.inspect}"))
     end
   end
 

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -113,6 +113,20 @@ class InatImport < ApplicationRecord
     Importing? && ended_at.nil? && updated_at < STUCK_THRESHOLD.ago
   end
 
+  def add_ignored_obs(reason)
+    case reason
+    when :not_importable    then increment!(:ignored_not_importable_count)
+    when :date_missing      then increment!(:ignored_date_missing_count)
+    when :already_imported  then increment!(:ignored_already_imported_count)
+    end
+  end
+
+  def ignored_total_count
+    ignored_not_importable_count.to_i +
+      ignored_date_missing_count.to_i +
+      ignored_already_imported_count.to_i
+  end
+
   def add_response_error(error)
     msg = if error.is_a?(::RestClient::Response)
             error.body

--- a/app/views/controllers/inat_imports/confirm.rb
+++ b/app/views/controllers/inat_imports/confirm.rb
@@ -2,24 +2,32 @@
 
 module Views::Controllers::InatImports
   # iNat import-confirmation page. Renders the form (already a
-  # Phlex `ConfirmForm`) with import estimate + unlicensed-obs
+  # Phlex `ConfirmForm`) with expected import count + breakdown
   # numbers passed through.
   class Confirm < Views::FullPageBase
     prop :confirm_form, ::FormObject::InatImportConfirm
-    prop :estimate, ::Integer
-    # `fetch_unlicensed_*_count` returns nil when the iNat licensed-
-    # estimate call errors; ConfirmForm handles nil.
+    prop :expected, _Nilable(::Integer), default: nil
     prop :unlicensed_obs, _Nilable(::Integer), default: nil
     prop :inat_import, ::InatImport
+    prop :requested, _Nilable(::Integer), default: nil
+    prop :after_taxon, _Nilable(::Integer), default: nil
+    prop :estimate_with_date, _Nilable(::Integer), default: nil
 
     def view_template
       add_page_title(:inat_import_confirm_title.l)
       add_context_nav(::Tab::InatImport::FormNew.new)
 
-      render(ConfirmForm.new(@confirm_form,
-                             estimate: @estimate,
-                             unlicensed_obs: @unlicensed_obs,
-                             inat_import: @inat_import))
+      render(ConfirmForm.new(
+               @confirm_form,
+               expected: @expected,
+               unlicensed_obs: @unlicensed_obs,
+               breakdown: {
+                 inat_import: @inat_import,
+                 requested: @requested,
+                 after_taxon: @after_taxon,
+                 estimate_with_date: @estimate_with_date
+               }
+             ))
     end
   end
 end

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -1,36 +1,45 @@
 # frozen_string_literal: true
 
 module Views::Controllers::InatImports
-  # Confirmation form for iNat import. Shows estimated import count
+  # Confirmation form for iNat import. Shows expected import count
   # and Proceed/Go Back buttons. Hidden fields carry form data
   # through the confirmation step. Rendered by `confirm.rb`.
   class ConfirmForm < ::Components::ApplicationForm
-    def initialize(model, estimate: nil, unlicensed_obs: nil,
-                   inat_import: nil, **)
-      @estimate = estimate
+    def initialize(model, expected: nil, unlicensed_obs: nil,
+                   breakdown: {}, **)
+      @expected = expected
       @unlicensed_obs = unlicensed_obs
-      @inat_import = inat_import
+      @inat_import = breakdown[:inat_import]
+      @requested = breakdown[:requested]
+      @after_taxon = breakdown[:after_taxon]
+      @estimate_with_date = breakdown[:estimate_with_date]
+      @estimated_at = Time.current
+      @urls = ::Inat::ConfirmURLBuilder.new(model, estimated_at: @estimated_at)
       super(model, **)
     end
 
     def view_template
-      render_estimate
+      render_expected
       render_explanation
       render_prompt
       render_hidden_fields
       render_buttons
     end
 
-    def form_action
-      inat_imports_path
-    end
+    def form_action = inat_imports_path
 
     private
 
-    def render_estimate
+    def render_expected
       render(Components::Panel.new) do |panel|
         panel.with_body do
-          count_estimate_line
+          render_timestamp_note
+          if @requested
+            requested_obs_line
+            br
+          end
+          render_ignored_section
+          count_expected_line
           br
           unlicensed_obs_line
           br
@@ -39,14 +48,125 @@ module Views::Controllers::InatImports
       end
     end
 
-    def count_estimate_line
-      b { plain(:inat_import_confirm_estimate_caption.l) }
-      plain(": ")
-      span(id: "estimated_count") { plain(estimated_count) }
+    def render_ignored_section
+      rows = ignored_row_data
+      return if rows.empty?
+
+      br
+      render_ignored_total
+      render_ignored_overlap_note if rows.size > 1
+      div(class: "ml-3") do
+        rows.each do |row|
+          render_ignored_row(row[:key], row[:count], row[:url])
+        end
+      end
+      br
     end
 
-    def estimated_count
-      @estimate.to_s
+    def render_ignored_total
+      return unless @requested && (@estimate_with_date || @expected)
+
+      total = @requested.to_i - (@estimate_with_date || @expected).to_i
+      b { plain(:inat_import_confirm_ignored_total_caption.l) }
+      plain(": ")
+      span(id: "total_ignored_count") { plain(total.to_s) }
+    end
+
+    def render_ignored_overlap_note
+      div do
+        small(class: "overlap-note") do
+          plain(:inat_import_confirm_ignored_overlap_note.l)
+        end
+      end
+    end
+
+    def ignored_row_data
+      [not_importable_row, already_imported_row, no_date_row].compact
+    end
+
+    def not_importable_row
+      return unless (c = not_importable_count)&.positive?
+
+      { key: :inat_import_confirm_not_importable_caption, count: c, url: nil }
+    end
+
+    def already_imported_row
+      return unless (c = already_imported_count)&.positive?
+
+      { key: :inat_import_confirm_already_imported_caption,
+        count: c, url: already_imported_url }
+    end
+
+    def no_date_row
+      return unless (c = no_date_count)&.positive?
+
+      { key: :inat_import_confirm_no_date_caption, count: c, url: nil }
+    end
+
+    def not_importable_count
+      @requested.to_i - @after_taxon.to_i if @requested && @after_taxon
+    end
+
+    def no_date_count
+      return unless @expected && @estimate_with_date
+
+      @expected.to_i - @estimate_with_date.to_i
+    end
+
+    def already_imported_count
+      return unless @after_taxon && @expected
+
+      @after_taxon.to_i - @expected.to_i
+    end
+
+    def requested_obs_line
+      b { plain(:inat_import_confirm_requested_caption.l) }
+      plain(": ")
+      span(id: "requested_count") do
+        url = requested_obs_url
+        if url
+          render(Components::Link::External.new(@requested.to_s, url))
+        else
+          plain(@requested.to_s)
+        end
+      end
+    end
+
+    def count_expected_line
+      b { plain(:inat_import_confirm_expected_caption.l) }
+      plain(": ")
+      span(id: "expected_count") do
+        url = expected_obs_url
+        count = (@estimate_with_date || @expected).to_s
+        if url
+          render(Components::Link::External.new(count, url))
+        else
+          plain(count)
+        end
+      end
+    end
+
+    def render_ignored_row(caption_key, count, url)
+      div(class: "mb-1") do
+        b { plain("#{caption_key.l}: ") }
+        if url
+          render(Components::Link::External.new(count.to_s, url))
+        else
+          plain(count.to_s)
+        end
+      end
+    end
+
+    def render_timestamp_note
+      return unless @expected
+
+      t = @estimated_at.strftime("%Y-%m-%d %H:%M:%S %Z")
+      p(id: "as_of") { plain(:inat_import_confirm_expected_as_of.t(time: t)) }
+      return if stable_result_set?
+
+      p(class: "staleness-note") do
+        plain(:inat_import_confirm_expected_staleness.l)
+      end
     end
 
     def unlicensed_obs_line
@@ -56,15 +176,12 @@ module Views::Controllers::InatImports
       return unless @unlicensed_obs.to_i.positive?
 
       plain(" ")
-      plain(unlicensed_obs_note)
-    end
-
-    def unlicensed_obs_note
-      if import_others?
-        :inat_import_confirm_unlicensed_others_note.l
-      else
-        :inat_import_confirm_unlicensed_obs_note.l
-      end
+      note = if import_others?
+               :inat_import_confirm_unlicensed_others_note
+             else
+               :inat_import_confirm_unlicensed_obs_note
+             end
+      plain(note.l)
     end
 
     def time_estimate_line
@@ -74,8 +191,7 @@ module Views::Controllers::InatImports
     end
 
     def estimated_time
-      seconds = @estimate * avg_import_seconds
-      format_hms(seconds)
+      format_hms((@estimate_with_date || @expected) * avg_import_seconds)
     end
 
     def avg_import_seconds
@@ -84,52 +200,37 @@ module Views::Controllers::InatImports
     end
 
     def format_hms(seconds)
-      total_seconds = seconds.to_i
-      hours = total_seconds / 3600
-      minutes = (total_seconds % 3600) / 60
-      remaining = total_seconds % 60
-      Kernel.format("%02d:%02d:%02d", hours, minutes, remaining)
+      s = seconds.to_i
+      Kernel.format("%02d:%02d:%02d", s / 3600, s % 3600 / 60, s % 60)
     end
 
-    def render_explanation
-      p { plain(:inat_import_confirm_explanation.l) }
-    end
+    def render_explanation = p { plain(:inat_import_confirm_explanation.l) }
 
-    def render_prompt
-      p { plain(:inat_import_confirm_prompt.l) }
-    end
+    def render_prompt = p { plain(:inat_import_confirm_prompt.l) }
 
     def render_hidden_fields
-      hidden_field(:inat_username)
-      hidden_field(:inat_ids)
-      hidden_field(:import_all)
-      hidden_field(:consent)
-      hidden_field(:import_others)
-      hidden_field(:inat_url)
-      hidden_field(:original_inat_url)
-      hidden_field(:skip_inat_writeback)
+      [:inat_username, :inat_ids, :import_all, :consent, :import_others,
+       :inat_url, :original_inat_url, :skip_inat_writeback].each do |f|
+        hidden_field(f)
+      end
     end
 
     def render_buttons
       div(class: "mt-3") do
-        proceed_button
+        submit(:inat_import_confirm_proceed.l, as: :button,
+                                               name: "confirmed", value: "1")
         whitespace
-        go_back_button
+        submit(:inat_import_confirm_go_back.l, as: :button,
+                                               name: "go_back", value: "1")
       end
     end
 
-    def proceed_button
-      submit(:inat_import_confirm_proceed.l, as: :button,
-                                             name: "confirmed", value: "1")
-    end
+    def import_others? = model.import_others == "1"
 
-    def go_back_button
-      submit(:inat_import_confirm_go_back.l, as: :button,
-                                             name: "go_back", value: "1")
-    end
-
-    def import_others?
-      model.import_others == "1"
-    end
+    def requested_obs_url = @urls.requested_obs_url
+    def expected_obs_url = @urls.expected_obs_url
+    def already_imported_url = @urls.already_imported_url
+    def unlicensed_obs_url = @urls.unlicensed_obs_url
+    def stable_result_set? = @urls.stable_result_set?
   end
 end

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -65,6 +65,8 @@ module Views::Controllers::InatImports
     end
 
     def results_observations_path
+      return "#" unless @inat_import.user
+
       observations_path(
         pattern: "user:#{@inat_import.user.id} created:" \
                  "#{Time.zone.today}-#{Time.zone.tomorrow}"

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -77,6 +77,7 @@ module Views::Controllers::InatImports
       render_remaining_line
       render_ended_line
       render_error_line
+      render_ignored_section if show_ignored_section?
     end
 
     def render_summary_paragraph
@@ -151,6 +152,31 @@ module Views::Controllers::InatImports
       return if @inat_import.response_errors.blank?
 
       span(class: "font-weight-bold") { plain("#{:ERRORS.l}: ") }
+    end
+
+    def show_ignored_section?
+      @inat_import.Done? && @inat_import.ignored_total_count.positive?
+    end
+
+    def render_ignored_section
+      render(::Components::Alert.new(level: :info, class: "mt-3")) do
+        h5 { plain(:inat_import_tracker_ignored_heading.l) }
+        render_ignored_row(:inat_import_tracker_ignored_not_importable,
+                           @inat_import.ignored_not_importable_count)
+        render_ignored_row(:inat_import_tracker_ignored_already_imported,
+                           @inat_import.ignored_already_imported_count)
+        render_ignored_row(:inat_import_tracker_ignored_date_missing,
+                           @inat_import.ignored_date_missing_count)
+      end
+    end
+
+    def render_ignored_row(caption_key, count)
+      return unless count.to_i.positive?
+
+      div(class: "mb-1") do
+        b { plain("#{caption_key.l}: ") }
+        plain(count.to_s)
+      end
     end
 
     def render_error_alert

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -77,7 +77,7 @@ module Views::Controllers::InatImports
       render_remaining_line
       render_ended_line
       render_error_line
-      render_ignored_section if show_ignored_section?
+      render_ignored_section
     end
 
     def render_summary_paragraph
@@ -159,7 +159,9 @@ module Views::Controllers::InatImports
     end
 
     def render_ignored_section
-      render(::Components::Alert.new(level: :info, class: "mt-3")) do
+      return unless show_ignored_section?
+
+      Alert(level: :info, class: "mt-3") do
         h5 { plain(:inat_import_tracker_ignored_heading.l) }
         render_ignored_row(:inat_import_tracker_ignored_not_importable,
                            @inat_import.ignored_not_importable_count)
@@ -183,20 +185,16 @@ module Views::Controllers::InatImports
       errors = @inat_import.response_errors.to_s.split("\n")
       return unless errors.any?
 
-      render(::Components::Alert.new(level: :warning) do
+      Alert(level: :warning) do
         errors.each_with_index do |error, i|
           br if i.positive?
           plain(error)
         end
-      end)
+      end
     end
 
     def render_alert
-      render(::Components::Alert.new(
-               message: alert_message,
-               level: alert_level,
-               class: "mt-3"
-             ))
+      Alert(message: alert_message, level: alert_level, class: "mt-3")
     end
 
     def alert_message

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3285,11 +3285,19 @@
   inat_not_imported: Not Imported
 
   inat_import_confirm_title: Confirm iNat Import
-  inat_import_confirm_estimate_caption: Estimated number of imports
+  inat_import_confirm_requested_caption: Requested Observations
+  inat_import_confirm_expected_caption: Expected imports
   inat_import_confirm_unlicensed_obs_caption: Unlicensed observations
   inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
   inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
   inat_import_confirm_time_estimate_caption: Estimated time
+  inat_import_confirm_ignored_total_caption: Total Ignored Observations
+  inat_import_confirm_ignored_overlap_note: "(following categories may overlap)"
+  inat_import_confirm_not_importable_caption: Not fungi or slime molds
+  inat_import_confirm_already_imported_caption: Already imported
+  inat_import_confirm_no_date_caption: No observation date
+  inat_import_confirm_expected_as_of: "As of [time]"
+  inat_import_confirm_expected_staleness: Actual counts may change after that time.
   inat_import_confirm_explanation: "MO will import your iNat observations that are identified as a fungus or slime mold and that were neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script. Unlicensed images will be imported with your default MO license. You can work on other things while the import is proceeding."
   inat_import_confirm_prompt: Would you like to proceed with the import?
   inat_import_confirm_proceed: Proceed
@@ -3319,6 +3327,10 @@
   inat_import_tracker_imported_count: Number Imported
   inat_import_tracker_leave_page: You may continue working in MO by opening another tab, or by leaving this page. To return to this page, you can (a) go back in your browser, or (b) click Create Observation, iNat Import; if the import is in progress, this page will be redisplayed.
   inat_import_tracker_pending: Please wait until your pending iNat Import is Done before starting a new one.
+  inat_import_tracker_ignored_heading: Ignored Observations
+  inat_import_tracker_ignored_not_importable: Not importable (not fungi or slime molds)
+  inat_import_tracker_ignored_already_imported: Already imported
+  inat_import_tracker_ignored_date_missing: No observation date
   inat_importables_explanation: "An ??importable?? observation is an iNat observation which: you created, whose iNat identity is a fungus or slime mold, and which was neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script."
 
   # observer/list_notifications

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3287,17 +3287,17 @@
   inat_import_confirm_title: Confirm iNat Import
   inat_import_confirm_requested_caption: Requested Observations
   inat_import_confirm_expected_caption: Expected imports
-  inat_import_confirm_unlicensed_obs_caption: Unlicensed observations
-  inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
-  inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
-  inat_import_confirm_time_estimate_caption: Estimated time
+  inat_import_confirm_expected_as_of: "As of [time]"
+  inat_import_confirm_expected_staleness: Actual counts may change after that time.
   inat_import_confirm_ignored_total_caption: Total Ignored Observations
   inat_import_confirm_ignored_overlap_note: "(following categories may overlap)"
   inat_import_confirm_not_importable_caption: Not fungi or slime molds
   inat_import_confirm_already_imported_caption: Already imported
   inat_import_confirm_no_date_caption: No observation date
-  inat_import_confirm_expected_as_of: "As of [time]"
-  inat_import_confirm_expected_staleness: Actual counts may change after that time.
+  inat_import_confirm_unlicensed_obs_caption: Unlicensed observations
+  inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
+  inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
+  inat_import_confirm_time_estimate_caption: Estimated time
   inat_import_confirm_explanation: "MO will import your iNat observations that are identified as a fungus or slime mold and that were neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script. Unlicensed images will be imported with your default MO license. You can work on other things while the import is proceeding."
   inat_import_confirm_prompt: Would you like to proceed with the import?
   inat_import_confirm_proceed: Proceed

--- a/db/migrate/20260701120000_add_ignored_counts_to_inat_imports.rb
+++ b/db/migrate/20260701120000_add_ignored_counts_to_inat_imports.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddIgnoredCountsToInatImports < ActiveRecord::Migration[7.2]
+  def change
+    change_table(:inat_imports, bulk: true) do |t|
+      t.integer(:ignored_not_importable_count, default: 0, null: false)
+      t.integer(:ignored_date_missing_count, default: 0, null: false)
+      t.integer(:ignored_already_imported_count, default: 0, null: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_30_230000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_01_120000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -234,6 +234,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_30_230000) do
     t.text "inat_url"
     t.datetime "started_at"
     t.integer "total_importables"
+    t.integer "ignored_not_importable_count", default: 0, null: false
+    t.integer "ignored_date_missing_count", default: 0, null: false
+    t.integer "ignored_already_imported_count", default: 0, null: false
   end
 
   create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -653,13 +653,13 @@ class InatImportsControllerTest < FunctionalTestCase
     user = users(:rolf)
     inat_ids = "12345"
 
-    # Total query (no licensed filter) returns 1 (the unlicensed obs)
+    # All queries return 1 (1 obs in scope, which is unlicensed)
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       to_return(status: 200, body: { total_results: 1 }.to_json)
-    # Licensed query returns 0 (unlicensed obs excluded)
+    # Unlicensed query (own import uses licensed=false) also returns 1
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including("licensed" => "true")).
-      to_return(status: 200, body: { total_results: 0 }.to_json)
+      with(query: hash_including("licensed" => "false")).
+      to_return(status: 200, body: { total_results: 1 }.to_json)
 
     login(user.login)
     post(:create,

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -470,10 +470,10 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1 })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     body = @response.body
-    assert_match(:inat_import_confirm_estimate_caption.l, body)
-    assert_select("#estimated_count", "2")
+    assert_match(:inat_import_confirm_expected_caption.l, body)
+    assert_select("#expected_count", "2")
     assert_match(:inat_import_confirm_time_estimate_caption.l, body)
     assert_select("#estimated_time", "00:00:24")
   end
@@ -502,9 +502,9 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1, import_others: "1" })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
-      "#estimated_count", "1",
+      "#expected_count", "1",
       "Estimate should not filter by user_login if a super_importer " \
       "imports listed observations"
     )
@@ -641,9 +641,9 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_username: user.inat_username, all: 1, consent: 1 })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
-      "#estimated_count", "1",
+      "#expected_count", "1",
       "Estimate for a super_importer's own import-all should filter " \
       "by user_login, not return a global count"
     )
@@ -658,7 +658,7 @@ class InatImportsControllerTest < FunctionalTestCase
       to_return(status: 200, body: { total_results: 1 }.to_json)
     # Licensed query returns 0 (unlicensed obs excluded)
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including("license" => Inat::Constants::LICENSED_FILTER[:license])).
+      with(query: hash_including("licensed" => "true")).
       to_return(status: 200, body: { total_results: 0 }.to_json)
 
     login(user.login)
@@ -667,9 +667,9 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1 })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
-      "#estimated_count", "1",
+      "#expected_count", "1",
       "Estimate should include unlicensed own observations"
     )
     assert_select(
@@ -688,8 +688,12 @@ class InatImportsControllerTest < FunctionalTestCase
       to_return(status: 200, body: { total_results: 5 }.to_json)
     # Licensed query (the estimate) returns 3 — registered last, matched first
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including("license" => Inat::Constants::LICENSED_FILTER[:license])).
+      with(query: hash_including("licensed" => "true")).
       to_return(status: 200, body: { total_results: 3 }.to_json)
+    # Unlicensed query returns 2 (obs that will be skipped)
+    stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
+      with(query: hash_including("licensed" => "false")).
+      to_return(status: 200, body: { total_results: 2 }.to_json)
 
     login(user.login)
     post(:create,
@@ -697,9 +701,9 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1, import_others: "1" })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
-      "#estimated_count", "3",
+      "#expected_count", "3",
       "Estimate for import-others should be licensed obs count"
     )
     assert_select(
@@ -712,7 +716,7 @@ class InatImportsControllerTest < FunctionalTestCase
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       to_return(status: 200, body: { total_results: 3 }.to_json)
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
-      with(query: hash_including("license" => Inat::Constants::LICENSED_FILTER[:license])).
+      with(query: hash_including("licensed" => "false")).
       to_return(status: 500, body: "error")
 
     login(users(:rolf).login)
@@ -720,7 +724,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_ids: "1,2,3", inat_username: "rolf", consent: 1 })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
     assert_select(
       "#unlicensed_obs_count", "",
       "Unlicensed count should be blank when licensed estimate fails"
@@ -739,7 +743,7 @@ class InatImportsControllerTest < FunctionalTestCase
     # Licensed estimate returns valid JSON — registered last, matched first.
     stub_request(:get, %r{api\.inaturalist\.org/v1/observations}).
       with(query: hash_including(
-        "license" => Inat::Constants::LICENSED_FILTER[:license]
+        "licensed" => "true"
       )).
       to_return(status: 200, body: { total_results: 3 }.to_json)
 
@@ -750,7 +754,7 @@ class InatImportsControllerTest < FunctionalTestCase
 
     assert_response(:success)
     assert_select(
-      "#estimated_count", "3",
+      "#expected_count", "3",
       "Estimate should still show when only unlicensed-others request fails"
     )
     assert_select(
@@ -914,7 +918,7 @@ class InatImportsControllerTest < FunctionalTestCase
                    consent: 1, all: 1, import_others: "1" })
 
     assert_response(:success)
-    assert_select("#estimated_count")
+    assert_select("#expected_count")
   end
 
   def test_superimporter_not_own_import_all_without_username_blocked
@@ -1049,7 +1053,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: inat_username, consent: 1 })
 
     assert_response(:success, "Valid URL should proceed to confirmation")
-    assert_select("#estimated_count", "5",
+    assert_select("#expected_count", "5",
                   "Confirmation should show estimate from URL query")
   end
 
@@ -1265,7 +1269,7 @@ class InatImportsControllerTest < FunctionalTestCase
       "Confirm page must show the ignored-params warning for user_login " \
       "stripped from the URL for a non-superimporter"
     )
-    assert_select("#estimated_count", "3",
+    assert_select("#expected_count", "3",
                   "Confirm page should render with the estimate")
   end
 
@@ -1333,7 +1337,7 @@ class InatImportsControllerTest < FunctionalTestCase
     post(:create,
          params: { inat_url: url, import_others: "1", consent: 1 })
 
-    assert_select("#estimated_count", true,
+    assert_select("#expected_count", true,
                   "Superimporter URL import without username should confirm")
   end
 
@@ -1354,7 +1358,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "7",
+    assert_select("#expected_count", "7",
                   "Estimate should include project_id from user URL")
   end
 
@@ -1383,7 +1387,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "5",
+    assert_select("#expected_count", "5",
                   "MO taxon_id and only_id must override user-supplied values")
   end
 
@@ -1411,7 +1415,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "3",
+    assert_select("#expected_count", "3",
                   "Importable user-supplied taxon_id should be used " \
                   "in the estimate, not replaced by IMPORTABLE_TAXON_IDS_ARG")
   end
@@ -1434,7 +1438,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "9",
+    assert_select("#expected_count", "9",
                   "id param from URL must be excluded from the estimate")
   end
 
@@ -1459,7 +1463,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1 })
 
-    assert_select("#estimated_count", "5",
+    assert_select("#expected_count", "5",
                   "user_id must be stripped from the estimate request")
   end
 


### PR DESCRIPTION
## Summary

This is a redo of @JoeCohen 's #4617, that works with #4632, and should include all changes/improvements from that PR. Stacked on PR #4632 (iNat Turbo Stream broadcasting). Adds two things:

**1. Ignored observation counts**

- Adds three integer columns to `inat_imports`: `ignored_not_importable_count`, `ignored_date_missing_count`, `ignored_already_imported_count`
- `InatImport#add_ignored_obs(:reason)` — called by `ObservationImporter` on each skip
- Status panel renders an info-level `Alert` with per-reason counts when the import completes with at least one ignored observation

**2. Confirm form rewrite**

- Introduces `Inat::ConfirmURLBuilder` PORO: builds iNat URLs for requested / expected / already-imported / unlicensed obs counts so each count in the confirm page links directly to the corresponding iNat search
- Refactors `Inat::Estimators`: renames `fetch_import_estimate` → `fetch_expected_count`, adds `fetch_raw_requested_count`, `fetch_after_taxon_count`, `fetch_estimate_with_date_count`
- Simplifies `LICENSED_FILTER` from a comma-delimited string to `{ licensed: true }`
- Rewrites `ConfirmForm`: shows timestamp with staleness warning, requested-obs line, ignored-obs breakdown (not importable / already imported / no date), expected count with iNat link, unlicensed count with own-vs-others note, time estimate

## Test plan

- [ ] `bin/rails test test/models/inat_import_test.rb`
- [ ] `bin/rails test test/views/controllers/inat_imports/`
- [ ] `bin/rails test test/controllers/inat_imports_controller_test.rb`
- [ ] Verify CI passes
