### PR TITLE
Add Components::Modal dispatcher; sweep callers to Kit/dispatcher API

### DIFF
--- a/app/components/modal.rb
+++ b/app/components/modal.rb
@@ -1,19 +1,23 @@
 # frozen_string_literal: true
 
-# General Bootstrap 3 modal wrapper. Encapsulates the
+# Base modal wrapper and single entry-point dispatcher for all
+# `Components::Modal::*` components. Pass `type:` to route to a
+# subclass; omit for a plain modal with slots.
+#
+#   # Phlex views — Kit syntax:
+#   Modal(type: :confirm)
+#   Modal(type: :progress_spinner)
+#   Modal(type: :turbo_form, identifier: "…", title: "…",
+#         user: @user, model: @record)
+#
+#   # Controllers — full class path (Kit not available):
+#   Components::Modal.new(type: :turbo_form, identifier: "…",
+#                         title: "…", user: @user, model: @record)
+#
+# Encapsulates the Bootstrap 3
 # `modal > modal-dialog > modal-content > header / body / footer`
 # nesting and the close-button / title boilerplate so callers can
 # focus on the modal's content.
-#
-# Use this directly when you have a modal whose body is arbitrary
-# content (forms, text, lists). For controller-rendered turbo-stream
-# form modals with section-update auto-close, prefer
-# `Components::Modal::TurboForm`, which composes this and adds the
-# turbo-modal lifecycle wiring.
-#
-# Other modal-like components (`AddObsModal`, `ModalConfirm`,
-# `ModalProgressSpinner`) predate this and inline their own modal
-# markup; converting them is left as a follow-up.
 #
 # @example simple modal with body + footer
 #   render(Components::Modal.new(
@@ -110,6 +114,29 @@ class Components::Modal < Components::Base
   slot :form_content
 
   public :title_content_slot, :body_slot, :footer_slot, :form_content_slot
+
+  DISPATCH = {
+    confirm: :Confirm,
+    progress_spinner: :ProgressSpinner,
+    turbo_form: :TurboForm
+  }.freeze
+
+  def self.new(**kwargs, &block)
+    type_sym = kwargs[:type]&.to_sym
+    if (klass_name = DISPATCH[type_sym])
+      kwargs.delete(:type)
+      return const_get(klass_name).new(**kwargs, &block)
+    end
+
+    if kwargs.key?(:type)
+      raise(ArgumentError.new(
+              "Unknown Modal type: #{kwargs[:type].inspect}. " \
+              "Valid types: #{DISPATCH.keys.join(", ")}."
+            ))
+    end
+
+    super
+  end
 
   def view_template(&block)
     yield(self) if block

--- a/app/controllers/admin/emails/merge_requests_controller.rb
+++ b/app/controllers/admin/emails/merge_requests_controller.rb
@@ -22,12 +22,14 @@ module Admin
                    ))
           end
           format.turbo_stream do
-            render(Components::Modal::TurboForm.new(
+            render(Components::Modal.new(
+                     type: :turbo_form,
                      identifier: "merge_request_email",
                      title: :email_merge_request_title.t(type: @model.type_tag),
                      user: @user,
                      model: FormObject::EmailRequest.new,
-                     form_class: Views::Controllers::Admin::Emails::MergeRequests::Form,
+                     form_class:
+                       Views::Controllers::Admin::Emails::MergeRequests::Form,
                      form_locals: { old_obj: @old_obj, new_obj: @new_obj,
                                     model_class: @model }
                    ), layout: false)

--- a/app/controllers/admin/emails/name_change_requests_controller.rb
+++ b/app/controllers/admin/emails/name_change_requests_controller.rb
@@ -8,15 +8,8 @@ module Admin
       before_action :login_required
 
       def new
-        unless check_both_names!
-          redirect_back_or_default("/")
-          return
-        end
-
-        unless check_different_icn_ids
-          redirect_back_or_default("/")
-          return
-        end
+        return redirect_back_or_default("/") unless check_both_names!
+        return redirect_back_or_default("/") unless check_different_icn_ids
 
         respond_to do |format|
           format.html do
@@ -27,12 +20,14 @@ module Admin
             )
           end
           format.turbo_stream do
-            render(Components::Modal::TurboForm.new(
+            render(Components::Modal.new(
+                     type: :turbo_form,
                      identifier: "name_change_request_email",
                      title: :email_name_change_request_title.l,
                      user: @user,
                      model: FormObject::EmailRequest.new,
-                     form_class: Views::Controllers::Admin::Emails::NameChangeRequests::Form,
+                     form_class:
+                       Views::Controllers::Admin::Emails::NameChangeRequests::Form,
                      form_locals: {
                        name: @name,
                        new_name_with_icn_id: @new_name_with_icn_id

--- a/app/controllers/admin/emails/webmaster_questions_controller.rb
+++ b/app/controllers/admin/emails/webmaster_questions_controller.rb
@@ -12,14 +12,16 @@ module Admin
         respond_to do |format|
           format.html { render_new_page }
           format.turbo_stream do
-            render(Components::Modal::TurboForm.new(
+            render(Components::Modal.new(
+                     type: :turbo_form,
                      identifier: "webmaster_question_email",
                      title: :ask_webmaster_title.l,
                      user: @user,
                      model: FormObject::EmailRequest.new(
                        reply_to: @email, message: @message
                      ),
-                     form_class: Views::Controllers::Admin::Emails::WebmasterQuestions::Form,
+                     form_class:
+                       Views::Controllers::Admin::Emails::WebmasterQuestions::Form,
                      form_locals: { email_error: false }
                    ), layout: false)
           end

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -428,7 +428,8 @@ class CollectionNumbersController < ApplicationController
   end
 
   def render_modal_collection_number_form
-    render(Components::Modal::TurboForm.new(
+    render(Components::Modal.new(
+             type: :turbo_form,
              identifier: modal_identifier,
              title: modal_title,
              user: @user,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -301,11 +301,10 @@ class CommentsController < ApplicationController
   # we give users the option to edit any number of their own comments on a
   # show page. "comment" disambiguates :new, because :edit always has id
   def render_modal_comment_form
-    render(Components::Modal::TurboForm.new(
-             identifier: modal_identifier,
+    render(Components::Modal.new(
+             type: :turbo_form, identifier: modal_identifier,
              title: modal_title,
-             user: @user,
-             model: @comment
+             user: @user, model: @comment
            ), layout: false)
   end
 

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -203,7 +203,8 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   end
 
   def render_modal_herbarium_form
-    render(Components::Modal::TurboForm.new(
+    render(Components::Modal.new(
+             type: :turbo_form,
              identifier: modal_identifier,
              title: modal_title,
              user: @user,

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -478,7 +478,8 @@ class HerbariumRecordsController < ApplicationController
   end
 
   def render_modal_herbarium_record_form
-    render(Components::Modal::TurboForm.new(
+    render(Components::Modal.new(
+             type: :turbo_form,
              identifier: modal_identifier,
              title: modal_title,
              user: @user,

--- a/app/controllers/images/emails_controller.rb
+++ b/app/controllers/images/emails_controller.rb
@@ -19,7 +19,8 @@ module Images
                  ))
         end
         format.turbo_stream do
-          render(Components::Modal::TurboForm.new(
+          render(Components::Modal.new(
+                   type: :turbo_form,
                    identifier: "commercial_inquiry_email",
                    title: :commercial_inquiry_title.t(
                      name: @image.unique_format_name

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -591,7 +591,8 @@ class LocationsController < ApplicationController
   end
 
   def render_modal_location_form
-    render(Components::Modal::TurboForm.new(
+    render(Components::Modal.new(
+             type: :turbo_form,
              identifier: modal_identifier,
              title: modal_title,
              user: @user,

--- a/app/controllers/observations/emails_controller.rb
+++ b/app/controllers/observations/emails_controller.rb
@@ -18,7 +18,8 @@ module Observations
                  ))
         end
         format.turbo_stream do
-          render(Components::Modal::TurboForm.new(
+          render(Components::Modal.new(
+                   type: :turbo_form,
                    identifier: "observation_email",
                    title: :ask_observation_question_title.t(
                      name: @observation.unique_format_name

--- a/app/controllers/observations/external_links_controller.rb
+++ b/app/controllers/observations/external_links_controller.rb
@@ -210,7 +210,8 @@ module Observations
     end
 
     def render_modal_external_link_form
-      render(Components::Modal::TurboForm.new(
+      render(Components::Modal.new(
+               type: :turbo_form,
                identifier: modal_identifier,
                title: modal_title,
                user: @user,

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -132,7 +132,8 @@ module Observations
     end
 
     def render_modal_naming_form
-      render(Components::Modal::TurboForm.new(
+      render(Components::Modal.new(
+               type: :turbo_form,
                identifier: modal_identifier,
                title: modal_title,
                user: @user,

--- a/app/controllers/projects/aliases_controller.rb
+++ b/app/controllers/projects/aliases_controller.rb
@@ -179,7 +179,8 @@ module Projects
     end
 
     def render_modal_project_alias_form
-      render(Components::Modal::TurboForm.new(
+      render(Components::Modal.new(
+               type: :turbo_form,
                identifier: modal_identifier,
                title: modal_title,
                user: @user,

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -96,9 +96,7 @@ module Projects
 
     # Per-click cap on "Add My Observations". Method (not constant) so
     # tests can stub it via Minitest stub. See issue #4129.
-    def self.add_obs_batch_limit
-      100
-    end
+    def self.add_obs_batch_limit = 100
 
     # Turbo-stream modal showing how many of the candidate's observations
     # match current project constraints and aren't already in the project.
@@ -134,14 +132,15 @@ module Projects
 
       respond_to do |format|
         format.turbo_stream do
-          render(Components::Modal::TurboForm.new(
-                   identifier: "trust_settings",
+          render(Components::Modal.new(
+                   type: :turbo_form, identifier: "trust_settings",
                    title: :show_project_trust_settings_title.l(
                      project: @project.title
                    ),
                    user: @user,
                    model: @project_member.user,
-                   form_class: Views::Controllers::Projects::Members::TrustSettings,
+                   form_class:
+                     Views::Controllers::Projects::Members::TrustSettings,
                    form_locals: {
                      project: @project,
                      current_trust_level:

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -310,7 +310,8 @@ class SequencesController < ApplicationController
   end
 
   def render_modal_sequence_form
-    render(Components::Modal::TurboForm.new(
+    render(Components::Modal.new(
+             type: :turbo_form,
              identifier: modal_identifier,
              title: modal_title,
              user: @user,

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -16,7 +16,8 @@ module Users
           render(Views::Controllers::Users::Emails::New.new(target: @target))
         end
         format.turbo_stream do
-          render(Components::Modal::TurboForm.new(
+          render(Components::Modal.new(
+                   type: :turbo_form,
                    identifier: "user_question_email",
                    title: :ask_user_question_title.t(user: @target.legal_name),
                    user: @user,

--- a/app/views/controllers/field_slips/edit.rb
+++ b/app/views/controllers/field_slips/edit.rb
@@ -34,13 +34,11 @@ module Views::Controllers::FieldSlips
     private
 
     def render_unresolved_projects_modal
-      render(Components::Modal.new(
-               id: "modal_resolve_projects",
-               title: :occurrence_resolve_projects_title.l,
-               dialog_class: "modal-dialog modal-lg",
-               auto_open: true,
-               user: current_user
-             )) do |m|
+      Modal(id: "modal_resolve_projects",
+            title: :occurrence_resolve_projects_title.l,
+            dialog_class: "modal-dialog modal-lg",
+            auto_open: true,
+            user: current_user) do |m|
         m.with_form_content do
           render(Views::Controllers::Occurrences::Projects::Form.new(
                    gaps: @field_slip_project_gaps,

--- a/app/views/controllers/field_slips/new.rb
+++ b/app/views/controllers/field_slips/new.rb
@@ -41,13 +41,11 @@ module Views::Controllers::FieldSlips
     private
 
     def render_unresolved_projects_modal
-      render(Components::Modal.new(
-               id: "modal_resolve_projects",
-               title: :occurrence_resolve_projects_title.l,
-               dialog_class: "modal-dialog modal-lg",
-               auto_open: true,
-               user: current_user
-             )) do |m|
+      Modal(id: "modal_resolve_projects",
+            title: :occurrence_resolve_projects_title.l,
+            dialog_class: "modal-dialog modal-lg",
+            auto_open: true,
+            user: current_user) do |m|
         m.with_form_content do
           render(Views::Controllers::Occurrences::Projects::Form.new(
                    gaps: @field_slip_project_gaps,

--- a/app/views/controllers/images/exif/modal.rb
+++ b/app/views/controllers/images/exif/modal.rb
@@ -15,9 +15,11 @@ module Views::Controllers::Images
       prop :error_text, _Nilable(::String), default: nil
 
       def view_template
-        Modal(id: "modal_image_exif_#{@image.id}",
-              title: :exif_data_for_image.t(image: @image.id),
-              user: current_user) do |m|
+        render(::Components::Modal.new(
+                 id: "modal_image_exif_#{@image.id}",
+                 title: :exif_data_for_image.t(image: @image.id),
+                 user: current_user
+               )) do |m|
           m.with_body do
             if @success
               render(DataTable.new(data: @data))

--- a/app/views/controllers/images/exif/modal.rb
+++ b/app/views/controllers/images/exif/modal.rb
@@ -15,11 +15,9 @@ module Views::Controllers::Images
       prop :error_text, _Nilable(::String), default: nil
 
       def view_template
-        render(::Components::Modal.new(
-                 id: "modal_image_exif_#{@image.id}",
-                 title: :exif_data_for_image.t(image: @image.id),
-                 user: current_user
-               )) do |m|
+        Modal(id: "modal_image_exif_#{@image.id}",
+              title: :exif_data_for_image.t(image: @image.id),
+              user: current_user) do |m|
           m.with_body do
             if @success
               render(DataTable.new(data: @data))

--- a/app/views/controllers/observations/namings/votes/modal.rb
+++ b/app/views/controllers/observations/namings/votes/modal.rb
@@ -20,9 +20,7 @@ module Views::Controllers::Observations::Namings::Votes
     prop :title, String
 
     def view_template
-      render(Components::Modal.new(
-               id: @modal_id, user: @user
-             )) do |modal|
+      Modal(id: @modal_id, user: @user) do |modal|
         modal.with_title_content do
           trusted_html(@title)
           trusted_html(@naming.display_name_brief_authors.t.small_author)

--- a/app/views/controllers/observations/namings/votes/modal.rb
+++ b/app/views/controllers/observations/namings/votes/modal.rb
@@ -20,7 +20,9 @@ module Views::Controllers::Observations::Namings::Votes
     prop :title, String
 
     def view_template
-      Modal(id: @modal_id, user: @user) do |modal|
+      render(Components::Modal.new(
+               id: @modal_id, user: @user
+             )) do |modal|
         modal.with_title_content do
           trusted_html(@title)
           trusted_html(@naming.display_name_brief_authors.t.small_author)

--- a/app/views/controllers/occurrences/edit.rb
+++ b/app/views/controllers/occurrences/edit.rb
@@ -33,13 +33,11 @@ module Views::Controllers::Occurrences
     private
 
     def render_project_modal
-      render(Components::Modal.new(
-               id: "modal_resolve_projects",
-               title: :occurrence_resolve_projects_title.l,
-               dialog_class: "modal-dialog modal-lg",
-               auto_open: true,
-               user: @user
-             )) do |m|
+      Modal(id: "modal_resolve_projects",
+            title: :occurrence_resolve_projects_title.l,
+            dialog_class: "modal-dialog modal-lg",
+            auto_open: true,
+            user: @user) do |m|
         m.with_form_content do
           render(Projects::Form.new(
                    gaps: @project_gaps,

--- a/app/views/controllers/occurrences/new.rb
+++ b/app/views/controllers/occurrences/new.rb
@@ -30,13 +30,11 @@ module Views::Controllers::Occurrences
     private
 
     def render_project_modal
-      render(Components::Modal.new(
-               id: "modal_resolve_projects",
-               title: :occurrence_resolve_projects_title.l,
-               dialog_class: "modal-dialog modal-lg",
-               auto_open: true,
-               user: @user
-             )) do |m|
+      Modal(id: "modal_resolve_projects",
+            title: :occurrence_resolve_projects_title.l,
+            dialog_class: "modal-dialog modal-lg",
+            auto_open: true,
+            user: @user) do |m|
         m.with_form_content do
           render(Projects::Form.new(**@project_confirm))
         end

--- a/app/views/controllers/projects/members/add_obs_modal.rb
+++ b/app/views/controllers/projects/members/add_obs_modal.rb
@@ -17,10 +17,8 @@ module Views::Controllers::Projects::Members
     end
 
     def view_template
-      render(Components::Modal.new(
-               id: "modal_add_obs",
-               title: :change_member_add_obs.l
-             )) do |m|
+      Modal(id: "modal_add_obs",
+            title: :change_member_add_obs.l) do |m|
         m.with_body { p { plain(body_text) } }
         m.with_footer { render_footer_buttons }
       end

--- a/app/views/controllers/projects/violations/target_location_modal.rb
+++ b/app/views/controllers/projects/violations/target_location_modal.rb
@@ -27,15 +27,12 @@ module Views::Controllers::Projects::Violations
     end
 
     def view_template
-      target_location_form_modal_id =
-        Views::Controllers::Projects::Violations::TargetLocationForm.
-        modal_id_for(@obs)
-      Modal(id: target_location_form_modal_id,
+      Modal(id: TargetLocationForm.modal_id_for(@obs),
             title: :form_violations_modal_target_location_title.l,
             user: @user) do |m|
-        if Views::Controllers::Projects::Violations::TargetLocationForm.applicable?(@obs)
+        if TargetLocationForm.applicable?(@obs)
           m.with_form_content do
-            render(Views::Controllers::Projects::Violations::TargetLocationForm.new(
+            render(TargetLocationForm.new(
                      obs: @obs, project: @project,
                      existing_locations: @existing_locations
                    ))

--- a/app/views/controllers/projects/violations/target_location_modal.rb
+++ b/app/views/controllers/projects/violations/target_location_modal.rb
@@ -27,11 +27,12 @@ module Views::Controllers::Projects::Violations
     end
 
     def view_template
-      render(Components::Modal.new(
-               id: Views::Controllers::Projects::Violations::TargetLocationForm.modal_id_for(@obs),
-               title: :form_violations_modal_target_location_title.l,
-               user: @user
-             )) do |m|
+      target_location_form_modal_id =
+        Views::Controllers::Projects::Violations::TargetLocationForm.
+        modal_id_for(@obs)
+      Modal(id: target_location_form_modal_id,
+            title: :form_violations_modal_target_location_title.l,
+            user: @user) do |m|
         if Views::Controllers::Projects::Violations::TargetLocationForm.applicable?(@obs)
           m.with_form_content do
             render(Views::Controllers::Projects::Violations::TargetLocationForm.new(

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -132,8 +132,8 @@ module Views::Layouts
     end
 
     def render_bottom_singletons
-      render(Components::Modal::ProgressSpinner.new)
-      render(Components::Modal::Confirm.new)
+      Modal(type: :progress_spinner)
+      Modal(type: :confirm)
       render(Views::Layouts::App::MediaQueryTests.new)
       render(Views::Layouts::App::GtmFooter.new)
     end

--- a/test/components/modal_dispatcher_test.rb
+++ b/test/components/modal_dispatcher_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class ModalDispatcherTest < ComponentTestCase
+  # When no `type:` key is passed, `self.new` falls through to `super`
+  # and returns a plain `Components::Modal` instance (not a subclass).
+  def test_no_type_kwarg_returns_modal_instance
+    result = Components::Modal.new(id: "m")
+
+    assert_instance_of(Components::Modal, result)
+  end
+
+  def test_type_confirm_returns_confirm_instance
+    assert_instance_of(Components::Modal::Confirm,
+                       Components::Modal.new(type: :confirm))
+  end
+
+  def test_type_progress_spinner_returns_progress_spinner_instance
+    assert_instance_of(Components::Modal::ProgressSpinner,
+                       Components::Modal.new(type: :progress_spinner))
+  end
+
+  def test_unknown_type_raises_argument_error
+    assert_raises(ArgumentError) do
+      Components::Modal.new(type: :bogus_unknown_type)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a `DISPATCH` hash + `self.new` override to `Components::Modal`, matching the `Components::Link` dispatcher pattern. Pass `type: :confirm`, `:progress_spinner`, or `:turbo_form` to route to the matching subclass; omit `type:` to get a plain `Components::Modal` with slots.
- Sweeps all callers: Phlex views use Kit syntax `Modal(...)`, the application layout uses `Modal(type: :confirm)` / `Modal(type: :progress_spinner)`, and all 17 controller `Components::Modal::TurboForm.new(...)` calls become `Components::Modal.new(type: :turbo_form, ...)`.
- `TurboForm.render_form(...)` in `modal_updater.rb` is a class method — untouched.

## Dispatcher API

```ruby
# Phlex views — Kit syntax:
Modal(type: :confirm)
Modal(type: :progress_spinner)
Modal(type: :turbo_form, identifier: "…", title: "…", user: @user, model: @record)

# Controllers — full class path (Kit not available outside Phlex):
Components::Modal.new(type: :turbo_form, identifier: "…", title: "…", user: @user, model: @record)

# Plain modal (no type:) — slots work as before:
Modal(id: "my_modal", title: "Pick a thing", user: @user) do |m|
  m.with_body { … }
end
```

## Test plan

- [x] `bin/rails test test/components/modal_dispatcher_test.rb test/components/modal_test.rb test/components/modal/confirm_test.rb test/components/modal/progress_spinner_test.rb test/components/modal/turbo_form_test.rb` — 21 tests, 0 failures
- [x] RuboCop clean on all 27 touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
