### PR TITLE
Sweep plain(" ") → whitespace in components and views

### DIFF
--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -180,7 +180,7 @@ class Components::Map::Popup < Components::Base
 
     path_helper = :"#{type.to_s.pluralize}_path"
     render_mapset_link(:show_all, send(path_helper), bbox_query)
-    plain(" ")
+    whitespace
     render_mapset_link(:map_all, send(:"map_#{path_helper}"), bbox_query)
   end
 

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -163,7 +163,7 @@ class Components::Matrix::Box < Components::Base
     div(class: "small mt-3") do
       a(href: occurrence_path(occ), class: "occurrence-link") do
         render(::Components::Icon.new(type: :matrix))
-        plain(" ")
+        whitespace
         plain(:matrix_box_occurrence.l)
       end
     end

--- a/app/views/controllers/account/login/new.rb
+++ b/app/views/controllers/account/login/new.rb
@@ -56,7 +56,7 @@ module Views::Controllers::Account::Login
         end
         div do
           trusted_html(:login_images_without_login.tp)
-          plain(" ")
+          whitespace
           trusted_html(:login_data_without_login.tp)
         end
       end

--- a/app/views/controllers/articles/index/article_item.rb
+++ b/app/views/controllers/articles/index/article_item.rb
@@ -21,7 +21,7 @@ module Views::Controllers::Articles
 
       def render_byline
         small { plain("#{@article.created_at.web_time}:") }
-        plain(" ")
+        whitespace
         render(::Components::Link::User.new(user: @article.user))
       end
     end

--- a/app/views/controllers/articles/show.rb
+++ b/app/views/controllers/articles/show.rb
@@ -24,7 +24,7 @@ module Views::Controllers::Articles
     def render_byline
       render(::Components::ContentPadded.new) do
         plain(:BY.t)
-        plain(" ")
+        whitespace
         render(::Components::Link::User.new(user: @article.user))
         plain(", ")
         small { plain(@article.created_at.display_time) }

--- a/app/views/controllers/comments/comment_item.rb
+++ b/app/views/controllers/comments/comment_item.rb
@@ -123,7 +123,7 @@ module Views::Controllers::Comments
         else
           plain(@comment.user.unique_text_name)
         end
-        plain(" ")
+        whitespace
       end
     end
 

--- a/app/views/controllers/descriptions/form.rb
+++ b/app/views/controllers/descriptions/form.rb
@@ -68,7 +68,7 @@ module Views::Controllers::Descriptions
         # trusted_html (NOT interpolated — that yields a plain String and
         # trusted_html would escape it) so entities in the source name
         # (e.g. "&" in a project title) aren't double-escaped (#4491).
-        plain(" ")
+        whitespace
         trusted_html(@description.source_name.t)
       else
         text_field(:source_name, class: "form-control")

--- a/app/views/controllers/field_slips/field_slip_panel.rb
+++ b/app/views/controllers/field_slips/field_slip_panel.rb
@@ -36,7 +36,7 @@ module Views::Controllers::FieldSlips
 
     def render_project_line
       strong { plain("#{:PROJECT.t}:") }
-      plain(" ")
+      whitespace
       if @field_slip.project
         render(Components::Link::Object.new(object: @field_slip.project))
       else
@@ -103,7 +103,7 @@ module Views::Controllers::FieldSlips
     def render_creator_line
       usr = @field_slip.user
       strong { plain("#{:field_slip_creator.t}:") }
-      plain(" ")
+      whitespace
       render(Components::Link::User.new(user: usr,
                                         name: usr.legal_name))
       br
@@ -119,7 +119,7 @@ module Views::Controllers::FieldSlips
       if all_obs.any?
         render_observations_matrix(all_obs)
       else
-        plain(" ")
+        whitespace
         plain(:field_slip_no_observation.t)
       end
     end

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -72,7 +72,7 @@ module Views::Controllers::FieldSlips
       div(class: "alert alert-info mt-3",
           id: "field_slip_no_prefix_nudge") do
         plain(:show_project_field_slip_no_prefix.t)
-        plain(" ")
+        whitespace
         link_to(:show_project_field_slip_set_prefix.t,
                 project_admin_path(project_id: @project.id),
                 class: "alert-link")

--- a/app/views/controllers/glossary_terms/versions/show/term.rb
+++ b/app/views/controllers/glossary_terms/versions/show/term.rb
@@ -11,7 +11,7 @@ module Views::Controllers::GlossaryTerms
         def view_template
           p(class: "mt-3") do
             b { trusted_html("#{:glossary_term_name.t}:") }
-            plain(" ")
+            whitespace
             trusted_html(@glossary_term.name.t)
           end
 

--- a/app/views/controllers/info/translators_note.rb
+++ b/app/views/controllers/info/translators_note.rb
@@ -22,7 +22,7 @@ module Views::Controllers::Info
       li do
         link_to(lang.name, reload_with_args(user_locale: lang.locale))
         if lang.beta
-          plain(" ")
+          whitespace
           span { "(beta)" }
         end
       end

--- a/app/views/controllers/licenses/show.rb
+++ b/app/views/controllers/licenses/show.rb
@@ -35,7 +35,7 @@ module Views::Controllers::Licenses
     def show_title
       capture do
         plain(@license.display_name)
-        plain(" ")
+        whitespace
         span(class: "smaller") { span { "#(#{@license.id || "?"}):" } }
       end
     end

--- a/app/views/controllers/locations/help/show.rb
+++ b/app/views/controllers/locations/help/show.rb
@@ -104,7 +104,7 @@ module Views::Controllers::Locations
       def render_footnote
         p(class: "mt-3") do
           sup { "(*)" }
-          plain(" ")
+          whitespace
           plain(:location_help_example_help.l)
         end
       end

--- a/app/views/controllers/locations/index.rb
+++ b/app/views/controllers/locations/index.rb
@@ -48,7 +48,7 @@ module Views::Controllers::Locations
       div(class: css) do
         plain(label_key.l)
         if @default_orders
-          plain(" ")
+          whitespace
           plain(order_key.l)
         end
       end

--- a/app/views/controllers/locations/show/coordinates.rb
+++ b/app/views/controllers/locations/show/coordinates.rb
@@ -70,7 +70,7 @@ module Views::Controllers::Locations
       def render_north
         div(class: "text-center my-4") do
           b { "#{:NORTH.l}:" }
-          plain(" ")
+          whitespace
           plain("#{@location.north}°")
         end
       end
@@ -78,7 +78,7 @@ module Views::Controllers::Locations
       def render_south
         div(class: "text-center my-4") do
           b { "#{:SOUTH.l}:" }
-          plain(" ")
+          whitespace
           plain("#{@location.south}°")
         end
       end
@@ -88,14 +88,14 @@ module Views::Controllers::Locations
           div(class: Grid::HALF) do
             span(class: "pull-left") do
               b { "#{:WEST.l}:" }
-              plain(" ")
+              whitespace
               plain("#{@location.west}°")
             end
           end
           div(class: Grid::HALF) do
             span(class: "pull-right") do
               b { "#{:EAST.l}:" }
-              plain(" ")
+              whitespace
               plain("#{@location.east}°")
             end
           end

--- a/app/views/controllers/observations/imported_source_banner.rb
+++ b/app/views/controllers/observations/imported_source_banner.rb
@@ -28,7 +28,7 @@ module Views::Controllers::Observations
       render(panel) do |panel|
         panel.with_body do
           render_credit(link)
-          plain(" ")
+          whitespace
           render_help_link
         end
       end

--- a/app/views/controllers/observations/show/associated_observations_panel.rb
+++ b/app/views/controllers/observations/show/associated_observations_panel.rb
@@ -30,13 +30,13 @@ class Views::Controllers::Observations::Show::AssociatedObservationsPanel < View
     if siblings?
       a(href: occurrence_path(@occurrence)) do
         render(::Components::Icon.new(type: :matrix))
-        plain(" ")
+        whitespace
         plain(:show_observation_matching_observations.l)
       end
     else
       a(href: new_occurrence_path(observation_id: @obs.id)) do
         render(::Components::Icon.new(type: :matrix))
-        plain(" ")
+        whitespace
         plain(:show_observation_add_matching_observations.l)
       end
     end

--- a/app/views/controllers/observations/show/external_links_panel.rb
+++ b/app/views/controllers/observations/show/external_links_panel.rb
@@ -75,7 +75,7 @@ class Views::Controllers::Observations::Show::ExternalLinksPanel < Views::Base
   def render_sibling_row(link, sibling)
     li do
       render(Components::Link::External.new(link: link))
-      plain(" ")
+      whitespace
       sibling_attribution(sibling)
     end
   end

--- a/app/views/controllers/observations/show/observation_details_panel.rb
+++ b/app/views/controllers/observations/show/observation_details_panel.rb
@@ -276,7 +276,7 @@ class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::B
       a(href: collection_number_path(cn.id)) do
         trusted_html(cn.format_name)
       end
-      plain(" ")
+      whitespace
       sibling_attribution(sib)
     end
   end
@@ -299,7 +299,7 @@ class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::B
     render_sibling_records(:sequences) do |seq, sib|
       a(href: sequence_path(seq.id)) { trusted_html(seq.format_name) }
       render_sibling_sequence_archive(seq) if seq.deposit?
-      plain(" ")
+      whitespace
       sibling_attribution(sib)
     end
   end

--- a/app/views/controllers/observations/show/sibling_records.rb
+++ b/app/views/controllers/observations/show/sibling_records.rb
@@ -41,7 +41,7 @@ module Views::Controllers::Observations::Show::SiblingRecords
     a(href: herbarium_record_path(record.id)) do
       trusted_html(record.accession_at_herbarium.t)
     end
-    plain(" ")
+    whitespace
     sibling_attribution(sibling)
     render_mcp_search_link(record) if record.herbarium.web_searchable?
   end

--- a/app/views/controllers/occurrences/form.rb
+++ b/app/views/controllers/occurrences/form.rb
@@ -257,7 +257,7 @@ module Views::Controllers::Occurrences
       br
       a(href: occurrence_path(obs.occurrence_id)) do
         render(::Components::Icon.new(type: :matrix))
-        plain(" ")
+        whitespace
         plain(:in_existing_occurrence.l)
       end
     end

--- a/app/views/controllers/projects/banner.rb
+++ b/app/views/controllers/projects/banner.rb
@@ -80,7 +80,7 @@ module Views::Controllers::Projects
       h1(class: title_classes, id: "title") do
         div(class: "d-flex align-items-center") do
           render(Components::IdBadge.new(object: @project))
-          plain(" ")
+          whitespace
           render(Components::Link::Object.new(object: @project))
         end
       end

--- a/app/views/controllers/projects/locations/table.rb
+++ b/app/views/controllers/projects/locations/table.rb
@@ -98,7 +98,7 @@ module Views::Controllers::Projects::Locations
     def render_target_name_cell(target, collapse_id, subs)
       td(class: "align-middle") do
         render_chevron(collapse_id) if subs.any?
-        plain(" ") if subs.any?
+        whitespace if subs.any?
         link_to(
           target.display_name,
           checklist_path(project_id: @project.id,

--- a/app/views/controllers/projects/members/form.rb
+++ b/app/views/controllers/projects/members/form.rb
@@ -46,7 +46,7 @@ module Views::Controllers::Projects::Members
     def render_status_button(key)
       div(class: "form-group mt-3") do
         submit(key.l, center: true)
-        plain(" ")
+        whitespace
         trusted_html(:"#{key}_help".t)
       end
     end

--- a/app/views/controllers/projects/violations/target_location_form.rb
+++ b/app/views/controllers/projects/violations/target_location_form.rb
@@ -187,7 +187,7 @@ module Views::Controllers::Projects::Violations
       # passing the event, so no preventDefault — the link's new
       # tab opens *and* the modal closes.
       capture do
-        plain(" ")
+        whitespace
         render(::Components::Button.new(
                  type: :get,
                  name: :form_violations_modal_target_location_create.l,

--- a/app/views/controllers/publications/index.rb
+++ b/app/views/controllers/publications/index.rb
@@ -83,7 +83,7 @@ module Views::Controllers::Publications
 
       capture do
         link_to(:EDIT.l, edit_publication_path(pub))
-        plain(" ")
+        whitespace
         link_to(:DESTROY.l, { action: :destroy, id: pub.id },
                 data: { confirm: :are_you_sure.t })
       end

--- a/app/views/controllers/sequences/edit.rb
+++ b/app/views/controllers/sequences/edit.rb
@@ -28,7 +28,7 @@ module Views::Controllers::Sequences
       render(Form.new(@sequence, back: @back))
       div(class: "small") do
         span(class: "font-weight-bold") { "#{:CREATED_BY.l}:" }
-        plain(" ")
+        whitespace
         render(::Components::Link::User.new(user: @sequence.user))
       end
       render(::Views::Layouts::ObjectFooter.new(

--- a/app/views/controllers/sequences/observation_title.rb
+++ b/app/views/controllers/sequences/observation_title.rb
@@ -9,7 +9,7 @@ module Views::Controllers::Sequences
     def view_template
       div(class: "mt-3") do
         strong { "#{:OBSERVATION.l}:" }
-        plain(" ")
+        whitespace
         trusted_html(@observation.name.display_name.t)
         plain(" (#{@observation.id})")
       end

--- a/app/views/controllers/sequences/show.rb
+++ b/app/views/controllers/sequences/show.rb
@@ -46,7 +46,7 @@ module Views::Controllers::Sequences
       obs = @sequence.observation
       p do
         strong { "#{:OBSERVATION.l}:" }
-        plain(" ")
+        whitespace
         link_to(obs.show_link_args) do
           trusted_html(obs.name.display_name.t)
         end
@@ -57,7 +57,7 @@ module Views::Controllers::Sequences
     def render_field(label_key, value)
       p do
         strong { "#{label_key.l}:" }
-        plain(" ")
+        whitespace
         value.is_a?(::Proc) ? value.call : plain(value.to_s)
       end
     end
@@ -68,7 +68,7 @@ module Views::Controllers::Sequences
     def render_locus
       div(class: "mb-3") do
         strong { "#{:LOCUS.l}:" }
-        plain(" ")
+        whitespace
         pre(class: "d-inline text-monospace") { plain(@sequence.locus) }
       end
     end
@@ -76,7 +76,7 @@ module Views::Controllers::Sequences
     def render_bases
       p do
         strong { "#{:BASES.l}:" }
-        plain(" ")
+        whitespace
         render(::Components::Button::Clipboard.new(
                  text: @sequence.bases, name: :COPY_THIS_SEQUENCE.l,
                  class: "ml-1"
@@ -91,7 +91,7 @@ module Views::Controllers::Sequences
     def render_deposit
       p do
         strong { "#{:DEPOSIT.l}:" }
-        plain(" ")
+        whitespace
         render_archive_link
         plain(": ")
         render_accession_link
@@ -107,7 +107,7 @@ module Views::Controllers::Sequences
         render(::Components::Button.new(type: :external,
                                         name: blast_tab.title,
                                         url: blast_tab.path))
-        plain(" ")
+        whitespace
         render(::Components::Button.new(
                  type: :external,
                  name: :show_observation_mycoblast_link.l,

--- a/app/views/controllers/translations/index.rb
+++ b/app/views/controllers/translations/index.rb
@@ -83,7 +83,7 @@ module Views::Controllers::Translations
                 data: { tag: ttag, role: "show_tag", turbo_stream: true }) do
           span(class: "tag") { "#{ttag}:" }
         end
-        plain(" ")
+        whitespace
         span(class: tag_str_class(ttag), id: "str_#{ttag}") { plain(str) }
       end
     end

--- a/app/views/controllers/users/show/profile.rb
+++ b/app/views/controllers/users/show/profile.rb
@@ -67,7 +67,7 @@ module Views::Controllers::Users
       def render_primary_location
         p do
           strong { "#{:show_user_primary_location.l}:" }
-          plain(" ")
+          whitespace
           render(::Components::Link::Location.new(
                    location: @show_user.location
                  ))
@@ -84,7 +84,7 @@ module Views::Controllers::Users
       def render_personal_herbarium
         p do
           strong { "#{:show_user_personal_herbarium.l}:" }
-          plain(" ")
+          whitespace
           link_to(@show_user.personal_herbarium.show_link_args) do
             trusted_html(@show_user.personal_herbarium.name.t)
           end

--- a/app/views/layouts/header/object_title.rb
+++ b/app/views/layouts/header/object_title.rb
@@ -29,7 +29,7 @@ module Views::Layouts
       div(class: "d-flex align-items-center") do
         render(::Components::IdBadge.new(object: @object,
                                          extra_class: "mr-4"))
-        plain(" ")
+        whitespace
         span { render_title_span }
       end
     end

--- a/app/views/layouts/sidebar/languages.rb
+++ b/app/views/layouts/sidebar/languages.rb
@@ -81,7 +81,7 @@ class Views::Layouts::Sidebar
             class: "lang-flag",
             alt: lang.locale
           )
-          plain(" ")
+          whitespace
           plain(lang.name)
         end
       end


### PR DESCRIPTION
## Summary
- Replaces all `plain(" ")` calls with `whitespace` across `app/components/` and `app/views/`, excluding `app/views/controllers/inat_imports/` (in-flight PR).
- 47 occurrences across 33 files — mechanical find-and-replace, no logic changes.

## Test plan
- [ ] CI green
