### PR TITLE
Store iNat import results: Add `inat_import_id` to `observations`; error columns to `inat_imports`

### DIFF
--- a/.claude/hooks/block_index_active_params.sh
+++ b/.claude/hooks/block_index_active_params.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook — fires for Bash (git commit) and
+# Edit/Write/MultiEdit (save). Blocks adding new index_active_params
+# methods or new shortcut symbols to existing ones in controllers.
+#
+# index_active_params is deprecated — see .claude/rules/index_active_params.md
+# and GitHub issue #4636.
+#
+# Two modes:
+#   Bash + git commit → scan staged additions in app/controllers/
+#   Edit/Write        → scan new_string/content for controller files
+set -euo pipefail
+
+# Skip during merge commits — staged files include upstream content we don't own.
+[ -f .git/MERGE_HEAD ] && exit 0
+
+INPUT="$(cat)"
+TOOL="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""')"
+
+CONTENT=""
+
+case "$TOOL" in
+  Bash)
+    COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')"
+    case "$COMMAND" in
+      *"git commit"*) ;;
+      *) exit 0 ;;
+    esac
+    CONTENT="$(git diff --cached -U0 \
+      -- 'app/controllers/*.rb' 'app/controllers/**/*.rb' \
+      | grep '^+[^+]' | sed 's/^+//' \
+      || true)"
+    ;;
+
+  Edit|Write)
+    FILE="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""')"
+    case "$FILE" in
+      */app/controllers/*.rb|*/app/controllers/**/*.rb) ;;
+      *) exit 0 ;;
+    esac
+    case "$TOOL" in
+      Edit)  CONTENT="$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // ""')" ;;
+      Write) CONTENT="$(printf '%s' "$INPUT" | jq -r '.tool_input.content // ""')" ;;
+    esac
+    ;;
+
+  MultiEdit)
+    FILE="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""')"
+    case "$FILE" in
+      */app/controllers/*.rb|*/app/controllers/**/*.rb) ;;
+      *) exit 0 ;;
+    esac
+    CONTENT="$(printf '%s' "$INPUT" \
+      | jq -r '[.tool_input.edits[].new_string] | join("\n")' 2>/dev/null \
+      || true)"
+    ;;
+
+  *) exit 0 ;;
+esac
+
+[ -z "$CONTENT" ] && exit 0
+
+# Detect: new def index_active_params, OR new symbols being spliced into
+# an existing index_active_params array.  The second pattern looks for
+# a bare :symbol_name inside what would be that method's array body —
+# the surrounding `def`/`freeze` heuristic keeps false-positive rate low.
+if printf '%s\n' "$CONTENT" | grep -qE '^\s*def index_active_params|index_active_params'; then
+  cat >&2 <<'EOF'
+⚠️  index_active_params is deprecated (issue #4636).
+
+Every entry is a legacy shortcut URL alias (?project=123, ?by_user=456,
+etc.) for something the Query system already handles natively via stable
+?q[...] params. We are removing all of these, not adding more.
+
+If you are building a filtered-index URL, use the Query system instead:
+
+  # In a controller:
+  query = Query.lookup(:Observation, projects: [@project])
+  redirect_with_query(observations_path, query)
+
+  # In a view/helper:
+  link_to("Results", add_q_param(observations_path, query))
+
+The resulting ?q[model]=Observation&q[projects][]=123 URL is fully
+self-contained — no session or DB lookup needed. See:
+  .claude/rules/index_active_params.md
+EOF
+fi
+
+exit 0

--- a/.claude/hooks/check_coveralls_pr.sh
+++ b/.claude/hooks/check_coveralls_pr.sh
@@ -172,6 +172,18 @@ ${TOUCHED_REPORT}
 
 Per the project's testing rules: every Ruby file in a PR must be at
 100% line coverage before declaring done. Fix gaps in the same PR.
+
+⚠️  To find the specific uncovered lines:
+  The Coveralls source_files API returns SUMMARY COUNTS ONLY
+  (missed_line_count, covered_line_count, covered_percent) — no
+  line-by-line coverage arrays. Do NOT keep fetching the API looking
+  for line data; it does not exist in the public response.
+
+  Correct workflow:
+    1. Run: git diff origin/main -- <file.rb>  (see which lines changed)
+    2. Read the source file to identify branches not hit by tests
+       (rescue blocks, format.turbo_stream branches, guard clauses, etc.)
+    3. Add a test that exercises the uncovered path
 EOF
 else
   echo "" >&2

--- a/.claude/rules/index_active_params.md
+++ b/.claude/rules/index_active_params.md
@@ -1,0 +1,50 @@
+# `index_active_params` — Deprecated, Do Not Extend
+
+## What it is
+
+`index_active_params` is a method on controller classes (overriding `ApplicationController::Indexes`) that declares a list of "shortcut" URL params the index action accepts directly — e.g. `?project=123`, `?by_user=456`, `?pattern=foo`. The framework translates these into `Query` objects behind the scenes.
+
+Example of what **not** to add:
+
+```ruby
+# ❌ DO NOT ADD — deprecated pattern
+def index_active_params
+  [:pattern, :project, :by_user, :by, :q, :id].freeze
+end
+```
+
+## Why it is deprecated
+
+MO's observation index (and all other model indexes) use the `Query` system for filtering. Queries are encoded directly in URLs as nested params:
+
+```
+/observations?q[model]=Observation&q[projects][]=123
+/observations?q[model]=Observation&q[by_users][]=456&q[order_by]=date
+```
+
+These URLs are fully self-contained and stable — any user with the URL lands on the exact same result set, no session or database lookup required.
+
+`index_active_params` shortcuts (`?project=123`) are a parallel path that pre-dates the current Query URL format. They exist only for backward compatibility with old links. Every shortcut in the list is a second way to express something the Query system already handles natively. The plan (tracked in GitHub issue #4636) is to remove all of them.
+
+## What to do instead
+
+**Never** add a new `index_active_params` entry or a new `def index_active_params` override to any controller.
+
+To link to a filtered index, build the Query and use `redirect_with_query` (in controllers) or `add_q_param` (in views/helpers) to produce the proper `?q[...]` URL:
+
+```ruby
+# In a controller action — redirect to filtered observations
+query = Query.lookup(:Observation, projects: [@project])
+redirect_with_query(observations_path, query)
+
+# In a view — link to filtered observations
+link_to("Project obs", add_q_param(observations_path, query))
+```
+
+The `?q[model]=Observation&q[projects][]=123` URL produced this way is the stable, correct form. It does not require a database record or session to reconstruct — all params are in the URL itself.
+
+## The sweep
+
+Issue #4636 tracks removing every existing `index_active_params` override across all controllers. When that sweep lands, the base method in `ApplicationController::Indexes` will be deleted too.
+
+Until then: leave existing entries alone (removing them requires coordinated route/link updates), but **add nothing new**.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,11 @@
             "type": "command",
             "command": "test -x .claude/hooks/block_raw_component_classes.sh && exec .claude/hooks/block_raw_component_classes.sh || exit 0",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "test -x .claude/hooks/block_index_active_params.sh && exec .claude/hooks/block_index_active_params.sh || exit 0",
+            "timeout": 10
           }
         ]
       },
@@ -53,6 +58,11 @@
             "type": "command",
             "command": "test -x .claude/hooks/block_raw_component_classes.sh && exec .claude/hooks/block_raw_component_classes.sh || exit 0",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "test -x .claude/hooks/block_index_active_params.sh && exec .claude/hooks/block_index_active_params.sh || exit 0",
+            "timeout": 10
           }
         ]
       }

--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -10,11 +10,13 @@ class Inat
 
     MO_API_KEY_NOTES = InatImportsController::MO_API_KEY_NOTES
 
-    def initialize(inat_obs:, user:, import_others: false, external_site: nil)
+    def initialize(inat_obs:, user:, import_others: false,
+                   external_site: nil, inat_import: nil)
       @inat_obs = inat_obs
       @user = user
       @import_others = import_others
       @external_site = external_site || ExternalSite.inaturalist
+      @inat_import = inat_import
       @skipped_images = 0
       @unlicensed_obs = inat_obs[:license_code].blank? ? 1 : 0
     end
@@ -56,7 +58,8 @@ class Inat
         name_id: lead_name.id,
         specimen: inat_obs.specimen?,
         text_name: lead_name.text_name,
-        notes: inat_obs.notes }.merge(collector_attrs)
+        notes: inat_obs.notes,
+        inat_import_id: @inat_import&.id }.merge(collector_attrs)
     end
 
     # Link the collector to an MO user when the iNat collector (a custom

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -56,7 +56,7 @@ class Inat
       log_with_response_error(
         "Skipped #{@inat_obs[:id]} #{:inat_observed_missing_date.l}"
       )
-      inat_import.add_ignored_obs(:date_missing)
+      inat_import.add_ignored_obs(:date_missing, inat_id: @inat_obs[:id])
       true
     end
 
@@ -119,6 +119,9 @@ class Inat
     def accumulate_counts(builder)
       @unlicensed_obs_count += builder.unlicensed_obs
       @skipped_images_count += builder.skipped_images
+      return unless builder.unlicensed_obs == 1
+
+      inat_import.add_license_added_obs(inat_id: @inat_obs[:id])
     end
 
     def finalize_import

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -96,7 +96,8 @@ class Inat
       builder = Inat::MoObservationBuilder.new(
         inat_obs: @inat_obs, user: @user,
         import_others: @inat_import.import_others,
-        external_site: inat_site
+        external_site: inat_site,
+        inat_import: @inat_import
       )
       @observation = builder.mo_observation
       builder

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -54,6 +54,7 @@ class Query::Observations < Query
   # query_attr(:search_where, :string) # advanced search
   # query_attr(:search_user, :string) # advanced search
   # query_attr(:search_content, :string) # advanced search
+  query_attr(:inat_import, InatImport)
   query_attr(:image_query, { subquery: :Image })
   query_attr(:location_query, { subquery: :Location })
   query_attr(:name_query, { subquery: :Name })

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -33,10 +33,11 @@ class InatImportsController < ApplicationController
   before_action :flatten_new_form_params, only: :create
 
   def index
-    imports = in_admin_mode? ? InatImport.all : InatImport.where(user: @user)
+    admin = in_admin_mode? == true
+    imports = admin ? InatImport.all : InatImport.where(user: @user)
     render(Views::Controllers::InatImports::Index.new(
-             imports: imports.order(created_at: :desc),
-             admin: in_admin_mode?
+             imports: imports.order(created_at: :desc).to_a,
+             admin: admin
            ))
   end
 

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -32,6 +32,20 @@ class InatImportsController < ApplicationController
   before_action :flatten_confirm_params, only: :create
   before_action :flatten_new_form_params, only: :create
 
+  def index
+    imports = in_admin_mode? ? InatImport.all : InatImport.where(user: @user)
+    render(Views::Controllers::InatImports::Index.new(
+             imports: imports.order(created_at: :desc),
+             admin: in_admin_mode?
+           ))
+  end
+
+  def results
+    @inat_import = InatImport.find(params[:id])
+    query = Query.lookup(:Observation, inat_import: @inat_import)
+    redirect_with_query(observations_path, query)
+  end
+
   def show
     @inat_import = InatImport.find(params[:id])
     respond_to do |format|

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -165,7 +165,8 @@ class InatImportJob < ApplicationJob
   def parsing_should_stop?(parsed_page)
     parsed_page.nil? ||
       parsed_page["total_results"].zero? ||
-      inat_import.reload.canceled?
+      inat_import.reload.canceled? ||
+      inat_import.reached_import_cap?
   end
 
   def import_parsed_page_of_observations(parsed_page)

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -63,6 +63,8 @@ class InatImport < ApplicationRecord
   has_many :observations, dependent: :nullify
 
   serialize :log, type: Array, coder: YAML
+  serialize :date_missing_inat_ids, coder: JSON
+  serialize :license_added_inat_ids, coder: JSON
 
   after_update_commit lambda { |inat_import|
     html = ApplicationController.renderer.render(
@@ -79,6 +81,9 @@ class InatImport < ApplicationRecord
   # Expected average import time if no user has ever imported anything
   # (Only gets used once.)
   BASE_AVG_IMPORT_SECONDS = 15
+
+  # Hard cap on observations imported per InatImport run.
+  MAX_IMPORTABLE = 2_500
 
   # An import stuck in Importing state longer than this is assumed to have
   # crashed. Must match the schedule in config/recurring.yml.
@@ -114,13 +119,22 @@ class InatImport < ApplicationRecord
     Importing? && ended_at.nil? && updated_at < STUCK_THRESHOLD.ago
   end
 
-  def add_ignored_obs(reason)
+  def add_ignored_obs(reason, inat_id: nil)
     case reason
-    when :not_importable    then increment!(:ignored_not_importable_count)
-    when :date_missing      then increment!(:ignored_date_missing_count)
-    when :already_imported  then increment!(:ignored_already_imported_count)
+    when :not_importable   then increment!(:ignored_not_importable_count)
+    when :date_missing     then append_date_missing(inat_id)
+    when :already_imported then increment!(:ignored_already_imported_count)
     else raise(ArgumentError.new("Unknown ignored reason: #{reason.inspect}"))
     end
+  end
+
+  def add_license_added_obs(inat_id:)
+    reload
+    update!(license_added_inat_ids: license_added_inat_ids + [inat_id])
+  end
+
+  def reached_import_cap?
+    imported_count.to_i >= MAX_IMPORTABLE
   end
 
   def ignored_total_count
@@ -215,5 +229,14 @@ class InatImport < ApplicationRecord
 
   def ensure_response_errors_initialized
     self.response_errors ||= ""
+    self.date_missing_inat_ids ||= []
+    self.license_added_inat_ids ||= []
+  end
+
+  def append_date_missing(inat_id)
+    reload
+    self.ignored_date_missing_count = ignored_date_missing_count.to_i + 1
+    self.date_missing_inat_ids = date_missing_inat_ids + [inat_id].compact
+    save!
   end
 end

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -60,6 +60,7 @@ class InatImport < ApplicationRecord
   }, prefix: true
 
   belongs_to :user
+  has_many :observations, dependent: :nullify
 
   serialize :log, type: Array, coder: YAML
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -177,6 +177,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # Distinct from `user` (who entered the record). Null for imports until
   # the identity is claimed (#4217) and for legacy native obs. See #4211.
   belongs_to :collector_user, class_name: "User", optional: true
+  belongs_to :inat_import, optional: true
 
   # Has to go before "has many interests" or interests will be destroyed
   # before it has a chance to notify the interested users of the destruction.

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -573,6 +573,10 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         where(species_list_observations: { species_list: spl_ids }).distinct
     }
 
+    scope :inat_import, lambda { |inat_import|
+      where(inat_import_id: inat_import)
+    }
+
     scope :image_query, lambda { |hash|
       joins(:images).subquery(:Image, hash)
     }

--- a/app/views/controllers/inat_imports/index.rb
+++ b/app/views/controllers/inat_imports/index.rb
@@ -4,7 +4,7 @@ module Views::Controllers::InatImports
   # Table of iNat imports. Admins see all imports; regular users see their own.
   class Index < Views::FullPageBase
     prop :imports, _Array(::InatImport)
-    prop :admin, :boolean, default: false
+    prop :admin, _Boolean, default: false
 
     def view_template
       add_page_title(:inat_imports_index_title.l)
@@ -14,7 +14,11 @@ module Views::Controllers::InatImports
     end
 
     def render_columns(tbl)
-      tbl.column(:USER.t) { |imp| user_link(imp.user) } if @admin
+      if @admin
+        tbl.column(:USER.t) do |imp|
+          render(Components::Link::User.new(user: imp.user))
+        end
+      end
       render_count_columns(tbl)
       tbl.column(:results.l) { |imp| results_link(imp) }
     end

--- a/app/views/controllers/inat_imports/index.rb
+++ b/app/views/controllers/inat_imports/index.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Views::Controllers::InatImports
+  # Table of iNat imports. Admins see all imports; regular users see their own.
+  class Index < Views::FullPageBase
+    prop :imports, _Array(::InatImport)
+    prop :admin, :boolean, default: false
+
+    def view_template
+      add_page_title(:inat_imports_index_title.l)
+      render(Components::Table.new(@imports, class: "table-striped")) do |t|
+        render_columns(t)
+      end
+    end
+
+    def render_columns(tbl)
+      tbl.column(:USER.t) { |imp| user_link(imp.user) } if @admin
+      render_count_columns(tbl)
+      tbl.column(:results.l) { |imp| results_link(imp) }
+    end
+
+    def render_count_columns(tbl)
+      tbl.column(:STATUS.l) { |imp| plain(imp.state.to_s) }
+      tbl.column(:inat_import_tracker_imported_count.l) do |imp|
+        plain(imp.imported_count.to_s)
+      end
+      tbl.column(:inat_import_confirm_ignored_total_caption.l) do |imp|
+        plain(imp.ignored_total_count.to_s)
+      end
+    end
+
+    private
+
+    def results_link(import)
+      return unless import.Done? && import.imported_count.to_i.positive?
+
+      link_to(:results.l, results_inat_import_path(import))
+    end
+  end
+end

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -164,9 +164,9 @@ module Views::Controllers::InatImports
                            @inat_import.ignored_not_importable_count)
         render_ignored_row(:inat_import_tracker_ignored_already_imported,
                            @inat_import.ignored_already_imported_count)
-        render_ignored_row(:inat_import_tracker_ignored_date_missing,
-                           @inat_import.ignored_date_missing_count)
+        render_date_missing_row
       end
+      render_license_added_section
     end
 
     def render_ignored_row(caption_key, count)
@@ -176,6 +176,49 @@ module Views::Controllers::InatImports
         b { plain("#{caption_key.l}: ") }
         plain(count.to_s)
       end
+    end
+
+    def render_date_missing_row
+      count = @inat_import.ignored_date_missing_count.to_i
+      return unless count.positive?
+
+      ids = @inat_import.date_missing_inat_ids
+      div(class: "mb-1") do
+        b { plain("#{:inat_import_tracker_ignored_date_missing.l}: ") }
+        plain(count.to_s)
+        render_date_missing_reimport_link(ids) if ids.any?
+      end
+    end
+
+    def render_date_missing_reimport_link(ids)
+      label = :inat_import_tracker_date_missing_reimport.t(count: ids.size)
+      plain(" — ")
+      render(Components::Link::Get.new(
+               name: label,
+               target: new_inat_import_path(inat_ids: ids.join(","))
+             ))
+    end
+
+    def render_license_added_section
+      ids = @inat_import.license_added_inat_ids
+      return unless ids.any?
+
+      Alert(level: :info, class: "mt-3") do
+        h5 { plain(:inat_import_tracker_license_added_heading.l) }
+        div do
+          plain(:inat_import_tracker_license_added_note.t(count: ids.size))
+          plain(" ")
+          render_license_added_reimport_link(ids)
+        end
+      end
+    end
+
+    def render_license_added_reimport_link(ids)
+      label = :inat_import_tracker_license_added_reimport.t(count: ids.size)
+      render(Components::Link::Get.new(
+               name: label,
+               target: new_inat_import_path(inat_ids: ids.join(","))
+             ))
     end
 
     def render_error_alert

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -40,7 +40,7 @@ module Views::Controllers::InatImports
         render(Components::Button.new(
                  type: :get,
                  name: :results.l,
-                 target: results_observations_path,
+                 target: results_path,
                  **results_disabled_attrs
                ))
         unless @inat_import.Done?
@@ -64,11 +64,8 @@ module Views::Controllers::InatImports
       @inat_import.Done? && @inat_import.imported_count.to_i.positive?
     end
 
-    def results_observations_path
-      observations_path(
-        pattern: "user:#{@inat_import.user.id} created:" \
-                 "#{Time.zone.today}-#{Time.zone.tomorrow}"
-      )
+    def results_path
+      results_inat_import_path(@inat_import)
     end
 
     def render_timing_details

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3323,6 +3323,7 @@
   # /inat_import_job_tracker
   INAT_IMPORTS: iNat Imports
   INAT_IMPORT_JOB_TRACKERS: iNat Import Trackers
+  inat_imports_index_title: iNat Imports
   inat_import_tracker: iNat Import Tracker
   inat_import_tracker_started: Started
   inat_import_tracker_elapsed_time: Elapsed Time

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3298,13 +3298,6 @@
   inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
   inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
   inat_import_confirm_time_estimate_caption: Estimated time
-  inat_import_confirm_ignored_total_caption: Total Ignored Observations
-  inat_import_confirm_ignored_overlap_note: "(following categories may overlap)"
-  inat_import_confirm_not_importable_caption: Not fungi or slime molds
-  inat_import_confirm_already_imported_caption: Already imported
-  inat_import_confirm_no_date_caption: No observation date
-  inat_import_confirm_expected_as_of: "As of [time]"
-  inat_import_confirm_expected_staleness: Actual counts may change after that time.
   inat_import_confirm_explanation: "MO will import your iNat observations that are identified as a fungus or slime mold and that were neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script. Unlicensed images will be imported with your default MO license. You can work on other things while the import is proceeding."
   inat_import_confirm_prompt: Would you like to proceed with the import?
   inat_import_confirm_proceed: Proceed

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3332,6 +3332,10 @@
   inat_import_tracker_ignored_not_importable: Not importable (not fungi or slime molds)
   inat_import_tracker_ignored_already_imported: Already imported
   inat_import_tracker_ignored_date_missing: No observation date
+  inat_import_tracker_date_missing_reimport: "Re-import [count] observation(s) after adding dates on iNat"
+  inat_import_tracker_license_added_heading: Observations Imported with MO Default License
+  inat_import_tracker_license_added_note: "[count] observation(s) had no iNat license; your default MO license was applied."
+  inat_import_tracker_license_added_reimport: "Re-import [count] observation(s) after adding a license on iNat"
   inat_importables_explanation: "An ??importable?? observation is an iNat observation which: you created, whose iNat identity is a fungus or slime mold, and which was neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script."
 
   # observer/list_notifications

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3298,6 +3298,13 @@
   inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
   inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
   inat_import_confirm_time_estimate_caption: Estimated time
+  inat_import_confirm_ignored_total_caption: Total Ignored Observations
+  inat_import_confirm_ignored_overlap_note: "(following categories may overlap)"
+  inat_import_confirm_not_importable_caption: Not fungi or slime molds
+  inat_import_confirm_already_imported_caption: Already imported
+  inat_import_confirm_no_date_caption: No observation date
+  inat_import_confirm_expected_as_of: "As of [time]"
+  inat_import_confirm_expected_staleness: Actual counts may change after that time.
   inat_import_confirm_explanation: "MO will import your iNat observations that are identified as a fungus or slime mold and that were neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script. Unlicensed images will be imported with your default MO license. You can work on other things while the import is proceeding."
   inat_import_confirm_prompt: Would you like to proceed with the import?
   inat_import_confirm_proceed: Proceed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -456,7 +456,9 @@ MushroomObserver::Application.routes.draw do
       as: "inat_import_authorization_response")
   put("inat_imports/cancel/:id", to: "inat_imports#cancel",
                                  as: "inat_import_cancel")
-  resources :inat_imports, only: [:show, :new, :create]
+  resources :inat_imports, only: [:index, :show, :new, :create] do
+    member { get :results }
+  end
 
   # ----- Info: no resources, just forms and pages ----------------------------
   get("/info/how_to_help", to: "info#how_to_help")

--- a/db/migrate/20260701142244_add_inat_import_id_to_observations.rb
+++ b/db/migrate/20260701142244_add_inat_import_id_to_observations.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddInatImportIdToObservations < ActiveRecord::Migration[7.2]
+  def change
+    change_table(:observations, bulk: true) do |t|
+      t.integer(:inat_import_id)
+      t.index(:inat_import_id)
+    end
+  end
+end

--- a/db/migrate/20260701170000_add_actionable_inat_id_columns_to_inat_imports.rb
+++ b/db/migrate/20260701170000_add_actionable_inat_id_columns_to_inat_imports.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddActionableInatIdColumnsToInatImports < ActiveRecord::Migration[7.2]
+  def change
+    change_table(:inat_imports, bulk: true) do |t|
+      t.column(:date_missing_inat_ids, :text)
+      t.column(:license_added_inat_ids, :text)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_01_142244) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_01_170000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -237,6 +237,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_01_142244) do
     t.integer "ignored_not_importable_count", default: 0, null: false
     t.integer "ignored_date_missing_count", default: 0, null: false
     t.integer "ignored_already_imported_count", default: 0, null: false
+    t.text "date_missing_inat_ids"
+    t.text "license_added_inat_ids"
   end
 
   create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,1031 +12,1161 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_01_120000) do
-  create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "last_used", precision: nil
-    t.integer "num_uses", default: 0
-    t.integer "user_id", null: false
-    t.string "key", limit: 128, null: false
-    t.text "notes"
-    t.datetime "verified", precision: nil
+ActiveRecord::Schema[7.2].define(version: 20_260_701_142_244) do
+  create_table "api_keys", id: :integer, charset: "utf8mb3",
+                           force: :cascade do |t|
+    t.datetime("created_at", precision: nil)
+    t.datetime("last_used", precision: nil)
+    t.integer("num_uses", default: 0)
+    t.integer("user_id", null: false)
+    t.string("key", limit: 128, null: false)
+    t.text("notes")
+    t.datetime("verified", precision: nil)
   end
 
-  create_table "articles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "title"
-    t.text "body", size: :medium
-    t.integer "user_id"
-    t.integer "rss_log_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+  create_table "articles", id: :integer, charset: "utf8mb4",
+                           collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string("title")
+    t.text("body", size: :medium)
+    t.integer("user_id")
+    t.integer("rss_log_id")
+    t.datetime("created_at", precision: nil, null: false)
+    t.datetime("updated_at", precision: nil, null: false)
   end
 
-  create_table "banners", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.text "message"
-    t.integer "version"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "banners", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci",
+                          force: :cascade do |t|
+    t.text("message")
+    t.integer("version")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
   end
 
-  create_table "collection_numbers", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.string "name"
-    t.string "number"
+  create_table "collection_numbers", id: :integer, charset: "utf8mb3",
+                                     force: :cascade do |t|
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.string("name")
+    t.string("number")
   end
 
-  create_table "comments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.integer "user_id"
-    t.string "summary", limit: 100
-    t.text "comment"
-    t.string "target_type", limit: 30
-    t.integer "target_id"
-    t.datetime "updated_at", precision: nil
-    t.index ["target_id", "target_type"], name: "target_index"
+  create_table "comments", id: :integer, charset: "utf8mb3",
+                           force: :cascade do |t|
+    t.datetime("created_at", precision: nil)
+    t.integer("user_id")
+    t.string("summary", limit: 100)
+    t.text("comment")
+    t.string("target_type", limit: 30)
+    t.integer("target_id")
+    t.datetime("updated_at", precision: nil)
+    t.index(%w[target_id target_type], name: "target_index")
   end
 
-  create_table "copyright_changes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.string "target_type", limit: 30, null: false
-    t.integer "target_id", null: false
-    t.integer "year"
-    t.string "name"
-    t.integer "license_id"
+  create_table "copyright_changes", id: :integer, charset: "utf8mb3",
+                                    force: :cascade do |t|
+    t.integer("user_id", null: false)
+    t.datetime("updated_at", precision: nil, null: false)
+    t.string("target_type", limit: 30, null: false)
+    t.integer("target_id", null: false)
+    t.integer("year")
+    t.string("name")
+    t.integer("license_id")
   end
 
-  create_table "donations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.decimal "amount", precision: 12, scale: 2
-    t.string "who", limit: 100
-    t.string "email", limit: 100
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.boolean "anonymous", default: false, null: false
-    t.boolean "reviewed", default: true, null: false
-    t.integer "user_id"
-    t.boolean "recurring", default: false
+  create_table "donations", id: :integer, charset: "utf8mb3",
+                            force: :cascade do |t|
+    t.decimal("amount", precision: 12, scale: 2)
+    t.string("who", limit: 100)
+    t.string("email", limit: 100)
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.boolean("anonymous", default: false, null: false)
+    t.boolean("reviewed", default: true, null: false)
+    t.integer("user_id")
+    t.boolean("recurring", default: false)
   end
 
-  create_table "external_links", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.integer "target_id"
-    t.integer "external_site_id"
-    t.string "url", limit: 100
-    t.string "target_type", limit: 64
-    t.string "external_id", limit: 64
-    t.integer "relationship", default: 0, null: false
-    t.datetime "last_synced_at"
-    t.virtual "import_target", type: :string, as: "(case when (`relationship` = 1) then concat(`target_type`,_utf8mb3':',`target_id`) end)", stored: true
-    t.date "external_created_on"
-    t.index ["external_site_id", "relationship", "target_type", "external_id"], name: "index_external_links_on_site_rel_target_extid"
-    t.index ["import_target"], name: "index_external_links_on_import_target", unique: true
-    t.index ["target_type", "target_id"], name: "index_external_links_on_target"
+  create_table "external_links", id: :integer, charset: "utf8mb3",
+                                 force: :cascade do |t|
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.integer("target_id")
+    t.integer("external_site_id")
+    t.string("url", limit: 100)
+    t.string("target_type", limit: 64)
+    t.string("external_id", limit: 64)
+    t.integer("relationship", default: 0, null: false)
+    t.datetime("last_synced_at")
+    t.virtual("import_target", type: :string,
+                               as: "(case when (`relationship` = 1) then concat(`target_type`,_utf8mb3':',`target_id`) end)", stored: true)
+    t.date("external_created_on")
+    t.index(%w[external_site_id relationship target_type external_id],
+            name: "index_external_links_on_site_rel_target_extid")
+    t.index(["import_target"], name: "index_external_links_on_import_target",
+                               unique: true)
+    t.index(%w[target_type target_id], name: "index_external_links_on_target")
   end
 
-  create_table "external_sites", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string "name", limit: 100
-    t.integer "project_id"
-    t.string "base_url", null: false
-    t.text "description"
-    t.datetime "last_successful_sync_at"
-    t.string "url_template"
+  create_table "external_sites", id: :integer, charset: "utf8mb3",
+                                 force: :cascade do |t|
+    t.string("name", limit: 100)
+    t.integer("project_id")
+    t.string("base_url", null: false)
+    t.text("description")
+    t.datetime("last_successful_sync_at")
+    t.string("url_template")
   end
 
-  create_table "field_slip_job_trackers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "start"
-    t.integer "count"
-    t.string "prefix"
-    t.integer "status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "pages", default: 0, null: false
-    t.string "title", limit: 100, default: "", null: false
-    t.integer "user_id"
-    t.boolean "one_per_page", default: false, null: false
+  create_table "field_slip_job_trackers", charset: "utf8mb4",
+                                          collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("start")
+    t.integer("count")
+    t.string("prefix")
+    t.integer("status")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.integer("pages", default: 0, null: false)
+    t.string("title", limit: 100, default: "", null: false)
+    t.integer("user_id")
+    t.boolean("one_per_page", default: false, null: false)
   end
 
-  create_table "field_slips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "project_id"
-    t.string "code", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "user_id"
-    t.index ["code"], name: "index_field_slips_on_code", unique: true
+  create_table "field_slips", charset: "utf8mb4",
+                              collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("project_id")
+    t.string("code", null: false)
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.integer("user_id")
+    t.index(["code"], name: "index_field_slips_on_code", unique: true)
   end
 
-  create_table "glossary_term_images", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "image_id"
-    t.integer "glossary_term_id"
+  create_table "glossary_term_images", charset: "utf8mb3",
+                                       force: :cascade do |t|
+    t.integer("image_id")
+    t.integer("glossary_term_id")
   end
 
-  create_table "glossary_term_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "glossary_term_id"
-    t.integer "version"
-    t.integer "user_id"
-    t.datetime "updated_at", precision: nil
-    t.string "name", limit: 1024
-    t.text "description"
+  create_table "glossary_term_versions", id: :integer, charset: "utf8mb3",
+                                         force: :cascade do |t|
+    t.integer("glossary_term_id")
+    t.integer("version")
+    t.integer("user_id")
+    t.datetime("updated_at", precision: nil)
+    t.string("name", limit: 1024)
+    t.text("description")
   end
 
-  create_table "glossary_terms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "version"
-    t.integer "user_id"
-    t.string "name", limit: 1024
-    t.integer "thumb_image_id"
-    t.text "description"
-    t.integer "rss_log_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.boolean "locked", default: false, null: false
+  create_table "glossary_terms", id: :integer, charset: "utf8mb3",
+                                 force: :cascade do |t|
+    t.integer("version")
+    t.integer("user_id")
+    t.string("name", limit: 1024)
+    t.integer("thumb_image_id")
+    t.text("description")
+    t.integer("rss_log_id")
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.boolean("locked", default: false, null: false)
   end
 
-  create_table "herbaria", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.text "mailing_address"
-    t.integer "location_id"
-    t.string "email", limit: 80, default: "", null: false
-    t.string "name", limit: 1024
-    t.text "description"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.string "code", limit: 8
-    t.integer "personal_user_id"
-    t.index ["code"], name: "index_herbaria_on_code", unique: true
+  create_table "herbaria", id: :integer, charset: "utf8mb3",
+                           force: :cascade do |t|
+    t.text("mailing_address")
+    t.integer("location_id")
+    t.string("email", limit: 80, default: "", null: false)
+    t.string("name", limit: 1024)
+    t.text("description")
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.string("code", limit: 8)
+    t.integer("personal_user_id")
+    t.index(["code"], name: "index_herbaria_on_code", unique: true)
   end
 
   create_table "herbarium_curators", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "user_id", default: 0, null: false
-    t.integer "herbarium_id", default: 0, null: false
+    t.integer("user_id", default: 0, null: false)
+    t.integer("herbarium_id", default: 0, null: false)
   end
 
-  create_table "herbarium_records", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "herbarium_id", null: false
-    t.text "notes"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id", null: false
-    t.string "initial_det", limit: 221, null: false
-    t.string "accession_number", limit: 80, null: false
+  create_table "herbarium_records", id: :integer, charset: "utf8mb3",
+                                    force: :cascade do |t|
+    t.integer("herbarium_id", null: false)
+    t.text("notes")
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id", null: false)
+    t.string("initial_det", limit: 221, null: false)
+    t.string("accession_number", limit: 80, null: false)
   end
 
-  create_table "image_votes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "value", null: false
-    t.boolean "anonymous", default: false, null: false
-    t.integer "user_id"
-    t.integer "image_id"
-    t.index ["image_id"], name: "index_image_votes_on_image_id"
-    t.index ["user_id"], name: "index_image_votes_on_user_id"
+  create_table "image_votes", id: :integer, charset: "utf8mb3",
+                              force: :cascade do |t|
+    t.integer("value", null: false)
+    t.boolean("anonymous", default: false, null: false)
+    t.integer("user_id")
+    t.integer("image_id")
+    t.index(["image_id"], name: "index_image_votes_on_image_id")
+    t.index(["user_id"], name: "index_image_votes_on_user_id")
   end
 
-  create_table "images", id: { type: :integer, unsigned: true }, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.string "content_type", limit: 100
-    t.integer "user_id"
-    t.date "when"
-    t.text "notes"
-    t.string "copyright_holder", limit: 100
-    t.integer "license_id", default: 10, null: false
-    t.integer "num_views", default: 0, null: false
-    t.datetime "last_view", precision: nil
-    t.integer "width"
-    t.integer "height"
-    t.float "vote_cache"
-    t.boolean "ok_for_export", default: true, null: false
-    t.string "original_name", limit: 120, default: ""
-    t.boolean "transferred", default: false, null: false
-    t.boolean "gps_stripped", default: false, null: false
-    t.boolean "diagnostic", default: true, null: false
+  create_table "images", id: { type: :integer, unsigned: true },
+                         charset: "utf8mb3", force: :cascade do |t|
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.string("content_type", limit: 100)
+    t.integer("user_id")
+    t.date("when")
+    t.text("notes")
+    t.string("copyright_holder", limit: 100)
+    t.integer("license_id", default: 10, null: false)
+    t.integer("num_views", default: 0, null: false)
+    t.datetime("last_view", precision: nil)
+    t.integer("width")
+    t.integer("height")
+    t.float("vote_cache")
+    t.boolean("ok_for_export", default: true, null: false)
+    t.string("original_name", limit: 120, default: "")
+    t.boolean("transferred", default: false, null: false)
+    t.boolean("gps_stripped", default: false, null: false)
+    t.boolean("diagnostic", default: true, null: false)
   end
 
-  create_table "inat_imports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "state", default: 0
-    t.text "inat_ids"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "token"
-    t.string "inat_username"
-    t.boolean "import_all"
-    t.integer "importables"
-    t.integer "imported_count"
-    t.text "response_errors"
-    t.datetime "ended_at"
-    t.integer "total_imported_count"
-    t.integer "total_seconds"
-    t.float "avg_import_time"
-    t.datetime "last_obs_start"
-    t.boolean "cancel"
-    t.boolean "import_others", default: false, null: false
-    t.integer "writeback", default: 0, null: false
-    t.text "inat_url"
-    t.datetime "started_at"
-    t.integer "total_importables"
-    t.integer "ignored_not_importable_count", default: 0, null: false
-    t.integer "ignored_date_missing_count", default: 0, null: false
-    t.integer "ignored_already_imported_count", default: 0, null: false
+  create_table "inat_imports", charset: "utf8mb4",
+                               collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("user_id")
+    t.integer("state", default: 0)
+    t.text("inat_ids")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.string("token")
+    t.string("inat_username")
+    t.boolean("import_all")
+    t.integer("importables")
+    t.integer("imported_count")
+    t.text("response_errors")
+    t.datetime("ended_at")
+    t.integer("total_imported_count")
+    t.integer("total_seconds")
+    t.float("avg_import_time")
+    t.datetime("last_obs_start")
+    t.boolean("cancel")
+    t.boolean("import_others", default: false, null: false)
+    t.integer("writeback", default: 0, null: false)
+    t.text("inat_url")
+    t.datetime("started_at")
+    t.integer("total_importables")
+    t.integer("ignored_not_importable_count", default: 0, null: false)
+    t.integer("ignored_date_missing_count", default: 0, null: false)
+    t.integer("ignored_already_imported_count", default: 0, null: false)
   end
 
-  create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string "target_type", limit: 30
-    t.integer "target_id"
-    t.integer "user_id"
-    t.boolean "state"
-    t.datetime "updated_at", precision: nil
+  create_table "interests", id: :integer, charset: "utf8mb3",
+                            force: :cascade do |t|
+    t.string("target_type", limit: 30)
+    t.integer("target_id")
+    t.integer("user_id")
+    t.boolean("state")
+    t.datetime("updated_at", precision: nil)
   end
 
-  create_table "languages", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string "locale", limit: 40
-    t.string "name", limit: 100
-    t.string "order", limit: 100
-    t.boolean "official", null: false
-    t.boolean "beta", null: false
+  create_table "languages", id: :integer, charset: "utf8mb3",
+                            force: :cascade do |t|
+    t.string("locale", limit: 40)
+    t.string("name", limit: 100)
+    t.string("order", limit: 100)
+    t.boolean("official", null: false)
+    t.boolean("beta", null: false)
   end
 
-  create_table "licenses", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string "display_name", limit: 80
-    t.string "url", limit: 200
-    t.boolean "deprecated", default: false, null: false
-    t.datetime "updated_at", precision: nil
-    t.datetime "created_at", precision: nil
+  create_table "licenses", id: :integer, charset: "utf8mb3",
+                           force: :cascade do |t|
+    t.string("display_name", limit: 80)
+    t.string("url", limit: 200)
+    t.boolean("deprecated", default: false, null: false)
+    t.datetime("updated_at", precision: nil)
+    t.datetime("created_at", precision: nil)
   end
 
-  create_table "location_description_admins", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "location_description_id", default: 0, null: false
-    t.integer "user_group_id", default: 0, null: false
+  create_table "location_description_admins", charset: "utf8mb3",
+                                              force: :cascade do |t|
+    t.integer("location_description_id", default: 0, null: false)
+    t.integer("user_group_id", default: 0, null: false)
   end
 
-  create_table "location_description_authors", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "location_description_id", default: 0, null: false
-    t.integer "user_id", default: 0, null: false
+  create_table "location_description_authors", charset: "utf8mb3",
+                                               force: :cascade do |t|
+    t.integer("location_description_id", default: 0, null: false)
+    t.integer("user_id", default: 0, null: false)
   end
 
-  create_table "location_description_editors", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "location_description_id", default: 0, null: false
-    t.integer "user_id", default: 0, null: false
+  create_table "location_description_editors", charset: "utf8mb3",
+                                               force: :cascade do |t|
+    t.integer("location_description_id", default: 0, null: false)
+    t.integer("user_id", default: 0, null: false)
   end
 
-  create_table "location_description_readers", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "location_description_id", default: 0, null: false
-    t.integer "user_group_id", default: 0, null: false
+  create_table "location_description_readers", charset: "utf8mb3",
+                                               force: :cascade do |t|
+    t.integer("location_description_id", default: 0, null: false)
+    t.integer("user_group_id", default: 0, null: false)
   end
 
-  create_table "location_description_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "location_description_id"
-    t.integer "version"
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.integer "license_id"
-    t.integer "merge_source_id"
-    t.text "gen_desc"
-    t.text "ecology"
-    t.text "species"
-    t.text "notes"
-    t.text "refs"
+  create_table "location_description_versions", id: :integer,
+                                                charset: "utf8mb3", force: :cascade do |t|
+    t.integer("location_description_id")
+    t.integer("version")
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.integer("license_id")
+    t.integer("merge_source_id")
+    t.text("gen_desc")
+    t.text("ecology")
+    t.text("species")
+    t.text("notes")
+    t.text("refs")
   end
 
-  create_table "location_description_writers", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "location_description_id", default: 0, null: false
-    t.integer "user_group_id", default: 0, null: false
+  create_table "location_description_writers", charset: "utf8mb3",
+                                               force: :cascade do |t|
+    t.integer("location_description_id", default: 0, null: false)
+    t.integer("user_group_id", default: 0, null: false)
   end
 
-  create_table "location_descriptions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "version"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.integer "location_id"
-    t.integer "num_views", default: 0
-    t.datetime "last_view", precision: nil
-    t.integer "source_type"
-    t.string "source_name", limit: 100
-    t.string "locale", limit: 8
-    t.boolean "public"
-    t.integer "license_id"
-    t.text "gen_desc"
-    t.text "ecology"
-    t.text "species"
-    t.text "notes"
-    t.text "refs"
-    t.boolean "ok_for_export", default: true, null: false
-    t.integer "project_id"
+  create_table "location_descriptions", id: :integer, charset: "utf8mb3",
+                                        force: :cascade do |t|
+    t.integer("version")
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.integer("location_id")
+    t.integer("num_views", default: 0)
+    t.datetime("last_view", precision: nil)
+    t.integer("source_type")
+    t.string("source_name", limit: 100)
+    t.string("locale", limit: 8)
+    t.boolean("public")
+    t.integer("license_id")
+    t.text("gen_desc")
+    t.text("ecology")
+    t.text("species")
+    t.text("notes")
+    t.text("refs")
+    t.boolean("ok_for_export", default: true, null: false)
+    t.integer("project_id")
   end
 
-  create_table "location_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string "location_id"
-    t.integer "version"
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.float "north"
-    t.float "south"
-    t.float "west"
-    t.float "east"
-    t.float "high"
-    t.float "low"
-    t.string "name", limit: 1024
-    t.text "notes"
-    t.string "scientific_name", limit: 1024
-    t.decimal "box_area", precision: 21, scale: 10
-    t.decimal "center_lat", precision: 15, scale: 10
-    t.decimal "center_lng", precision: 15, scale: 10
+  create_table "location_versions", id: :integer, charset: "utf8mb3",
+                                    force: :cascade do |t|
+    t.string("location_id")
+    t.integer("version")
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.float("north")
+    t.float("south")
+    t.float("west")
+    t.float("east")
+    t.float("high")
+    t.float("low")
+    t.string("name", limit: 1024)
+    t.text("notes")
+    t.string("scientific_name", limit: 1024)
+    t.decimal("box_area", precision: 21, scale: 10)
+    t.decimal("center_lat", precision: 15, scale: 10)
+    t.decimal("center_lng", precision: 15, scale: 10)
   end
 
-  create_table "locations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "version"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.integer "description_id"
-    t.integer "rss_log_id"
-    t.integer "num_views", default: 0
-    t.datetime "last_view", precision: nil
-    t.decimal "north", precision: 15, scale: 10, null: false
-    t.decimal "south", precision: 15, scale: 10, null: false
-    t.decimal "west", precision: 15, scale: 10, null: false
-    t.decimal "east", precision: 15, scale: 10, null: false
-    t.float "high"
-    t.float "low"
-    t.boolean "ok_for_export", default: true, null: false
-    t.text "notes"
-    t.string "name", limit: 1024
-    t.string "scientific_name", limit: 1024
-    t.boolean "locked", default: false, null: false
-    t.boolean "hidden", default: false, null: false
-    t.decimal "box_area", precision: 21, scale: 10
-    t.decimal "center_lat", precision: 15, scale: 10
-    t.decimal "center_lng", precision: 15, scale: 10
+  create_table "locations", id: :integer, charset: "utf8mb3",
+                            force: :cascade do |t|
+    t.integer("version")
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.integer("description_id")
+    t.integer("rss_log_id")
+    t.integer("num_views", default: 0)
+    t.datetime("last_view", precision: nil)
+    t.decimal("north", precision: 15, scale: 10, null: false)
+    t.decimal("south", precision: 15, scale: 10, null: false)
+    t.decimal("west", precision: 15, scale: 10, null: false)
+    t.decimal("east", precision: 15, scale: 10, null: false)
+    t.float("high")
+    t.float("low")
+    t.boolean("ok_for_export", default: true, null: false)
+    t.text("notes")
+    t.string("name", limit: 1024)
+    t.string("scientific_name", limit: 1024)
+    t.boolean("locked", default: false, null: false)
+    t.boolean("hidden", default: false, null: false)
+    t.decimal("box_area", precision: 21, scale: 10)
+    t.decimal("center_lat", precision: 15, scale: 10)
+    t.decimal("center_lng", precision: 15, scale: 10)
   end
 
-  create_table "name_description_admins", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "name_description_id", default: 0, null: false
-    t.integer "user_group_id", default: 0, null: false
+  create_table "name_description_admins", charset: "utf8mb3",
+                                          force: :cascade do |t|
+    t.integer("name_description_id", default: 0, null: false)
+    t.integer("user_group_id", default: 0, null: false)
   end
 
-  create_table "name_description_authors", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "name_description_id", default: 0, null: false
-    t.integer "user_id", default: 0, null: false
+  create_table "name_description_authors", charset: "utf8mb3",
+                                           force: :cascade do |t|
+    t.integer("name_description_id", default: 0, null: false)
+    t.integer("user_id", default: 0, null: false)
   end
 
-  create_table "name_description_editors", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "name_description_id", default: 0, null: false
-    t.integer "user_id", default: 0, null: false
+  create_table "name_description_editors", charset: "utf8mb3",
+                                           force: :cascade do |t|
+    t.integer("name_description_id", default: 0, null: false)
+    t.integer("user_id", default: 0, null: false)
   end
 
-  create_table "name_description_readers", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "name_description_id", default: 0, null: false
-    t.integer "user_group_id", default: 0, null: false
+  create_table "name_description_readers", charset: "utf8mb3",
+                                           force: :cascade do |t|
+    t.integer("name_description_id", default: 0, null: false)
+    t.integer("user_group_id", default: 0, null: false)
   end
 
-  create_table "name_description_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "name_description_id"
-    t.integer "version"
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.integer "license_id"
-    t.integer "merge_source_id"
-    t.text "gen_desc"
-    t.text "diag_desc"
-    t.text "distribution"
-    t.text "habitat"
-    t.text "look_alikes"
-    t.text "uses"
-    t.text "notes"
-    t.text "refs"
+  create_table "name_description_versions", id: :integer, charset: "utf8mb3",
+                                            force: :cascade do |t|
+    t.integer("name_description_id")
+    t.integer("version")
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.integer("license_id")
+    t.integer("merge_source_id")
+    t.text("gen_desc")
+    t.text("diag_desc")
+    t.text("distribution")
+    t.text("habitat")
+    t.text("look_alikes")
+    t.text("uses")
+    t.text("notes")
+    t.text("refs")
   end
 
-  create_table "name_description_writers", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "name_description_id", default: 0, null: false
-    t.integer "user_group_id", default: 0, null: false
+  create_table "name_description_writers", charset: "utf8mb3",
+                                           force: :cascade do |t|
+    t.integer("name_description_id", default: 0, null: false)
+    t.integer("user_group_id", default: 0, null: false)
   end
 
-  create_table "name_descriptions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "version"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.integer "name_id"
-    t.integer "review_status", default: 1
-    t.datetime "last_review", precision: nil
-    t.integer "reviewer_id"
-    t.boolean "ok_for_export", default: true, null: false
-    t.integer "num_views", default: 0
-    t.datetime "last_view", precision: nil
-    t.integer "source_type"
-    t.string "source_name", limit: 100
-    t.string "locale", limit: 8
-    t.boolean "public"
-    t.integer "license_id"
-    t.text "gen_desc"
-    t.text "diag_desc"
-    t.text "distribution"
-    t.text "habitat"
-    t.text "look_alikes"
-    t.text "uses"
-    t.text "notes"
-    t.text "refs"
-    t.integer "project_id"
+  create_table "name_descriptions", id: :integer, charset: "utf8mb3",
+                                    force: :cascade do |t|
+    t.integer("version")
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.integer("name_id")
+    t.integer("review_status", default: 1)
+    t.datetime("last_review", precision: nil)
+    t.integer("reviewer_id")
+    t.boolean("ok_for_export", default: true, null: false)
+    t.integer("num_views", default: 0)
+    t.datetime("last_view", precision: nil)
+    t.integer("source_type")
+    t.string("source_name", limit: 100)
+    t.string("locale", limit: 8)
+    t.boolean("public")
+    t.integer("license_id")
+    t.text("gen_desc")
+    t.text("diag_desc")
+    t.text("distribution")
+    t.text("habitat")
+    t.text("look_alikes")
+    t.text("uses")
+    t.text("notes")
+    t.text("refs")
+    t.integer("project_id")
   end
 
-  create_table "name_trackers", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "user_id", default: 0, null: false
-    t.integer "name_id"
-    t.text "note_template"
-    t.datetime "updated_at", precision: nil
-    t.boolean "require_specimen", default: false, null: false
-    t.boolean "approved", default: true, null: false
+  create_table "name_trackers", id: :integer, charset: "utf8mb3",
+                                force: :cascade do |t|
+    t.integer("user_id", default: 0, null: false)
+    t.integer("name_id")
+    t.text("note_template")
+    t.datetime("updated_at", precision: nil)
+    t.boolean("require_specimen", default: false, null: false)
+    t.boolean("approved", default: true, null: false)
   end
 
-  create_table "name_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "name_id"
-    t.integer "version"
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.string "text_name", limit: 100
-    t.string "search_name", limit: 221
-    t.string "display_name", limit: 204
-    t.string "sort_name", limit: 241
-    t.string "author", limit: 100
-    t.text "citation"
-    t.boolean "deprecated", default: false, null: false
-    t.integer "correct_spelling_id"
-    t.text "notes"
-    t.integer "rank"
-    t.string "lifeform", limit: 1024, default: " ", null: false
-    t.integer "icn_id"
-    t.text "classification"
-    t.index ["name_id", "version"], name: "index_name_versions_on_name_id_and_version"
+  create_table "name_versions", id: :integer, charset: "utf8mb3",
+                                force: :cascade do |t|
+    t.integer("name_id")
+    t.integer("version")
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.string("text_name", limit: 100)
+    t.string("search_name", limit: 221)
+    t.string("display_name", limit: 204)
+    t.string("sort_name", limit: 241)
+    t.string("author", limit: 100)
+    t.text("citation")
+    t.boolean("deprecated", default: false, null: false)
+    t.integer("correct_spelling_id")
+    t.text("notes")
+    t.integer("rank")
+    t.string("lifeform", limit: 1024, default: " ", null: false)
+    t.integer("icn_id")
+    t.text("classification")
+    t.index(%w[name_id version],
+            name: "index_name_versions_on_name_id_and_version")
   end
 
   create_table "names", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "version"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.integer "description_id"
-    t.integer "rss_log_id"
-    t.integer "num_views", default: 0
-    t.datetime "last_view", precision: nil
-    t.integer "rank"
-    t.string "text_name", limit: 100
-    t.string "search_name", limit: 221
-    t.string "display_name", limit: 204
-    t.string "sort_name", limit: 241
-    t.text "citation"
-    t.boolean "deprecated", default: false, null: false
-    t.integer "synonym_id"
-    t.integer "correct_spelling_id"
-    t.text "notes"
-    t.text "classification"
-    t.boolean "ok_for_export", default: true, null: false
-    t.string "author", limit: 100
-    t.string "lifeform", limit: 1024, default: " ", null: false
-    t.boolean "locked", default: false, null: false
-    t.integer "icn_id"
-    t.index ["synonym_id"], name: "synonym_index"
+    t.integer("version")
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.integer("description_id")
+    t.integer("rss_log_id")
+    t.integer("num_views", default: 0)
+    t.datetime("last_view", precision: nil)
+    t.integer("rank")
+    t.string("text_name", limit: 100)
+    t.string("search_name", limit: 221)
+    t.string("display_name", limit: 204)
+    t.string("sort_name", limit: 241)
+    t.text("citation")
+    t.boolean("deprecated", default: false, null: false)
+    t.integer("synonym_id")
+    t.integer("correct_spelling_id")
+    t.text("notes")
+    t.text("classification")
+    t.boolean("ok_for_export", default: true, null: false)
+    t.string("author", limit: 100)
+    t.string("lifeform", limit: 1024, default: " ", null: false)
+    t.boolean("locked", default: false, null: false)
+    t.integer("icn_id")
+    t.index(["synonym_id"], name: "synonym_index")
   end
 
-  create_table "naming_reasons", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "naming_id"
-    t.integer "reason"
-    t.text "notes"
+  create_table "naming_reasons", id: :integer, charset: "utf8mb3",
+                                 force: :cascade do |t|
+    t.integer("naming_id")
+    t.integer("reason")
+    t.text("notes")
   end
 
-  create_table "namings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "observation_id"
-    t.integer "name_id"
-    t.integer "user_id"
-    t.float "vote_cache", default: 0.0
-    t.text "reasons"
-    t.index ["observation_id"], name: "index_namings_on_observation_id"
+  create_table "namings", id: :integer, charset: "utf8mb3",
+                          force: :cascade do |t|
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("observation_id")
+    t.integer("name_id")
+    t.integer("user_id")
+    t.float("vote_cache", default: 0.0)
+    t.text("reasons")
+    t.index(["observation_id"], name: "index_namings_on_observation_id")
   end
 
-  create_table "observation_collection_numbers", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "collection_number_id"
-    t.integer "observation_id"
+  create_table "observation_collection_numbers", charset: "utf8mb3",
+                                                 force: :cascade do |t|
+    t.integer("collection_number_id")
+    t.integer("observation_id")
   end
 
-  create_table "observation_herbarium_records", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "observation_id", default: 0, null: false
-    t.integer "herbarium_record_id", default: 0, null: false
+  create_table "observation_herbarium_records", charset: "utf8mb3",
+                                                force: :cascade do |t|
+    t.integer("observation_id", default: 0, null: false)
+    t.integer("herbarium_record_id", default: 0, null: false)
   end
 
   create_table "observation_images", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "image_id", default: 0, null: false
-    t.integer "observation_id", default: 0, null: false
-    t.integer "rank", default: 0, null: false
-    t.index ["image_id"], name: "index_observation_images_on_image_id"
-    t.index ["observation_id"], name: "index_observation_images_on_observation_id"
+    t.integer("image_id", default: 0, null: false)
+    t.integer("observation_id", default: 0, null: false)
+    t.integer("rank", default: 0, null: false)
+    t.index(["image_id"], name: "index_observation_images_on_image_id")
+    t.index(["observation_id"],
+            name: "index_observation_images_on_observation_id")
   end
 
   create_table "observation_views", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "observation_id"
-    t.integer "user_id"
-    t.datetime "last_view", precision: nil
-    t.boolean "reviewed"
-    t.index ["observation_id"], name: "observation_index"
-    t.index ["user_id"], name: "user_index"
+    t.integer("observation_id")
+    t.integer("user_id")
+    t.datetime("last_view", precision: nil)
+    t.boolean("reviewed")
+    t.index(["observation_id"], name: "observation_index")
+    t.index(["user_id"], name: "user_index")
   end
 
-  create_table "observations", id: { type: :integer, unsigned: true }, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.date "when"
-    t.integer "user_id"
-    t.boolean "specimen", default: false, null: false
-    t.text "notes"
-    t.integer "thumb_image_id"
-    t.integer "name_id"
-    t.integer "location_id"
-    t.boolean "is_collection_location", default: true, null: false
-    t.float "vote_cache", default: 0.0
-    t.integer "num_views", default: 0, null: false
-    t.datetime "last_view", precision: nil
-    t.integer "rss_log_id"
-    t.decimal "lat", precision: 15, scale: 10
-    t.decimal "lng", precision: 15, scale: 10
-    t.string "where", limit: 1024
-    t.integer "alt"
-    t.string "lifeform", limit: 1024
-    t.string "text_name", limit: 100
-    t.boolean "gps_hidden", default: false, null: false
-    t.integer "source"
-    t.datetime "log_updated_at", precision: nil
-    t.boolean "needs_naming", default: false, null: false
-    t.integer "inat_id"
-    t.decimal "location_lat", precision: 15, scale: 10
-    t.decimal "location_lng", precision: 15, scale: 10
-    t.integer "occurrence_id"
-    t.boolean "gps_dubious", default: false, null: false
-    t.string "collector", limit: 1024
-    t.integer "collector_user_id"
-    t.index ["collector_user_id"], name: "index_observations_on_collector_user_id"
-    t.index ["location_id"], name: "index_observations_on_location_id"
-    t.index ["name_id"], name: "index_observations_on_name_id"
-    t.index ["needs_naming"], name: "needs_naming_index"
-    t.index ["occurrence_id"], name: "index_observations_on_occurrence_id"
+  create_table "observations", id: { type: :integer, unsigned: true },
+                               charset: "utf8mb3", force: :cascade do |t|
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.date("when")
+    t.integer("user_id")
+    t.boolean("specimen", default: false, null: false)
+    t.text("notes")
+    t.integer("thumb_image_id")
+    t.integer("name_id")
+    t.integer("location_id")
+    t.boolean("is_collection_location", default: true, null: false)
+    t.float("vote_cache", default: 0.0)
+    t.integer("num_views", default: 0, null: false)
+    t.datetime("last_view", precision: nil)
+    t.integer("rss_log_id")
+    t.decimal("lat", precision: 15, scale: 10)
+    t.decimal("lng", precision: 15, scale: 10)
+    t.string("where", limit: 1024)
+    t.integer("alt")
+    t.string("lifeform", limit: 1024)
+    t.string("text_name", limit: 100)
+    t.boolean("gps_hidden", default: false, null: false)
+    t.integer("source")
+    t.datetime("log_updated_at", precision: nil)
+    t.boolean("needs_naming", default: false, null: false)
+    t.integer("inat_id")
+    t.decimal("location_lat", precision: 15, scale: 10)
+    t.decimal("location_lng", precision: 15, scale: 10)
+    t.integer("occurrence_id")
+    t.boolean("gps_dubious", default: false, null: false)
+    t.string("collector", limit: 1024)
+    t.integer("collector_user_id")
+    t.integer("inat_import_id")
+    t.index(["collector_user_id"],
+            name: "index_observations_on_collector_user_id")
+    t.index(["inat_import_id"], name: "index_observations_on_inat_import_id")
+    t.index(["location_id"], name: "index_observations_on_location_id")
+    t.index(["name_id"], name: "index_observations_on_name_id")
+    t.index(["needs_naming"], name: "needs_naming_index")
+    t.index(["occurrence_id"], name: "index_observations_on_occurrence_id")
   end
 
-  create_table "occurrences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "primary_observation_id"
-    t.boolean "has_specimen", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "field_slip_id"
-    t.index ["field_slip_id"], name: "index_occurrences_on_field_slip_id", unique: true
-    t.index ["primary_observation_id"], name: "index_occurrences_on_primary_observation_id"
-    t.index ["user_id"], name: "index_occurrences_on_user_id"
+  create_table "occurrences", id: :integer, charset: "utf8mb4",
+                              collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("user_id")
+    t.integer("primary_observation_id")
+    t.boolean("has_specimen", default: false, null: false)
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.integer("field_slip_id")
+    t.index(["field_slip_id"], name: "index_occurrences_on_field_slip_id",
+                               unique: true)
+    t.index(["primary_observation_id"],
+            name: "index_occurrences_on_primary_observation_id")
+    t.index(["user_id"], name: "index_occurrences_on_user_id")
   end
 
-  create_table "original_image_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "image_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "original_image_requests", charset: "utf8mb4",
+                                          collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("user_id")
+    t.integer("image_id")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
   end
 
-  create_table "project_aliases", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "project_id", null: false
-    t.integer "target_id", null: false
-    t.string "target_type", null: false
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name", "project_id"], name: "index_project_aliases_on_name_and_project_id", unique: true
-    t.index ["project_id"], name: "index_project_aliases_on_project_id"
-    t.index ["target_type", "target_id"], name: "index_project_aliases_on_target_type_and_target_id"
+  create_table "project_aliases", charset: "utf8mb4",
+                                  collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("project_id", null: false)
+    t.integer("target_id", null: false)
+    t.string("target_type", null: false)
+    t.string("name")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.index(%w[name project_id],
+            name: "index_project_aliases_on_name_and_project_id", unique: true)
+    t.index(["project_id"], name: "index_project_aliases_on_project_id")
+    t.index(%w[target_type target_id],
+            name: "index_project_aliases_on_target_type_and_target_id")
   end
 
-  create_table "project_excluded_observations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "observation_id", null: false
-    t.integer "project_id", null: false
-    t.index ["observation_id"], name: "index_project_excluded_observations_on_observation_id"
-    t.index ["project_id", "observation_id"], name: "index_project_excluded_observations_on_project_and_obs", unique: true
-    t.index ["project_id"], name: "index_project_excluded_observations_on_project_id"
+  create_table "project_excluded_observations", charset: "utf8mb4",
+                                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("observation_id", null: false)
+    t.integer("project_id", null: false)
+    t.index(["observation_id"],
+            name: "index_project_excluded_observations_on_observation_id")
+    t.index(%w[project_id observation_id],
+            name: "index_project_excluded_observations_on_project_and_obs", unique: true)
+    t.index(["project_id"],
+            name: "index_project_excluded_observations_on_project_id")
   end
 
   create_table "project_images", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "image_id", null: false
-    t.integer "project_id", null: false
+    t.integer("image_id", null: false)
+    t.integer("project_id", null: false)
   end
 
-  create_table "project_members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "project_id"
-    t.integer "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "trust_level", default: 1, null: false
+  create_table "project_members", charset: "utf8mb4",
+                                  collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("project_id")
+    t.integer("user_id")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.integer("trust_level", default: 1, null: false)
   end
 
-  create_table "project_observations", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "observation_id", null: false
-    t.integer "project_id", null: false
-    t.index ["observation_id"], name: "index_project_observations_on_observation_id"
-    t.index ["project_id"], name: "index_project_observations_on_project_id"
+  create_table "project_observations", charset: "utf8mb3",
+                                       force: :cascade do |t|
+    t.integer("observation_id", null: false)
+    t.integer("project_id", null: false)
+    t.index(["observation_id"],
+            name: "index_project_observations_on_observation_id")
+    t.index(["project_id"], name: "index_project_observations_on_project_id")
   end
 
-  create_table "project_species_lists", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "project_id", null: false
-    t.integer "species_list_id", null: false
+  create_table "project_species_lists", charset: "utf8mb3",
+                                        force: :cascade do |t|
+    t.integer("project_id", null: false)
+    t.integer("species_list_id", null: false)
   end
 
-  create_table "project_target_locations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "project_id", null: false
-    t.integer "location_id", null: false
-    t.index ["location_id"], name: "index_project_target_locations_on_location_id"
-    t.index ["project_id", "location_id"], name: "index_project_target_locations_on_project_id_and_location_id", unique: true
-    t.index ["project_id"], name: "index_project_target_locations_on_project_id"
+  create_table "project_target_locations", charset: "utf8mb4",
+                                           collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("project_id", null: false)
+    t.integer("location_id", null: false)
+    t.index(["location_id"],
+            name: "index_project_target_locations_on_location_id")
+    t.index(%w[project_id location_id],
+            name: "index_project_target_locations_on_project_id_and_location_id", unique: true)
+    t.index(["project_id"],
+            name: "index_project_target_locations_on_project_id")
   end
 
-  create_table "project_target_names", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "project_id", null: false
-    t.integer "name_id", null: false
-    t.index ["name_id"], name: "index_project_target_names_on_name_id"
-    t.index ["project_id", "name_id"], name: "index_project_target_names_on_project_id_and_name_id", unique: true
-    t.index ["project_id"], name: "index_project_target_names_on_project_id"
+  create_table "project_target_names", charset: "utf8mb4",
+                                       collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("project_id", null: false)
+    t.integer("name_id", null: false)
+    t.index(["name_id"], name: "index_project_target_names_on_name_id")
+    t.index(%w[project_id name_id],
+            name: "index_project_target_names_on_project_id_and_name_id", unique: true)
+    t.index(["project_id"], name: "index_project_target_names_on_project_id")
   end
 
-  create_table "projects", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "user_id", default: 0, null: false
-    t.integer "admin_group_id", default: 0, null: false
-    t.integer "user_group_id", default: 0, null: false
-    t.string "title", limit: 100, default: "", null: false
-    t.text "summary"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "rss_log_id"
-    t.boolean "open_membership", default: false, null: false
-    t.integer "location_id"
-    t.integer "image_id"
-    t.date "start_date"
-    t.date "end_date"
-    t.string "field_slip_prefix"
-    t.integer "next_field_slip", default: 0, null: false
-    t.index ["field_slip_prefix"], name: "index_projects_on_field_slip_prefix", unique: true
+  create_table "projects", id: :integer, charset: "utf8mb3",
+                           force: :cascade do |t|
+    t.integer("user_id", default: 0, null: false)
+    t.integer("admin_group_id", default: 0, null: false)
+    t.integer("user_group_id", default: 0, null: false)
+    t.string("title", limit: 100, default: "", null: false)
+    t.text("summary")
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("rss_log_id")
+    t.boolean("open_membership", default: false, null: false)
+    t.integer("location_id")
+    t.integer("image_id")
+    t.date("start_date")
+    t.date("end_date")
+    t.string("field_slip_prefix")
+    t.integer("next_field_slip", default: 0, null: false)
+    t.index(["field_slip_prefix"], name: "index_projects_on_field_slip_prefix",
+                                   unique: true)
   end
 
-  create_table "publications", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "user_id"
-    t.text "full"
-    t.string "link"
-    t.text "how_helped"
-    t.boolean "mo_mentioned"
-    t.boolean "peer_reviewed"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+  create_table "publications", id: :integer, charset: "utf8mb3",
+                               force: :cascade do |t|
+    t.integer("user_id")
+    t.text("full")
+    t.string("link")
+    t.text("how_helped")
+    t.boolean("mo_mentioned")
+    t.boolean("peer_reviewed")
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
   end
 
-  create_table "query_records", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "updated_at", precision: nil
-    t.integer "access_count"
-    t.text "description"
-    t.boolean "permalink", default: false
+  create_table "query_records", id: :integer, charset: "utf8mb3",
+                                force: :cascade do |t|
+    t.datetime("updated_at", precision: nil)
+    t.integer("access_count")
+    t.text("description")
+    t.boolean("permalink", default: false)
   end
 
-  create_table "rss_logs", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "observation_id"
-    t.integer "species_list_id"
-    t.datetime "updated_at", precision: nil
-    t.text "notes"
-    t.integer "name_id"
-    t.integer "location_id"
-    t.integer "project_id"
-    t.integer "glossary_term_id"
-    t.integer "article_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.index ["observation_id"], name: "index_rss_logs_on_observation_id"
-    t.index ["updated_at"], name: "index_rss_logs_on_updated_at"
+  create_table "rss_logs", id: :integer, charset: "utf8mb3",
+                           force: :cascade do |t|
+    t.integer("observation_id")
+    t.integer("species_list_id")
+    t.datetime("updated_at", precision: nil)
+    t.text("notes")
+    t.integer("name_id")
+    t.integer("location_id")
+    t.integer("project_id")
+    t.integer("glossary_term_id")
+    t.integer("article_id")
+    t.datetime("created_at", precision: nil, null: false)
+    t.index(["observation_id"], name: "index_rss_logs_on_observation_id")
+    t.index(["updated_at"], name: "index_rss_logs_on_updated_at")
   end
 
-  create_table "sequences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "observation_id"
-    t.integer "user_id"
-    t.text "locus", size: :medium
-    t.text "bases", size: :medium
-    t.string "archive"
-    t.string "accession"
-    t.text "notes", size: :medium
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+  create_table "sequences", id: :integer, charset: "utf8mb4",
+                            collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("observation_id")
+    t.integer("user_id")
+    t.text("locus", size: :medium)
+    t.text("bases", size: :medium)
+    t.string("archive")
+    t.string("accession")
+    t.text("notes", size: :medium)
+    t.datetime("created_at", precision: nil, null: false)
+    t.datetime("updated_at", precision: nil, null: false)
   end
 
-  create_table "solid_cable_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.binary "channel", limit: 1024, null: false
-    t.binary "payload", size: :long, null: false
-    t.datetime "created_at", null: false
-    t.bigint "channel_hash", null: false
-    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
-    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
-    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  create_table "solid_cable_messages", charset: "utf8mb4",
+                                       collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.binary("channel", limit: 1024, null: false)
+    t.binary("payload", size: :long, null: false)
+    t.datetime("created_at", null: false)
+    t.bigint("channel_hash", null: false)
+    t.index(["channel"], name: "index_solid_cable_messages_on_channel")
+    t.index(["channel_hash"],
+            name: "index_solid_cable_messages_on_channel_hash")
+    t.index(["created_at"], name: "index_solid_cable_messages_on_created_at")
   end
 
-  create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
-    t.string "concurrency_key", null: false
-    t.datetime "expires_at", null: false
-    t.datetime "created_at", null: false
-    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
-    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
-    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  create_table "solid_queue_blocked_executions", charset: "utf8mb4",
+                                                 collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint("job_id", null: false)
+    t.string("queue_name", null: false)
+    t.integer("priority", default: 0, null: false)
+    t.string("concurrency_key", null: false)
+    t.datetime("expires_at", null: false)
+    t.datetime("created_at", null: false)
+    t.index(%w[concurrency_key priority job_id],
+            name: "index_solid_queue_blocked_executions_for_release")
+    t.index(%w[expires_at concurrency_key],
+            name: "index_solid_queue_blocked_executions_for_maintenance")
+    t.index(["job_id"], name: "index_solid_queue_blocked_executions_on_job_id",
+                        unique: true)
   end
 
-  create_table "solid_queue_claimed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.bigint "process_id"
-    t.datetime "created_at", null: false
-    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  create_table "solid_queue_claimed_executions", charset: "utf8mb4",
+                                                 collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint("job_id", null: false)
+    t.bigint("process_id")
+    t.datetime("created_at", null: false)
+    t.index(["job_id"], name: "index_solid_queue_claimed_executions_on_job_id",
+                        unique: true)
+    t.index(%w[process_id job_id],
+            name: "index_solid_queue_claimed_executions_on_process_id_and_job_id")
   end
 
-  create_table "solid_queue_failed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.text "error"
-    t.datetime "created_at", null: false
-    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  create_table "solid_queue_failed_executions", charset: "utf8mb4",
+                                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint("job_id", null: false)
+    t.text("error")
+    t.datetime("created_at", null: false)
+    t.index(["job_id"], name: "index_solid_queue_failed_executions_on_job_id",
+                        unique: true)
   end
 
-  create_table "solid_queue_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "queue_name", null: false
-    t.string "class_name", null: false
-    t.text "arguments"
-    t.integer "priority", default: 0, null: false
-    t.string "active_job_id"
-    t.datetime "scheduled_at"
-    t.datetime "finished_at"
-    t.string "concurrency_key"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
-    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
-    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
-    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
-    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  create_table "solid_queue_jobs", charset: "utf8mb4",
+                                   collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string("queue_name", null: false)
+    t.string("class_name", null: false)
+    t.text("arguments")
+    t.integer("priority", default: 0, null: false)
+    t.string("active_job_id")
+    t.datetime("scheduled_at")
+    t.datetime("finished_at")
+    t.string("concurrency_key")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.index(["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id")
+    t.index(["class_name"], name: "index_solid_queue_jobs_on_class_name")
+    t.index(["finished_at"], name: "index_solid_queue_jobs_on_finished_at")
+    t.index(%w[queue_name finished_at],
+            name: "index_solid_queue_jobs_for_filtering")
+    t.index(%w[scheduled_at finished_at],
+            name: "index_solid_queue_jobs_for_alerting")
   end
 
-  create_table "solid_queue_pauses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "queue_name", null: false
-    t.datetime "created_at", null: false
-    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  create_table "solid_queue_pauses", charset: "utf8mb4",
+                                     collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string("queue_name", null: false)
+    t.datetime("created_at", null: false)
+    t.index(["queue_name"], name: "index_solid_queue_pauses_on_queue_name",
+                            unique: true)
   end
 
-  create_table "solid_queue_processes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "kind", null: false
-    t.datetime "last_heartbeat_at", null: false
-    t.bigint "supervisor_id"
-    t.integer "pid", null: false
-    t.string "hostname"
-    t.text "metadata"
-    t.datetime "created_at", null: false
-    t.string "name", null: false
-    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
-    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  create_table "solid_queue_processes", charset: "utf8mb4",
+                                        collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string("kind", null: false)
+    t.datetime("last_heartbeat_at", null: false)
+    t.bigint("supervisor_id")
+    t.integer("pid", null: false)
+    t.string("hostname")
+    t.text("metadata")
+    t.datetime("created_at", null: false)
+    t.string("name", null: false)
+    t.index(["last_heartbeat_at"],
+            name: "index_solid_queue_processes_on_last_heartbeat_at")
+    t.index(%w[name supervisor_id],
+            name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true)
+    t.index(["supervisor_id"],
+            name: "index_solid_queue_processes_on_supervisor_id")
   end
 
-  create_table "solid_queue_ready_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
-    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
-    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  create_table "solid_queue_ready_executions", charset: "utf8mb4",
+                                               collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint("job_id", null: false)
+    t.string("queue_name", null: false)
+    t.integer("priority", default: 0, null: false)
+    t.datetime("created_at", null: false)
+    t.index(["job_id"], name: "index_solid_queue_ready_executions_on_job_id",
+                        unique: true)
+    t.index(%w[priority job_id], name: "index_solid_queue_poll_all")
+    t.index(%w[queue_name priority job_id],
+            name: "index_solid_queue_poll_by_queue")
   end
 
-  create_table "solid_queue_recurring_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "task_key", null: false
-    t.datetime "run_at", null: false
-    t.datetime "created_at", null: false
-    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  create_table "solid_queue_recurring_executions", charset: "utf8mb4",
+                                                   collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint("job_id", null: false)
+    t.string("task_key", null: false)
+    t.datetime("run_at", null: false)
+    t.datetime("created_at", null: false)
+    t.index(["job_id"],
+            name: "index_solid_queue_recurring_executions_on_job_id", unique: true)
+    t.index(%w[task_key run_at],
+            name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true)
   end
 
-  create_table "solid_queue_recurring_tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "schedule", null: false
-    t.string "command", limit: 2048
-    t.string "class_name"
-    t.text "arguments"
-    t.string "queue_name"
-    t.integer "priority", default: 0
-    t.boolean "static", default: true, null: false
-    t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
-    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  create_table "solid_queue_recurring_tasks", charset: "utf8mb4",
+                                              collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string("key", null: false)
+    t.string("schedule", null: false)
+    t.string("command", limit: 2048)
+    t.string("class_name")
+    t.text("arguments")
+    t.string("queue_name")
+    t.integer("priority", default: 0)
+    t.boolean("static", default: true, null: false)
+    t.text("description")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.index(["key"], name: "index_solid_queue_recurring_tasks_on_key",
+                     unique: true)
+    t.index(["static"], name: "index_solid_queue_recurring_tasks_on_static")
   end
 
-  create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "job_id", null: false
-    t.string "queue_name", null: false
-    t.integer "priority", default: 0, null: false
-    t.datetime "scheduled_at", null: false
-    t.datetime "created_at", null: false
-    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
-    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  create_table "solid_queue_scheduled_executions", charset: "utf8mb4",
+                                                   collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint("job_id", null: false)
+    t.string("queue_name", null: false)
+    t.integer("priority", default: 0, null: false)
+    t.datetime("scheduled_at", null: false)
+    t.datetime("created_at", null: false)
+    t.index(["job_id"],
+            name: "index_solid_queue_scheduled_executions_on_job_id", unique: true)
+    t.index(%w[scheduled_at priority job_id],
+            name: "index_solid_queue_dispatch_all")
   end
 
-  create_table "solid_queue_semaphores", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "key", null: false
-    t.integer "value", default: 1, null: false
-    t.datetime "expires_at", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
-    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  create_table "solid_queue_semaphores", charset: "utf8mb4",
+                                         collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string("key", null: false)
+    t.integer("value", default: 1, null: false)
+    t.datetime("expires_at", null: false)
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.index(["expires_at"], name: "index_solid_queue_semaphores_on_expires_at")
+    t.index(%w[key value],
+            name: "index_solid_queue_semaphores_on_key_and_value")
+    t.index(["key"], name: "index_solid_queue_semaphores_on_key", unique: true)
   end
 
-  create_table "species_list_observations", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "observation_id", default: 0, null: false
-    t.integer "species_list_id", default: 0, null: false
+  create_table "species_list_observations", charset: "utf8mb3",
+                                            force: :cascade do |t|
+    t.integer("observation_id", default: 0, null: false)
+    t.integer("species_list_id", default: 0, null: false)
   end
 
-  create_table "species_lists", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.date "when"
-    t.integer "user_id"
-    t.string "where", limit: 1024
-    t.string "title", limit: 100
-    t.text "notes"
-    t.integer "rss_log_id"
-    t.integer "location_id"
+  create_table "species_lists", id: :integer, charset: "utf8mb3",
+                                force: :cascade do |t|
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.date("when")
+    t.integer("user_id")
+    t.string("where", limit: 1024)
+    t.string("title", limit: 100)
+    t.text("notes")
+    t.integer("rss_log_id")
+    t.integer("location_id")
   end
 
-  create_table "synonyms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "synonyms", id: :integer, charset: "utf8mb3",
+                           force: :cascade do |t|
   end
 
-  create_table "translation_string_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "version"
-    t.integer "translation_string_id"
-    t.text "text"
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
-    t.integer "language_id"
+  create_table "translation_string_versions", id: :integer, charset: "utf8mb3",
+                                              force: :cascade do |t|
+    t.integer("version")
+    t.integer("translation_string_id")
+    t.text("text")
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
+    t.integer("language_id")
   end
 
-  create_table "translation_strings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer "version"
-    t.integer "language_id", null: false
-    t.string "tag", limit: 100
-    t.text "text"
-    t.datetime "updated_at", precision: nil
-    t.integer "user_id"
+  create_table "translation_strings", id: :integer, charset: "utf8mb3",
+                                      force: :cascade do |t|
+    t.integer("version")
+    t.integer("language_id", null: false)
+    t.string("tag", limit: 100)
+    t.text("text")
+    t.datetime("updated_at", precision: nil)
+    t.integer("user_id")
   end
 
-  create_table "triples", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string "subject", limit: 1024
-    t.string "predicate", limit: 1024
-    t.string "object", limit: 1024
+  create_table "triples", id: :integer, charset: "utf8mb3",
+                          force: :cascade do |t|
+    t.string("subject", limit: 1024)
+    t.string("predicate", limit: 1024)
+    t.string("object", limit: 1024)
   end
 
   create_table "user_group_users", charset: "utf8mb3", force: :cascade do |t|
-    t.integer "user_id", default: 0, null: false
-    t.integer "user_group_id", default: 0, null: false
+    t.integer("user_id", default: 0, null: false)
+    t.integer("user_group_id", default: 0, null: false)
   end
 
-  create_table "user_groups", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string "name", default: "", null: false
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.boolean "meta", default: false
+  create_table "user_groups", id: :integer, charset: "utf8mb3",
+                              force: :cascade do |t|
+    t.string("name", default: "", null: false)
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.boolean("meta", default: false)
   end
 
-  create_table "user_stats", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "user_id", default: 0, null: false
-    t.integer "comments", default: 0, null: false
-    t.integer "images", default: 0, null: false
-    t.integer "location_description_authors", default: 0, null: false
-    t.integer "location_description_editors", default: 0, null: false
-    t.integer "locations", default: 0, null: false
-    t.integer "location_versions", default: 0, null: false
-    t.integer "name_description_authors", default: 0, null: false
-    t.integer "name_description_editors", default: 0, null: false
-    t.integer "names", default: 0, null: false
-    t.integer "name_versions", default: 0, null: false
-    t.integer "namings", default: 0, null: false
-    t.integer "observations", default: 0, null: false
-    t.integer "sequences", default: 0, null: false
-    t.integer "sequenced_observations", default: 0, null: false
-    t.integer "species_list_entries", default: 0, null: false
-    t.integer "species_lists", default: 0, null: false
-    t.integer "translation_strings", default: 0, null: false
-    t.integer "votes", default: 0, null: false
-    t.string "languages"
-    t.string "bonuses"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "user_index"
+  create_table "user_stats", charset: "utf8mb4",
+                             collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("user_id", default: 0, null: false)
+    t.integer("comments", default: 0, null: false)
+    t.integer("images", default: 0, null: false)
+    t.integer("location_description_authors", default: 0, null: false)
+    t.integer("location_description_editors", default: 0, null: false)
+    t.integer("locations", default: 0, null: false)
+    t.integer("location_versions", default: 0, null: false)
+    t.integer("name_description_authors", default: 0, null: false)
+    t.integer("name_description_editors", default: 0, null: false)
+    t.integer("names", default: 0, null: false)
+    t.integer("name_versions", default: 0, null: false)
+    t.integer("namings", default: 0, null: false)
+    t.integer("observations", default: 0, null: false)
+    t.integer("sequences", default: 0, null: false)
+    t.integer("sequenced_observations", default: 0, null: false)
+    t.integer("species_list_entries", default: 0, null: false)
+    t.integer("species_lists", default: 0, null: false)
+    t.integer("translation_strings", default: 0, null: false)
+    t.integer("votes", default: 0, null: false)
+    t.string("languages")
+    t.string("bonuses")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
+    t.index(["user_id"], name: "user_index")
   end
 
   create_table "users", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string "login", limit: 80, default: "", null: false
-    t.string "password", limit: 40, default: "", null: false
-    t.string "email", limit: 80, default: "", null: false
-    t.string "theme", limit: 40
-    t.string "name", limit: 80
-    t.datetime "created_at", precision: nil
-    t.datetime "last_login", precision: nil
-    t.datetime "verified", precision: nil
-    t.integer "license_id", default: 10, null: false
-    t.integer "contribution", default: 0
-    t.integer "location_id"
-    t.integer "image_id"
-    t.string "locale", limit: 5
-    t.boolean "email_comments_owner", default: true, null: false
-    t.boolean "email_comments_response", default: true, null: false
-    t.boolean "email_observations_consensus", default: true, null: false
-    t.boolean "email_observations_naming", default: true, null: false
-    t.boolean "email_names_author", default: true, null: false
-    t.boolean "email_names_editor", default: false, null: false
-    t.boolean "email_names_reviewer", default: true, null: false
-    t.boolean "email_locations_author", default: true, null: false
-    t.boolean "email_locations_editor", default: false, null: false
-    t.boolean "email_general_feature", default: true, null: false
-    t.boolean "email_general_commercial", default: true, null: false
-    t.boolean "email_general_question", default: true, null: false
-    t.boolean "email_html", default: true, null: false
-    t.datetime "updated_at", precision: nil
-    t.boolean "admin"
-    t.text "alert"
-    t.boolean "email_locations_admin", default: false
-    t.boolean "email_names_admin", default: false
-    t.integer "thumbnail_size", default: 1
-    t.integer "image_size", default: 5
-    t.string "default_rss_type", limit: 40, default: "all"
-    t.integer "votes_anonymous", default: 1
-    t.integer "location_format", default: 1
-    t.datetime "last_activity", precision: nil
-    t.integer "hide_authors", default: 1, null: false
-    t.boolean "thumbnail_maps", default: true, null: false
-    t.string "auth_code", limit: 40
-    t.integer "keep_filenames", default: 1, null: false
-    t.text "notes"
-    t.text "mailing_address"
-    t.integer "layout_count"
-    t.boolean "view_owner_id", default: false, null: false
-    t.string "content_filter"
-    t.text "notes_template"
-    t.boolean "blocked", default: false, null: false
-    t.boolean "no_emails", default: false, null: false
-    t.string "inat_username"
-    t.integer "original_image_quota", default: 0
-    t.integer "label_format", default: 1
-    t.index ["inat_username"], name: "index_users_on_inat_username"
-    t.index ["login"], name: "login_index"
-    t.index ["name"], name: "index_users_on_name"
+    t.string("login", limit: 80, default: "", null: false)
+    t.string("password", limit: 40, default: "", null: false)
+    t.string("email", limit: 80, default: "", null: false)
+    t.string("theme", limit: 40)
+    t.string("name", limit: 80)
+    t.datetime("created_at", precision: nil)
+    t.datetime("last_login", precision: nil)
+    t.datetime("verified", precision: nil)
+    t.integer("license_id", default: 10, null: false)
+    t.integer("contribution", default: 0)
+    t.integer("location_id")
+    t.integer("image_id")
+    t.string("locale", limit: 5)
+    t.boolean("email_comments_owner", default: true, null: false)
+    t.boolean("email_comments_response", default: true, null: false)
+    t.boolean("email_observations_consensus", default: true, null: false)
+    t.boolean("email_observations_naming", default: true, null: false)
+    t.boolean("email_names_author", default: true, null: false)
+    t.boolean("email_names_editor", default: false, null: false)
+    t.boolean("email_names_reviewer", default: true, null: false)
+    t.boolean("email_locations_author", default: true, null: false)
+    t.boolean("email_locations_editor", default: false, null: false)
+    t.boolean("email_general_feature", default: true, null: false)
+    t.boolean("email_general_commercial", default: true, null: false)
+    t.boolean("email_general_question", default: true, null: false)
+    t.boolean("email_html", default: true, null: false)
+    t.datetime("updated_at", precision: nil)
+    t.boolean("admin")
+    t.text("alert")
+    t.boolean("email_locations_admin", default: false)
+    t.boolean("email_names_admin", default: false)
+    t.integer("thumbnail_size", default: 1)
+    t.integer("image_size", default: 5)
+    t.string("default_rss_type", limit: 40, default: "all")
+    t.integer("votes_anonymous", default: 1)
+    t.integer("location_format", default: 1)
+    t.datetime("last_activity", precision: nil)
+    t.integer("hide_authors", default: 1, null: false)
+    t.boolean("thumbnail_maps", default: true, null: false)
+    t.string("auth_code", limit: 40)
+    t.integer("keep_filenames", default: 1, null: false)
+    t.text("notes")
+    t.text("mailing_address")
+    t.integer("layout_count")
+    t.boolean("view_owner_id", default: false, null: false)
+    t.string("content_filter")
+    t.text("notes_template")
+    t.boolean("blocked", default: false, null: false)
+    t.boolean("no_emails", default: false, null: false)
+    t.string("inat_username")
+    t.integer("original_image_quota", default: 0)
+    t.integer("label_format", default: 1)
+    t.index(["inat_username"], name: "index_users_on_inat_username")
+    t.index(["login"], name: "login_index")
+    t.index(["name"], name: "index_users_on_name")
   end
 
-  create_table "visual_group_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "image_id"
-    t.integer "visual_group_id"
-    t.boolean "included", default: true, null: false
+  create_table "visual_group_images", charset: "utf8mb4",
+                                      collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("image_id")
+    t.integer("visual_group_id")
+    t.boolean("included", default: true, null: false)
   end
 
-  create_table "visual_groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "visual_model_id"
-    t.string "name", null: false
-    t.boolean "approved", default: false, null: false
-    t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "visual_groups", charset: "utf8mb4",
+                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer("visual_model_id")
+    t.string("name", null: false)
+    t.boolean("approved", default: false, null: false)
+    t.text("description")
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
   end
 
-  create_table "visual_models", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "visual_models", charset: "utf8mb4",
+                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string("name", null: false)
+    t.datetime("created_at", null: false)
+    t.datetime("updated_at", null: false)
   end
 
   create_table "votes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.integer "naming_id"
-    t.integer "user_id"
-    t.integer "observation_id", default: 0
-    t.boolean "favorite"
-    t.float "value"
-    t.index ["naming_id"], name: "naming_index"
-    t.index ["observation_id"], name: "observation_index"
+    t.datetime("created_at", precision: nil)
+    t.datetime("updated_at", precision: nil)
+    t.integer("naming_id")
+    t.integer("user_id")
+    t.integer("observation_id", default: 0)
+    t.boolean("favorite")
+    t.float("value")
+    t.index(["naming_id"], name: "naming_index")
+    t.index(["observation_id"], name: "observation_index")
   end
 
   add_foreign_key "observations", "users", column: "collector_user_id"
   add_foreign_key "project_aliases", "projects"
-  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs",
+                  column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs",
+                  column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs",
+                  column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs",
+                  column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs",
+                  column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs",
+                  column: "job_id", on_delete: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,1161 +10,1033 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 20_260_701_142_244) do
-  create_table "api_keys", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("last_used", precision: nil)
-    t.integer("num_uses", default: 0)
-    t.integer("user_id", null: false)
-    t.string("key", limit: 128, null: false)
-    t.text("notes")
-    t.datetime("verified", precision: nil)
+ActiveRecord::Schema[7.2].define(version: 2026_07_01_142244) do
+  create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "last_used", precision: nil
+    t.integer "num_uses", default: 0
+    t.integer "user_id", null: false
+    t.string "key", limit: 128, null: false
+    t.text "notes"
+    t.datetime "verified", precision: nil
   end
 
-  create_table "articles", id: :integer, charset: "utf8mb4",
-                           collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("title")
-    t.text("body", size: :medium)
-    t.integer("user_id")
-    t.integer("rss_log_id")
-    t.datetime("created_at", precision: nil, null: false)
-    t.datetime("updated_at", precision: nil, null: false)
+  create_table "articles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "title"
+    t.text "body", size: :medium
+    t.integer "user_id"
+    t.integer "rss_log_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "banners", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci",
-                          force: :cascade do |t|
-    t.text("message")
-    t.integer("version")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+  create_table "banners", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "message"
+    t.integer "version"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "collection_numbers", id: :integer, charset: "utf8mb3",
-                                     force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.string("name")
-    t.string("number")
+  create_table "collection_numbers", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.string "name"
+    t.string "number"
   end
 
-  create_table "comments", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.integer("user_id")
-    t.string("summary", limit: 100)
-    t.text("comment")
-    t.string("target_type", limit: 30)
-    t.integer("target_id")
-    t.datetime("updated_at", precision: nil)
-    t.index(%w[target_id target_type], name: "target_index")
+  create_table "comments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.integer "user_id"
+    t.string "summary", limit: 100
+    t.text "comment"
+    t.string "target_type", limit: 30
+    t.integer "target_id"
+    t.datetime "updated_at", precision: nil
+    t.index ["target_id", "target_type"], name: "target_index"
   end
 
-  create_table "copyright_changes", id: :integer, charset: "utf8mb3",
-                                    force: :cascade do |t|
-    t.integer("user_id", null: false)
-    t.datetime("updated_at", precision: nil, null: false)
-    t.string("target_type", limit: 30, null: false)
-    t.integer("target_id", null: false)
-    t.integer("year")
-    t.string("name")
-    t.integer("license_id")
+  create_table "copyright_changes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "target_type", limit: 30, null: false
+    t.integer "target_id", null: false
+    t.integer "year"
+    t.string "name"
+    t.integer "license_id"
   end
 
-  create_table "donations", id: :integer, charset: "utf8mb3",
-                            force: :cascade do |t|
-    t.decimal("amount", precision: 12, scale: 2)
-    t.string("who", limit: 100)
-    t.string("email", limit: 100)
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.boolean("anonymous", default: false, null: false)
-    t.boolean("reviewed", default: true, null: false)
-    t.integer("user_id")
-    t.boolean("recurring", default: false)
+  create_table "donations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.decimal "amount", precision: 12, scale: 2
+    t.string "who", limit: 100
+    t.string "email", limit: 100
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.boolean "anonymous", default: false, null: false
+    t.boolean "reviewed", default: true, null: false
+    t.integer "user_id"
+    t.boolean "recurring", default: false
   end
 
-  create_table "external_links", id: :integer, charset: "utf8mb3",
-                                 force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("target_id")
-    t.integer("external_site_id")
-    t.string("url", limit: 100)
-    t.string("target_type", limit: 64)
-    t.string("external_id", limit: 64)
-    t.integer("relationship", default: 0, null: false)
-    t.datetime("last_synced_at")
-    t.virtual("import_target", type: :string,
-                               as: "(case when (`relationship` = 1) then concat(`target_type`,_utf8mb3':',`target_id`) end)", stored: true)
-    t.date("external_created_on")
-    t.index(%w[external_site_id relationship target_type external_id],
-            name: "index_external_links_on_site_rel_target_extid")
-    t.index(["import_target"], name: "index_external_links_on_import_target",
-                               unique: true)
-    t.index(%w[target_type target_id], name: "index_external_links_on_target")
+  create_table "external_links", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "target_id"
+    t.integer "external_site_id"
+    t.string "url", limit: 100
+    t.string "target_type", limit: 64
+    t.string "external_id", limit: 64
+    t.integer "relationship", default: 0, null: false
+    t.datetime "last_synced_at"
+    t.virtual "import_target", type: :string, as: "(case when (`relationship` = 1) then concat(`target_type`,_utf8mb3':',`target_id`) end)", stored: true
+    t.date "external_created_on"
+    t.index ["external_site_id", "relationship", "target_type", "external_id"], name: "index_external_links_on_site_rel_target_extid"
+    t.index ["import_target"], name: "index_external_links_on_import_target", unique: true
+    t.index ["target_type", "target_id"], name: "index_external_links_on_target"
   end
 
-  create_table "external_sites", id: :integer, charset: "utf8mb3",
-                                 force: :cascade do |t|
-    t.string("name", limit: 100)
-    t.integer("project_id")
-    t.string("base_url", null: false)
-    t.text("description")
-    t.datetime("last_successful_sync_at")
-    t.string("url_template")
+  create_table "external_sites", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name", limit: 100
+    t.integer "project_id"
+    t.string "base_url", null: false
+    t.text "description"
+    t.datetime "last_successful_sync_at"
+    t.string "url_template"
   end
 
-  create_table "field_slip_job_trackers", charset: "utf8mb4",
-                                          collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("start")
-    t.integer("count")
-    t.string("prefix")
-    t.integer("status")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.integer("pages", default: 0, null: false)
-    t.string("title", limit: 100, default: "", null: false)
-    t.integer("user_id")
-    t.boolean("one_per_page", default: false, null: false)
+  create_table "field_slip_job_trackers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "start"
+    t.integer "count"
+    t.string "prefix"
+    t.integer "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "pages", default: 0, null: false
+    t.string "title", limit: 100, default: "", null: false
+    t.integer "user_id"
+    t.boolean "one_per_page", default: false, null: false
   end
 
-  create_table "field_slips", charset: "utf8mb4",
-                              collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id")
-    t.string("code", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.integer("user_id")
-    t.index(["code"], name: "index_field_slips_on_code", unique: true)
+  create_table "field_slips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id"
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["code"], name: "index_field_slips_on_code", unique: true
   end
 
-  create_table "glossary_term_images", charset: "utf8mb3",
-                                       force: :cascade do |t|
-    t.integer("image_id")
-    t.integer("glossary_term_id")
+  create_table "glossary_term_images", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "image_id"
+    t.integer "glossary_term_id"
   end
 
-  create_table "glossary_term_versions", id: :integer, charset: "utf8mb3",
-                                         force: :cascade do |t|
-    t.integer("glossary_term_id")
-    t.integer("version")
-    t.integer("user_id")
-    t.datetime("updated_at", precision: nil)
-    t.string("name", limit: 1024)
-    t.text("description")
+  create_table "glossary_term_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "glossary_term_id"
+    t.integer "version"
+    t.integer "user_id"
+    t.datetime "updated_at", precision: nil
+    t.string "name", limit: 1024
+    t.text "description"
   end
 
-  create_table "glossary_terms", id: :integer, charset: "utf8mb3",
-                                 force: :cascade do |t|
-    t.integer("version")
-    t.integer("user_id")
-    t.string("name", limit: 1024)
-    t.integer("thumb_image_id")
-    t.text("description")
-    t.integer("rss_log_id")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.boolean("locked", default: false, null: false)
+  create_table "glossary_terms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.integer "user_id"
+    t.string "name", limit: 1024
+    t.integer "thumb_image_id"
+    t.text "description"
+    t.integer "rss_log_id"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.boolean "locked", default: false, null: false
   end
 
-  create_table "herbaria", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.text("mailing_address")
-    t.integer("location_id")
-    t.string("email", limit: 80, default: "", null: false)
-    t.string("name", limit: 1024)
-    t.text("description")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.string("code", limit: 8)
-    t.integer("personal_user_id")
-    t.index(["code"], name: "index_herbaria_on_code", unique: true)
+  create_table "herbaria", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.text "mailing_address"
+    t.integer "location_id"
+    t.string "email", limit: 80, default: "", null: false
+    t.string "name", limit: 1024
+    t.text "description"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.string "code", limit: 8
+    t.integer "personal_user_id"
+    t.index ["code"], name: "index_herbaria_on_code", unique: true
   end
 
   create_table "herbarium_curators", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("herbarium_id", default: 0, null: false)
+    t.integer "user_id", default: 0, null: false
+    t.integer "herbarium_id", default: 0, null: false
   end
 
-  create_table "herbarium_records", id: :integer, charset: "utf8mb3",
-                                    force: :cascade do |t|
-    t.integer("herbarium_id", null: false)
-    t.text("notes")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id", null: false)
-    t.string("initial_det", limit: 221, null: false)
-    t.string("accession_number", limit: 80, null: false)
+  create_table "herbarium_records", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "herbarium_id", null: false
+    t.text "notes"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id", null: false
+    t.string "initial_det", limit: 221, null: false
+    t.string "accession_number", limit: 80, null: false
   end
 
-  create_table "image_votes", id: :integer, charset: "utf8mb3",
-                              force: :cascade do |t|
-    t.integer("value", null: false)
-    t.boolean("anonymous", default: false, null: false)
-    t.integer("user_id")
-    t.integer("image_id")
-    t.index(["image_id"], name: "index_image_votes_on_image_id")
-    t.index(["user_id"], name: "index_image_votes_on_user_id")
+  create_table "image_votes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "value", null: false
+    t.boolean "anonymous", default: false, null: false
+    t.integer "user_id"
+    t.integer "image_id"
+    t.index ["image_id"], name: "index_image_votes_on_image_id"
+    t.index ["user_id"], name: "index_image_votes_on_user_id"
   end
 
-  create_table "images", id: { type: :integer, unsigned: true },
-                         charset: "utf8mb3", force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.string("content_type", limit: 100)
-    t.integer("user_id")
-    t.date("when")
-    t.text("notes")
-    t.string("copyright_holder", limit: 100)
-    t.integer("license_id", default: 10, null: false)
-    t.integer("num_views", default: 0, null: false)
-    t.datetime("last_view", precision: nil)
-    t.integer("width")
-    t.integer("height")
-    t.float("vote_cache")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.string("original_name", limit: 120, default: "")
-    t.boolean("transferred", default: false, null: false)
-    t.boolean("gps_stripped", default: false, null: false)
-    t.boolean("diagnostic", default: true, null: false)
+  create_table "images", id: { type: :integer, unsigned: true }, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.string "content_type", limit: 100
+    t.integer "user_id"
+    t.date "when"
+    t.text "notes"
+    t.string "copyright_holder", limit: 100
+    t.integer "license_id", default: 10, null: false
+    t.integer "num_views", default: 0, null: false
+    t.datetime "last_view", precision: nil
+    t.integer "width"
+    t.integer "height"
+    t.float "vote_cache"
+    t.boolean "ok_for_export", default: true, null: false
+    t.string "original_name", limit: 120, default: ""
+    t.boolean "transferred", default: false, null: false
+    t.boolean "gps_stripped", default: false, null: false
+    t.boolean "diagnostic", default: true, null: false
   end
 
-  create_table "inat_imports", charset: "utf8mb4",
-                               collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("user_id")
-    t.integer("state", default: 0)
-    t.text("inat_ids")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("token")
-    t.string("inat_username")
-    t.boolean("import_all")
-    t.integer("importables")
-    t.integer("imported_count")
-    t.text("response_errors")
-    t.datetime("ended_at")
-    t.integer("total_imported_count")
-    t.integer("total_seconds")
-    t.float("avg_import_time")
-    t.datetime("last_obs_start")
-    t.boolean("cancel")
-    t.boolean("import_others", default: false, null: false)
-    t.integer("writeback", default: 0, null: false)
-    t.text("inat_url")
-    t.datetime("started_at")
-    t.integer("total_importables")
-    t.integer("ignored_not_importable_count", default: 0, null: false)
-    t.integer("ignored_date_missing_count", default: 0, null: false)
-    t.integer("ignored_already_imported_count", default: 0, null: false)
+  create_table "inat_imports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "state", default: 0
+    t.text "inat_ids"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "token"
+    t.string "inat_username"
+    t.boolean "import_all"
+    t.integer "importables"
+    t.integer "imported_count"
+    t.text "response_errors"
+    t.datetime "ended_at"
+    t.integer "total_imported_count"
+    t.integer "total_seconds"
+    t.float "avg_import_time"
+    t.datetime "last_obs_start"
+    t.boolean "cancel"
+    t.boolean "import_others", default: false, null: false
+    t.integer "writeback", default: 0, null: false
+    t.text "inat_url"
+    t.datetime "started_at"
+    t.integer "total_importables"
+    t.integer "ignored_not_importable_count", default: 0, null: false
+    t.integer "ignored_date_missing_count", default: 0, null: false
+    t.integer "ignored_already_imported_count", default: 0, null: false
   end
 
-  create_table "interests", id: :integer, charset: "utf8mb3",
-                            force: :cascade do |t|
-    t.string("target_type", limit: 30)
-    t.integer("target_id")
-    t.integer("user_id")
-    t.boolean("state")
-    t.datetime("updated_at", precision: nil)
+  create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "target_type", limit: 30
+    t.integer "target_id"
+    t.integer "user_id"
+    t.boolean "state"
+    t.datetime "updated_at", precision: nil
   end
 
-  create_table "languages", id: :integer, charset: "utf8mb3",
-                            force: :cascade do |t|
-    t.string("locale", limit: 40)
-    t.string("name", limit: 100)
-    t.string("order", limit: 100)
-    t.boolean("official", null: false)
-    t.boolean("beta", null: false)
+  create_table "languages", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "locale", limit: 40
+    t.string "name", limit: 100
+    t.string "order", limit: 100
+    t.boolean "official", null: false
+    t.boolean "beta", null: false
   end
 
-  create_table "licenses", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.string("display_name", limit: 80)
-    t.string("url", limit: 200)
-    t.boolean("deprecated", default: false, null: false)
-    t.datetime("updated_at", precision: nil)
-    t.datetime("created_at", precision: nil)
+  create_table "licenses", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "display_name", limit: 80
+    t.string "url", limit: 200
+    t.boolean "deprecated", default: false, null: false
+    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil
   end
 
-  create_table "location_description_admins", charset: "utf8mb3",
-                                              force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "location_description_admins", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "location_description_authors", charset: "utf8mb3",
-                                               force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_id", default: 0, null: false)
+  create_table "location_description_authors", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_id", default: 0, null: false
   end
 
-  create_table "location_description_editors", charset: "utf8mb3",
-                                               force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_id", default: 0, null: false)
+  create_table "location_description_editors", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_id", default: 0, null: false
   end
 
-  create_table "location_description_readers", charset: "utf8mb3",
-                                               force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "location_description_readers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "location_description_versions", id: :integer,
-                                                charset: "utf8mb3", force: :cascade do |t|
-    t.integer("location_description_id")
-    t.integer("version")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("license_id")
-    t.integer("merge_source_id")
-    t.text("gen_desc")
-    t.text("ecology")
-    t.text("species")
-    t.text("notes")
-    t.text("refs")
+  create_table "location_description_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id"
+    t.integer "version"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "license_id"
+    t.integer "merge_source_id"
+    t.text "gen_desc"
+    t.text "ecology"
+    t.text "species"
+    t.text "notes"
+    t.text "refs"
   end
 
-  create_table "location_description_writers", charset: "utf8mb3",
-                                               force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "location_description_writers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "location_descriptions", id: :integer, charset: "utf8mb3",
-                                        force: :cascade do |t|
-    t.integer("version")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("location_id")
-    t.integer("num_views", default: 0)
-    t.datetime("last_view", precision: nil)
-    t.integer("source_type")
-    t.string("source_name", limit: 100)
-    t.string("locale", limit: 8)
-    t.boolean("public")
-    t.integer("license_id")
-    t.text("gen_desc")
-    t.text("ecology")
-    t.text("species")
-    t.text("notes")
-    t.text("refs")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.integer("project_id")
+  create_table "location_descriptions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "location_id"
+    t.integer "num_views", default: 0
+    t.datetime "last_view", precision: nil
+    t.integer "source_type"
+    t.string "source_name", limit: 100
+    t.string "locale", limit: 8
+    t.boolean "public"
+    t.integer "license_id"
+    t.text "gen_desc"
+    t.text "ecology"
+    t.text "species"
+    t.text "notes"
+    t.text "refs"
+    t.boolean "ok_for_export", default: true, null: false
+    t.integer "project_id"
   end
 
-  create_table "location_versions", id: :integer, charset: "utf8mb3",
-                                    force: :cascade do |t|
-    t.string("location_id")
-    t.integer("version")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.float("north")
-    t.float("south")
-    t.float("west")
-    t.float("east")
-    t.float("high")
-    t.float("low")
-    t.string("name", limit: 1024)
-    t.text("notes")
-    t.string("scientific_name", limit: 1024)
-    t.decimal("box_area", precision: 21, scale: 10)
-    t.decimal("center_lat", precision: 15, scale: 10)
-    t.decimal("center_lng", precision: 15, scale: 10)
+  create_table "location_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "location_id"
+    t.integer "version"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.float "north"
+    t.float "south"
+    t.float "west"
+    t.float "east"
+    t.float "high"
+    t.float "low"
+    t.string "name", limit: 1024
+    t.text "notes"
+    t.string "scientific_name", limit: 1024
+    t.decimal "box_area", precision: 21, scale: 10
+    t.decimal "center_lat", precision: 15, scale: 10
+    t.decimal "center_lng", precision: 15, scale: 10
   end
 
-  create_table "locations", id: :integer, charset: "utf8mb3",
-                            force: :cascade do |t|
-    t.integer("version")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("description_id")
-    t.integer("rss_log_id")
-    t.integer("num_views", default: 0)
-    t.datetime("last_view", precision: nil)
-    t.decimal("north", precision: 15, scale: 10, null: false)
-    t.decimal("south", precision: 15, scale: 10, null: false)
-    t.decimal("west", precision: 15, scale: 10, null: false)
-    t.decimal("east", precision: 15, scale: 10, null: false)
-    t.float("high")
-    t.float("low")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.text("notes")
-    t.string("name", limit: 1024)
-    t.string("scientific_name", limit: 1024)
-    t.boolean("locked", default: false, null: false)
-    t.boolean("hidden", default: false, null: false)
-    t.decimal("box_area", precision: 21, scale: 10)
-    t.decimal("center_lat", precision: 15, scale: 10)
-    t.decimal("center_lng", precision: 15, scale: 10)
+  create_table "locations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "description_id"
+    t.integer "rss_log_id"
+    t.integer "num_views", default: 0
+    t.datetime "last_view", precision: nil
+    t.decimal "north", precision: 15, scale: 10, null: false
+    t.decimal "south", precision: 15, scale: 10, null: false
+    t.decimal "west", precision: 15, scale: 10, null: false
+    t.decimal "east", precision: 15, scale: 10, null: false
+    t.float "high"
+    t.float "low"
+    t.boolean "ok_for_export", default: true, null: false
+    t.text "notes"
+    t.string "name", limit: 1024
+    t.string "scientific_name", limit: 1024
+    t.boolean "locked", default: false, null: false
+    t.boolean "hidden", default: false, null: false
+    t.decimal "box_area", precision: 21, scale: 10
+    t.decimal "center_lat", precision: 15, scale: 10
+    t.decimal "center_lng", precision: 15, scale: 10
   end
 
-  create_table "name_description_admins", charset: "utf8mb3",
-                                          force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "name_description_admins", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "name_description_authors", charset: "utf8mb3",
-                                           force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_id", default: 0, null: false)
+  create_table "name_description_authors", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_id", default: 0, null: false
   end
 
-  create_table "name_description_editors", charset: "utf8mb3",
-                                           force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_id", default: 0, null: false)
+  create_table "name_description_editors", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_id", default: 0, null: false
   end
 
-  create_table "name_description_readers", charset: "utf8mb3",
-                                           force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "name_description_readers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "name_description_versions", id: :integer, charset: "utf8mb3",
-                                            force: :cascade do |t|
-    t.integer("name_description_id")
-    t.integer("version")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("license_id")
-    t.integer("merge_source_id")
-    t.text("gen_desc")
-    t.text("diag_desc")
-    t.text("distribution")
-    t.text("habitat")
-    t.text("look_alikes")
-    t.text("uses")
-    t.text("notes")
-    t.text("refs")
+  create_table "name_description_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id"
+    t.integer "version"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "license_id"
+    t.integer "merge_source_id"
+    t.text "gen_desc"
+    t.text "diag_desc"
+    t.text "distribution"
+    t.text "habitat"
+    t.text "look_alikes"
+    t.text "uses"
+    t.text "notes"
+    t.text "refs"
   end
 
-  create_table "name_description_writers", charset: "utf8mb3",
-                                           force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "name_description_writers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "name_descriptions", id: :integer, charset: "utf8mb3",
-                                    force: :cascade do |t|
-    t.integer("version")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("name_id")
-    t.integer("review_status", default: 1)
-    t.datetime("last_review", precision: nil)
-    t.integer("reviewer_id")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.integer("num_views", default: 0)
-    t.datetime("last_view", precision: nil)
-    t.integer("source_type")
-    t.string("source_name", limit: 100)
-    t.string("locale", limit: 8)
-    t.boolean("public")
-    t.integer("license_id")
-    t.text("gen_desc")
-    t.text("diag_desc")
-    t.text("distribution")
-    t.text("habitat")
-    t.text("look_alikes")
-    t.text("uses")
-    t.text("notes")
-    t.text("refs")
-    t.integer("project_id")
+  create_table "name_descriptions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "name_id"
+    t.integer "review_status", default: 1
+    t.datetime "last_review", precision: nil
+    t.integer "reviewer_id"
+    t.boolean "ok_for_export", default: true, null: false
+    t.integer "num_views", default: 0
+    t.datetime "last_view", precision: nil
+    t.integer "source_type"
+    t.string "source_name", limit: 100
+    t.string "locale", limit: 8
+    t.boolean "public"
+    t.integer "license_id"
+    t.text "gen_desc"
+    t.text "diag_desc"
+    t.text "distribution"
+    t.text "habitat"
+    t.text "look_alikes"
+    t.text "uses"
+    t.text "notes"
+    t.text "refs"
+    t.integer "project_id"
   end
 
-  create_table "name_trackers", id: :integer, charset: "utf8mb3",
-                                force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("name_id")
-    t.text("note_template")
-    t.datetime("updated_at", precision: nil)
-    t.boolean("require_specimen", default: false, null: false)
-    t.boolean("approved", default: true, null: false)
+  create_table "name_trackers", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id", default: 0, null: false
+    t.integer "name_id"
+    t.text "note_template"
+    t.datetime "updated_at", precision: nil
+    t.boolean "require_specimen", default: false, null: false
+    t.boolean "approved", default: true, null: false
   end
 
-  create_table "name_versions", id: :integer, charset: "utf8mb3",
-                                force: :cascade do |t|
-    t.integer("name_id")
-    t.integer("version")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.string("text_name", limit: 100)
-    t.string("search_name", limit: 221)
-    t.string("display_name", limit: 204)
-    t.string("sort_name", limit: 241)
-    t.string("author", limit: 100)
-    t.text("citation")
-    t.boolean("deprecated", default: false, null: false)
-    t.integer("correct_spelling_id")
-    t.text("notes")
-    t.integer("rank")
-    t.string("lifeform", limit: 1024, default: " ", null: false)
-    t.integer("icn_id")
-    t.text("classification")
-    t.index(%w[name_id version],
-            name: "index_name_versions_on_name_id_and_version")
+  create_table "name_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_id"
+    t.integer "version"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.string "text_name", limit: 100
+    t.string "search_name", limit: 221
+    t.string "display_name", limit: 204
+    t.string "sort_name", limit: 241
+    t.string "author", limit: 100
+    t.text "citation"
+    t.boolean "deprecated", default: false, null: false
+    t.integer "correct_spelling_id"
+    t.text "notes"
+    t.integer "rank"
+    t.string "lifeform", limit: 1024, default: " ", null: false
+    t.integer "icn_id"
+    t.text "classification"
+    t.index ["name_id", "version"], name: "index_name_versions_on_name_id_and_version"
   end
 
   create_table "names", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer("version")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("description_id")
-    t.integer("rss_log_id")
-    t.integer("num_views", default: 0)
-    t.datetime("last_view", precision: nil)
-    t.integer("rank")
-    t.string("text_name", limit: 100)
-    t.string("search_name", limit: 221)
-    t.string("display_name", limit: 204)
-    t.string("sort_name", limit: 241)
-    t.text("citation")
-    t.boolean("deprecated", default: false, null: false)
-    t.integer("synonym_id")
-    t.integer("correct_spelling_id")
-    t.text("notes")
-    t.text("classification")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.string("author", limit: 100)
-    t.string("lifeform", limit: 1024, default: " ", null: false)
-    t.boolean("locked", default: false, null: false)
-    t.integer("icn_id")
-    t.index(["synonym_id"], name: "synonym_index")
+    t.integer "version"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "description_id"
+    t.integer "rss_log_id"
+    t.integer "num_views", default: 0
+    t.datetime "last_view", precision: nil
+    t.integer "rank"
+    t.string "text_name", limit: 100
+    t.string "search_name", limit: 221
+    t.string "display_name", limit: 204
+    t.string "sort_name", limit: 241
+    t.text "citation"
+    t.boolean "deprecated", default: false, null: false
+    t.integer "synonym_id"
+    t.integer "correct_spelling_id"
+    t.text "notes"
+    t.text "classification"
+    t.boolean "ok_for_export", default: true, null: false
+    t.string "author", limit: 100
+    t.string "lifeform", limit: 1024, default: " ", null: false
+    t.boolean "locked", default: false, null: false
+    t.integer "icn_id"
+    t.index ["synonym_id"], name: "synonym_index"
   end
 
-  create_table "naming_reasons", id: :integer, charset: "utf8mb3",
-                                 force: :cascade do |t|
-    t.integer("naming_id")
-    t.integer("reason")
-    t.text("notes")
+  create_table "naming_reasons", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "naming_id"
+    t.integer "reason"
+    t.text "notes"
   end
 
-  create_table "namings", id: :integer, charset: "utf8mb3",
-                          force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("observation_id")
-    t.integer("name_id")
-    t.integer("user_id")
-    t.float("vote_cache", default: 0.0)
-    t.text("reasons")
-    t.index(["observation_id"], name: "index_namings_on_observation_id")
+  create_table "namings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "observation_id"
+    t.integer "name_id"
+    t.integer "user_id"
+    t.float "vote_cache", default: 0.0
+    t.text "reasons"
+    t.index ["observation_id"], name: "index_namings_on_observation_id"
   end
 
-  create_table "observation_collection_numbers", charset: "utf8mb3",
-                                                 force: :cascade do |t|
-    t.integer("collection_number_id")
-    t.integer("observation_id")
+  create_table "observation_collection_numbers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "collection_number_id"
+    t.integer "observation_id"
   end
 
-  create_table "observation_herbarium_records", charset: "utf8mb3",
-                                                force: :cascade do |t|
-    t.integer("observation_id", default: 0, null: false)
-    t.integer("herbarium_record_id", default: 0, null: false)
+  create_table "observation_herbarium_records", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "observation_id", default: 0, null: false
+    t.integer "herbarium_record_id", default: 0, null: false
   end
 
   create_table "observation_images", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("image_id", default: 0, null: false)
-    t.integer("observation_id", default: 0, null: false)
-    t.integer("rank", default: 0, null: false)
-    t.index(["image_id"], name: "index_observation_images_on_image_id")
-    t.index(["observation_id"],
-            name: "index_observation_images_on_observation_id")
+    t.integer "image_id", default: 0, null: false
+    t.integer "observation_id", default: 0, null: false
+    t.integer "rank", default: 0, null: false
+    t.index ["image_id"], name: "index_observation_images_on_image_id"
+    t.index ["observation_id"], name: "index_observation_images_on_observation_id"
   end
 
   create_table "observation_views", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("observation_id")
-    t.integer("user_id")
-    t.datetime("last_view", precision: nil)
-    t.boolean("reviewed")
-    t.index(["observation_id"], name: "observation_index")
-    t.index(["user_id"], name: "user_index")
+    t.integer "observation_id"
+    t.integer "user_id"
+    t.datetime "last_view", precision: nil
+    t.boolean "reviewed"
+    t.index ["observation_id"], name: "observation_index"
+    t.index ["user_id"], name: "user_index"
   end
 
-  create_table "observations", id: { type: :integer, unsigned: true },
-                               charset: "utf8mb3", force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.date("when")
-    t.integer("user_id")
-    t.boolean("specimen", default: false, null: false)
-    t.text("notes")
-    t.integer("thumb_image_id")
-    t.integer("name_id")
-    t.integer("location_id")
-    t.boolean("is_collection_location", default: true, null: false)
-    t.float("vote_cache", default: 0.0)
-    t.integer("num_views", default: 0, null: false)
-    t.datetime("last_view", precision: nil)
-    t.integer("rss_log_id")
-    t.decimal("lat", precision: 15, scale: 10)
-    t.decimal("lng", precision: 15, scale: 10)
-    t.string("where", limit: 1024)
-    t.integer("alt")
-    t.string("lifeform", limit: 1024)
-    t.string("text_name", limit: 100)
-    t.boolean("gps_hidden", default: false, null: false)
-    t.integer("source")
-    t.datetime("log_updated_at", precision: nil)
-    t.boolean("needs_naming", default: false, null: false)
-    t.integer("inat_id")
-    t.decimal("location_lat", precision: 15, scale: 10)
-    t.decimal("location_lng", precision: 15, scale: 10)
-    t.integer("occurrence_id")
-    t.boolean("gps_dubious", default: false, null: false)
-    t.string("collector", limit: 1024)
-    t.integer("collector_user_id")
-    t.integer("inat_import_id")
-    t.index(["collector_user_id"],
-            name: "index_observations_on_collector_user_id")
-    t.index(["inat_import_id"], name: "index_observations_on_inat_import_id")
-    t.index(["location_id"], name: "index_observations_on_location_id")
-    t.index(["name_id"], name: "index_observations_on_name_id")
-    t.index(["needs_naming"], name: "needs_naming_index")
-    t.index(["occurrence_id"], name: "index_observations_on_occurrence_id")
+  create_table "observations", id: { type: :integer, unsigned: true }, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.date "when"
+    t.integer "user_id"
+    t.boolean "specimen", default: false, null: false
+    t.text "notes"
+    t.integer "thumb_image_id"
+    t.integer "name_id"
+    t.integer "location_id"
+    t.boolean "is_collection_location", default: true, null: false
+    t.float "vote_cache", default: 0.0
+    t.integer "num_views", default: 0, null: false
+    t.datetime "last_view", precision: nil
+    t.integer "rss_log_id"
+    t.decimal "lat", precision: 15, scale: 10
+    t.decimal "lng", precision: 15, scale: 10
+    t.string "where", limit: 1024
+    t.integer "alt"
+    t.string "lifeform", limit: 1024
+    t.string "text_name", limit: 100
+    t.boolean "gps_hidden", default: false, null: false
+    t.integer "source"
+    t.datetime "log_updated_at", precision: nil
+    t.boolean "needs_naming", default: false, null: false
+    t.integer "inat_id"
+    t.decimal "location_lat", precision: 15, scale: 10
+    t.decimal "location_lng", precision: 15, scale: 10
+    t.integer "occurrence_id"
+    t.boolean "gps_dubious", default: false, null: false
+    t.string "collector", limit: 1024
+    t.integer "collector_user_id"
+    t.integer "inat_import_id"
+    t.index ["collector_user_id"], name: "index_observations_on_collector_user_id"
+    t.index ["inat_import_id"], name: "index_observations_on_inat_import_id"
+    t.index ["location_id"], name: "index_observations_on_location_id"
+    t.index ["name_id"], name: "index_observations_on_name_id"
+    t.index ["needs_naming"], name: "needs_naming_index"
+    t.index ["occurrence_id"], name: "index_observations_on_occurrence_id"
   end
 
-  create_table "occurrences", id: :integer, charset: "utf8mb4",
-                              collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("user_id")
-    t.integer("primary_observation_id")
-    t.boolean("has_specimen", default: false, null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.integer("field_slip_id")
-    t.index(["field_slip_id"], name: "index_occurrences_on_field_slip_id",
-                               unique: true)
-    t.index(["primary_observation_id"],
-            name: "index_occurrences_on_primary_observation_id")
-    t.index(["user_id"], name: "index_occurrences_on_user_id")
+  create_table "occurrences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "primary_observation_id"
+    t.boolean "has_specimen", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "field_slip_id"
+    t.index ["field_slip_id"], name: "index_occurrences_on_field_slip_id", unique: true
+    t.index ["primary_observation_id"], name: "index_occurrences_on_primary_observation_id"
+    t.index ["user_id"], name: "index_occurrences_on_user_id"
   end
 
-  create_table "original_image_requests", charset: "utf8mb4",
-                                          collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("user_id")
-    t.integer("image_id")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+  create_table "original_image_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "image_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "project_aliases", charset: "utf8mb4",
-                                  collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id", null: false)
-    t.integer("target_id", null: false)
-    t.string("target_type", null: false)
-    t.string("name")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(%w[name project_id],
-            name: "index_project_aliases_on_name_and_project_id", unique: true)
-    t.index(["project_id"], name: "index_project_aliases_on_project_id")
-    t.index(%w[target_type target_id],
-            name: "index_project_aliases_on_target_type_and_target_id")
+  create_table "project_aliases", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.integer "target_id", null: false
+    t.string "target_type", null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "project_id"], name: "index_project_aliases_on_name_and_project_id", unique: true
+    t.index ["project_id"], name: "index_project_aliases_on_project_id"
+    t.index ["target_type", "target_id"], name: "index_project_aliases_on_target_type_and_target_id"
   end
 
-  create_table "project_excluded_observations", charset: "utf8mb4",
-                                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("observation_id", null: false)
-    t.integer("project_id", null: false)
-    t.index(["observation_id"],
-            name: "index_project_excluded_observations_on_observation_id")
-    t.index(%w[project_id observation_id],
-            name: "index_project_excluded_observations_on_project_and_obs", unique: true)
-    t.index(["project_id"],
-            name: "index_project_excluded_observations_on_project_id")
+  create_table "project_excluded_observations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "observation_id", null: false
+    t.integer "project_id", null: false
+    t.index ["observation_id"], name: "index_project_excluded_observations_on_observation_id"
+    t.index ["project_id", "observation_id"], name: "index_project_excluded_observations_on_project_and_obs", unique: true
+    t.index ["project_id"], name: "index_project_excluded_observations_on_project_id"
   end
 
   create_table "project_images", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("image_id", null: false)
-    t.integer("project_id", null: false)
+    t.integer "image_id", null: false
+    t.integer "project_id", null: false
   end
 
-  create_table "project_members", charset: "utf8mb4",
-                                  collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id")
-    t.integer("user_id")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.integer("trust_level", default: 1, null: false)
+  create_table "project_members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "trust_level", default: 1, null: false
   end
 
-  create_table "project_observations", charset: "utf8mb3",
-                                       force: :cascade do |t|
-    t.integer("observation_id", null: false)
-    t.integer("project_id", null: false)
-    t.index(["observation_id"],
-            name: "index_project_observations_on_observation_id")
-    t.index(["project_id"], name: "index_project_observations_on_project_id")
+  create_table "project_observations", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "observation_id", null: false
+    t.integer "project_id", null: false
+    t.index ["observation_id"], name: "index_project_observations_on_observation_id"
+    t.index ["project_id"], name: "index_project_observations_on_project_id"
   end
 
-  create_table "project_species_lists", charset: "utf8mb3",
-                                        force: :cascade do |t|
-    t.integer("project_id", null: false)
-    t.integer("species_list_id", null: false)
+  create_table "project_species_lists", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.integer "species_list_id", null: false
   end
 
-  create_table "project_target_locations", charset: "utf8mb4",
-                                           collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id", null: false)
-    t.integer("location_id", null: false)
-    t.index(["location_id"],
-            name: "index_project_target_locations_on_location_id")
-    t.index(%w[project_id location_id],
-            name: "index_project_target_locations_on_project_id_and_location_id", unique: true)
-    t.index(["project_id"],
-            name: "index_project_target_locations_on_project_id")
+  create_table "project_target_locations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.integer "location_id", null: false
+    t.index ["location_id"], name: "index_project_target_locations_on_location_id"
+    t.index ["project_id", "location_id"], name: "index_project_target_locations_on_project_id_and_location_id", unique: true
+    t.index ["project_id"], name: "index_project_target_locations_on_project_id"
   end
 
-  create_table "project_target_names", charset: "utf8mb4",
-                                       collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id", null: false)
-    t.integer("name_id", null: false)
-    t.index(["name_id"], name: "index_project_target_names_on_name_id")
-    t.index(%w[project_id name_id],
-            name: "index_project_target_names_on_project_id_and_name_id", unique: true)
-    t.index(["project_id"], name: "index_project_target_names_on_project_id")
+  create_table "project_target_names", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.integer "name_id", null: false
+    t.index ["name_id"], name: "index_project_target_names_on_name_id"
+    t.index ["project_id", "name_id"], name: "index_project_target_names_on_project_id_and_name_id", unique: true
+    t.index ["project_id"], name: "index_project_target_names_on_project_id"
   end
 
-  create_table "projects", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("admin_group_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
-    t.string("title", limit: 100, default: "", null: false)
-    t.text("summary")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("rss_log_id")
-    t.boolean("open_membership", default: false, null: false)
-    t.integer("location_id")
-    t.integer("image_id")
-    t.date("start_date")
-    t.date("end_date")
-    t.string("field_slip_prefix")
-    t.integer("next_field_slip", default: 0, null: false)
-    t.index(["field_slip_prefix"], name: "index_projects_on_field_slip_prefix",
-                                   unique: true)
+  create_table "projects", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id", default: 0, null: false
+    t.integer "admin_group_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
+    t.string "title", limit: 100, default: "", null: false
+    t.text "summary"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "rss_log_id"
+    t.boolean "open_membership", default: false, null: false
+    t.integer "location_id"
+    t.integer "image_id"
+    t.date "start_date"
+    t.date "end_date"
+    t.string "field_slip_prefix"
+    t.integer "next_field_slip", default: 0, null: false
+    t.index ["field_slip_prefix"], name: "index_projects_on_field_slip_prefix", unique: true
   end
 
-  create_table "publications", id: :integer, charset: "utf8mb3",
-                               force: :cascade do |t|
-    t.integer("user_id")
-    t.text("full")
-    t.string("link")
-    t.text("how_helped")
-    t.boolean("mo_mentioned")
-    t.boolean("peer_reviewed")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
+  create_table "publications", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id"
+    t.text "full"
+    t.string "link"
+    t.text "how_helped"
+    t.boolean "mo_mentioned"
+    t.boolean "peer_reviewed"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
   end
 
-  create_table "query_records", id: :integer, charset: "utf8mb3",
-                                force: :cascade do |t|
-    t.datetime("updated_at", precision: nil)
-    t.integer("access_count")
-    t.text("description")
-    t.boolean("permalink", default: false)
+  create_table "query_records", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "updated_at", precision: nil
+    t.integer "access_count"
+    t.text "description"
+    t.boolean "permalink", default: false
   end
 
-  create_table "rss_logs", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.integer("observation_id")
-    t.integer("species_list_id")
-    t.datetime("updated_at", precision: nil)
-    t.text("notes")
-    t.integer("name_id")
-    t.integer("location_id")
-    t.integer("project_id")
-    t.integer("glossary_term_id")
-    t.integer("article_id")
-    t.datetime("created_at", precision: nil, null: false)
-    t.index(["observation_id"], name: "index_rss_logs_on_observation_id")
-    t.index(["updated_at"], name: "index_rss_logs_on_updated_at")
+  create_table "rss_logs", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "observation_id"
+    t.integer "species_list_id"
+    t.datetime "updated_at", precision: nil
+    t.text "notes"
+    t.integer "name_id"
+    t.integer "location_id"
+    t.integer "project_id"
+    t.integer "glossary_term_id"
+    t.integer "article_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.index ["observation_id"], name: "index_rss_logs_on_observation_id"
+    t.index ["updated_at"], name: "index_rss_logs_on_updated_at"
   end
 
-  create_table "sequences", id: :integer, charset: "utf8mb4",
-                            collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("observation_id")
-    t.integer("user_id")
-    t.text("locus", size: :medium)
-    t.text("bases", size: :medium)
-    t.string("archive")
-    t.string("accession")
-    t.text("notes", size: :medium)
-    t.datetime("created_at", precision: nil, null: false)
-    t.datetime("updated_at", precision: nil, null: false)
+  create_table "sequences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "observation_id"
+    t.integer "user_id"
+    t.text "locus", size: :medium
+    t.text "bases", size: :medium
+    t.string "archive"
+    t.string "accession"
+    t.text "notes", size: :medium
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "solid_cable_messages", charset: "utf8mb4",
-                                       collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.binary("channel", limit: 1024, null: false)
-    t.binary("payload", size: :long, null: false)
-    t.datetime("created_at", null: false)
-    t.bigint("channel_hash", null: false)
-    t.index(["channel"], name: "index_solid_cable_messages_on_channel")
-    t.index(["channel_hash"],
-            name: "index_solid_cable_messages_on_channel_hash")
-    t.index(["created_at"], name: "index_solid_cable_messages_on_created_at")
+  create_table "solid_cable_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.binary "payload", size: :long, null: false
+    t.datetime "created_at", null: false
+    t.bigint "channel_hash", null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
   end
 
-  create_table "solid_queue_blocked_executions", charset: "utf8mb4",
-                                                 collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.string("queue_name", null: false)
-    t.integer("priority", default: 0, null: false)
-    t.string("concurrency_key", null: false)
-    t.datetime("expires_at", null: false)
-    t.datetime("created_at", null: false)
-    t.index(%w[concurrency_key priority job_id],
-            name: "index_solid_queue_blocked_executions_for_release")
-    t.index(%w[expires_at concurrency_key],
-            name: "index_solid_queue_blocked_executions_for_maintenance")
-    t.index(["job_id"], name: "index_solid_queue_blocked_executions_on_job_id",
-                        unique: true)
+  create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_claimed_executions", charset: "utf8mb4",
-                                                 collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.bigint("process_id")
-    t.datetime("created_at", null: false)
-    t.index(["job_id"], name: "index_solid_queue_claimed_executions_on_job_id",
-                        unique: true)
-    t.index(%w[process_id job_id],
-            name: "index_solid_queue_claimed_executions_on_process_id_and_job_id")
+  create_table "solid_queue_claimed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
-  create_table "solid_queue_failed_executions", charset: "utf8mb4",
-                                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.text("error")
-    t.datetime("created_at", null: false)
-    t.index(["job_id"], name: "index_solid_queue_failed_executions_on_job_id",
-                        unique: true)
+  create_table "solid_queue_failed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_jobs", charset: "utf8mb4",
-                                   collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("queue_name", null: false)
-    t.string("class_name", null: false)
-    t.text("arguments")
-    t.integer("priority", default: 0, null: false)
-    t.string("active_job_id")
-    t.datetime("scheduled_at")
-    t.datetime("finished_at")
-    t.string("concurrency_key")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id")
-    t.index(["class_name"], name: "index_solid_queue_jobs_on_class_name")
-    t.index(["finished_at"], name: "index_solid_queue_jobs_on_finished_at")
-    t.index(%w[queue_name finished_at],
-            name: "index_solid_queue_jobs_for_filtering")
-    t.index(%w[scheduled_at finished_at],
-            name: "index_solid_queue_jobs_for_alerting")
+  create_table "solid_queue_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
   end
 
-  create_table "solid_queue_pauses", charset: "utf8mb4",
-                                     collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("queue_name", null: false)
-    t.datetime("created_at", null: false)
-    t.index(["queue_name"], name: "index_solid_queue_pauses_on_queue_name",
-                            unique: true)
+  create_table "solid_queue_pauses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
-  create_table "solid_queue_processes", charset: "utf8mb4",
-                                        collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("kind", null: false)
-    t.datetime("last_heartbeat_at", null: false)
-    t.bigint("supervisor_id")
-    t.integer("pid", null: false)
-    t.string("hostname")
-    t.text("metadata")
-    t.datetime("created_at", null: false)
-    t.string("name", null: false)
-    t.index(["last_heartbeat_at"],
-            name: "index_solid_queue_processes_on_last_heartbeat_at")
-    t.index(%w[name supervisor_id],
-            name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true)
-    t.index(["supervisor_id"],
-            name: "index_solid_queue_processes_on_supervisor_id")
+  create_table "solid_queue_processes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
-  create_table "solid_queue_ready_executions", charset: "utf8mb4",
-                                               collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.string("queue_name", null: false)
-    t.integer("priority", default: 0, null: false)
-    t.datetime("created_at", null: false)
-    t.index(["job_id"], name: "index_solid_queue_ready_executions_on_job_id",
-                        unique: true)
-    t.index(%w[priority job_id], name: "index_solid_queue_poll_all")
-    t.index(%w[queue_name priority job_id],
-            name: "index_solid_queue_poll_by_queue")
+  create_table "solid_queue_ready_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
-  create_table "solid_queue_recurring_executions", charset: "utf8mb4",
-                                                   collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.string("task_key", null: false)
-    t.datetime("run_at", null: false)
-    t.datetime("created_at", null: false)
-    t.index(["job_id"],
-            name: "index_solid_queue_recurring_executions_on_job_id", unique: true)
-    t.index(%w[task_key run_at],
-            name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true)
+  create_table "solid_queue_recurring_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
-  create_table "solid_queue_recurring_tasks", charset: "utf8mb4",
-                                              collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("key", null: false)
-    t.string("schedule", null: false)
-    t.string("command", limit: 2048)
-    t.string("class_name")
-    t.text("arguments")
-    t.string("queue_name")
-    t.integer("priority", default: 0)
-    t.boolean("static", default: true, null: false)
-    t.text("description")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["key"], name: "index_solid_queue_recurring_tasks_on_key",
-                     unique: true)
-    t.index(["static"], name: "index_solid_queue_recurring_tasks_on_static")
+  create_table "solid_queue_recurring_tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
-  create_table "solid_queue_scheduled_executions", charset: "utf8mb4",
-                                                   collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.string("queue_name", null: false)
-    t.integer("priority", default: 0, null: false)
-    t.datetime("scheduled_at", null: false)
-    t.datetime("created_at", null: false)
-    t.index(["job_id"],
-            name: "index_solid_queue_scheduled_executions_on_job_id", unique: true)
-    t.index(%w[scheduled_at priority job_id],
-            name: "index_solid_queue_dispatch_all")
+  create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
-  create_table "solid_queue_semaphores", charset: "utf8mb4",
-                                         collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("key", null: false)
-    t.integer("value", default: 1, null: false)
-    t.datetime("expires_at", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["expires_at"], name: "index_solid_queue_semaphores_on_expires_at")
-    t.index(%w[key value],
-            name: "index_solid_queue_semaphores_on_key_and_value")
-    t.index(["key"], name: "index_solid_queue_semaphores_on_key", unique: true)
+  create_table "solid_queue_semaphores", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
-  create_table "species_list_observations", charset: "utf8mb3",
-                                            force: :cascade do |t|
-    t.integer("observation_id", default: 0, null: false)
-    t.integer("species_list_id", default: 0, null: false)
+  create_table "species_list_observations", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "observation_id", default: 0, null: false
+    t.integer "species_list_id", default: 0, null: false
   end
 
-  create_table "species_lists", id: :integer, charset: "utf8mb3",
-                                force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.date("when")
-    t.integer("user_id")
-    t.string("where", limit: 1024)
-    t.string("title", limit: 100)
-    t.text("notes")
-    t.integer("rss_log_id")
-    t.integer("location_id")
+  create_table "species_lists", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.date "when"
+    t.integer "user_id"
+    t.string "where", limit: 1024
+    t.string "title", limit: 100
+    t.text "notes"
+    t.integer "rss_log_id"
+    t.integer "location_id"
   end
 
-  create_table "synonyms", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
+  create_table "synonyms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
   end
 
-  create_table "translation_string_versions", id: :integer, charset: "utf8mb3",
-                                              force: :cascade do |t|
-    t.integer("version")
-    t.integer("translation_string_id")
-    t.text("text")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("language_id")
+  create_table "translation_string_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.integer "translation_string_id"
+    t.text "text"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "language_id"
   end
 
-  create_table "translation_strings", id: :integer, charset: "utf8mb3",
-                                      force: :cascade do |t|
-    t.integer("version")
-    t.integer("language_id", null: false)
-    t.string("tag", limit: 100)
-    t.text("text")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
+  create_table "translation_strings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.integer "language_id", null: false
+    t.string "tag", limit: 100
+    t.text "text"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
   end
 
-  create_table "triples", id: :integer, charset: "utf8mb3",
-                          force: :cascade do |t|
-    t.string("subject", limit: 1024)
-    t.string("predicate", limit: 1024)
-    t.string("object", limit: 1024)
+  create_table "triples", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "subject", limit: 1024
+    t.string "predicate", limit: 1024
+    t.string "object", limit: 1024
   end
 
   create_table "user_group_users", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+    t.integer "user_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "user_groups", id: :integer, charset: "utf8mb3",
-                              force: :cascade do |t|
-    t.string("name", default: "", null: false)
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.boolean("meta", default: false)
+  create_table "user_groups", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.boolean "meta", default: false
   end
 
-  create_table "user_stats", charset: "utf8mb4",
-                             collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("comments", default: 0, null: false)
-    t.integer("images", default: 0, null: false)
-    t.integer("location_description_authors", default: 0, null: false)
-    t.integer("location_description_editors", default: 0, null: false)
-    t.integer("locations", default: 0, null: false)
-    t.integer("location_versions", default: 0, null: false)
-    t.integer("name_description_authors", default: 0, null: false)
-    t.integer("name_description_editors", default: 0, null: false)
-    t.integer("names", default: 0, null: false)
-    t.integer("name_versions", default: 0, null: false)
-    t.integer("namings", default: 0, null: false)
-    t.integer("observations", default: 0, null: false)
-    t.integer("sequences", default: 0, null: false)
-    t.integer("sequenced_observations", default: 0, null: false)
-    t.integer("species_list_entries", default: 0, null: false)
-    t.integer("species_lists", default: 0, null: false)
-    t.integer("translation_strings", default: 0, null: false)
-    t.integer("votes", default: 0, null: false)
-    t.string("languages")
-    t.string("bonuses")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["user_id"], name: "user_index")
+  create_table "user_stats", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id", default: 0, null: false
+    t.integer "comments", default: 0, null: false
+    t.integer "images", default: 0, null: false
+    t.integer "location_description_authors", default: 0, null: false
+    t.integer "location_description_editors", default: 0, null: false
+    t.integer "locations", default: 0, null: false
+    t.integer "location_versions", default: 0, null: false
+    t.integer "name_description_authors", default: 0, null: false
+    t.integer "name_description_editors", default: 0, null: false
+    t.integer "names", default: 0, null: false
+    t.integer "name_versions", default: 0, null: false
+    t.integer "namings", default: 0, null: false
+    t.integer "observations", default: 0, null: false
+    t.integer "sequences", default: 0, null: false
+    t.integer "sequenced_observations", default: 0, null: false
+    t.integer "species_list_entries", default: 0, null: false
+    t.integer "species_lists", default: 0, null: false
+    t.integer "translation_strings", default: 0, null: false
+    t.integer "votes", default: 0, null: false
+    t.string "languages"
+    t.string "bonuses"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "user_index"
   end
 
   create_table "users", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string("login", limit: 80, default: "", null: false)
-    t.string("password", limit: 40, default: "", null: false)
-    t.string("email", limit: 80, default: "", null: false)
-    t.string("theme", limit: 40)
-    t.string("name", limit: 80)
-    t.datetime("created_at", precision: nil)
-    t.datetime("last_login", precision: nil)
-    t.datetime("verified", precision: nil)
-    t.integer("license_id", default: 10, null: false)
-    t.integer("contribution", default: 0)
-    t.integer("location_id")
-    t.integer("image_id")
-    t.string("locale", limit: 5)
-    t.boolean("email_comments_owner", default: true, null: false)
-    t.boolean("email_comments_response", default: true, null: false)
-    t.boolean("email_observations_consensus", default: true, null: false)
-    t.boolean("email_observations_naming", default: true, null: false)
-    t.boolean("email_names_author", default: true, null: false)
-    t.boolean("email_names_editor", default: false, null: false)
-    t.boolean("email_names_reviewer", default: true, null: false)
-    t.boolean("email_locations_author", default: true, null: false)
-    t.boolean("email_locations_editor", default: false, null: false)
-    t.boolean("email_general_feature", default: true, null: false)
-    t.boolean("email_general_commercial", default: true, null: false)
-    t.boolean("email_general_question", default: true, null: false)
-    t.boolean("email_html", default: true, null: false)
-    t.datetime("updated_at", precision: nil)
-    t.boolean("admin")
-    t.text("alert")
-    t.boolean("email_locations_admin", default: false)
-    t.boolean("email_names_admin", default: false)
-    t.integer("thumbnail_size", default: 1)
-    t.integer("image_size", default: 5)
-    t.string("default_rss_type", limit: 40, default: "all")
-    t.integer("votes_anonymous", default: 1)
-    t.integer("location_format", default: 1)
-    t.datetime("last_activity", precision: nil)
-    t.integer("hide_authors", default: 1, null: false)
-    t.boolean("thumbnail_maps", default: true, null: false)
-    t.string("auth_code", limit: 40)
-    t.integer("keep_filenames", default: 1, null: false)
-    t.text("notes")
-    t.text("mailing_address")
-    t.integer("layout_count")
-    t.boolean("view_owner_id", default: false, null: false)
-    t.string("content_filter")
-    t.text("notes_template")
-    t.boolean("blocked", default: false, null: false)
-    t.boolean("no_emails", default: false, null: false)
-    t.string("inat_username")
-    t.integer("original_image_quota", default: 0)
-    t.integer("label_format", default: 1)
-    t.index(["inat_username"], name: "index_users_on_inat_username")
-    t.index(["login"], name: "login_index")
-    t.index(["name"], name: "index_users_on_name")
+    t.string "login", limit: 80, default: "", null: false
+    t.string "password", limit: 40, default: "", null: false
+    t.string "email", limit: 80, default: "", null: false
+    t.string "theme", limit: 40
+    t.string "name", limit: 80
+    t.datetime "created_at", precision: nil
+    t.datetime "last_login", precision: nil
+    t.datetime "verified", precision: nil
+    t.integer "license_id", default: 10, null: false
+    t.integer "contribution", default: 0
+    t.integer "location_id"
+    t.integer "image_id"
+    t.string "locale", limit: 5
+    t.boolean "email_comments_owner", default: true, null: false
+    t.boolean "email_comments_response", default: true, null: false
+    t.boolean "email_observations_consensus", default: true, null: false
+    t.boolean "email_observations_naming", default: true, null: false
+    t.boolean "email_names_author", default: true, null: false
+    t.boolean "email_names_editor", default: false, null: false
+    t.boolean "email_names_reviewer", default: true, null: false
+    t.boolean "email_locations_author", default: true, null: false
+    t.boolean "email_locations_editor", default: false, null: false
+    t.boolean "email_general_feature", default: true, null: false
+    t.boolean "email_general_commercial", default: true, null: false
+    t.boolean "email_general_question", default: true, null: false
+    t.boolean "email_html", default: true, null: false
+    t.datetime "updated_at", precision: nil
+    t.boolean "admin"
+    t.text "alert"
+    t.boolean "email_locations_admin", default: false
+    t.boolean "email_names_admin", default: false
+    t.integer "thumbnail_size", default: 1
+    t.integer "image_size", default: 5
+    t.string "default_rss_type", limit: 40, default: "all"
+    t.integer "votes_anonymous", default: 1
+    t.integer "location_format", default: 1
+    t.datetime "last_activity", precision: nil
+    t.integer "hide_authors", default: 1, null: false
+    t.boolean "thumbnail_maps", default: true, null: false
+    t.string "auth_code", limit: 40
+    t.integer "keep_filenames", default: 1, null: false
+    t.text "notes"
+    t.text "mailing_address"
+    t.integer "layout_count"
+    t.boolean "view_owner_id", default: false, null: false
+    t.string "content_filter"
+    t.text "notes_template"
+    t.boolean "blocked", default: false, null: false
+    t.boolean "no_emails", default: false, null: false
+    t.string "inat_username"
+    t.integer "original_image_quota", default: 0
+    t.integer "label_format", default: 1
+    t.index ["inat_username"], name: "index_users_on_inat_username"
+    t.index ["login"], name: "login_index"
+    t.index ["name"], name: "index_users_on_name"
   end
 
-  create_table "visual_group_images", charset: "utf8mb4",
-                                      collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("image_id")
-    t.integer("visual_group_id")
-    t.boolean("included", default: true, null: false)
+  create_table "visual_group_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "image_id"
+    t.integer "visual_group_id"
+    t.boolean "included", default: true, null: false
   end
 
-  create_table "visual_groups", charset: "utf8mb4",
-                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("visual_model_id")
-    t.string("name", null: false)
-    t.boolean("approved", default: false, null: false)
-    t.text("description")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+  create_table "visual_groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "visual_model_id"
+    t.string "name", null: false
+    t.boolean "approved", default: false, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "visual_models", charset: "utf8mb4",
-                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("name", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+  create_table "visual_models", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "votes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("naming_id")
-    t.integer("user_id")
-    t.integer("observation_id", default: 0)
-    t.boolean("favorite")
-    t.float("value")
-    t.index(["naming_id"], name: "naming_index")
-    t.index(["observation_id"], name: "observation_index")
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "naming_id"
+    t.integer "user_id"
+    t.integer "observation_id", default: 0
+    t.boolean "favorite"
+    t.float "value"
+    t.index ["naming_id"], name: "naming_index"
+    t.index ["observation_id"], name: "observation_index"
   end
 
   add_foreign_key "observations", "users", column: "collector_user_id"
   add_foreign_key "project_aliases", "projects"
-  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
 end

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -18,6 +18,44 @@ class InatImportsControllerTest < FunctionalTestCase
   include ActiveJob::TestHelper
   include Inat::Constants
 
+  def test_index_user_sees_own_imports
+    import = inat_imports(:rolf_inat_import)
+
+    login(users(:rolf).login)
+    get(:index)
+
+    assert_response(:success)
+    assert_select("td", text: import.state.to_s)
+  end
+
+  def test_index_user_does_not_see_others_imports
+    other_import = inat_imports(:katrina_inat_import)
+
+    login(users(:rolf).login)
+    get(:index)
+
+    assert_select("td", text: other_import.state.to_s, count: 0)
+  end
+
+  def test_index_admin_sees_all_imports
+    make_admin
+
+    get(:index)
+
+    assert_response(:success)
+    assert_select("th", text: :USER.t)
+  end
+
+  def test_results_redirects_to_observations_with_query
+    import = inat_imports(:lone_wolf_import)
+    import.update!(imported_count: 2)
+
+    login(users(:lone_wolf).login)
+    get(:results, params: { id: import.id })
+
+    assert_redirected_to(/#{observations_path}/)
+  end
+
   def test_show
     import = inat_imports(:rolf_inat_import)
 

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -172,4 +172,97 @@ class InatImportTest < ActiveSupport::TestCase
     assert_match(/Test error message/, import.response_errors,
                  "Error message should be added to response_errors")
   end
+
+  def test_new_instance_initializes_id_arrays
+    import = InatImport.new(user: users(:rolf))
+
+    assert_equal([], import.date_missing_inat_ids)
+    assert_equal([], import.license_added_inat_ids)
+  end
+
+  def test_add_ignored_obs_date_missing_increments_count_and_appends_id
+    import = inat_imports(:rolf_inat_import)
+
+    import.add_ignored_obs(:date_missing, inat_id: 42)
+    import.reload
+
+    assert_equal(1, import.ignored_date_missing_count)
+    assert_equal([42], import.date_missing_inat_ids)
+  end
+
+  def test_add_ignored_obs_date_missing_nil_id_still_increments
+    import = inat_imports(:rolf_inat_import)
+
+    import.add_ignored_obs(:date_missing, inat_id: nil)
+    import.reload
+
+    assert_equal(1, import.ignored_date_missing_count)
+    assert_equal([], import.date_missing_inat_ids)
+  end
+
+  def test_add_ignored_obs_date_missing_accumulates_multiple_ids
+    import = inat_imports(:rolf_inat_import)
+
+    import.add_ignored_obs(:date_missing, inat_id: 10)
+    import.add_ignored_obs(:date_missing, inat_id: 20)
+    import.reload
+
+    assert_equal(2, import.ignored_date_missing_count)
+    assert_equal([10, 20], import.date_missing_inat_ids)
+  end
+
+  def test_add_ignored_obs_unknown_reason_raises
+    import = inat_imports(:rolf_inat_import)
+
+    assert_raises(ArgumentError) do
+      import.add_ignored_obs(:bogus_reason)
+    end
+  end
+
+  def test_add_license_added_obs_appends_id
+    import = inat_imports(:rolf_inat_import)
+
+    import.add_license_added_obs(inat_id: 99)
+    import.reload
+
+    assert_equal([99], import.license_added_inat_ids)
+  end
+
+  def test_add_license_added_obs_accumulates_multiple_ids
+    import = inat_imports(:rolf_inat_import)
+
+    import.add_license_added_obs(inat_id: 11)
+    import.add_license_added_obs(inat_id: 22)
+    import.reload
+
+    assert_equal([11, 22], import.license_added_inat_ids)
+  end
+
+  def test_reached_import_cap_false_below_cap
+    import = inat_imports(:rolf_inat_import)
+    import.update_columns(imported_count: InatImport::MAX_IMPORTABLE - 1)
+
+    assert_not(import.reached_import_cap?)
+  end
+
+  def test_reached_import_cap_true_at_cap
+    import = inat_imports(:rolf_inat_import)
+    import.update_columns(imported_count: InatImport::MAX_IMPORTABLE)
+
+    assert(import.reached_import_cap?)
+  end
+
+  def test_reached_import_cap_true_above_cap
+    import = inat_imports(:rolf_inat_import)
+    import.update_columns(imported_count: InatImport::MAX_IMPORTABLE + 1)
+
+    assert(import.reached_import_cap?)
+  end
+
+  def test_reached_import_cap_false_when_nil
+    import = inat_imports(:rolf_inat_import)
+    import.update_columns(imported_count: nil)
+
+    assert_not(import.reached_import_cap?)
+  end
 end

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -145,6 +145,24 @@ class InatImportTest < ActiveSupport::TestCase
     assert_not(import.stuck?, "Done import should not be stuck")
   end
 
+  def test_ignored_total_count
+    import = inat_imports(:rolf_inat_import)
+    import.update!(
+      ignored_not_importable_count: 3,
+      ignored_date_missing_count: 2,
+      ignored_already_imported_count: 1
+    )
+
+    assert_equal(6, import.ignored_total_count)
+  end
+
+  def test_ignored_total_count_with_nils
+    import = inat_imports(:rolf_inat_import)
+
+    assert_equal(0, import.ignored_total_count,
+                 "nil counts should sum as 0")
+  end
+
   def test_add_response_error_without_prior_errors
     import = InatImport.new(user: users(:rolf))
     import.save!

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1574,6 +1574,16 @@ class ObservationTest < UnitTestCase
     )
   end
 
+  def test_scope_inat_import
+    import = inat_imports(:rolf_inat_import)
+    obs = Observation.first
+    obs.update!(inat_import: import)
+
+    result = Observation.inat_import(import)
+    assert_includes(result, obs)
+    assert_not_includes(result, Observation.where.not(id: obs.id).first)
+  end
+
   def test_scope_has_geolocation
     geoloc = Observation.where.not(lat: nil).first
     no_geoloc = Observation.where(lat: nil).first

--- a/test/views/controllers/inat_imports/index_test.rb
+++ b/test/views/controllers/inat_imports/index_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Views::Controllers::InatImports
+  class IndexTest < ComponentTestCase
+    def setup
+      super
+      @user = users(:rolf)
+      controller.instance_variable_set(:@user, @user)
+      @import = inat_imports(:rolf_inat_import)
+    end
+
+    def test_user_index_shows_import_row
+      html = render_index(imports: InatImport.where(user: @user).to_a)
+
+      assert_html(html, "td", text: @import.state.to_s)
+    end
+
+    def test_user_index_hides_user_column
+      html = render_index(imports: InatImport.where(user: @user).to_a,
+                          admin: false)
+
+      assert_no_html(html, "th", text: :USER.t)
+    end
+
+    def test_admin_index_shows_user_column
+      html = render_index(imports: InatImport.all.to_a, admin: true)
+
+      assert_html(html, "th", text: :USER.t)
+    end
+
+    def test_results_link_shown_for_done_import_with_obs
+      import = inat_imports(:lone_wolf_import)
+      import.update!(imported_count: 3)
+
+      html = render_index(imports: [import])
+
+      path = routes.results_inat_import_path(import)
+      assert_html(html, "a[href='#{path}']")
+    end
+
+    def test_results_link_hidden_when_imported_count_zero
+      import = inat_imports(:lone_wolf_import)
+      import.update!(imported_count: 0)
+
+      html = render_index(imports: [import])
+
+      path = routes.results_inat_import_path(import)
+      assert_no_html(html, "a[href='#{path}']")
+    end
+
+    def test_results_link_hidden_for_non_done_import
+      import = inat_imports(:katrina_inat_import)
+      assert_not(import.Done?,
+                 "Test needs an import fixture that is not Done")
+
+      html = render_index(imports: [import])
+
+      path = routes.results_inat_import_path(import)
+      assert_no_html(html, "a[href='#{path}']")
+    end
+
+    private
+
+    def render_index(imports:, admin: false)
+      render(Index.new(imports: imports, admin: admin))
+    end
+  end
+end

--- a/test/views/controllers/inat_imports/status_test.rb
+++ b/test/views/controllers/inat_imports/status_test.rb
@@ -72,7 +72,8 @@ module Views::Controllers::InatImports
       # katrina_inat_import is in Importing state
       html = render_status
 
-      assert_html(html, "a[aria-disabled='true'][href*='/observations']")
+      path = routes.results_inat_import_path(@import)
+      assert_html(html, "a[aria-disabled='true'][href='#{path}']")
     end
 
     def test_results_button_enabled_when_done_with_imports
@@ -83,7 +84,8 @@ module Views::Controllers::InatImports
       )
       html = render_status
 
-      assert_html(html, "a[href*='/observations'][href*='pattern=']")
+      path = routes.results_inat_import_path(@import)
+      assert_html(html, "a[href='#{path}']")
       assert_no_html(html, "a[aria-disabled='true']")
     end
 

--- a/test/views/controllers/inat_imports/status_test.rb
+++ b/test/views/controllers/inat_imports/status_test.rb
@@ -109,6 +109,63 @@ module Views::Controllers::InatImports
       assert_no_html(html, "form[action='#{cancel_path}']")
     end
 
+    def test_date_missing_row_absent_when_no_date_missing_skips
+      @import.update_columns(
+        state: InatImport.states[:Done],
+        ended_at: Time.zone.now,
+        ignored_not_importable_count: 1
+      )
+      html = render_status
+
+      assert_no_html(
+        html,
+        "*",
+        text: :inat_import_tracker_ignored_date_missing.l.as_displayed
+      )
+    end
+
+    def test_date_missing_row_shown_with_count_and_reimport_link
+      @import.update_columns(
+        state: InatImport.states[:Done],
+        ended_at: Time.zone.now,
+        ignored_date_missing_count: 2
+      )
+      @import.update!(date_missing_inat_ids: [101, 202])
+      html = render_status
+
+      reimport_path = routes.new_inat_import_path(inat_ids: "101,202")
+      assert_html(html, "a[href='#{reimport_path}']")
+    end
+
+    def test_license_added_section_absent_when_no_license_added_obs
+      @import.update_columns(
+        state: InatImport.states[:Done],
+        ended_at: Time.zone.now,
+        imported_count: 3
+      )
+      html = render_status
+
+      assert_no_html(
+        html,
+        "*",
+        text: :inat_import_tracker_license_added_heading.l.as_displayed
+      )
+    end
+
+    def test_license_added_section_shown_with_reimport_link
+      @import.update_columns(
+        state: InatImport.states[:Done],
+        ended_at: Time.zone.now,
+        imported_count: 2,
+        ignored_not_importable_count: 1
+      )
+      @import.update!(license_added_inat_ids: [55, 66])
+      html = render_status
+
+      reimport_path = routes.new_inat_import_path(inat_ids: "55,66")
+      assert_html(html, "a[href='#{reimport_path}']")
+    end
+
     private
 
     def render_status


### PR DESCRIPTION
## Summary

Stacked on #4634 (`nimmo-inat-import-ignored-counts`).

Adds an `inat_import_id` foreign key to `observations` so each observation can be traced back to the iNat import that created it. Adds a Results action that builds a `Query::Observations` scoped to that import and redirects the user to the standard observations index (no new `index_active_params` entry — the Query mechanism handles it entirely). Also adds an iNat imports index page so users can see all their imports and admins can see everything.

- `add_inat_import_id_to_observations` migration + `belongs_to :inat_import` on `Observation`
- `has_many :observations, dependent: :nullify` on `InatImport`
- `Observation.inat_import(import)` scope + `query_attr(:inat_import, InatImport)` in `Query::Observations`
- `Inat::MoObservationBuilder` stamps `inat_import_id` on each new observation
- `GET /inat_imports` — index page (admin sees all, user sees own, with STATUS / imported / ignored counts and a Results link)
- `GET /inat_imports/:id/results` — builds `Query.lookup(:Observation, inat_import: @inat_import)` and `redirect_with_query` to observations index; no query is saved until the user actually clicks

## Test plan

- [x] `bin/rails test test/models/observation_test.rb -n test_scope_inat_import`
- [x] `bin/rails test test/models/inat_import_test.rb -n /test_ignored_total_count/`
- [x] `bin/rails test test/controllers/inat_imports_controller_test.rb -n "/test_index|test_results/"`
- [x] `bin/rails test test/views/controllers/inat_imports/index_test.rb`
- [x] `bin/rails test test/views/controllers/inat_imports/show_test.rb`
- [x] RuboCop clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
