### PR TITLE
Sweep render(Components::Alert.new) → Alert() Kit syntax

### DIFF
--- a/app/components/form/name_feedback.rb
+++ b/app/components/form/name_feedback.rb
@@ -35,7 +35,7 @@ class Components::Form::NameFeedback < Components::Base
   # ----- Warning alerts -----
 
   def render_warning_alert
-    render(Components::Alert.new(level: :warning, id: "name_messages")) do
+    Alert(level: :warning, id: "name_messages") do
       div { warning_message }
       render_warning_help
       render_valid_name_choices if @valid_names&.any?
@@ -82,7 +82,7 @@ class Components::Form::NameFeedback < Components::Base
   # ----- Error alerts -----
 
   def render_not_recognized_error
-    render(Components::Alert.new(level: :danger, id: "name_messages")) do
+    Alert(level: :danger, id: "name_messages") do
       div { :form_naming_not_recognized.t(name: @given_name) }
       render(::Components::Help::Note.new(:div)) do
         plain(:form_naming_not_recognized_help.t(button: @button_name))
@@ -91,7 +91,7 @@ class Components::Form::NameFeedback < Components::Base
   end
 
   def render_multiple_names_error
-    render(Components::Alert.new(level: :danger, id: "name_messages")) do
+    Alert(level: :danger, id: "name_messages") do
       div { [:form_naming_multiple_names.t(name: @given_name), ":"].safe_join }
       render_name_radio_buttons_with_counts(@names)
       render(::Components::Help::Note.new(:div)) do

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -95,7 +95,7 @@ module Views::Controllers::FieldSlips
 
     def render_errors
       count = pluralize(model.errors.count, :error.t, plural: :errors.t)
-      render(Components::Alert.new(level: :danger)) do
+      Alert(level: :danger) do
         ul do
           model.errors.each { |error| li { error.full_message } }
         end

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -33,7 +33,7 @@ module Views::Controllers::FieldSlips
     def render_notice
       return unless @notice
 
-      render(Components::Alert.new(message: @notice, level: :success))
+      Alert(message: @notice, level: :success)
     end
 
     def render_project_or_filter_section

--- a/app/views/controllers/field_slips/show.rb
+++ b/app/views/controllers/field_slips/show.rb
@@ -14,9 +14,7 @@ module Views::Controllers::FieldSlips
       add_edit_icons(@field_slip, current_user)
       container_class(:full)
 
-      if @notice
-        render(Components::Alert.new(message: @notice, level: :success))
-      end
+      Alert(message: @notice, level: :success) if @notice
 
       render(Components::ContentPadded.new) do
         render(FieldSlipPanel.new(field_slip: @field_slip))

--- a/app/views/controllers/names/classification/inherit/form.rb
+++ b/app/views/controllers/names/classification/inherit/form.rb
@@ -26,7 +26,7 @@ module Views::Controllers::Names::Classification::Inherit
     private
 
     def render_candidates_alert
-      render(Components::Alert.new(level: :warning)) do
+      Alert(level: :warning) do
         trusted_html(@message.tp)
         options = @candidates.map { |opt| [opt.id, opt.display_name.t] }
         radio_field(:candidates, *options)

--- a/app/views/controllers/names/index/name_suggestions_alert.rb
+++ b/app/views/controllers/names/index/name_suggestions_alert.rb
@@ -9,7 +9,7 @@ class Views::Controllers::Names::Index::NameSuggestionsAlert < Views::Base
   prop :user, _Nilable(::User), default: nil
 
   def view_template
-    render(Components::Alert.new(level: :warning)) do
+    Alert(level: :warning) do
       div { plain(:list_observations_alternate_spellings.t) }
       ul(type: "none") do
         @names.sort_by(&:sort_name).each do |name|

--- a/app/views/controllers/names/synonyms/form.rb
+++ b/app/views/controllers/names/synonyms/form.rb
@@ -120,7 +120,7 @@ module Views::Controllers::Names::Synonyms
     end
 
     def render_new_names_alert
-      render(Components::Alert.new(level: :danger)) do
+      Alert(level: :danger) do
         div { :form_synonyms_missing_names.l }
         div(class: "pl-3") do
           @new_names.each { |n| div { n } }

--- a/app/views/controllers/observations/form/projects.rb
+++ b/app/views/controllers/observations/form/projects.rb
@@ -96,7 +96,7 @@ class Views::Controllers::Observations::Form::Projects < Views::Base
   end
 
   def render_constraint_alert(level, projects, help_text)
-    render(Components::Alert.new(level: level)) do
+    Alert(level: level) do
       div { plain("#{:form_observations_projects_out_of_range.t}:") }
       ul do
         projects.each do |proj|

--- a/app/views/controllers/observations/show/name_suggestions_alert.rb
+++ b/app/views/controllers/observations/show/name_suggestions_alert.rb
@@ -17,7 +17,7 @@ class Views::Controllers::Observations::Show::NameSuggestionsAlert < Views::Base
   prop :names, _Array(_Tuple(::Name, Integer))
 
   def view_template
-    render(Components::Alert.new(level: :warning)) do
+    Alert(level: :warning) do
       p { plain("#{:list_observations_suggestions.t}:") }
       @names.each { |name, count| render_row(name, count) }
     end

--- a/app/views/controllers/occurrences/show.rb
+++ b/app/views/controllers/occurrences/show.rb
@@ -27,10 +27,10 @@ module Views::Controllers::Occurrences
     def render_location_warning
       return unless locations_differ?
 
-      render(Components::Alert.new(
-               message: :show_occurrence_location_differs.t,
-               level: :warning
-             ))
+      Alert(
+        message: :show_occurrence_location_differs.t,
+        level: :warning
+      )
     end
 
     def locations_differ?

--- a/app/views/controllers/species_lists/write_in/list_feedback.rb
+++ b/app/views/controllers/species_lists/write_in/list_feedback.rb
@@ -26,8 +26,7 @@ module Views::Controllers::SpeciesLists::WriteIn
     private
 
     def render_missing_names
-      render(Components::Alert.new(level: :danger,
-                                   id: "missing_names")) do
+      Alert(level: :danger, id: "missing_names") do
         div(class: "font-weight-bold") do
           :form_list_feedback_missing_names.t
         end
@@ -45,8 +44,7 @@ module Views::Controllers::SpeciesLists::WriteIn
     end
 
     def render_deprecated_names
-      render(Components::Alert.new(level: :warning,
-                                   id: "deprecated_names")) do
+      Alert(level: :warning, id: "deprecated_names") do
         div(class: "font-weight-bold") do
           :form_species_lists_deprecated.t
         end
@@ -74,8 +72,7 @@ module Views::Controllers::SpeciesLists::WriteIn
     end
 
     def render_multiple_names
-      render(Components::Alert.new(level: :warning,
-                                   id: "ambiguous_names")) do
+      Alert(level: :warning, id: "ambiguous_names") do
         div(class: "font-weight-bold") do
           :form_species_lists_multiple_names.t
         end


### PR DESCRIPTION
## Summary

Sweeps all 14 `render(Components::Alert.new(...))` call sites across `app/components/` and `app/views/controllers/` to use Phlex Kit syntax (`Alert(...)`) instead.

No behavior changes — purely a call-site simplification enabled by Kit registration.

## Files changed

- `app/components/form/name_feedback.rb` (3 calls)
- `app/views/controllers/field_slips/form.rb`
- `app/views/controllers/field_slips/index.rb`
- `app/views/controllers/field_slips/show.rb`
- `app/views/controllers/names/classification/inherit/form.rb`
- `app/views/controllers/names/index/name_suggestions_alert.rb`
- `app/views/controllers/names/synonyms/form.rb`
- `app/views/controllers/observations/form/projects.rb`
- `app/views/controllers/observations/show/name_suggestions_alert.rb`
- `app/views/controllers/occurrences/show.rb`
- `app/views/controllers/species_lists/write_in/list_feedback.rb` (3 calls)

## Test plan

- [ ] Existing component and view tests cover all changed files; no new tests needed for a call-site-only refactor
- [ ] `bin/rails test test/components/` passes
