### PR TITLE
iNaturalist imports: one persistent record per import

### DIFF
--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -328,15 +328,15 @@ class InatImportsController < ApplicationController
     auth_code = params[:code]
     return not_authorized if auth_code.blank?
 
-    inat_import = inat_import_authenticating(auth_code)
+    inat_import = InatImport.find_by(id: params[:state], user: @user)
     return not_authorized unless inat_import
 
-    inat_import.reset_last_obs_start
-
-    Rails.logger.info(
-      "Enqueueing InatImportJob for InatImport id: #{inat_import.id}"
-    )
-    InatImportJob.perform_later(inat_import)
+    # Guard against a repeated (browser refresh) or late callback: only a
+    # record still awaiting authorization gets authenticated and enqueued,
+    # so we never start a duplicate job or regress a running/done import.
+    if inat_import.Authorizing?
+      start_authenticated_import(inat_import, auth_code)
+    end
 
     redirect_to(inat_import_path(inat_import))
   end
@@ -350,14 +350,15 @@ class InatImportsController < ApplicationController
     redirect_to(observations_path)
   end
 
-  # Load the specific import from the OAuth `state` param, scoped to the
-  # logged-in user so a forged state can't touch another user's import.
-  def inat_import_authenticating(auth_code)
-    inat_import = InatImport.find_by(id: params[:state], user: @user)
-    return nil unless inat_import
-
+  # Authenticate the loaded import and kick off its job. Called only for a
+  # record still in the Authorizing state (see authorization_response).
+  def start_authenticated_import(inat_import, auth_code)
     inat_import.update(token: auth_code, state: "Authenticating")
-    inat_import
+    inat_import.reset_last_obs_start
+    Rails.logger.info(
+      "Enqueueing InatImportJob for InatImport id: #{inat_import.id}"
+    )
+    InatImportJob.perform_later(inat_import)
   end
 
   public

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -82,11 +82,13 @@ class InatImportsController < ApplicationController
   end
 
   def new
-    @inat_import = InatImport.find_or_create_by(user: @user)
-    return render_new_form unless @inat_import.job_pending?
+    pending = InatImport.where(user: @user).
+              where(state: %w[Authenticating Importing]).
+              order(:updated_at).last
+    return render_new_form unless pending
 
     flash_warning(:inat_import_tracker_pending.l)
-    redirect_to(inat_import_path(@inat_import))
+    redirect_to(inat_import_path(pending))
   end
 
   def create
@@ -115,7 +117,7 @@ class InatImportsController < ApplicationController
                       else
                         fetch_unlicensed_obs_count
                       end
-    @inat_import = InatImport.find_or_create_by(user: @user)
+    @inat_import = InatImport.new(user: @user)
     warn_about_listed_previous_imports
     @confirm_form = build_confirm_form
     render(Views::Controllers::InatImports::Confirm.new(
@@ -242,15 +244,18 @@ class InatImportsController < ApplicationController
     key.verify! if key.verified.nil?
   end
 
+  # A new persistent record per import, so each import's results are kept.
+  # avg_import_time derives from the user's prior records (a throwaway
+  # instance computes it since the new one isn't saved yet).
   def init_ivars
-    @inat_import = InatImport.find_or_create_by(user: @user)
-    @inat_import.update(
+    @inat_import = InatImport.create!(
+      user: @user,
       state: "Authorizing",
       import_all: params[:all],
       importables: importables_count,
       total_importables: importables_count,
       imported_count: 0,
-      avg_import_time: @inat_import.initial_avg_import_seconds,
+      avg_import_time: InatImport.new(user: @user).initial_avg_import_seconds,
       inat_username: params[:inat_username]&.strip,
       inat_ids: clean_inat_ids,
       inat_url: params[:inat_url].presence,
@@ -307,8 +312,11 @@ class InatImportsController < ApplicationController
     remaining_ids.join(",")
   end
 
+  # Pass the new record's id through the OAuth `state` param; iNat echoes it
+  # back to authorization_response so we know which import to resume.
   def request_inat_user_authorization
-    redirect_to(INAT_AUTHORIZATION_URL, allow_other_host: true)
+    redirect_to("#{INAT_AUTHORIZATION_URL}&state=#{@inat_import.id}",
+                allow_other_host: true)
   end
 
   # ---------------------------------
@@ -321,6 +329,8 @@ class InatImportsController < ApplicationController
     return not_authorized if auth_code.blank?
 
     inat_import = inat_import_authenticating(auth_code)
+    return not_authorized unless inat_import
+
     inat_import.reset_last_obs_start
 
     Rails.logger.info(
@@ -340,8 +350,12 @@ class InatImportsController < ApplicationController
     redirect_to(observations_path)
   end
 
+  # Load the specific import from the OAuth `state` param, scoped to the
+  # logged-in user so a forged state can't touch another user's import.
   def inat_import_authenticating(auth_code)
-    inat_import = InatImport.find_or_create_by(user: @user)
+    inat_import = InatImport.find_by(id: params[:state], user: @user)
+    return nil unless inat_import
+
     inat_import.update(token: auth_code, state: "Authenticating")
     inat_import
   end

--- a/app/jobs/inat_import_recovery_job.rb
+++ b/app/jobs/inat_import_recovery_job.rb
@@ -7,18 +7,26 @@
 class InatImportRecoveryJob < ApplicationJob
   queue_as :default
 
+  STUCK_MSG = "Import did not complete — the import may have crashed. " \
+              "You can restart the import."
+  ABANDONED_MSG = "Authorization was not completed — this import never ran. " \
+                  "You can start a new import."
+
   def perform
-    InatImport.stuck.find_each do |import|
-      crashed_msg = "Import did not complete — the import may have crashed. " \
-                    "You can restart the import."
-      import.update!(
-        state: "Done",
-        ended_at: Time.zone.now,
-        response_errors: "#{import.response_errors}#{crashed_msg}\n"
-      )
-      Rails.logger.warn(
-        "InatImportRecoveryJob: marked stuck import #{import.id} as Done"
-      )
-    end
+    InatImport.stuck.find_each { |import| finalize(import, STUCK_MSG) }
+    InatImport.abandoned.find_each { |import| finalize(import, ABANDONED_MSG) }
+  end
+
+  private
+
+  def finalize(import, message)
+    import.update!(
+      state: "Done",
+      ended_at: Time.zone.now,
+      response_errors: "#{import.response_errors}#{message}\n"
+    )
+    Rails.logger.warn(
+      "InatImportRecoveryJob: finalized import #{import.id} as Done"
+    )
   end
 end

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -220,11 +220,12 @@ class InatImport < ApplicationRecord
   private
 
   def user_import_history?
-    total_imported_count.to_i.positive?
+    InatImport.where(user: user).sum(:total_imported_count).to_i.positive?
   end
 
   def personal_initial_avg_import_seconds
-    total_seconds / total_imported_count
+    scope = InatImport.where(user: user)
+    scope.sum(:total_seconds) / scope.sum(:total_imported_count)
   end
 
   def system_import_history?

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -102,6 +102,16 @@ class InatImport < ApplicationRecord
       where(updated_at: ...STUCK_THRESHOLD.ago)
   }
 
+  # An import that never completed the OAuth authorization handshake is
+  # assumed abandoned after this long. Generous on purpose — a user won't
+  # take an hour to authorize on iNat, but might take a couple of minutes.
+  ABANDONED_THRESHOLD = 1.hour
+
+  scope :abandoned, lambda {
+    where(state: %w[Authorizing Authenticating]).
+      where(updated_at: ...ABANDONED_THRESHOLD.ago)
+  }
+
   # Are there enough constraints on which observations to import?
   # See also InatImportsController::Validators#adequately_constrained?
   # Need to make sure that the iNat API query has enough constrains so

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,1163 +10,1035 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 20_260_702_000_000) do
-  create_table "api_keys", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("last_used", precision: nil)
-    t.integer("num_uses", default: 0)
-    t.integer("user_id", null: false)
-    t.string("key", limit: 128, null: false)
-    t.text("notes")
-    t.datetime("verified", precision: nil)
+ActiveRecord::Schema[7.2].define(version: 2026_07_02_000000) do
+  create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "last_used", precision: nil
+    t.integer "num_uses", default: 0
+    t.integer "user_id", null: false
+    t.string "key", limit: 128, null: false
+    t.text "notes"
+    t.datetime "verified", precision: nil
   end
 
-  create_table "articles", id: :integer, charset: "utf8mb4",
-                           collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("title")
-    t.text("body", size: :medium)
-    t.integer("user_id")
-    t.integer("rss_log_id")
-    t.datetime("created_at", precision: nil, null: false)
-    t.datetime("updated_at", precision: nil, null: false)
+  create_table "articles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "title"
+    t.text "body", size: :medium
+    t.integer "user_id"
+    t.integer "rss_log_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "banners", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci",
-                          force: :cascade do |t|
-    t.text("message")
-    t.integer("version")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+  create_table "banners", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "message"
+    t.integer "version"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "collection_numbers", id: :integer, charset: "utf8mb3",
-                                     force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.string("name")
-    t.string("number")
+  create_table "collection_numbers", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.string "name"
+    t.string "number"
   end
 
-  create_table "comments", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.integer("user_id")
-    t.string("summary", limit: 100)
-    t.text("comment")
-    t.string("target_type", limit: 30)
-    t.integer("target_id")
-    t.datetime("updated_at", precision: nil)
-    t.index(%w[target_id target_type], name: "target_index")
+  create_table "comments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.integer "user_id"
+    t.string "summary", limit: 100
+    t.text "comment"
+    t.string "target_type", limit: 30
+    t.integer "target_id"
+    t.datetime "updated_at", precision: nil
+    t.index ["target_id", "target_type"], name: "target_index"
   end
 
-  create_table "copyright_changes", id: :integer, charset: "utf8mb3",
-                                    force: :cascade do |t|
-    t.integer("user_id", null: false)
-    t.datetime("updated_at", precision: nil, null: false)
-    t.string("target_type", limit: 30, null: false)
-    t.integer("target_id", null: false)
-    t.integer("year")
-    t.string("name")
-    t.integer("license_id")
+  create_table "copyright_changes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "target_type", limit: 30, null: false
+    t.integer "target_id", null: false
+    t.integer "year"
+    t.string "name"
+    t.integer "license_id"
   end
 
-  create_table "donations", id: :integer, charset: "utf8mb3",
-                            force: :cascade do |t|
-    t.decimal("amount", precision: 12, scale: 2)
-    t.string("who", limit: 100)
-    t.string("email", limit: 100)
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.boolean("anonymous", default: false, null: false)
-    t.boolean("reviewed", default: true, null: false)
-    t.integer("user_id")
-    t.boolean("recurring", default: false)
+  create_table "donations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.decimal "amount", precision: 12, scale: 2
+    t.string "who", limit: 100
+    t.string "email", limit: 100
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.boolean "anonymous", default: false, null: false
+    t.boolean "reviewed", default: true, null: false
+    t.integer "user_id"
+    t.boolean "recurring", default: false
   end
 
-  create_table "external_links", id: :integer, charset: "utf8mb3",
-                                 force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("target_id")
-    t.integer("external_site_id")
-    t.string("url", limit: 100)
-    t.string("target_type", limit: 64)
-    t.string("external_id", limit: 64)
-    t.integer("relationship", default: 0, null: false)
-    t.datetime("last_synced_at")
-    t.virtual("import_target", type: :string,
-                               as: "(case when (`relationship` = 1) then concat(`target_type`,_utf8mb3':',`target_id`) end)", stored: true)
-    t.date("external_created_on")
-    t.index(%w[external_site_id relationship target_type external_id],
-            name: "index_external_links_on_site_rel_target_extid")
-    t.index(["import_target"], name: "index_external_links_on_import_target",
-                               unique: true)
-    t.index(%w[target_type target_id], name: "index_external_links_on_target")
+  create_table "external_links", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "target_id"
+    t.integer "external_site_id"
+    t.string "url", limit: 100
+    t.string "target_type", limit: 64
+    t.string "external_id", limit: 64
+    t.integer "relationship", default: 0, null: false
+    t.datetime "last_synced_at"
+    t.virtual "import_target", type: :string, as: "(case when (`relationship` = 1) then concat(`target_type`,_utf8mb3':',`target_id`) end)", stored: true
+    t.date "external_created_on"
+    t.index ["external_site_id", "relationship", "target_type", "external_id"], name: "index_external_links_on_site_rel_target_extid"
+    t.index ["import_target"], name: "index_external_links_on_import_target", unique: true
+    t.index ["target_type", "target_id"], name: "index_external_links_on_target"
   end
 
-  create_table "external_sites", id: :integer, charset: "utf8mb3",
-                                 force: :cascade do |t|
-    t.string("name", limit: 100)
-    t.integer("project_id")
-    t.string("base_url", null: false)
-    t.text("description")
-    t.datetime("last_successful_sync_at")
-    t.string("url_template")
+  create_table "external_sites", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name", limit: 100
+    t.integer "project_id"
+    t.string "base_url", null: false
+    t.text "description"
+    t.datetime "last_successful_sync_at"
+    t.string "url_template"
   end
 
-  create_table "field_slip_job_trackers", charset: "utf8mb4",
-                                          collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("start")
-    t.integer("count")
-    t.string("prefix")
-    t.integer("status")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.integer("pages", default: 0, null: false)
-    t.string("title", limit: 100, default: "", null: false)
-    t.integer("user_id")
-    t.boolean("one_per_page", default: false, null: false)
+  create_table "field_slip_job_trackers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "start"
+    t.integer "count"
+    t.string "prefix"
+    t.integer "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "pages", default: 0, null: false
+    t.string "title", limit: 100, default: "", null: false
+    t.integer "user_id"
+    t.boolean "one_per_page", default: false, null: false
   end
 
-  create_table "field_slips", charset: "utf8mb4",
-                              collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id")
-    t.string("code", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.integer("user_id")
-    t.index(["code"], name: "index_field_slips_on_code", unique: true)
+  create_table "field_slips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id"
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["code"], name: "index_field_slips_on_code", unique: true
   end
 
-  create_table "glossary_term_images", charset: "utf8mb3",
-                                       force: :cascade do |t|
-    t.integer("image_id")
-    t.integer("glossary_term_id")
+  create_table "glossary_term_images", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "image_id"
+    t.integer "glossary_term_id"
   end
 
-  create_table "glossary_term_versions", id: :integer, charset: "utf8mb3",
-                                         force: :cascade do |t|
-    t.integer("glossary_term_id")
-    t.integer("version")
-    t.integer("user_id")
-    t.datetime("updated_at", precision: nil)
-    t.string("name", limit: 1024)
-    t.text("description")
+  create_table "glossary_term_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "glossary_term_id"
+    t.integer "version"
+    t.integer "user_id"
+    t.datetime "updated_at", precision: nil
+    t.string "name", limit: 1024
+    t.text "description"
   end
 
-  create_table "glossary_terms", id: :integer, charset: "utf8mb3",
-                                 force: :cascade do |t|
-    t.integer("version")
-    t.integer("user_id")
-    t.string("name", limit: 1024)
-    t.integer("thumb_image_id")
-    t.text("description")
-    t.integer("rss_log_id")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.boolean("locked", default: false, null: false)
+  create_table "glossary_terms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.integer "user_id"
+    t.string "name", limit: 1024
+    t.integer "thumb_image_id"
+    t.text "description"
+    t.integer "rss_log_id"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.boolean "locked", default: false, null: false
   end
 
-  create_table "herbaria", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.text("mailing_address")
-    t.integer("location_id")
-    t.string("email", limit: 80, default: "", null: false)
-    t.string("name", limit: 1024)
-    t.text("description")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.string("code", limit: 8)
-    t.integer("personal_user_id")
-    t.index(["code"], name: "index_herbaria_on_code", unique: true)
+  create_table "herbaria", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.text "mailing_address"
+    t.integer "location_id"
+    t.string "email", limit: 80, default: "", null: false
+    t.string "name", limit: 1024
+    t.text "description"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.string "code", limit: 8
+    t.integer "personal_user_id"
+    t.index ["code"], name: "index_herbaria_on_code", unique: true
   end
 
   create_table "herbarium_curators", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("herbarium_id", default: 0, null: false)
+    t.integer "user_id", default: 0, null: false
+    t.integer "herbarium_id", default: 0, null: false
   end
 
-  create_table "herbarium_records", id: :integer, charset: "utf8mb3",
-                                    force: :cascade do |t|
-    t.integer("herbarium_id", null: false)
-    t.text("notes")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id", null: false)
-    t.string("initial_det", limit: 221, null: false)
-    t.string("accession_number", limit: 80, null: false)
+  create_table "herbarium_records", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "herbarium_id", null: false
+    t.text "notes"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id", null: false
+    t.string "initial_det", limit: 221, null: false
+    t.string "accession_number", limit: 80, null: false
   end
 
-  create_table "image_votes", id: :integer, charset: "utf8mb3",
-                              force: :cascade do |t|
-    t.integer("value", null: false)
-    t.boolean("anonymous", default: false, null: false)
-    t.integer("user_id")
-    t.integer("image_id")
-    t.index(["image_id"], name: "index_image_votes_on_image_id")
-    t.index(["user_id"], name: "index_image_votes_on_user_id")
+  create_table "image_votes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "value", null: false
+    t.boolean "anonymous", default: false, null: false
+    t.integer "user_id"
+    t.integer "image_id"
+    t.index ["image_id"], name: "index_image_votes_on_image_id"
+    t.index ["user_id"], name: "index_image_votes_on_user_id"
   end
 
-  create_table "images", id: { type: :integer, unsigned: true },
-                         charset: "utf8mb3", force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.string("content_type", limit: 100)
-    t.integer("user_id")
-    t.date("when")
-    t.text("notes")
-    t.string("copyright_holder")
-    t.integer("license_id", default: 10, null: false)
-    t.integer("num_views", default: 0, null: false)
-    t.datetime("last_view", precision: nil)
-    t.integer("width")
-    t.integer("height")
-    t.float("vote_cache")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.string("original_name", limit: 120, default: "")
-    t.boolean("transferred", default: false, null: false)
-    t.boolean("gps_stripped", default: false, null: false)
-    t.boolean("diagnostic", default: true, null: false)
+  create_table "images", id: { type: :integer, unsigned: true }, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.string "content_type", limit: 100
+    t.integer "user_id"
+    t.date "when"
+    t.text "notes"
+    t.string "copyright_holder"
+    t.integer "license_id", default: 10, null: false
+    t.integer "num_views", default: 0, null: false
+    t.datetime "last_view", precision: nil
+    t.integer "width"
+    t.integer "height"
+    t.float "vote_cache"
+    t.boolean "ok_for_export", default: true, null: false
+    t.string "original_name", limit: 120, default: ""
+    t.boolean "transferred", default: false, null: false
+    t.boolean "gps_stripped", default: false, null: false
+    t.boolean "diagnostic", default: true, null: false
   end
 
-  create_table "inat_imports", charset: "utf8mb4",
-                               collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("user_id")
-    t.integer("state", default: 0)
-    t.text("inat_ids")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("token")
-    t.string("inat_username")
-    t.boolean("import_all")
-    t.integer("importables")
-    t.integer("imported_count")
-    t.text("response_errors")
-    t.datetime("ended_at")
-    t.integer("total_imported_count")
-    t.integer("total_seconds")
-    t.float("avg_import_time")
-    t.datetime("last_obs_start")
-    t.boolean("cancel")
-    t.boolean("import_others", default: false, null: false)
-    t.integer("writeback", default: 0, null: false)
-    t.text("inat_url")
-    t.datetime("started_at")
-    t.integer("total_importables")
-    t.integer("ignored_not_importable_count", default: 0, null: false)
-    t.integer("ignored_date_missing_count", default: 0, null: false)
-    t.integer("ignored_already_imported_count", default: 0, null: false)
-    t.text("date_missing_inat_ids")
-    t.text("license_added_inat_ids")
+  create_table "inat_imports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "state", default: 0
+    t.text "inat_ids"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "token"
+    t.string "inat_username"
+    t.boolean "import_all"
+    t.integer "importables"
+    t.integer "imported_count"
+    t.text "response_errors"
+    t.datetime "ended_at"
+    t.integer "total_imported_count"
+    t.integer "total_seconds"
+    t.float "avg_import_time"
+    t.datetime "last_obs_start"
+    t.boolean "cancel"
+    t.boolean "import_others", default: false, null: false
+    t.integer "writeback", default: 0, null: false
+    t.text "inat_url"
+    t.datetime "started_at"
+    t.integer "total_importables"
+    t.integer "ignored_not_importable_count", default: 0, null: false
+    t.integer "ignored_date_missing_count", default: 0, null: false
+    t.integer "ignored_already_imported_count", default: 0, null: false
+    t.text "date_missing_inat_ids"
+    t.text "license_added_inat_ids"
   end
 
-  create_table "interests", id: :integer, charset: "utf8mb3",
-                            force: :cascade do |t|
-    t.string("target_type", limit: 30)
-    t.integer("target_id")
-    t.integer("user_id")
-    t.boolean("state")
-    t.datetime("updated_at", precision: nil)
+  create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "target_type", limit: 30
+    t.integer "target_id"
+    t.integer "user_id"
+    t.boolean "state"
+    t.datetime "updated_at", precision: nil
   end
 
-  create_table "languages", id: :integer, charset: "utf8mb3",
-                            force: :cascade do |t|
-    t.string("locale", limit: 40)
-    t.string("name", limit: 100)
-    t.string("order", limit: 100)
-    t.boolean("official", null: false)
-    t.boolean("beta", null: false)
+  create_table "languages", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "locale", limit: 40
+    t.string "name", limit: 100
+    t.string "order", limit: 100
+    t.boolean "official", null: false
+    t.boolean "beta", null: false
   end
 
-  create_table "licenses", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.string("display_name", limit: 80)
-    t.string("url", limit: 200)
-    t.boolean("deprecated", default: false, null: false)
-    t.datetime("updated_at", precision: nil)
-    t.datetime("created_at", precision: nil)
+  create_table "licenses", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "display_name", limit: 80
+    t.string "url", limit: 200
+    t.boolean "deprecated", default: false, null: false
+    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", precision: nil
   end
 
-  create_table "location_description_admins", charset: "utf8mb3",
-                                              force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "location_description_admins", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "location_description_authors", charset: "utf8mb3",
-                                               force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_id", default: 0, null: false)
+  create_table "location_description_authors", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_id", default: 0, null: false
   end
 
-  create_table "location_description_editors", charset: "utf8mb3",
-                                               force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_id", default: 0, null: false)
+  create_table "location_description_editors", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_id", default: 0, null: false
   end
 
-  create_table "location_description_readers", charset: "utf8mb3",
-                                               force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "location_description_readers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "location_description_versions", id: :integer,
-                                                charset: "utf8mb3", force: :cascade do |t|
-    t.integer("location_description_id")
-    t.integer("version")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("license_id")
-    t.integer("merge_source_id")
-    t.text("gen_desc")
-    t.text("ecology")
-    t.text("species")
-    t.text("notes")
-    t.text("refs")
+  create_table "location_description_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id"
+    t.integer "version"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "license_id"
+    t.integer "merge_source_id"
+    t.text "gen_desc"
+    t.text "ecology"
+    t.text "species"
+    t.text "notes"
+    t.text "refs"
   end
 
-  create_table "location_description_writers", charset: "utf8mb3",
-                                               force: :cascade do |t|
-    t.integer("location_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "location_description_writers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "location_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "location_descriptions", id: :integer, charset: "utf8mb3",
-                                        force: :cascade do |t|
-    t.integer("version")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("location_id")
-    t.integer("num_views", default: 0)
-    t.datetime("last_view", precision: nil)
-    t.integer("source_type")
-    t.string("source_name", limit: 100)
-    t.string("locale", limit: 8)
-    t.boolean("public")
-    t.integer("license_id")
-    t.text("gen_desc")
-    t.text("ecology")
-    t.text("species")
-    t.text("notes")
-    t.text("refs")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.integer("project_id")
+  create_table "location_descriptions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "location_id"
+    t.integer "num_views", default: 0
+    t.datetime "last_view", precision: nil
+    t.integer "source_type"
+    t.string "source_name", limit: 100
+    t.string "locale", limit: 8
+    t.boolean "public"
+    t.integer "license_id"
+    t.text "gen_desc"
+    t.text "ecology"
+    t.text "species"
+    t.text "notes"
+    t.text "refs"
+    t.boolean "ok_for_export", default: true, null: false
+    t.integer "project_id"
   end
 
-  create_table "location_versions", id: :integer, charset: "utf8mb3",
-                                    force: :cascade do |t|
-    t.string("location_id")
-    t.integer("version")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.float("north")
-    t.float("south")
-    t.float("west")
-    t.float("east")
-    t.float("high")
-    t.float("low")
-    t.string("name", limit: 1024)
-    t.text("notes")
-    t.string("scientific_name", limit: 1024)
-    t.decimal("box_area", precision: 21, scale: 10)
-    t.decimal("center_lat", precision: 15, scale: 10)
-    t.decimal("center_lng", precision: 15, scale: 10)
+  create_table "location_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "location_id"
+    t.integer "version"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.float "north"
+    t.float "south"
+    t.float "west"
+    t.float "east"
+    t.float "high"
+    t.float "low"
+    t.string "name", limit: 1024
+    t.text "notes"
+    t.string "scientific_name", limit: 1024
+    t.decimal "box_area", precision: 21, scale: 10
+    t.decimal "center_lat", precision: 15, scale: 10
+    t.decimal "center_lng", precision: 15, scale: 10
   end
 
-  create_table "locations", id: :integer, charset: "utf8mb3",
-                            force: :cascade do |t|
-    t.integer("version")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("description_id")
-    t.integer("rss_log_id")
-    t.integer("num_views", default: 0)
-    t.datetime("last_view", precision: nil)
-    t.decimal("north", precision: 15, scale: 10, null: false)
-    t.decimal("south", precision: 15, scale: 10, null: false)
-    t.decimal("west", precision: 15, scale: 10, null: false)
-    t.decimal("east", precision: 15, scale: 10, null: false)
-    t.float("high")
-    t.float("low")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.text("notes")
-    t.string("name", limit: 1024)
-    t.string("scientific_name", limit: 1024)
-    t.boolean("locked", default: false, null: false)
-    t.boolean("hidden", default: false, null: false)
-    t.decimal("box_area", precision: 21, scale: 10)
-    t.decimal("center_lat", precision: 15, scale: 10)
-    t.decimal("center_lng", precision: 15, scale: 10)
+  create_table "locations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "description_id"
+    t.integer "rss_log_id"
+    t.integer "num_views", default: 0
+    t.datetime "last_view", precision: nil
+    t.decimal "north", precision: 15, scale: 10, null: false
+    t.decimal "south", precision: 15, scale: 10, null: false
+    t.decimal "west", precision: 15, scale: 10, null: false
+    t.decimal "east", precision: 15, scale: 10, null: false
+    t.float "high"
+    t.float "low"
+    t.boolean "ok_for_export", default: true, null: false
+    t.text "notes"
+    t.string "name", limit: 1024
+    t.string "scientific_name", limit: 1024
+    t.boolean "locked", default: false, null: false
+    t.boolean "hidden", default: false, null: false
+    t.decimal "box_area", precision: 21, scale: 10
+    t.decimal "center_lat", precision: 15, scale: 10
+    t.decimal "center_lng", precision: 15, scale: 10
   end
 
-  create_table "name_description_admins", charset: "utf8mb3",
-                                          force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "name_description_admins", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "name_description_authors", charset: "utf8mb3",
-                                           force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_id", default: 0, null: false)
+  create_table "name_description_authors", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_id", default: 0, null: false
   end
 
-  create_table "name_description_editors", charset: "utf8mb3",
-                                           force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_id", default: 0, null: false)
+  create_table "name_description_editors", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_id", default: 0, null: false
   end
 
-  create_table "name_description_readers", charset: "utf8mb3",
-                                           force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "name_description_readers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "name_description_versions", id: :integer, charset: "utf8mb3",
-                                            force: :cascade do |t|
-    t.integer("name_description_id")
-    t.integer("version")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("license_id")
-    t.integer("merge_source_id")
-    t.text("gen_desc")
-    t.text("diag_desc")
-    t.text("distribution")
-    t.text("habitat")
-    t.text("look_alikes")
-    t.text("uses")
-    t.text("notes")
-    t.text("refs")
+  create_table "name_description_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id"
+    t.integer "version"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "license_id"
+    t.integer "merge_source_id"
+    t.text "gen_desc"
+    t.text "diag_desc"
+    t.text "distribution"
+    t.text "habitat"
+    t.text "look_alikes"
+    t.text "uses"
+    t.text "notes"
+    t.text "refs"
   end
 
-  create_table "name_description_writers", charset: "utf8mb3",
-                                           force: :cascade do |t|
-    t.integer("name_description_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+  create_table "name_description_writers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_description_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "name_descriptions", id: :integer, charset: "utf8mb3",
-                                    force: :cascade do |t|
-    t.integer("version")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("name_id")
-    t.integer("review_status", default: 1)
-    t.datetime("last_review", precision: nil)
-    t.integer("reviewer_id")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.integer("num_views", default: 0)
-    t.datetime("last_view", precision: nil)
-    t.integer("source_type")
-    t.string("source_name", limit: 100)
-    t.string("locale", limit: 8)
-    t.boolean("public")
-    t.integer("license_id")
-    t.text("gen_desc")
-    t.text("diag_desc")
-    t.text("distribution")
-    t.text("habitat")
-    t.text("look_alikes")
-    t.text("uses")
-    t.text("notes")
-    t.text("refs")
-    t.integer("project_id")
+  create_table "name_descriptions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "name_id"
+    t.integer "review_status", default: 1
+    t.datetime "last_review", precision: nil
+    t.integer "reviewer_id"
+    t.boolean "ok_for_export", default: true, null: false
+    t.integer "num_views", default: 0
+    t.datetime "last_view", precision: nil
+    t.integer "source_type"
+    t.string "source_name", limit: 100
+    t.string "locale", limit: 8
+    t.boolean "public"
+    t.integer "license_id"
+    t.text "gen_desc"
+    t.text "diag_desc"
+    t.text "distribution"
+    t.text "habitat"
+    t.text "look_alikes"
+    t.text "uses"
+    t.text "notes"
+    t.text "refs"
+    t.integer "project_id"
   end
 
-  create_table "name_trackers", id: :integer, charset: "utf8mb3",
-                                force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("name_id")
-    t.text("note_template")
-    t.datetime("updated_at", precision: nil)
-    t.boolean("require_specimen", default: false, null: false)
-    t.boolean("approved", default: true, null: false)
+  create_table "name_trackers", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id", default: 0, null: false
+    t.integer "name_id"
+    t.text "note_template"
+    t.datetime "updated_at", precision: nil
+    t.boolean "require_specimen", default: false, null: false
+    t.boolean "approved", default: true, null: false
   end
 
-  create_table "name_versions", id: :integer, charset: "utf8mb3",
-                                force: :cascade do |t|
-    t.integer("name_id")
-    t.integer("version")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.string("text_name", limit: 100)
-    t.string("search_name", limit: 221)
-    t.string("display_name", limit: 204)
-    t.string("sort_name", limit: 241)
-    t.string("author", limit: 100)
-    t.text("citation")
-    t.boolean("deprecated", default: false, null: false)
-    t.integer("correct_spelling_id")
-    t.text("notes")
-    t.integer("rank")
-    t.string("lifeform", limit: 1024, default: " ", null: false)
-    t.integer("icn_id")
-    t.text("classification")
-    t.index(%w[name_id version],
-            name: "index_name_versions_on_name_id_and_version")
+  create_table "name_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "name_id"
+    t.integer "version"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.string "text_name", limit: 100
+    t.string "search_name", limit: 221
+    t.string "display_name", limit: 204
+    t.string "sort_name", limit: 241
+    t.string "author", limit: 100
+    t.text "citation"
+    t.boolean "deprecated", default: false, null: false
+    t.integer "correct_spelling_id"
+    t.text "notes"
+    t.integer "rank"
+    t.string "lifeform", limit: 1024, default: " ", null: false
+    t.integer "icn_id"
+    t.text "classification"
+    t.index ["name_id", "version"], name: "index_name_versions_on_name_id_and_version"
   end
 
   create_table "names", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.integer("version")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("description_id")
-    t.integer("rss_log_id")
-    t.integer("num_views", default: 0)
-    t.datetime("last_view", precision: nil)
-    t.integer("rank")
-    t.string("text_name", limit: 100)
-    t.string("search_name", limit: 221)
-    t.string("display_name", limit: 204)
-    t.string("sort_name", limit: 241)
-    t.text("citation")
-    t.boolean("deprecated", default: false, null: false)
-    t.integer("synonym_id")
-    t.integer("correct_spelling_id")
-    t.text("notes")
-    t.text("classification")
-    t.boolean("ok_for_export", default: true, null: false)
-    t.string("author", limit: 100)
-    t.string("lifeform", limit: 1024, default: " ", null: false)
-    t.boolean("locked", default: false, null: false)
-    t.integer("icn_id")
-    t.index(["synonym_id"], name: "synonym_index")
+    t.integer "version"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "description_id"
+    t.integer "rss_log_id"
+    t.integer "num_views", default: 0
+    t.datetime "last_view", precision: nil
+    t.integer "rank"
+    t.string "text_name", limit: 100
+    t.string "search_name", limit: 221
+    t.string "display_name", limit: 204
+    t.string "sort_name", limit: 241
+    t.text "citation"
+    t.boolean "deprecated", default: false, null: false
+    t.integer "synonym_id"
+    t.integer "correct_spelling_id"
+    t.text "notes"
+    t.text "classification"
+    t.boolean "ok_for_export", default: true, null: false
+    t.string "author", limit: 100
+    t.string "lifeform", limit: 1024, default: " ", null: false
+    t.boolean "locked", default: false, null: false
+    t.integer "icn_id"
+    t.index ["synonym_id"], name: "synonym_index"
   end
 
-  create_table "naming_reasons", id: :integer, charset: "utf8mb3",
-                                 force: :cascade do |t|
-    t.integer("naming_id")
-    t.integer("reason")
-    t.text("notes")
+  create_table "naming_reasons", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "naming_id"
+    t.integer "reason"
+    t.text "notes"
   end
 
-  create_table "namings", id: :integer, charset: "utf8mb3",
-                          force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("observation_id")
-    t.integer("name_id")
-    t.integer("user_id")
-    t.float("vote_cache", default: 0.0)
-    t.text("reasons")
-    t.index(["observation_id"], name: "index_namings_on_observation_id")
+  create_table "namings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "observation_id"
+    t.integer "name_id"
+    t.integer "user_id"
+    t.float "vote_cache", default: 0.0
+    t.text "reasons"
+    t.index ["observation_id"], name: "index_namings_on_observation_id"
   end
 
-  create_table "observation_collection_numbers", charset: "utf8mb3",
-                                                 force: :cascade do |t|
-    t.integer("collection_number_id")
-    t.integer("observation_id")
+  create_table "observation_collection_numbers", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "collection_number_id"
+    t.integer "observation_id"
   end
 
-  create_table "observation_herbarium_records", charset: "utf8mb3",
-                                                force: :cascade do |t|
-    t.integer("observation_id", default: 0, null: false)
-    t.integer("herbarium_record_id", default: 0, null: false)
+  create_table "observation_herbarium_records", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "observation_id", default: 0, null: false
+    t.integer "herbarium_record_id", default: 0, null: false
   end
 
   create_table "observation_images", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("image_id", default: 0, null: false)
-    t.integer("observation_id", default: 0, null: false)
-    t.integer("rank", default: 0, null: false)
-    t.index(["image_id"], name: "index_observation_images_on_image_id")
-    t.index(["observation_id"],
-            name: "index_observation_images_on_observation_id")
+    t.integer "image_id", default: 0, null: false
+    t.integer "observation_id", default: 0, null: false
+    t.integer "rank", default: 0, null: false
+    t.index ["image_id"], name: "index_observation_images_on_image_id"
+    t.index ["observation_id"], name: "index_observation_images_on_observation_id"
   end
 
   create_table "observation_views", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("observation_id")
-    t.integer("user_id")
-    t.datetime("last_view", precision: nil)
-    t.boolean("reviewed")
-    t.index(["observation_id"], name: "observation_index")
-    t.index(["user_id"], name: "user_index")
+    t.integer "observation_id"
+    t.integer "user_id"
+    t.datetime "last_view", precision: nil
+    t.boolean "reviewed"
+    t.index ["observation_id"], name: "observation_index"
+    t.index ["user_id"], name: "user_index"
   end
 
-  create_table "observations", id: { type: :integer, unsigned: true },
-                               charset: "utf8mb3", force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.date("when")
-    t.integer("user_id")
-    t.boolean("specimen", default: false, null: false)
-    t.text("notes")
-    t.integer("thumb_image_id")
-    t.integer("name_id")
-    t.integer("location_id")
-    t.boolean("is_collection_location", default: true, null: false)
-    t.float("vote_cache", default: 0.0)
-    t.integer("num_views", default: 0, null: false)
-    t.datetime("last_view", precision: nil)
-    t.integer("rss_log_id")
-    t.decimal("lat", precision: 15, scale: 10)
-    t.decimal("lng", precision: 15, scale: 10)
-    t.string("where", limit: 1024)
-    t.integer("alt")
-    t.string("lifeform", limit: 1024)
-    t.string("text_name", limit: 100)
-    t.boolean("gps_hidden", default: false, null: false)
-    t.integer("source")
-    t.datetime("log_updated_at", precision: nil)
-    t.boolean("needs_naming", default: false, null: false)
-    t.integer("inat_id")
-    t.decimal("location_lat", precision: 15, scale: 10)
-    t.decimal("location_lng", precision: 15, scale: 10)
-    t.integer("occurrence_id")
-    t.boolean("gps_dubious", default: false, null: false)
-    t.string("collector", limit: 1024)
-    t.integer("collector_user_id")
-    t.integer("inat_import_id")
-    t.index(["collector_user_id"],
-            name: "index_observations_on_collector_user_id")
-    t.index(["inat_import_id"], name: "index_observations_on_inat_import_id")
-    t.index(["location_id"], name: "index_observations_on_location_id")
-    t.index(["name_id"], name: "index_observations_on_name_id")
-    t.index(["needs_naming"], name: "needs_naming_index")
-    t.index(["occurrence_id"], name: "index_observations_on_occurrence_id")
+  create_table "observations", id: { type: :integer, unsigned: true }, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.date "when"
+    t.integer "user_id"
+    t.boolean "specimen", default: false, null: false
+    t.text "notes"
+    t.integer "thumb_image_id"
+    t.integer "name_id"
+    t.integer "location_id"
+    t.boolean "is_collection_location", default: true, null: false
+    t.float "vote_cache", default: 0.0
+    t.integer "num_views", default: 0, null: false
+    t.datetime "last_view", precision: nil
+    t.integer "rss_log_id"
+    t.decimal "lat", precision: 15, scale: 10
+    t.decimal "lng", precision: 15, scale: 10
+    t.string "where", limit: 1024
+    t.integer "alt"
+    t.string "lifeform", limit: 1024
+    t.string "text_name", limit: 100
+    t.boolean "gps_hidden", default: false, null: false
+    t.integer "source"
+    t.datetime "log_updated_at", precision: nil
+    t.boolean "needs_naming", default: false, null: false
+    t.integer "inat_id"
+    t.decimal "location_lat", precision: 15, scale: 10
+    t.decimal "location_lng", precision: 15, scale: 10
+    t.integer "occurrence_id"
+    t.boolean "gps_dubious", default: false, null: false
+    t.string "collector", limit: 1024
+    t.integer "collector_user_id"
+    t.integer "inat_import_id"
+    t.index ["collector_user_id"], name: "index_observations_on_collector_user_id"
+    t.index ["inat_import_id"], name: "index_observations_on_inat_import_id"
+    t.index ["location_id"], name: "index_observations_on_location_id"
+    t.index ["name_id"], name: "index_observations_on_name_id"
+    t.index ["needs_naming"], name: "needs_naming_index"
+    t.index ["occurrence_id"], name: "index_observations_on_occurrence_id"
   end
 
-  create_table "occurrences", id: :integer, charset: "utf8mb4",
-                              collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("user_id")
-    t.integer("primary_observation_id")
-    t.boolean("has_specimen", default: false, null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.integer("field_slip_id")
-    t.index(["field_slip_id"], name: "index_occurrences_on_field_slip_id",
-                               unique: true)
-    t.index(["primary_observation_id"],
-            name: "index_occurrences_on_primary_observation_id")
-    t.index(["user_id"], name: "index_occurrences_on_user_id")
+  create_table "occurrences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "primary_observation_id"
+    t.boolean "has_specimen", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "field_slip_id"
+    t.index ["field_slip_id"], name: "index_occurrences_on_field_slip_id", unique: true
+    t.index ["primary_observation_id"], name: "index_occurrences_on_primary_observation_id"
+    t.index ["user_id"], name: "index_occurrences_on_user_id"
   end
 
-  create_table "original_image_requests", charset: "utf8mb4",
-                                          collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("user_id")
-    t.integer("image_id")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+  create_table "original_image_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "image_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "project_aliases", charset: "utf8mb4",
-                                  collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id", null: false)
-    t.integer("target_id", null: false)
-    t.string("target_type", null: false)
-    t.string("name")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(%w[name project_id],
-            name: "index_project_aliases_on_name_and_project_id", unique: true)
-    t.index(["project_id"], name: "index_project_aliases_on_project_id")
-    t.index(%w[target_type target_id],
-            name: "index_project_aliases_on_target_type_and_target_id")
+  create_table "project_aliases", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.integer "target_id", null: false
+    t.string "target_type", null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "project_id"], name: "index_project_aliases_on_name_and_project_id", unique: true
+    t.index ["project_id"], name: "index_project_aliases_on_project_id"
+    t.index ["target_type", "target_id"], name: "index_project_aliases_on_target_type_and_target_id"
   end
 
-  create_table "project_excluded_observations", charset: "utf8mb4",
-                                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("observation_id", null: false)
-    t.integer("project_id", null: false)
-    t.index(["observation_id"],
-            name: "index_project_excluded_observations_on_observation_id")
-    t.index(%w[project_id observation_id],
-            name: "index_project_excluded_observations_on_project_and_obs", unique: true)
-    t.index(["project_id"],
-            name: "index_project_excluded_observations_on_project_id")
+  create_table "project_excluded_observations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "observation_id", null: false
+    t.integer "project_id", null: false
+    t.index ["observation_id"], name: "index_project_excluded_observations_on_observation_id"
+    t.index ["project_id", "observation_id"], name: "index_project_excluded_observations_on_project_and_obs", unique: true
+    t.index ["project_id"], name: "index_project_excluded_observations_on_project_id"
   end
 
   create_table "project_images", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("image_id", null: false)
-    t.integer("project_id", null: false)
+    t.integer "image_id", null: false
+    t.integer "project_id", null: false
   end
 
-  create_table "project_members", charset: "utf8mb4",
-                                  collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id")
-    t.integer("user_id")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.integer("trust_level", default: 1, null: false)
+  create_table "project_members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "trust_level", default: 1, null: false
   end
 
-  create_table "project_observations", charset: "utf8mb3",
-                                       force: :cascade do |t|
-    t.integer("observation_id", null: false)
-    t.integer("project_id", null: false)
-    t.index(["observation_id"],
-            name: "index_project_observations_on_observation_id")
-    t.index(["project_id"], name: "index_project_observations_on_project_id")
+  create_table "project_observations", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "observation_id", null: false
+    t.integer "project_id", null: false
+    t.index ["observation_id"], name: "index_project_observations_on_observation_id"
+    t.index ["project_id"], name: "index_project_observations_on_project_id"
   end
 
-  create_table "project_species_lists", charset: "utf8mb3",
-                                        force: :cascade do |t|
-    t.integer("project_id", null: false)
-    t.integer("species_list_id", null: false)
+  create_table "project_species_lists", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.integer "species_list_id", null: false
   end
 
-  create_table "project_target_locations", charset: "utf8mb4",
-                                           collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id", null: false)
-    t.integer("location_id", null: false)
-    t.index(["location_id"],
-            name: "index_project_target_locations_on_location_id")
-    t.index(%w[project_id location_id],
-            name: "index_project_target_locations_on_project_id_and_location_id", unique: true)
-    t.index(["project_id"],
-            name: "index_project_target_locations_on_project_id")
+  create_table "project_target_locations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.integer "location_id", null: false
+    t.index ["location_id"], name: "index_project_target_locations_on_location_id"
+    t.index ["project_id", "location_id"], name: "index_project_target_locations_on_project_id_and_location_id", unique: true
+    t.index ["project_id"], name: "index_project_target_locations_on_project_id"
   end
 
-  create_table "project_target_names", charset: "utf8mb4",
-                                       collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("project_id", null: false)
-    t.integer("name_id", null: false)
-    t.index(["name_id"], name: "index_project_target_names_on_name_id")
-    t.index(%w[project_id name_id],
-            name: "index_project_target_names_on_project_id_and_name_id", unique: true)
-    t.index(["project_id"], name: "index_project_target_names_on_project_id")
+  create_table "project_target_names", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "project_id", null: false
+    t.integer "name_id", null: false
+    t.index ["name_id"], name: "index_project_target_names_on_name_id"
+    t.index ["project_id", "name_id"], name: "index_project_target_names_on_project_id_and_name_id", unique: true
+    t.index ["project_id"], name: "index_project_target_names_on_project_id"
   end
 
-  create_table "projects", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("admin_group_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
-    t.string("title", limit: 100, default: "", null: false)
-    t.text("summary")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("rss_log_id")
-    t.boolean("open_membership", default: false, null: false)
-    t.integer("location_id")
-    t.integer("image_id")
-    t.date("start_date")
-    t.date("end_date")
-    t.string("field_slip_prefix")
-    t.integer("next_field_slip", default: 0, null: false)
-    t.index(["field_slip_prefix"], name: "index_projects_on_field_slip_prefix",
-                                   unique: true)
+  create_table "projects", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id", default: 0, null: false
+    t.integer "admin_group_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
+    t.string "title", limit: 100, default: "", null: false
+    t.text "summary"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "rss_log_id"
+    t.boolean "open_membership", default: false, null: false
+    t.integer "location_id"
+    t.integer "image_id"
+    t.date "start_date"
+    t.date "end_date"
+    t.string "field_slip_prefix"
+    t.integer "next_field_slip", default: 0, null: false
+    t.index ["field_slip_prefix"], name: "index_projects_on_field_slip_prefix", unique: true
   end
 
-  create_table "publications", id: :integer, charset: "utf8mb3",
-                               force: :cascade do |t|
-    t.integer("user_id")
-    t.text("full")
-    t.string("link")
-    t.text("how_helped")
-    t.boolean("mo_mentioned")
-    t.boolean("peer_reviewed")
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
+  create_table "publications", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id"
+    t.text "full"
+    t.string "link"
+    t.text "how_helped"
+    t.boolean "mo_mentioned"
+    t.boolean "peer_reviewed"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
   end
 
-  create_table "query_records", id: :integer, charset: "utf8mb3",
-                                force: :cascade do |t|
-    t.datetime("updated_at", precision: nil)
-    t.integer("access_count")
-    t.text("description")
-    t.boolean("permalink", default: false)
+  create_table "query_records", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "updated_at", precision: nil
+    t.integer "access_count"
+    t.text "description"
+    t.boolean "permalink", default: false
   end
 
-  create_table "rss_logs", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
-    t.integer("observation_id")
-    t.integer("species_list_id")
-    t.datetime("updated_at", precision: nil)
-    t.text("notes")
-    t.integer("name_id")
-    t.integer("location_id")
-    t.integer("project_id")
-    t.integer("glossary_term_id")
-    t.integer("article_id")
-    t.datetime("created_at", precision: nil, null: false)
-    t.index(["observation_id"], name: "index_rss_logs_on_observation_id")
-    t.index(["updated_at"], name: "index_rss_logs_on_updated_at")
+  create_table "rss_logs", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "observation_id"
+    t.integer "species_list_id"
+    t.datetime "updated_at", precision: nil
+    t.text "notes"
+    t.integer "name_id"
+    t.integer "location_id"
+    t.integer "project_id"
+    t.integer "glossary_term_id"
+    t.integer "article_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.index ["observation_id"], name: "index_rss_logs_on_observation_id"
+    t.index ["updated_at"], name: "index_rss_logs_on_updated_at"
   end
 
-  create_table "sequences", id: :integer, charset: "utf8mb4",
-                            collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("observation_id")
-    t.integer("user_id")
-    t.text("locus", size: :medium)
-    t.text("bases", size: :medium)
-    t.string("archive")
-    t.string("accession")
-    t.text("notes", size: :medium)
-    t.datetime("created_at", precision: nil, null: false)
-    t.datetime("updated_at", precision: nil, null: false)
+  create_table "sequences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "observation_id"
+    t.integer "user_id"
+    t.text "locus", size: :medium
+    t.text "bases", size: :medium
+    t.string "archive"
+    t.string "accession"
+    t.text "notes", size: :medium
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "solid_cable_messages", charset: "utf8mb4",
-                                       collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.binary("channel", limit: 1024, null: false)
-    t.binary("payload", size: :long, null: false)
-    t.datetime("created_at", null: false)
-    t.bigint("channel_hash", null: false)
-    t.index(["channel"], name: "index_solid_cable_messages_on_channel")
-    t.index(["channel_hash"],
-            name: "index_solid_cable_messages_on_channel_hash")
-    t.index(["created_at"], name: "index_solid_cable_messages_on_created_at")
+  create_table "solid_cable_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.binary "payload", size: :long, null: false
+    t.datetime "created_at", null: false
+    t.bigint "channel_hash", null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
   end
 
-  create_table "solid_queue_blocked_executions", charset: "utf8mb4",
-                                                 collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.string("queue_name", null: false)
-    t.integer("priority", default: 0, null: false)
-    t.string("concurrency_key", null: false)
-    t.datetime("expires_at", null: false)
-    t.datetime("created_at", null: false)
-    t.index(%w[concurrency_key priority job_id],
-            name: "index_solid_queue_blocked_executions_for_release")
-    t.index(%w[expires_at concurrency_key],
-            name: "index_solid_queue_blocked_executions_for_maintenance")
-    t.index(["job_id"], name: "index_solid_queue_blocked_executions_on_job_id",
-                        unique: true)
+  create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_claimed_executions", charset: "utf8mb4",
-                                                 collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.bigint("process_id")
-    t.datetime("created_at", null: false)
-    t.index(["job_id"], name: "index_solid_queue_claimed_executions_on_job_id",
-                        unique: true)
-    t.index(%w[process_id job_id],
-            name: "index_solid_queue_claimed_executions_on_process_id_and_job_id")
+  create_table "solid_queue_claimed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
-  create_table "solid_queue_failed_executions", charset: "utf8mb4",
-                                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.text("error")
-    t.datetime("created_at", null: false)
-    t.index(["job_id"], name: "index_solid_queue_failed_executions_on_job_id",
-                        unique: true)
+  create_table "solid_queue_failed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_jobs", charset: "utf8mb4",
-                                   collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("queue_name", null: false)
-    t.string("class_name", null: false)
-    t.text("arguments")
-    t.integer("priority", default: 0, null: false)
-    t.string("active_job_id")
-    t.datetime("scheduled_at")
-    t.datetime("finished_at")
-    t.string("concurrency_key")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id")
-    t.index(["class_name"], name: "index_solid_queue_jobs_on_class_name")
-    t.index(["finished_at"], name: "index_solid_queue_jobs_on_finished_at")
-    t.index(%w[queue_name finished_at],
-            name: "index_solid_queue_jobs_for_filtering")
-    t.index(%w[scheduled_at finished_at],
-            name: "index_solid_queue_jobs_for_alerting")
+  create_table "solid_queue_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
   end
 
-  create_table "solid_queue_pauses", charset: "utf8mb4",
-                                     collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("queue_name", null: false)
-    t.datetime("created_at", null: false)
-    t.index(["queue_name"], name: "index_solid_queue_pauses_on_queue_name",
-                            unique: true)
+  create_table "solid_queue_pauses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
-  create_table "solid_queue_processes", charset: "utf8mb4",
-                                        collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("kind", null: false)
-    t.datetime("last_heartbeat_at", null: false)
-    t.bigint("supervisor_id")
-    t.integer("pid", null: false)
-    t.string("hostname")
-    t.text("metadata")
-    t.datetime("created_at", null: false)
-    t.string("name", null: false)
-    t.index(["last_heartbeat_at"],
-            name: "index_solid_queue_processes_on_last_heartbeat_at")
-    t.index(%w[name supervisor_id],
-            name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true)
-    t.index(["supervisor_id"],
-            name: "index_solid_queue_processes_on_supervisor_id")
+  create_table "solid_queue_processes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
-  create_table "solid_queue_ready_executions", charset: "utf8mb4",
-                                               collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.string("queue_name", null: false)
-    t.integer("priority", default: 0, null: false)
-    t.datetime("created_at", null: false)
-    t.index(["job_id"], name: "index_solid_queue_ready_executions_on_job_id",
-                        unique: true)
-    t.index(%w[priority job_id], name: "index_solid_queue_poll_all")
-    t.index(%w[queue_name priority job_id],
-            name: "index_solid_queue_poll_by_queue")
+  create_table "solid_queue_ready_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
-  create_table "solid_queue_recurring_executions", charset: "utf8mb4",
-                                                   collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.string("task_key", null: false)
-    t.datetime("run_at", null: false)
-    t.datetime("created_at", null: false)
-    t.index(["job_id"],
-            name: "index_solid_queue_recurring_executions_on_job_id", unique: true)
-    t.index(%w[task_key run_at],
-            name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true)
+  create_table "solid_queue_recurring_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
-  create_table "solid_queue_recurring_tasks", charset: "utf8mb4",
-                                              collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("key", null: false)
-    t.string("schedule", null: false)
-    t.string("command", limit: 2048)
-    t.string("class_name")
-    t.text("arguments")
-    t.string("queue_name")
-    t.integer("priority", default: 0)
-    t.boolean("static", default: true, null: false)
-    t.text("description")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["key"], name: "index_solid_queue_recurring_tasks_on_key",
-                     unique: true)
-    t.index(["static"], name: "index_solid_queue_recurring_tasks_on_static")
+  create_table "solid_queue_recurring_tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
-  create_table "solid_queue_scheduled_executions", charset: "utf8mb4",
-                                                   collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint("job_id", null: false)
-    t.string("queue_name", null: false)
-    t.integer("priority", default: 0, null: false)
-    t.datetime("scheduled_at", null: false)
-    t.datetime("created_at", null: false)
-    t.index(["job_id"],
-            name: "index_solid_queue_scheduled_executions_on_job_id", unique: true)
-    t.index(%w[scheduled_at priority job_id],
-            name: "index_solid_queue_dispatch_all")
+  create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
-  create_table "solid_queue_semaphores", charset: "utf8mb4",
-                                         collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("key", null: false)
-    t.integer("value", default: 1, null: false)
-    t.datetime("expires_at", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["expires_at"], name: "index_solid_queue_semaphores_on_expires_at")
-    t.index(%w[key value],
-            name: "index_solid_queue_semaphores_on_key_and_value")
-    t.index(["key"], name: "index_solid_queue_semaphores_on_key", unique: true)
+  create_table "solid_queue_semaphores", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
-  create_table "species_list_observations", charset: "utf8mb3",
-                                            force: :cascade do |t|
-    t.integer("observation_id", default: 0, null: false)
-    t.integer("species_list_id", default: 0, null: false)
+  create_table "species_list_observations", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "observation_id", default: 0, null: false
+    t.integer "species_list_id", default: 0, null: false
   end
 
-  create_table "species_lists", id: :integer, charset: "utf8mb3",
-                                force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.date("when")
-    t.integer("user_id")
-    t.string("where", limit: 1024)
-    t.string("title", limit: 100)
-    t.text("notes")
-    t.integer("rss_log_id")
-    t.integer("location_id")
+  create_table "species_lists", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.date "when"
+    t.integer "user_id"
+    t.string "where", limit: 1024
+    t.string "title", limit: 100
+    t.text "notes"
+    t.integer "rss_log_id"
+    t.integer "location_id"
   end
 
-  create_table "synonyms", id: :integer, charset: "utf8mb3",
-                           force: :cascade do |t|
+  create_table "synonyms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
   end
 
-  create_table "translation_string_versions", id: :integer, charset: "utf8mb3",
-                                              force: :cascade do |t|
-    t.integer("version")
-    t.integer("translation_string_id")
-    t.text("text")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
-    t.integer("language_id")
+  create_table "translation_string_versions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.integer "translation_string_id"
+    t.text "text"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
+    t.integer "language_id"
   end
 
-  create_table "translation_strings", id: :integer, charset: "utf8mb3",
-                                      force: :cascade do |t|
-    t.integer("version")
-    t.integer("language_id", null: false)
-    t.string("tag", limit: 100)
-    t.text("text")
-    t.datetime("updated_at", precision: nil)
-    t.integer("user_id")
+  create_table "translation_strings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "version"
+    t.integer "language_id", null: false
+    t.string "tag", limit: 100
+    t.text "text"
+    t.datetime "updated_at", precision: nil
+    t.integer "user_id"
   end
 
-  create_table "triples", id: :integer, charset: "utf8mb3",
-                          force: :cascade do |t|
-    t.string("subject", limit: 1024)
-    t.string("predicate", limit: 1024)
-    t.string("object", limit: 1024)
+  create_table "triples", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "subject", limit: 1024
+    t.string "predicate", limit: 1024
+    t.string "object", limit: 1024
   end
 
   create_table "user_group_users", charset: "utf8mb3", force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("user_group_id", default: 0, null: false)
+    t.integer "user_id", default: 0, null: false
+    t.integer "user_group_id", default: 0, null: false
   end
 
-  create_table "user_groups", id: :integer, charset: "utf8mb3",
-                              force: :cascade do |t|
-    t.string("name", default: "", null: false)
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.boolean("meta", default: false)
+  create_table "user_groups", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.boolean "meta", default: false
   end
 
-  create_table "user_stats", charset: "utf8mb4",
-                             collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("user_id", default: 0, null: false)
-    t.integer("comments", default: 0, null: false)
-    t.integer("images", default: 0, null: false)
-    t.integer("location_description_authors", default: 0, null: false)
-    t.integer("location_description_editors", default: 0, null: false)
-    t.integer("locations", default: 0, null: false)
-    t.integer("location_versions", default: 0, null: false)
-    t.integer("name_description_authors", default: 0, null: false)
-    t.integer("name_description_editors", default: 0, null: false)
-    t.integer("names", default: 0, null: false)
-    t.integer("name_versions", default: 0, null: false)
-    t.integer("namings", default: 0, null: false)
-    t.integer("observations", default: 0, null: false)
-    t.integer("sequences", default: 0, null: false)
-    t.integer("sequenced_observations", default: 0, null: false)
-    t.integer("species_list_entries", default: 0, null: false)
-    t.integer("species_lists", default: 0, null: false)
-    t.integer("translation_strings", default: 0, null: false)
-    t.integer("votes", default: 0, null: false)
-    t.string("languages")
-    t.string("bonuses")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["user_id"], name: "user_index")
+  create_table "user_stats", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id", default: 0, null: false
+    t.integer "comments", default: 0, null: false
+    t.integer "images", default: 0, null: false
+    t.integer "location_description_authors", default: 0, null: false
+    t.integer "location_description_editors", default: 0, null: false
+    t.integer "locations", default: 0, null: false
+    t.integer "location_versions", default: 0, null: false
+    t.integer "name_description_authors", default: 0, null: false
+    t.integer "name_description_editors", default: 0, null: false
+    t.integer "names", default: 0, null: false
+    t.integer "name_versions", default: 0, null: false
+    t.integer "namings", default: 0, null: false
+    t.integer "observations", default: 0, null: false
+    t.integer "sequences", default: 0, null: false
+    t.integer "sequenced_observations", default: 0, null: false
+    t.integer "species_list_entries", default: 0, null: false
+    t.integer "species_lists", default: 0, null: false
+    t.integer "translation_strings", default: 0, null: false
+    t.integer "votes", default: 0, null: false
+    t.string "languages"
+    t.string "bonuses"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "user_index"
   end
 
   create_table "users", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.string("login", limit: 80, default: "", null: false)
-    t.string("password", limit: 40, default: "", null: false)
-    t.string("email", limit: 80, default: "", null: false)
-    t.string("theme", limit: 40)
-    t.string("name", limit: 80)
-    t.datetime("created_at", precision: nil)
-    t.datetime("last_login", precision: nil)
-    t.datetime("verified", precision: nil)
-    t.integer("license_id", default: 10, null: false)
-    t.integer("contribution", default: 0)
-    t.integer("location_id")
-    t.integer("image_id")
-    t.string("locale", limit: 5)
-    t.boolean("email_comments_owner", default: true, null: false)
-    t.boolean("email_comments_response", default: true, null: false)
-    t.boolean("email_observations_consensus", default: true, null: false)
-    t.boolean("email_observations_naming", default: true, null: false)
-    t.boolean("email_names_author", default: true, null: false)
-    t.boolean("email_names_editor", default: false, null: false)
-    t.boolean("email_names_reviewer", default: true, null: false)
-    t.boolean("email_locations_author", default: true, null: false)
-    t.boolean("email_locations_editor", default: false, null: false)
-    t.boolean("email_general_feature", default: true, null: false)
-    t.boolean("email_general_commercial", default: true, null: false)
-    t.boolean("email_general_question", default: true, null: false)
-    t.boolean("email_html", default: true, null: false)
-    t.datetime("updated_at", precision: nil)
-    t.boolean("admin")
-    t.text("alert")
-    t.boolean("email_locations_admin", default: false)
-    t.boolean("email_names_admin", default: false)
-    t.integer("thumbnail_size", default: 1)
-    t.integer("image_size", default: 5)
-    t.string("default_rss_type", limit: 40, default: "all")
-    t.integer("votes_anonymous", default: 1)
-    t.integer("location_format", default: 1)
-    t.datetime("last_activity", precision: nil)
-    t.integer("hide_authors", default: 1, null: false)
-    t.boolean("thumbnail_maps", default: true, null: false)
-    t.string("auth_code", limit: 40)
-    t.integer("keep_filenames", default: 1, null: false)
-    t.text("notes")
-    t.text("mailing_address")
-    t.integer("layout_count")
-    t.boolean("view_owner_id", default: false, null: false)
-    t.string("content_filter")
-    t.text("notes_template")
-    t.boolean("blocked", default: false, null: false)
-    t.boolean("no_emails", default: false, null: false)
-    t.string("inat_username")
-    t.integer("original_image_quota", default: 0)
-    t.integer("label_format", default: 1)
-    t.index(["inat_username"], name: "index_users_on_inat_username")
-    t.index(["login"], name: "login_index")
-    t.index(["name"], name: "index_users_on_name")
+    t.string "login", limit: 80, default: "", null: false
+    t.string "password", limit: 40, default: "", null: false
+    t.string "email", limit: 80, default: "", null: false
+    t.string "theme", limit: 40
+    t.string "name", limit: 80
+    t.datetime "created_at", precision: nil
+    t.datetime "last_login", precision: nil
+    t.datetime "verified", precision: nil
+    t.integer "license_id", default: 10, null: false
+    t.integer "contribution", default: 0
+    t.integer "location_id"
+    t.integer "image_id"
+    t.string "locale", limit: 5
+    t.boolean "email_comments_owner", default: true, null: false
+    t.boolean "email_comments_response", default: true, null: false
+    t.boolean "email_observations_consensus", default: true, null: false
+    t.boolean "email_observations_naming", default: true, null: false
+    t.boolean "email_names_author", default: true, null: false
+    t.boolean "email_names_editor", default: false, null: false
+    t.boolean "email_names_reviewer", default: true, null: false
+    t.boolean "email_locations_author", default: true, null: false
+    t.boolean "email_locations_editor", default: false, null: false
+    t.boolean "email_general_feature", default: true, null: false
+    t.boolean "email_general_commercial", default: true, null: false
+    t.boolean "email_general_question", default: true, null: false
+    t.boolean "email_html", default: true, null: false
+    t.datetime "updated_at", precision: nil
+    t.boolean "admin"
+    t.text "alert"
+    t.boolean "email_locations_admin", default: false
+    t.boolean "email_names_admin", default: false
+    t.integer "thumbnail_size", default: 1
+    t.integer "image_size", default: 5
+    t.string "default_rss_type", limit: 40, default: "all"
+    t.integer "votes_anonymous", default: 1
+    t.integer "location_format", default: 1
+    t.datetime "last_activity", precision: nil
+    t.integer "hide_authors", default: 1, null: false
+    t.boolean "thumbnail_maps", default: true, null: false
+    t.string "auth_code", limit: 40
+    t.integer "keep_filenames", default: 1, null: false
+    t.text "notes"
+    t.text "mailing_address"
+    t.integer "layout_count"
+    t.boolean "view_owner_id", default: false, null: false
+    t.string "content_filter"
+    t.text "notes_template"
+    t.boolean "blocked", default: false, null: false
+    t.boolean "no_emails", default: false, null: false
+    t.string "inat_username"
+    t.integer "original_image_quota", default: 0
+    t.integer "label_format", default: 1
+    t.index ["inat_username"], name: "index_users_on_inat_username"
+    t.index ["login"], name: "login_index"
+    t.index ["name"], name: "index_users_on_name"
   end
 
-  create_table "visual_group_images", charset: "utf8mb4",
-                                      collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("image_id")
-    t.integer("visual_group_id")
-    t.boolean("included", default: true, null: false)
+  create_table "visual_group_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "image_id"
+    t.integer "visual_group_id"
+    t.boolean "included", default: true, null: false
   end
 
-  create_table "visual_groups", charset: "utf8mb4",
-                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer("visual_model_id")
-    t.string("name", null: false)
-    t.boolean("approved", default: false, null: false)
-    t.text("description")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+  create_table "visual_groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "visual_model_id"
+    t.string "name", null: false
+    t.boolean "approved", default: false, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "visual_models", charset: "utf8mb4",
-                                collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string("name", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+  create_table "visual_models", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "votes", id: :integer, charset: "utf8mb3", force: :cascade do |t|
-    t.datetime("created_at", precision: nil)
-    t.datetime("updated_at", precision: nil)
-    t.integer("naming_id")
-    t.integer("user_id")
-    t.integer("observation_id", default: 0)
-    t.boolean("favorite")
-    t.float("value")
-    t.index(["naming_id"], name: "naming_index")
-    t.index(["observation_id"], name: "observation_index")
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.integer "naming_id"
+    t.integer "user_id"
+    t.integer "observation_id", default: 0
+    t.boolean "favorite"
+    t.float "value"
+    t.index ["naming_id"], name: "naming_index"
+    t.index ["observation_id"], name: "observation_index"
   end
 
   add_foreign_key "observations", "users", column: "collector_user_id"
   add_foreign_key "project_aliases", "projects"
-  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
-  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs",
-                  column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
 end

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -163,7 +163,7 @@ class InatImportsControllerTest < FunctionalTestCase
     login(user.login)
     post(:create, params: params)
 
-    assert_not(import.reload.canceled?,
+    assert_not(created_import(user).canceled?,
                "`cancel` should be false when starting an import")
   end
 
@@ -309,7 +309,7 @@ class InatImportsControllerTest < FunctionalTestCase
     end
 
     assert_response(:redirect)
-    assert_equal(id_list, inat_import.reload.inat_ids,
+    assert_equal(id_list, created_import(user).inat_ids,
                  "Failed to save inat_ids at maximum length")
   end
 
@@ -342,12 +342,13 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_ids: inat_ids, inat_username: "rolf",
                    consent: 1, confirmed: 1 })
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL,
+    import = created_import(user)
+    assert_redirected_to("#{INAT_AUTHORIZATION_URL}&state=#{import.id}",
                          "Newline-delimited IDs should pass validation")
-    assert_equal(expected_ids, inat_import.reload.inat_ids,
+    assert_equal(expected_ids, import.inat_ids,
                  "Newline-delimited IDs should be normalized to " \
                  "comma-separated")
-    assert_equal(3, inat_import.reload.importables,
+    assert_equal(3, import.importables,
                  "importables_count should reflect the number of IDs")
   end
 
@@ -365,12 +366,13 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_ids: inat_ids, inat_username: "rolf",
                    consent: 1, confirmed: 1 })
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL,
+    import = created_import(user)
+    assert_redirected_to("#{INAT_AUTHORIZATION_URL}&state=#{import.id}",
                          "Input with a header row should pass validation")
-    assert_equal(expected_ids, inat_import.reload.inat_ids,
+    assert_equal(expected_ids, import.inat_ids,
                  "Non-digit header token should be stripped from " \
                  "stored inat_ids")
-    assert_equal(3, inat_import.reload.importables,
+    assert_equal(3, import.importables,
                  "importables_count should not include the header row token")
   end
 
@@ -452,7 +454,9 @@ class InatImportsControllerTest < FunctionalTestCase
     # It should continue even if some ids were previously imported
     # The job will exclude previous imports via the iNat API
     # `without_field: "Mushroom Observer URL"` param.
-    assert_redirected_to(INAT_AUTHORIZATION_URL)
+    assert_redirected_to(
+      "#{INAT_AUTHORIZATION_URL}&state=#{created_import(user).id}"
+    )
   end
 
   def test_create_strip_inat_username
@@ -482,7 +486,7 @@ class InatImportsControllerTest < FunctionalTestCase
     )
     assert_response(:redirect)
     assert_equal(
-      user.name, inat_import.reload.inat_username,
+      user.name, created_import(user).inat_username,
       "It should strip leading/trailing whitespace from inat_username"
     )
   end
@@ -508,16 +512,17 @@ class InatImportsControllerTest < FunctionalTestCase
                      consent: 1, confirmed: 1 })
     end
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL)
-    assert_equal(inat_ids.split(",").length, inat_import.reload.importables,
+    import = created_import(user)
+    assert_redirected_to("#{INAT_AUTHORIZATION_URL}&state=#{import.id}")
+    assert_equal(inat_ids.split(",").length, import.importables,
                  "Failed to save InatImport.importables")
-    assert_equal("Authorizing", inat_import.reload.state,
+    assert_equal("Authorizing", import.state,
                  "MO should be awaiting authorization from iNat")
     assert_equal(
       InatImport.sum(:total_seconds) / InatImport.sum(:total_imported_count),
-      inat_import.avg_import_time
+      import.avg_import_time
     )
-    assert_equal(inat_username, inat_import.inat_username,
+    assert_equal(inat_username, import.inat_username,
                  "Failed to save InatImport.inat_username")
   end
 
@@ -578,7 +583,6 @@ class InatImportsControllerTest < FunctionalTestCase
 
   def test_create_confirmed_with_superform_params
     user = users(:rolf)
-    inat_import = inat_imports(:rolf_inat_import)
     inat_username = "rolf"
     inat_ids = "123,456"
 
@@ -595,8 +599,9 @@ class InatImportsControllerTest < FunctionalTestCase
            }
          })
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL)
-    assert_equal(inat_username, inat_import.reload.inat_username,
+    import = created_import(user)
+    assert_redirected_to("#{INAT_AUTHORIZATION_URL}&state=#{import.id}")
+    assert_equal(inat_username, import.inat_username,
                  "Should flatten inat_username from namespaced params")
   end
 
@@ -630,7 +635,6 @@ class InatImportsControllerTest < FunctionalTestCase
   end
 
   def test_admin_checked_skip_writeback_persists_as_skip
-    inat_import = inat_imports(:rolf_inat_import)
     make_admin
 
     post(:create,
@@ -642,13 +646,13 @@ class InatImportsControllerTest < FunctionalTestCase
            }
          })
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL)
-    assert_equal("skip", inat_import.reload.writeback,
+    import = created_import(users(:rolf))
+    assert_redirected_to("#{INAT_AUTHORIZATION_URL}&state=#{import.id}")
+    assert_equal("skip", import.writeback,
                  "Admin's checked skip-writeback box should persist as :skip")
   end
 
   def test_admin_unchecked_skip_writeback_persists_as_force
-    inat_import = inat_imports(:rolf_inat_import)
     make_admin
 
     post(:create,
@@ -659,14 +663,14 @@ class InatImportsControllerTest < FunctionalTestCase
            }
          })
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL)
-    assert_equal("force", inat_import.reload.writeback,
+    import = created_import(users(:rolf))
+    assert_redirected_to("#{INAT_AUTHORIZATION_URL}&state=#{import.id}")
+    assert_equal("force", import.writeback,
                  "Admin's unchecked skip box should persist as :force")
   end
 
   def test_non_admin_leaves_writeback_default
     user = users(:rolf)
-    inat_import = inat_imports(:rolf_inat_import)
     login(user.login)
 
     post(:create,
@@ -678,8 +682,9 @@ class InatImportsControllerTest < FunctionalTestCase
            }
          })
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL)
-    assert_equal("default", inat_import.reload.writeback,
+    import = created_import(user)
+    assert_redirected_to("#{INAT_AUTHORIZATION_URL}&state=#{import.id}")
+    assert_equal("default", import.writeback,
                  "Non-admin import should leave writeback :default so the " \
                  "importer applies its environment default")
   end
@@ -942,7 +947,10 @@ class InatImportsControllerTest < FunctionalTestCase
     login(user.login)
     post(:create, params: params)
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL, allow_other_host: true)
+    assert_redirected_to(
+      "#{INAT_AUTHORIZATION_URL}&state=#{created_import(user).id}",
+      allow_other_host: true
+    )
   end
 
   def test_allow_first_time_import_all
@@ -953,7 +961,10 @@ class InatImportsControllerTest < FunctionalTestCase
     login(user.login)
     post(:create, params: params)
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL, allow_other_host: true)
+    assert_redirected_to(
+      "#{INAT_AUTHORIZATION_URL}&state=#{created_import(user).id}",
+      allow_other_host: true
+    )
   end
 
   def test_import_all_anothers_observations_not_allowed
@@ -1012,7 +1023,10 @@ class InatImportsControllerTest < FunctionalTestCase
     login(user.login)
     post(:create, params: params)
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL, allow_other_host: true)
+    assert_redirected_to(
+      "#{INAT_AUTHORIZATION_URL}&state=#{created_import(user).id}",
+      allow_other_host: true
+    )
   end
 
   def test_super_importer_can_import_specific_ids_from_another_user
@@ -1025,7 +1039,9 @@ class InatImportsControllerTest < FunctionalTestCase
     login(user.login)
     post(:create, params: params)
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL)
+    assert_redirected_to(
+      "#{INAT_AUTHORIZATION_URL}&state=#{created_import(user).id}"
+    )
   end
 
   def test_import_authorized
@@ -1037,7 +1053,8 @@ class InatImportsControllerTest < FunctionalTestCase
     # empty id_list to prevent importing any observations in this test
     inat_import.inat_ids = ""
     inat_import.save
-    inat_authorization_callback_params = { code: "MockCode" }
+    inat_authorization_callback_params = { code: "MockCode",
+                                           state: inat_import.id }
 
     login(user.login)
 
@@ -1363,7 +1380,6 @@ class InatImportsControllerTest < FunctionalTestCase
 
   def test_create_confirmed_with_url_saves_inat_url
     user = users(:rolf)
-    inat_import = inat_imports(:rolf_inat_import)
     url = "#{INAT_SITE_OBS_URL}?project_id=291058"
     normalized = "project_id=291058"
 
@@ -1372,15 +1388,15 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1, confirmed: 1 })
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL,
+    import = created_import(user)
+    assert_redirected_to("#{INAT_AUTHORIZATION_URL}&state=#{import.id}",
                          "Confirmed URL import should redirect to iNat auth")
-    assert_equal(normalized, inat_import.reload.inat_url,
+    assert_equal(normalized, import.inat_url,
                  "Normalized URL query string should be saved on InatImport")
   end
 
   def test_url_mode_importables_is_nil
     user = users(:rolf)
-    inat_import = inat_imports(:rolf_inat_import)
     url = "#{INAT_SITE_OBS_URL}?project_id=291058"
 
     login(user.login)
@@ -1388,7 +1404,7 @@ class InatImportsControllerTest < FunctionalTestCase
          params: { inat_url: url, inat_username: "rolf_inat_user",
                    consent: 1, confirmed: 1 })
 
-    assert_nil(inat_import.reload.importables,
+    assert_nil(created_import(user).importables,
                "URL mode should save nil importables (unknown until job runs)")
   end
 
@@ -1537,7 +1553,6 @@ class InatImportsControllerTest < FunctionalTestCase
 
   def test_url_params_preserved_through_confirm_round_trip
     user = users(:rolf)
-    inat_import = inat_imports(:rolf_inat_import)
     normalized = "project_id=291058"
 
     login(user.login)
@@ -1553,9 +1568,10 @@ class InatImportsControllerTest < FunctionalTestCase
            }
          })
 
-    assert_redirected_to(INAT_AUTHORIZATION_URL,
+    import = created_import(user)
+    assert_redirected_to("#{INAT_AUTHORIZATION_URL}&state=#{import.id}",
                          "Confirmed URL via superform params should auth")
-    assert_equal(normalized, inat_import.reload.inat_url,
+    assert_equal(normalized, import.inat_url,
                  "inat_url should be saved from superform hidden field")
   end
 
@@ -1614,6 +1630,12 @@ class InatImportsControllerTest < FunctionalTestCase
   end
 
   ########## Utilities
+
+  # Each import now creates a brand-new persistent InatImport record; the
+  # freshly created one is the last by created_at for the logged-in user.
+  def created_import(user)
+    InatImport.where(user: user).order(:created_at).last
+  end
 
   def authorization_denial_callback_params
     { error: "access_denied",

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -1050,9 +1050,10 @@ class InatImportsControllerTest < FunctionalTestCase
                  "Test needs user fixture without an iNat username")
     inat_import = inat_imports(:rolf_inat_import)
 
-    # empty id_list to prevent importing any observations in this test
-    inat_import.inat_ids = ""
-    inat_import.save
+    # Empty id_list prevents importing observations. Authorizing is the
+    # state init_ivars leaves the record in before the iNat redirect, and
+    # the only state the callback resumes.
+    inat_import.update!(inat_ids: "", state: "Authorizing")
     inat_authorization_callback_params = { code: "MockCode",
                                            state: inat_import.id }
 
@@ -1072,6 +1073,27 @@ class InatImportsControllerTest < FunctionalTestCase
       "When job starts, elapsed time for 1st import should be <= 0.5 seconds"
     )
 
+    assert_redirected_to(inat_import_path(inat_import))
+  end
+
+  def test_authorization_response_ignores_repeated_callback
+    user = users(:rolf)
+    inat_import = inat_imports(:rolf_inat_import)
+    # An import that has already progressed past authorization.
+    inat_import.update!(state: "Importing", token: "existing")
+
+    login(user.login)
+
+    assert_no_difference(
+      "enqueued_jobs.size",
+      "A repeated or late callback must not enqueue another job"
+    ) do
+      get(:authorization_response,
+          params: { code: "MockCode", state: inat_import.id })
+    end
+
+    assert_equal("Importing", inat_import.reload.state,
+                 "Callback must not regress a running import")
     assert_redirected_to(inat_import_path(inat_import))
   end
 
@@ -1632,9 +1654,10 @@ class InatImportsControllerTest < FunctionalTestCase
   ########## Utilities
 
   # Each import now creates a brand-new persistent InatImport record; the
-  # freshly created one is the last by created_at for the logged-in user.
+  # freshly created one is the last by id (deterministic insertion order,
+  # unlike created_at which can tie under coarse/frozen timestamps).
   def created_import(user)
-    InatImport.where(user: user).order(:created_at).last
+    InatImport.where(user: user).order(:id).last
   end
 
   def authorization_denial_callback_params

--- a/test/jobs/inat_import_recovery_job_test.rb
+++ b/test/jobs/inat_import_recovery_job_test.rb
@@ -40,4 +40,30 @@ class InatImportRecoveryJobTest < ActiveJob::TestCase
     assert_equal(original_errors, import.response_errors,
                  "Done import should not be modified")
   end
+
+  def test_marks_abandoned_authorizing_import_as_done
+    import = inat_imports(:rolf_inat_import)
+    import.update!(state: "Authorizing")
+    import.update_column(:updated_at,
+                         InatImport::ABANDONED_THRESHOLD.ago - 1.second)
+
+    InatImportRecoveryJob.perform_now
+
+    import.reload
+    assert_equal("Done", import.state,
+                 "Abandoned import should be marked Done")
+    assert_not_nil(import.ended_at, "Abandoned import should have ended_at set")
+    assert_match(/Authorization was not completed/, import.response_errors,
+                 "Abandoned import should note the incomplete authorization")
+  end
+
+  def test_does_not_touch_recent_authorizing_import
+    import = inat_imports(:rolf_inat_import)
+    import.update!(state: "Authorizing")
+
+    InatImportRecoveryJob.perform_now
+
+    assert_equal("Authorizing", import.reload.state,
+                 "Recently started authorizing import should not be touched")
+  end
 end

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -160,6 +160,23 @@ class InatImportTest < ActiveSupport::TestCase
     assert_not(import.stuck?, "Done import should not be stuck")
   end
 
+  def test_abandoned_scope
+    stale = inat_imports(:rolf_inat_import)
+    stale.update!(state: "Authorizing")
+    stale.update_column(:updated_at,
+                        InatImport::ABANDONED_THRESHOLD.ago - 1.second)
+    recent = inat_imports(:mary_inat_import)
+    recent.update!(state: "Authenticating")
+
+    abandoned = InatImport.abandoned
+    assert_includes(abandoned, stale,
+                    "Stale Authorizing import should be abandoned")
+    assert_not_includes(abandoned, recent,
+                        "Recent Authenticating import should not be abandoned")
+    assert_not_includes(abandoned, inat_imports(:katrina_inat_import),
+                        "Importing import is stuck, not abandoned")
+  end
+
   def test_ignored_total_count
     import = inat_imports(:rolf_inat_import)
     import.update!(

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -39,6 +39,21 @@ class InatImportTest < ActiveSupport::TestCase
                  import.total_expected_time)
   end
 
+  # A user's import history is summed across ALL their import records, not
+  # read off a single one, so it survives the move to one record per import.
+  def test_personal_avg_sums_across_a_users_imports
+    user = users(:rolf)
+    InatImport.where(user: user).
+      update_all(total_imported_count: nil, total_seconds: nil)
+    InatImport.create!(user: user, total_imported_count: 2, total_seconds: 20)
+    InatImport.create!(user: user, total_imported_count: 3, total_seconds: 40)
+
+    import = InatImport.new(user: user)
+
+    # (20 + 40) seconds / (2 + 3) observations = 12 seconds per observation
+    assert_equal(12, import.initial_avg_import_seconds)
+  end
+
   def test_adequate_constraints
     assert(
       inat_imports(:rolf_inat_import).adequate_constraints?,


### PR DESCRIPTION
## Summary

Changes iNaturalist imports from a single reused `InatImport` record per user to a **new persistent record per import**, so every import is kept as its own record of what it did. Previously `InatImport.find_or_create_by(user:)` meant each user had exactly one record that every import reset and overwrote, so there was no history of past imports.

## What changed

- **New record per import.** `init_ivars` now `create!`s a fresh `InatImport` for each confirmed import instead of reusing/resetting the user's one record (`app/controllers/inat_imports_controller.rb`).
- **OAuth `state` threading.** Because a single import spans the iNat OAuth redirect, the new record's id rides through the OAuth `state` param: `request_inat_user_authorization` appends `&state=<id>`, and `authorization_response` loads `InatImport.find_by(id: params[:state], user:)` — user-scoped so a forged `state` can't reach another user's import, with a `not_authorized` guard when `state` is missing or invalid. Verified against the real iNat API, which echoes `state` back unchanged.
- **ETA history across records.** `user_import_history?` / `personal_initial_avg_import_seconds` now sum `total_imported_count` / `total_seconds` over the user's records instead of reading a single one, so the time estimate stays correct once records multiply (`app/models/inat_import.rb`).
- **Recovery of abandoned attempts.** A user who abandons the iNat authorization leaves a record stranded in `Authorizing`/`Authenticating`. A new `InatImport.abandoned` scope (those states, older than the new `ABANDONED_THRESHOLD` of 1 hour) plus `InatImportRecoveryJob` finalizes them the same way it finalizes crashed `Importing` records — mark `Done` with an explanatory note — so the list is not cluttered with dead pre-import attempts.

## Notes

- **No migration.** The `inat_imports` table already had no unique index on `user_id`; the one-per-user behavior was purely a code convention. Existing records simply become each user's first historical record, and new imports accumulate alongside them.
- Stacked on `nimmo-inat-import-broadcast-new` (this PR targets that branch), which carries the prerequisite import UI / index work.

## Test plan

- [x] `bin/rails test test/controllers/inat_imports_controller_test.rb test/views/controllers/inat_imports/ test/jobs/inat_import_job_test.rb test/jobs/inat_import_recovery_job_test.rb test/models/inat_import_test.rb` — 225 tests, 0 failures
- [x] Real-iNat OAuth `state` echo verified via a live authorize round-trip
- [x] Live end-to-end import run confirmed a new record is created per import

🤖 Generated with [Claude Code](https://claude.com/claude-code)
