### PR TITLE
Sweep render(Components::Button.new) → Button() Kit syntax

### DIFF
--- a/app/components/button.rb
+++ b/app/components/button.rb
@@ -11,26 +11,26 @@
 # `Components::Button::Styling` concern.
 #
 # @example Stimulus action button
-#   render(Components::Button.new(
+#   Button(
 #     name: :CANCEL.l,
 #     data: { action: "confirm-modal#cancel" }
-#   ))
+#   )
 #
 # @example Danger variant
-#   render(Components::Button.new(
+#   Button(
 #     name: :OK.l,
 #     variant: :danger,
 #     data: { action: "confirm-modal#confirm",
 #             confirm_modal_target: "confirmButton" }
-#   ))
+#   )
 #
 # @example Icon-only (sr-only label)
-#   render(Components::Button.new(name: :REMOVE.l, icon: :x, variant: :strip))
+#   Button(name: :REMOVE.l, icon: :x, variant: :strip)
 #
 # @example Rich content via block (name: optional)
-#   render(Components::Button.new(
+#   Button(
 #     data: { action: "form-exif#transfer:prevent" }
-#   )) do
+#   ) do
 #     span(class: "when-enabled") { :ENABLED.l }
 #     span(class: "when-disabled") { :DISABLED.l }
 #   end

--- a/app/components/button/collapse_toggle.rb
+++ b/app/components/button/collapse_toggle.rb
@@ -8,7 +8,7 @@
 # Dispatched via `Components::Button.new(type: :collapse_toggle, ...)`.
 #
 # @example Map expand/collapse toggle
-#   render(Components::Button.new(
+#   Button(
 #     type: :collapse_toggle,
 #     target_id: "herbarium_form_map",
 #     open_text: :form_observations_hide_map.l,
@@ -19,7 +19,7 @@
 #     data: { map_target: "toggleMapBtn",
 #             action: "map#toggleMap" },
 #     aria: { expanded: "false", controls: "herbarium_form_map" }
-#   ))
+#   )
 class Components::Button::CollapseToggle < Components::Button
   include Components::Button::CollapseContent
 

--- a/app/components/button/delete.rb
+++ b/app/components/button/delete.rb
@@ -7,19 +7,19 @@
 # outline style.
 #
 # @example default (standard btn-default frame with danger icon)
-#   render(Components::Button.new(type: :delete, target: @api_key))
+#   Button(type: :delete, target: @api_key)
 #
 # @example outline button (common CRUD row usage)
-#   render(Components::Button.new(type: :delete, target: @api_key,
-#                                 variant: :outline))
+#   Button(type: :delete, target: @api_key,
+#                                 variant: :outline)
 #
 # @example with overrides
-#   render(Components::Button.new(type: :delete, target: @api_key,
-#                                 name: :REMOVE.l, icon: :remove))
+#   Button(type: :delete, target: @api_key,
+#                                 name: :REMOVE.l, icon: :remove)
 #
 # @example bare icon, no btn frame
-#   render(Components::Button.new(type: :delete, target: @term,
-#                                 variant: :strip))
+#   Button(type: :delete, target: @term,
+#                                 variant: :strip)
 class Components::Button::Delete < Components::Button::CRUDBase
   def initialize(target:, name: nil, icon: :delete, **html_attrs)
     confirm = html_attrs.delete(:confirm) || :are_you_sure.l

--- a/app/components/button/download.rb
+++ b/app/components/button/download.rb
@@ -5,10 +5,10 @@
 # Pass `variant:` to override.
 #
 # @example
-#   render(Components::Button.new(type: :download,
+#   Button(type: :download,
 #     name: :DOWNLOAD.t,
 #     target: new_download_species_list_path(id: @sl.id)
-#   ))
+#   )
 class Components::Button::Download < Components::Link::Download
   def initialize(target:, name: nil, icon: :download, variant: nil, **)
     super(target: target, name: name, icon: icon, button: variant, **)

--- a/app/components/button/edit.rb
+++ b/app/components/button/edit.rb
@@ -5,15 +5,15 @@
 # Pass `variant:` to override (e.g. `variant: :outline`, `variant: :strip`).
 #
 # @example default (btn-default frame with edit icon)
-#   render(Components::Button.new(type: :edit, target: @herbarium))
+#   Button(type: :edit, target: @herbarium)
 #
 # @example outline button (common CRUD row usage)
-#   render(Components::Button.new(type: :edit, target: @herbarium,
-#                                 variant: :outline))
+#   Button(type: :edit, target: @herbarium,
+#                                 variant: :outline)
 #
 # @example bare icon, no btn frame
-#   render(Components::Button.new(type: :edit, target: @herbarium,
-#                                 variant: :strip))
+#   Button(type: :edit, target: @herbarium,
+#                                 variant: :strip)
 class Components::Button::Edit < Components::Link::Edit
   def initialize(target:, name: nil, icon: :edit, variant: nil, **)
     super(target: target, name: name, icon: icon, button: variant, **)

--- a/app/components/button/external.rb
+++ b/app/components/button/external.rb
@@ -6,10 +6,10 @@
 # tab's html_options, or called directly for prominent external links.
 #
 # @example Sequence BLAST link
-#   render(Components::Button.new(type: :external,
+#   Button(type: :external,
 #     name: :show_observation_blast_link.l,
 #     url: @sequence.blast_url
-#   ))
+#   )
 class Components::Button::External < Components::Button
   def initialize(url:, name:, **)
     super(name: name, tag: :a,

--- a/app/components/button/get.rb
+++ b/app/components/button/get.rb
@@ -5,14 +5,14 @@
 # Pass `variant:` to override (e.g. `variant: :outline`, `variant: :strip`).
 #
 # @example via dispatcher
-#   render(Components::Button.new(type: :get,
+#   Button(type: :get,
 #     name: "View", target: @herbarium
-#   ))
+#   )
 #
 # @example btn-link variant (no btn frame, underlined)
-#   render(Components::Button.new(type: :get,
+#   Button(type: :get,
 #     name: user.login, target: user, variant: :btn_link
-#   ))
+#   )
 class Components::Button::Get < Components::Link::Get
   def initialize(name:, target:, variant: nil, **)
     super(name: name, target: target, button: variant, **)

--- a/app/components/button/modal_toggle.rb
+++ b/app/components/button/modal_toggle.rb
@@ -8,26 +8,26 @@
 # Pass `variant: :strip` for a plain text link or icon-only trigger.
 #
 # @example Button-shaped modal trigger (the common case)
-#   render(Components::Button.new(type: :modal,
+#   Button(type: :modal,
 #     name: :show_project_trust_settings.l,
 #     target: trust_modal_project_member_path(...),
 #     modal_id: "trust_settings",
 #     size: :lg, class: "my-2 mr-2"
-#   ))
+#   )
 #
 # @example Plain text modal link
-#   render(Components::Button.new(type: :modal,
+#   Button(type: :modal,
 #     name: "Edit", target: edit_comment_path(comment),
 #     modal_id: "comment", variant: :strip
-#   ))
+#   )
 #
 # @example Icon-only modal trigger (tooltip from name:)
-#   render(Components::Button.new(type: :modal,
+#   Button(type: :modal,
 #     name: :show_comments_add_comment.l,
 #     target: new_comment_path(target: obj.id, type: obj.class.name),
 #     modal_id: "comment",
 #     variant: :strip, icon: :add
-#   ))
+#   )
 class Components::Button::ModalToggle < Components::Link::Modal
   def initialize(name:, target:, modal_id:, variant: nil, **)
     super(modal_id: modal_id, name: name, target: target, button: variant, **)

--- a/app/components/button/new.rb
+++ b/app/components/button/new.rb
@@ -9,11 +9,11 @@
 # instance target cannot express.
 #
 # @example outline "New" button
-#   render(Components::Button.new(type: :new,
+#   Button(type: :new,
 #     target: new_name_description_path(@name.id),
 #     name: :show_name_create_description.t,
 #     variant: :outline
-#   ))
+#   )
 class Components::Button::New < Components::Link::New
   def initialize(target:, name: nil, icon: :add, variant: nil, **)
     super(target: target, name: name, icon: icon, button: variant, **)

--- a/app/components/button/patch.rb
+++ b/app/components/button/patch.rb
@@ -3,10 +3,10 @@
 # PATCH-method button.
 #
 # @example
-#   render(Components::Button.new(type: :patch,
+#   Button(type: :patch,
 #     name: :ACTIVATE.l,
 #     target: account_activate_api_key_path(key.id)
-#   ))
+#   )
 class Components::Button::Patch < Components::Button::CRUDBase
   def initialize(target:, name:, **)
     super(target: target, name: name, method: :patch, **)

--- a/app/components/button/post.rb
+++ b/app/components/button/post.rb
@@ -3,10 +3,10 @@
 # POST-method button.
 #
 # @example
-#   render(Components::Button.new(type: :post,
+#   Button(type: :post,
 #     name: :show_project_join.l,
 #     target: project_members_path(project_id: @project.id)
-#   ))
+#   )
 class Components::Button::Post < Components::Button::CRUDBase
   def initialize(target:, name:, **)
     super(target: target, name: name, method: :post, **)

--- a/app/components/button/project.rb
+++ b/app/components/button/project.rb
@@ -13,12 +13,12 @@ class Components::Button::Project < Components::Base
   prop :target, _Union(String, Hash, ::AbstractModel)
 
   def view_template
-    render(Components::Button.new(
-             type: :get,
-             name: @name,
-             target: @target,
-             size: :lg,
-             class: "my-3 mr-3"
-           ))
+    Button(
+      type: :get,
+      name: @name,
+      target: @target,
+      size: :lg,
+      class: "my-3 mr-3"
+    )
   end
 end

--- a/app/components/button/put.rb
+++ b/app/components/button/put.rb
@@ -3,10 +3,10 @@
 # PUT-method button.
 #
 # @example
-#   render(Components::Button.new(type: :put,
+#   Button(type: :put,
 #     name: :show_project_leave.t,
 #     target: project_member_path(...)
-#   ))
+#   )
 class Components::Button::Put < Components::Button::CRUDBase
   def initialize(target:, name:, **)
     super(target: target, name: name, method: :put, **)

--- a/app/components/button/submit.rb
+++ b/app/components/button/submit.rb
@@ -8,12 +8,12 @@
 # `disable_with:` defaults to `name:` when set.
 #
 # @example Plain text
-#   render(Components::Button.new(type: :submit, name: :SAVE.l))
+#   Button(type: :submit, name: :SAVE.l)
 #
 # @example Rich content (block form)
-#   render(Components::Button.new(type: :submit,
+#   Button(type: :submit,
 #     variant: :outline, class: "px-2"
-#   )) do
+#   ) do
 #     span(class: "d-sm-none") { render(Components::Icon.new(type: :search)) }
 #     span(class: "hidden-xs") { plain(:SEARCH.l) }
 #   end

--- a/app/components/form/camera_info.rb
+++ b/app/components/form/camera_info.rb
@@ -143,13 +143,13 @@ class Components::Form::CameraInfo < Components::Base
 
   def transfer_exif_button
     has_exif = @date.present? || @lat.present?
-    render(Components::Button.new(
-             size: :sm,
-             class: class_names("use_exif_btn ab-top-right",
-                                "d-none": !has_exif),
-             data: { form_exif_target: "useExifBtn",
-                     action: "form-exif#transferExifToObs:prevent" }
-           )) do
+    Button(
+      size: :sm,
+      class: class_names("use_exif_btn ab-top-right",
+                         "d-none": !has_exif),
+      data: { form_exif_target: "useExifBtn",
+              action: "form-exif#transferExifToObs:prevent" }
+    ) do
       span(class: "when-enabled") { :image_use_exif.l }
       span(class: "when-disabled") { :image_exif_copied.l }
     end

--- a/app/components/form/elevation_fields.rb
+++ b/app/components/form/elevation_fields.rb
@@ -36,14 +36,14 @@ class Components::Form::ElevationFields < Components::Base
   end
 
   def render_get_elevation_button
-    render(Components::Button.new(
-             name: :form_locations_get_elevation.l,
-             data: {
-               map_target: "getElevation",
-               action: "map#getElevations",
-               map_points_param: "input",
-               map_type_param: "rectangle"
-             }
-           ))
+    Button(
+      name: :form_locations_get_elevation.l,
+      data: {
+        map_target: "getElevation",
+        action: "map#getElevations",
+        map_points_param: "input",
+        map_type_param: "rectangle"
+      }
+    )
   end
 end

--- a/app/components/form/live_data_filter.rb
+++ b/app/components/form/live_data_filter.rb
@@ -85,25 +85,25 @@ class Components::Form::LiveDataFilter < Components::ApplicationForm
   end
 
   def render_prev_button
-    render(Components::Button.new(
-             type: :get,
-             name: "« Prev",
-             target: prev_path || "#",
-             size: :sm,
-             class: ("opacity-0" unless show_prev?),
-             disabled: !show_prev?
-           ))
+    Button(
+      type: :get,
+      name: "« Prev",
+      target: prev_path || "#",
+      size: :sm,
+      class: ("opacity-0" unless show_prev?),
+      disabled: !show_prev?
+    )
   end
 
   def render_next_button
-    render(Components::Button.new(
-             type: :get,
-             name: "Next »",
-             target: next_path || "#",
-             size: :sm,
-             class: ("opacity-0" unless show_next?),
-             disabled: !show_next?
-           ))
+    Button(
+      type: :get,
+      name: "Next »",
+      target: next_path || "#",
+      size: :sm,
+      class: ("opacity-0" unless show_next?),
+      disabled: !show_next?
+    )
   end
 
   def show_prev?

--- a/app/components/form/location_map.rb
+++ b/app/components/form/location_map.rb
@@ -52,27 +52,27 @@ class Components::Form::LocationMap < Components::Base
   end
 
   def render_toggle_button
-    render(Components::Button.new(
-             type: :collapse_toggle,
-             target_id: @id,
-             open_text: :form_observations_hide_map.l,
-             closed_text: :form_observations_open_map.l,
-             icon: :globe,
-             class: "map-toggle",
-             data: { map_target: "toggleMapBtn",
-                     action: "map#toggleMap form-exif#showFields" },
-             aria: { expanded: "false", controls: @id }
-           ))
+    Button(
+      type: :collapse_toggle,
+      target_id: @id,
+      open_text: :form_observations_hide_map.l,
+      closed_text: :form_observations_open_map.l,
+      icon: :globe,
+      class: "map-toggle",
+      data: { map_target: "toggleMapBtn",
+              action: "map#toggleMap form-exif#showFields" },
+      aria: { expanded: "false", controls: @id }
+    )
   end
 
   def render_clear_button
-    render(Components::Button.new(
-             name: :form_observations_clear_map.l,
-             class: "map-clear",
-             data: {
-               map_target: "mapClearBtn",
-               action: "map#clearMap form-exif#reenableButtons"
-             }
-           ))
+    Button(
+      name: :form_observations_clear_map.l,
+      class: "map-clear",
+      data: {
+        map_target: "mapClearBtn",
+        action: "map#clearMap form-exif#reenableButtons"
+      }
+    )
   end
 end

--- a/app/components/form/pattern_search.rb
+++ b/app/components/form/pattern_search.rb
@@ -90,10 +90,10 @@ class Components::Form::PatternSearch < Components::ApplicationForm
 
   def render_submit
     div(class: "form-group text-nowrap") do
-      render(Components::Button.new(
-               type: :submit,
-               variant: :outline, class: "px-2"
-             )) do
+      Button(
+        type: :submit,
+        variant: :outline, class: "px-2"
+      ) do
         span(class: "d-sm-none") do
           render(Components::Icon.new(type: :search))
         end

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -464,13 +464,13 @@ class Components::Form::Search < Components::ApplicationForm
 
   def render_clear_button
     data_attrs = @local ? {} : turbo_stream_data
-    render(Components::Button.new(
-             type: :get,
-             name: :CLEAR.l,
-             target: clear_url,
-             class: "d-inline-block mx-3 clear-button",
-             data: data_attrs
-           ))
+    Button(
+      type: :get,
+      name: :CLEAR.l,
+      target: clear_url,
+      class: "d-inline-block mx-3 clear-button",
+      data: data_attrs
+    )
   end
 
   def clear_url

--- a/app/components/form/upload_gallery/item.rb
+++ b/app/components/form/upload_gallery/item.rb
@@ -132,11 +132,11 @@ class Components::Form::UploadGallery::Item < Components::Image::Base
              action: "form-images##{action}:prevent" }
     data[:image_id] = image_id if image_id
 
-    render(Components::Button.new(
-             size: :sm,
-             class: "remove_image_button fade in",
-             data: data
-           )) do
+    Button(
+      size: :sm,
+      class: "remove_image_button fade in",
+      data: data
+    ) do
       span { :image_remove_remove.l }
       render(Components::Icon.new(
                type: :remove, html_class: "text-danger ml-3"

--- a/app/components/image/exif_link.rb
+++ b/app/components/image/exif_link.rb
@@ -17,12 +17,12 @@ class Components::Image::EXIFLink < Components::Base
   prop :link_class, String, default: ""
 
   def view_template
-    render(Components::Button.new(
-             type: :modal,
-             name: :image_show_exif.t,
-             target: exif_image_path(id: @image_id),
-             modal_id: "image_exif_#{@image_id}",
-             variant: :strip, class: @link_class
-           ))
+    Button(
+      type: :modal,
+      name: :image_show_exif.t,
+      target: exif_image_path(id: @image_id),
+      modal_id: "image_exif_#{@image_id}",
+      variant: :strip, class: @link_class
+    )
   end
 end

--- a/app/components/image/lightbox/caption.rb
+++ b/app/components/image/lightbox/caption.rb
@@ -75,16 +75,16 @@ class Components::Image::Lightbox::Caption < Components::Base
   end
 
   def render_propose_naming_modal
-    render(Components::Button.new(
-             type: :modal,
-             name: :create_naming.t,
-             target: new_observation_naming_path(
-               observation_id: @obs.id, context: "lightgallery"
-             ),
-             modal_id: "obs_#{@obs.id}_naming",
-             variant: :primary,
-             class: "d-inline-block propose-naming-link"
-           ))
+    Button(
+      type: :modal,
+      name: :create_naming.t,
+      target: new_observation_naming_path(
+        observation_id: @obs.id, context: "lightgallery"
+      ),
+      modal_id: "obs_#{@obs.id}_naming",
+      variant: :primary,
+      class: "d-inline-block propose-naming-link"
+    )
   end
 
   def render_reviewed_toggle
@@ -198,13 +198,13 @@ class Components::Image::Lightbox::Caption < Components::Base
 
   def render_contact_link(_obs_user)
     plain(" [")
-    render(Components::Button.new(
-             type: :modal,
-             name: :show_observation_send_question.l,
-             target: new_question_for_observation_path(@obs.id),
-             modal_id: "observation_email",
-             variant: :strip, icon: :email
-           ))
+    Button(
+      type: :modal,
+      name: :show_observation_send_question.l,
+      target: new_question_for_observation_path(@obs.id),
+      modal_id: "observation_email",
+      variant: :strip, icon: :email
+    )
     plain("]")
   end
 

--- a/app/components/image/lightbox/observation_title.rb
+++ b/app/components/image/lightbox/observation_title.rb
@@ -53,14 +53,14 @@ class Components::Image::Lightbox::ObservationTitle < Components::Base
         class: "text-bold mr-3",
         id: "caption_obs_link_#{@obs.id}") { @obs.id }
     else
-      render(::Components::Button.new(
-               type: :get,
-               name: @obs.id.to_s,
-               target: url_for(@obs.show_link_args),
-               variant: :primary,
-               id: "caption_obs_link_#{@obs.id}",
-               class: "mr-3"
-             ))
+      Button(
+        type: :get,
+        name: @obs.id.to_s,
+        target: url_for(@obs.show_link_args),
+        variant: :primary,
+        id: "caption_obs_link_#{@obs.id}",
+        class: "mr-3"
+      )
     end
   end
 end

--- a/app/components/image/reuse_form.rb
+++ b/app/components/image/reuse_form.rb
@@ -64,8 +64,8 @@ class Components::Image::ReuseForm < Components::ApplicationForm
 
   def render_toggle_link
     div(class: "form-group mt-3") do
-      render(Components::Button.new(type: :get, target: toggle_url,
-                                    name: toggle_label))
+      Button(type: :get, target: toggle_url,
+             name: toggle_label)
     end
   end
 

--- a/app/components/image/vote_interface.rb
+++ b/app/components/image/vote_interface.rb
@@ -117,14 +117,14 @@ class Components::Image::VoteInterface < Components::Base
   def render_vote_button(vote)
     vote_text = vote.zero? ? "(x)" : image_vote_as_short_string(vote)
 
-    render(Components::Button.new(
-             type: :put,
-             variant: :strip,
-             name: vote_text,
-             class: "image-vote-link",
-             target: image_vote_path(image_id: @image.id, value: vote),
-             title: image_vote_as_help_string(vote),
-             data: { image_id: @image.id, value: vote }
-           ))
+    Button(
+      type: :put,
+      variant: :strip,
+      name: vote_text,
+      class: "image-vote-link",
+      target: image_vote_path(image_id: @image.id, value: vote),
+      title: image_vote_as_help_string(vote),
+      data: { image_id: @image.id, value: vote }
+    )
   end
 end

--- a/app/components/index_filter.rb
+++ b/app/components/index_filter.rb
@@ -53,8 +53,8 @@ class Components::IndexFilter < Components::Base
          class: form_class, id: @form_id) do
       div(class: "d-flex gap-2 align-items-end") do
         yield if block
-        render(::Components::Button.new(type: :submit, name: @submit_text,
-                                        html_name: "commit"))
+        Button(type: :submit, name: @submit_text,
+               html_name: "commit")
       end
     end
   end

--- a/app/components/link/inline_add.rb
+++ b/app/components/link/inline_add.rb
@@ -23,14 +23,14 @@ class Components::Link::InlineAdd < Components::Base
 
   def view_template
     plain("[")
-    render(Components::Button.new(
-             type: :modal,
-             name: @tab.title,
-             target: @tab.path,
-             modal_id: @modal_id,
-             variant: :strip,
-             **@tab.html_options
-           ))
+    Button(
+      type: :modal,
+      name: @tab.title,
+      target: @tab.path,
+      modal_id: @modal_id,
+      variant: :strip,
+      **@tab.html_options
+    )
     plain("]")
   end
 end

--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -184,14 +184,14 @@ class Components::Map::Popup < Components::Base
   end
 
   def render_mapset_link(label_sym, path, query)
-    render(::Components::Button.new(
-             type: :get,
-             name: label_sym.t,
-             target: add_q_param(path, query),
-             size: :xs,
-             class: "map-popup-btn",
-             data: query.params
-           ))
+    Button(
+      type: :get,
+      name: label_sym.t,
+      target: add_q_param(path, query),
+      size: :xs,
+      class: "map-popup-btn",
+      data: query.params
+    )
   end
 
   # ----------------------------------------------------------------

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -191,15 +191,15 @@ class Components::Matrix::Box < Components::Base
   end
 
   def render_propose_naming_modal(obs)
-    render(Components::Button.new(
-             type: :modal,
-             name: :create_naming.t,
-             target: new_observation_naming_path(
-               observation_id: obs.id, context: "matrix_box"
-             ),
-             modal_id: "obs_#{obs.id}_naming",
-             class: "d-inline-block mb-3 propose-naming-link"
-           ))
+    Button(
+      type: :modal,
+      name: :create_naming.t,
+      target: new_observation_naming_path(
+        observation_id: obs.id, context: "matrix_box"
+      ),
+      modal_id: "obs_#{obs.id}_naming",
+      class: "d-inline-block mb-3 propose-naming-link"
+    )
   end
 
   def render_where_section

--- a/app/components/matrix/box/footer.rb
+++ b/app/components/matrix/box/footer.rb
@@ -68,14 +68,14 @@ class Components::Matrix::Box
       return unless show_project_exclude_button?
 
       panel.with_footer(classes: "text-center") do
-        render(Components::Button.new(
-                 type: :post,
-                 name: :EXCLUDE.t,
-                 target: exclude_observation_project_update_path(
-                   project_id: @project.id, id: @data[:what].id
-                 ),
-                 size: :sm
-               ))
+        Button(
+          type: :post,
+          name: :EXCLUDE.t,
+          target: exclude_observation_project_update_path(
+            project_id: @project.id, id: @data[:what].id
+          ),
+          size: :sm
+        )
       end
     end
 

--- a/app/components/modal.rb
+++ b/app/components/modal.rb
@@ -200,12 +200,12 @@ class Components::Modal < Components::Base
   end
 
   def close_button
-    render(::Components::Button.new(
-             variant: :strip,
-             class: "close",
-             data: { dismiss: "modal" },
-             aria: { label: :CLOSE.l }
-           )) do
+    Button(
+      variant: :strip,
+      class: "close",
+      data: { dismiss: "modal" },
+      aria: { label: :CLOSE.l }
+    ) do
       span(aria: { hidden: "true" }) { "×" }
     end
   end

--- a/app/components/modal/confirm.rb
+++ b/app/components/modal/confirm.rb
@@ -54,16 +54,16 @@ class Components::Modal::Confirm < Components::Base
   end
 
   def render_buttons
-    render(Components::Button.new(
-             name: :CANCEL.l,
-             data: { action: "confirm-modal#cancel" }
-           ))
+    Button(
+      name: :CANCEL.l,
+      data: { action: "confirm-modal#cancel" }
+    )
     whitespace
-    render(Components::Button.new(
-             name: :OK.l,
-             variant: :danger,
-             data: { action: "confirm-modal#confirm",
-                     confirm_modal_target: "confirmButton" }
-           ))
+    Button(
+      name: :OK.l,
+      variant: :danger,
+      data: { action: "confirm-modal#confirm",
+              confirm_modal_target: "confirmButton" }
+    )
   end
 end

--- a/app/views/controllers/account/api_keys/form.rb
+++ b/app/views/controllers/account/api_keys/form.rb
@@ -98,12 +98,12 @@ module Views::Controllers::Account::APIKeys
         submit(:UPDATE.l)
         # A plain link (not a submit button) — Cancel should navigate
         # back without submitting the form.
-        render(::Components::Button.new(
-                 type: :get,
-                 name: :CANCEL.l,
-                 target: account_api_keys_path,
-                 class: "ml-3"
-               ))
+        Button(
+          type: :get,
+          name: :CANCEL.l,
+          target: account_api_keys_path,
+          class: "ml-3"
+        )
       end
     end
 

--- a/app/views/controllers/account/profile/edit.rb
+++ b/app/views/controllers/account/profile/edit.rb
@@ -42,13 +42,13 @@ module Views::Controllers::Account::Profile
       render(Components::Image::Interactive.new(
                user: @user, image: @user.image, votes: false
              ))
-      render(Components::Button.new(
-               type: :put,
-               variant: :strip,
-               name: :profile_image_remove.t,
-               target: account_profile_remove_image_path,
-               confirm: :are_you_sure.l
-             ))
+      Button(
+        type: :put,
+        variant: :strip,
+        name: :profile_image_remove.t,
+        target: account_profile_remove_image_path,
+        confirm: :are_you_sure.l
+      )
     end
   end
 end

--- a/app/views/controllers/account/verifications/reverify.rb
+++ b/app/views/controllers/account/verifications/reverify.rb
@@ -15,15 +15,15 @@ module Views::Controllers::Account::Verifications
         :reverify_note.tp(user: @unverified_user.login) +
           :email_spam_notice.tp
       )
-      render(Components::Button.new(
-               type: :post,
-               name: :reverify_link.t,
-               target: account_resend_verification_email_path(
-                 id: @unverified_user.id
-               ),
-               variant: :primary,
-               id: "account_reverify_link"
-             ))
+      Button(
+        type: :post,
+        name: :reverify_link.t,
+        target: account_resend_verification_email_path(
+          id: @unverified_user.id
+        ),
+        variant: :primary,
+        id: "account_reverify_link"
+      )
     end
   end
 end

--- a/app/views/controllers/account/welcome.rb
+++ b/app/views/controllers/account/welcome.rb
@@ -11,12 +11,12 @@ module Views::Controllers::Account
       add_page_title(welcome_title)
       if current_user
         trusted_html(:welcome_note.tp)
-        render(Components::Button.new(
-                 type: :post,
-                 name: :app_logout.t,
-                 target: account_logout_path,
-                 id: "nav_user_logout_link"
-               ))
+        Button(
+          type: :post,
+          name: :app_logout.t,
+          target: account_logout_path,
+          id: "nav_user_logout_link"
+        )
       else
         trusted_html(:welcome_no_user_note.tp)
       end

--- a/app/views/controllers/admin/blocked_ips/edit.rb
+++ b/app/views/controllers/admin/blocked_ips/edit.rb
@@ -35,11 +35,11 @@ module Views::Controllers::Admin::BlockedIps
     end
 
     def render_refresh_link
-      render(Components::Button.new(
-               type: :get,
-               name: "Refresh Stats",
-               target: edit_admin_blocked_ips_path
-             ))
+      Button(
+        type: :get,
+        name: "Refresh Stats",
+        target: edit_admin_blocked_ips_path
+      )
     end
 
     def render_manager(form:, type:, list:)

--- a/app/views/controllers/admin/blocked_ips/edit/ip_summary.rb
+++ b/app/views/controllers/admin/blocked_ips/edit/ip_summary.rb
@@ -55,11 +55,11 @@ module Views::Controllers::Admin::BlockedIps
         return if ::IpStats.blocked?(ip)
 
         # Inline of the `patch_button` helper (LinkHelper#patch_button).
-        render(::Components::Button.new(
-                 type: :patch,
-                 name: "Block",
-                 target: admin_blocked_ips_path(add_bad: ip)
-               ))
+        Button(
+          type: :patch,
+          name: "Block",
+          target: admin_blocked_ips_path(add_bad: ip)
+        )
       end
 
       def render_user_cell(ip)

--- a/app/views/controllers/checklists/panel.rb
+++ b/app/views/controllers/checklists/panel.rb
@@ -82,19 +82,19 @@ module Views::Controllers::Checklists
       return unless @context.admin?
       return unless @context.project.target_name_ids.include?(name_id)
 
-      render(Components::Button.new(
-               type: :delete,
-               name: :REMOVE.l,
-               target: project_target_name_path(
-                 project_id: @context.project.id, id: name_id
-               ),
-               confirm: :project_target_name_confirm_remove.t(
-                 name: Name.safe_find(name_id)&.text_name
-               ),
-               icon: :x,
-               variant: :btn_link,
-               class: "p-0 ml-1"
-             ))
+      Button(
+        type: :delete,
+        name: :REMOVE.l,
+        target: project_target_name_path(
+          project_id: @context.project.id, id: name_id
+        ),
+        confirm: :project_target_name_confirm_remove.t(
+          name: Name.safe_find(name_id)&.text_name
+        ),
+        icon: :x,
+        variant: :btn_link,
+        class: "p-0 ml-1"
+      )
     end
   end
 end

--- a/app/views/controllers/collection_numbers/index.rb
+++ b/app/views/controllers/collection_numbers/index.rb
@@ -43,8 +43,8 @@ module Views::Controllers::CollectionNumbers
     def render_edit_link(collection_number)
       return unless can_edit?(collection_number)
 
-      render(Components::Button.new(type: :edit, target: collection_number,
-                                    size: :sm))
+      Button(type: :edit, target: collection_number,
+             size: :sm)
     end
 
     def render_format_name_link(collection_number)
@@ -67,10 +67,10 @@ module Views::Controllers::CollectionNumbers
     def render_delete_button(collection_number)
       return unless can_edit?(collection_number)
 
-      render(Components::Button.new(
-               type: :delete,
-               target: collection_number, variant: :outline, size: :sm
-             ))
+      Button(
+        type: :delete,
+        target: collection_number, variant: :outline, size: :sm
+      )
     end
 
     def can_edit?(collection_number)

--- a/app/views/controllers/comments/comments_for_object.rb
+++ b/app/views/controllers/comments/comments_for_object.rb
@@ -66,15 +66,15 @@ module Views::Controllers::Comments
     # ---- header "+ Add comment" link ------------------------------
 
     def render_add_comment_link
-      render(Components::Button.new(
-               type: :modal,
-               name: :show_comments_add_comment.l,
-               target: new_comment_path(
-                 target: @object.id, type: @object.class.name
-               ),
-               modal_id: "comment",
-               variant: :strip, icon: :add
-             ))
+      Button(
+        type: :modal,
+        name: :show_comments_add_comment.l,
+        target: new_comment_path(
+          target: @object.id, type: @object.class.name
+        ),
+        modal_id: "comment",
+        variant: :strip, icon: :add
+      )
     end
 
     # ---- footer "and N more →" link -------------------------------

--- a/app/views/controllers/descriptions/authors/show.rb
+++ b/app/views/controllers/descriptions/authors/show.rb
@@ -36,14 +36,14 @@ module Views::Controllers::Descriptions::Authors
     def render_author_row(user, type)
       Link(type: :user, user: user)
       plain(" | ")
-      render(Components::Button.new(
-               type: :delete,
-               name: :review_authors_remove_author.t,
-               target: description_authors_path(
-                 id: @object.id, type: type, remove: user.id
-               ),
-               variant: :strip
-             ))
+      Button(
+        type: :delete,
+        name: :review_authors_remove_author.t,
+        target: description_authors_path(
+          id: @object.id, type: type, remove: user.id
+        ),
+        variant: :strip
+      )
       br
     end
 

--- a/app/views/controllers/descriptions/details_and_alts_panel.rb
+++ b/app/views/controllers/descriptions/details_and_alts_panel.rb
@@ -184,14 +184,14 @@ module Views::Controllers::Descriptions
         span { plain(" | ") }
         %w[unvetted vetted inaccurate].each_with_index do |w, idx|
           span { plain(" | ") } if idx.positive?
-          render(Components::Button.new(
-                   type: :put,
-                   variant: :strip,
-                   target: review_status_name_description_path(
-                     @description.id, value: w
-                   ),
-                   name: :"review_#{w}".l
-                 ))
+          Button(
+            type: :put,
+            variant: :strip,
+            target: review_status_name_description_path(
+              @description.id, value: w
+            ),
+            name: :"review_#{w}".l
+          )
         end
       end
     end

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -57,13 +57,13 @@ module Views::Controllers::FieldSlips
         b { plain("#{:show_project_field_slip_prefix.t}:") }
         plain(" #{@project.field_slip_prefix} ")
         if @project.member?(current_user)
-          render(Components::Button.new(
-                   type: :get,
-                   name: :show_project_field_slip_create.t,
-                   target: new_project_field_slip_path(
-                     project_id: @project.id
-                   )
-                 ))
+          Button(
+            type: :get,
+            name: :show_project_field_slip_create.t,
+            target: new_project_field_slip_path(
+              project_id: @project.id
+            )
+          )
         end
       end
     end

--- a/app/views/controllers/herbaria/index.rb
+++ b/app/views/controllers/herbaria/index.rb
@@ -85,15 +85,15 @@ module Views::Controllers::Herbaria
 
     # Cannot POST from a link without js; use a button instead.
     def render_merge_target_button(herbarium)
-      render(::Components::Button.new(
-               type: :post,
-               variant: :strip,
-               name: herbarium.name.t,
-               target: herbaria_merges_path(src: @merge.id,
-                                            dest: herbarium.id),
-               class: "herbaria_merges_link_#{@merge.id}_#{herbarium.id}",
-               confirm: :are_you_sure.l
-             ))
+      Button(
+        type: :post,
+        variant: :strip,
+        name: herbarium.name.t,
+        target: herbaria_merges_path(src: @merge.id,
+                                     dest: herbarium.id),
+        class: "herbaria_merges_link_#{@merge.id}_#{herbarium.id}",
+        confirm: :are_you_sure.l
+      )
     end
 
     def render_self_merge_marker(herbarium)
@@ -110,21 +110,21 @@ module Views::Controllers::Herbaria
 
     def render_admin_actions(herbarium)
       plain(" [")
-      render(::Components::Button.new(
-               type: :edit,
-               target: herbarium,
-               name: :EDIT.l,
-               icon: nil, variant: :strip,
-               class: "edit_herbarium_link_#{herbarium.id}"
-             ))
+      Button(
+        type: :edit,
+        target: herbarium,
+        name: :EDIT.l,
+        icon: nil, variant: :strip,
+        class: "edit_herbarium_link_#{herbarium.id}"
+      )
       plain(" | ")
-      render(::Components::Button.new(
-               type: :get,
-               name: :MERGE.l,
-               target: herbaria_path(merge: herbarium.id),
-               icon: nil, variant: :strip,
-               class: "merge_herbarium_link_#{herbarium.id}"
-             ))
+      Button(
+        type: :get,
+        name: :MERGE.l,
+        target: herbaria_path(merge: herbarium.id),
+        icon: nil, variant: :strip,
+        class: "merge_herbarium_link_#{herbarium.id}"
+      )
       plain("]")
     end
 

--- a/app/views/controllers/herbaria/show.rb
+++ b/app/views/controllers/herbaria/show.rb
@@ -96,11 +96,11 @@ module Views::Controllers::Herbaria
                    type: :user, label: false
                  ))
           label(for: "add_curator") do
-            render(::Components::Button.new(
-                     type: :submit,
-                     name: :show_herbarium_add_curator.t,
-                     html_name: "commit"
-                   ))
+            Button(
+              type: :submit,
+              name: :show_herbarium_add_curator.t,
+              html_name: "commit"
+            )
           end
         end
       end

--- a/app/views/controllers/herbaria/show/curator_table.rb
+++ b/app/views/controllers/herbaria/show/curator_table.rb
@@ -33,13 +33,13 @@ module Views::Controllers::Herbaria
       end
 
       def render_delete_cell(user)
-        render(::Components::Button.new(
-                 type: :delete,
-                 name: "X",
-                 target: herbaria_curator_path(@herbarium, user: user.id),
-                 id: "delete_herbarium_curator_link_#{user.id}",
-                 variant: :strip
-               ))
+        Button(
+          type: :delete,
+          name: "X",
+          target: herbaria_curator_path(@herbarium, user: user.id),
+          id: "delete_herbarium_curator_link_#{user.id}",
+          variant: :strip
+        )
       end
 
       def render_user_cell(user)

--- a/app/views/controllers/herbarium_records/index.rb
+++ b/app/views/controllers/herbarium_records/index.rb
@@ -47,13 +47,13 @@ module Views::Controllers::HerbariumRecords
     def render_edit_link(rec)
       return unless can_edit?(rec)
 
-      render(Components::Button.new(
-               type: :edit,
-               target: edit_herbarium_record_path(id: rec.id, back: :index,
-                                                  q: q_param),
-               size: :sm,
-               class: "edit_herbarium_record_link_#{rec.id}"
-             ))
+      Button(
+        type: :edit,
+        target: edit_herbarium_record_path(id: rec.id, back: :index,
+                                           q: q_param),
+        size: :sm,
+        class: "edit_herbarium_record_link_#{rec.id}"
+      )
     end
 
     def render_herbarium_link(rec)
@@ -83,13 +83,13 @@ module Views::Controllers::HerbariumRecords
     def render_delete_button(rec)
       return unless can_edit?(rec)
 
-      render(Components::Button.new(
-               type: :delete,
-               target: herbarium_record_path(rec.id, back: :index),
-               name: :destroy_object.t(type: :herbarium_record),
-               variant: :outline, size: :sm,
-               class: "destroy_herbarium_record_link_#{rec.id}"
-             ))
+      Button(
+        type: :delete,
+        target: herbarium_record_path(rec.id, back: :index),
+        name: :destroy_object.t(type: :herbarium_record),
+        variant: :outline, size: :sm,
+        class: "destroy_herbarium_record_link_#{rec.id}"
+      )
     end
 
     def can_edit?(rec)

--- a/app/views/controllers/images/show/image_panel.rb
+++ b/app/views/controllers/images/show/image_panel.rb
@@ -41,13 +41,13 @@ module Views::Controllers::Images
       end
 
       def render_transform_button(operation, label_key)
-        render(::Components::Button.new(
-                 type: :put,
-                 name: label_key.t,
-                 target: transform_image_path(id: @image.id,
-                                              op: operation, size: @size),
-                 variant: :strip, icon: nil
-               ))
+        Button(
+          type: :put,
+          name: label_key.t,
+          target: transform_image_path(id: @image.id,
+                                       op: operation, size: @size),
+          variant: :strip, icon: nil
+        )
       end
 
       # --- Body: interactive image + vote + original filename ------

--- a/app/views/controllers/inat_imports/show.rb
+++ b/app/views/controllers/inat_imports/show.rb
@@ -37,17 +37,17 @@ module Views::Controllers::InatImports
 
     def render_actions
       div(class: "mt-3") do
-        render(Components::Button.new(
-                 type: :get,
-                 name: :inat_import_tracker_results.l,
-                 target: results_observations_path
-               ))
+        Button(
+          type: :get,
+          name: :inat_import_tracker_results.l,
+          target: results_observations_path
+        )
         whitespace
-        render(::Components::Button.new(
-                 type: :put,
-                 name: :CANCEL.l,
-                 target: inat_import_cancel_path(id: @tracker.inat_import)
-               ))
+        Button(
+          type: :put,
+          name: :CANCEL.l,
+          target: inat_import_cancel_path(id: @tracker.inat_import)
+        )
       end
     end
 

--- a/app/views/controllers/interests/index.rb
+++ b/app/views/controllers/interests/index.rb
@@ -28,10 +28,10 @@ module Views::Controllers::Interests
 
     def render_type_filter
       div(class: "btn-group pb-1 hidden-xs text-nowrap mt-5") do
-        render(Components::Button.new(
-                 name: :rss_show.l, tag: :span, size: :sm,
-                 class: "disabled"
-               ))
+        Button(
+          name: :rss_show.l, tag: :span, size: :sm,
+          class: "disabled"
+        )
         render_filter_pill(nil, :rss_all.l, interests_path)
         @types.each do |type|
           label = type.underscore.pluralize.upcase.to_sym.l
@@ -42,9 +42,9 @@ module Views::Controllers::Interests
 
     def render_filter_pill(type, label, url)
       active = (type.to_s == @selected_type.to_s)
-      render(Components::Button.new(
-               tag: :span, size: :sm, class: ("active" if active)
-             )) do
+      Button(
+        tag: :span, size: :sm, class: ("active" if active)
+      ) do
         if active
           plain(label)
         else

--- a/app/views/controllers/locations/show/coordinates.rb
+++ b/app/views/controllers/locations/show/coordinates.rb
@@ -44,10 +44,10 @@ module Views::Controllers::Locations
       end
 
       def render_destroy_button
-        render(::Components::Button.new(
-                 type: :delete,
-                 target: @location, variant: :strip
-               ))
+        Button(
+          type: :delete,
+          target: @location, variant: :strip
+        )
       end
 
       def render_reverse_link

--- a/app/views/controllers/names/index/row.rb
+++ b/app/views/controllers/names/index/row.rb
@@ -57,14 +57,14 @@ class Views::Controllers::Names::Index::Row < Views::Base
   end
 
   def render_copy_button
-    render(::Components::Button.new(
-             variant: :btn_link,
-             class: "py-0 link-normal opacity-75",
-             role: "button",
-             data: { toggle: "tooltip", placement: "bottom",
-                     title: :COPY_THIS_NAME.l,
-                     action: "clipboard#copy" }
-           )) { render(Components::Icon.new(type: :copy)) }
+    Button(
+      variant: :btn_link,
+      class: "py-0 link-normal opacity-75",
+      role: "button",
+      data: { toggle: "tooltip", placement: "bottom",
+              title: :COPY_THIS_NAME.l,
+              action: "clipboard#copy" }
+    ) { render(Components::Icon.new(type: :copy)) }
   end
 
   def render_count_badge

--- a/app/views/controllers/names/show/classification_panel.rb
+++ b/app/views/controllers/names/show/classification_panel.rb
@@ -102,9 +102,9 @@ class Views::Controllers::Names::Show::ClassificationPanel < Views::Base
     li do
       text, url, opts = tab.to_a
       if opts[:button] == :put
-        render(Components::Button.new(
-                 type: :put, variant: :strip, name: text, target: url
-               ))
+        Button(
+          type: :put, variant: :strip, name: text, target: url
+        )
       else
         a(href: url, **opts.slice(:class, :data, :target, :rel)) do
           plain(text)

--- a/app/views/controllers/observations/images/form.rb
+++ b/app/views/controllers/observations/images/form.rb
@@ -97,12 +97,12 @@ module Views::Controllers::Observations::Images
     def render_footer_buttons
       div(class: "text-center mt-3 mb-5") do
         submit(:SAVE_EDITS.l)
-        render(Components::Button.new(
-                 type: :get,
-                 name: :cancel_and_show.t(type: :image),
-                 target: image_path(model.id),
-                 class: "ml-2"
-               ))
+        Button(
+          type: :get,
+          name: :cancel_and_show.t(type: :image),
+          target: image_path(model.id),
+          class: "ml-2"
+        )
       end
     end
 

--- a/app/views/controllers/observations/locations/edit.rb
+++ b/app/views/controllers/observations/locations/edit.rb
@@ -36,16 +36,16 @@ module Views::Controllers::Observations::Locations
 
     def render_match(list, location)
       list.item do
-        render(::Components::Button.new(
-                 type: :patch,
-                 variant: :strip,
-                 name: location.display_name.t,
-                 target: assign_location_to_observations_path(
-                   where: @where, location: location
-                 ),
-                 class: "text-left",
-                 data: { turbo_confirm: :list_merge_are_you_sure.l }
-               ))
+        Button(
+          type: :patch,
+          variant: :strip,
+          name: location.display_name.t,
+          target: assign_location_to_observations_path(
+            where: @where, location: location
+          ),
+          class: "text-left",
+          data: { turbo_confirm: :list_merge_are_you_sure.l }
+        )
       end
     end
   end

--- a/app/views/controllers/observations/namings/suggestions/show.rb
+++ b/app/views/controllers/observations/namings/suggestions/show.rb
@@ -82,12 +82,12 @@ module Views::Controllers::Observations::Namings::Suggestions
       if already_proposed?(sugg)
         plain("(#{:suggestions_already_proposed.t})")
       else
-        render(Components::Button.new(
-                 type: :get,
-                 name: :suggestions_propose_name.t,
-                 target: propose_path(sugg),
-                 class: "mt-3"
-               ))
+        Button(
+          type: :get,
+          name: :suggestions_propose_name.t,
+          target: propose_path(sugg),
+          class: "mt-3"
+        )
       end
     end
 

--- a/app/views/controllers/observations/show/namings/footer_buttons.rb
+++ b/app/views/controllers/observations/show/namings/footer_buttons.rb
@@ -35,17 +35,17 @@ class Views::Controllers::Observations::Show::Namings::FooterButtons < Views::Ba
   # Text-button variant of the propose-naming link (icon-only
   # variant lives in the panel `Header` for mobile).
   def render_propose_button
-    render(Components::Button.new(
-             type: :modal,
-             name: :show_namings_propose_new_name.t,
-             target: new_observation_naming_path(
-               observation_id: @obs.id,
-               context: "namings_table"
-             ),
-             modal_id: "obs_#{@obs.id}_naming",
-             size: :sm,
-             class: "d-none d-sm-inline-block propose-naming-link"
-           ))
+    Button(
+      type: :modal,
+      name: :show_namings_propose_new_name.t,
+      target: new_observation_naming_path(
+        observation_id: @obs.id,
+        context: "namings_table"
+      ),
+      modal_id: "obs_#{@obs.id}_naming",
+      size: :sm,
+      class: "d-none d-sm-inline-block propose-naming-link"
+    )
   end
 
   # Gating: a thumb image must exist (so
@@ -61,12 +61,12 @@ class Views::Controllers::Observations::Show::Namings::FooterButtons < Views::Ba
   # Stimulus `suggestions#suggestTaxa` action that fetches via
   # `data-results-url` and replaces page content.
   def render_suggest_button
-    render(Components::Button.new(
-             name: :show_namings_suggest_names.l,
-             size: :sm,
-             class: "mt-2",
-             data: suggest_button_data
-           ))
+    Button(
+      name: :show_namings_suggest_names.l,
+      size: :sm,
+      class: "mt-2",
+      data: suggest_button_data
+    )
   end
 
   def suggest_button_data

--- a/app/views/controllers/observations/show/namings/header.rb
+++ b/app/views/controllers/observations/show/namings/header.rb
@@ -67,16 +67,16 @@ class Views::Controllers::Observations::Show::Namings::Header < Views::Base
   def render_propose_icon_column
     div(class: "col-xs-2 col-sm-1") do
       span(class: "float-right d-sm-none") do
-        render(Components::Button.new(
-                 type: :modal,
-                 name: :show_namings_propose_new_name.t,
-                 target: new_observation_naming_path(
-                   observation_id: @obs.id,
-                   context: "namings_table"
-                 ),
-                 modal_id: "obs_#{@obs.id}_naming",
-                 variant: :strip, icon: :add
-               ))
+        Button(
+          type: :modal,
+          name: :show_namings_propose_new_name.t,
+          target: new_observation_naming_path(
+            observation_id: @obs.id,
+            context: "namings_table"
+          ),
+          modal_id: "obs_#{@obs.id}_naming",
+          variant: :strip, icon: :add
+        )
       end
     end
   end

--- a/app/views/controllers/observations/show/namings/row.rb
+++ b/app/views/controllers/observations/show/namings/row.rb
@@ -147,13 +147,13 @@ class Views::Controllers::Observations::Show::Namings::Row < Views::Base
   end
 
   def render_matching_observations_link
-    render(Components::Button.new(
-             type: :get,
-             target: url_for(occurrence_path(@naming.observation.occurrence)),
-             name: :show_observation_matching_observations.l,
-             variant: :btn_link,
-             class: "text-wrap text-left px-0"
-           ))
+    Button(
+      type: :get,
+      target: url_for(occurrence_path(@naming.observation.occurrence)),
+      name: :show_observation_matching_observations.l,
+      variant: :btn_link,
+      class: "text-wrap text-left px-0"
+    )
   end
 
   def render_single_proposer_link
@@ -195,13 +195,13 @@ class Views::Controllers::Observations::Show::Namings::Row < Views::Base
   end
 
   def render_vote_percent_link
-    render(Components::Button.new(
-             type: :modal,
-             name: "#{@naming.vote_percent.round}%",
-             target: vote_percent_modal_path,
-             modal_id: "naming_votes_#{primary.id}",
-             variant: :btn_link, class: "vote-percent px-0"
-           ))
+    Button(
+      type: :modal,
+      name: "#{@naming.vote_percent.round}%",
+      target: vote_percent_modal_path,
+      modal_id: "naming_votes_#{primary.id}",
+      variant: :btn_link, class: "vote-percent px-0"
+    )
   end
 
   def vote_percent_modal_path

--- a/app/views/controllers/observations/show/observation_details_panel.rb
+++ b/app/views/controllers/observations/show/observation_details_panel.rb
@@ -31,13 +31,13 @@ class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::B
     name = :download_observations_print_labels.l
     query = ::Query.lookup(::Observation, id_in_set: [@obs.id])
     path = add_q_param(observations_downloads_path(commit: name), query)
-    render(Components::Button.new(
-             type: :post,
-             variant: :strip,
-             name: name, target: path, icon: :print,
-             class: "print_label_observation_#{@obs.id}",
-             form: { data: { turbo: false } }
-           ))
+    Button(
+      type: :post,
+      variant: :strip,
+      name: name, target: path, icon: :print,
+      class: "print_label_observation_#{@obs.id}",
+      form: { data: { turbo: false } }
+    )
   end
 
   def render_body
@@ -182,13 +182,13 @@ class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::B
 
   def render_send_question_link
     plain(" [")
-    render(Components::Button.new(
-             type: :modal,
-             name: :show_observation_send_question.l,
-             target: new_question_for_observation_path(@obs.id),
-             modal_id: "observation_email",
-             variant: :strip, icon: :email
-           ))
+    Button(
+      type: :modal,
+      name: :show_observation_send_question.l,
+      target: new_question_for_observation_path(@obs.id),
+      modal_id: "observation_email",
+      variant: :strip, icon: :email
+    )
     plain("]")
   end
 

--- a/app/views/controllers/observations/show/species_lists_panel.rb
+++ b/app/views/controllers/observations/show/species_lists_panel.rb
@@ -50,12 +50,12 @@ class Views::Controllers::Observations::Show::SpeciesListsPanel < Views::Base
     remove_path = observation_species_list_path(
       id: @obs.id, species_list_id: spl.id, commit: "remove"
     )
-    render(Components::Button.new(
-             type: :put,
-             variant: :strip,
-             name: "[#{:REMOVE.t}]",
-             target: remove_path,
-             confirm: :are_you_sure.l
-           ))
+    Button(
+      type: :put,
+      variant: :strip,
+      name: "[#{:REMOVE.t}]",
+      target: remove_path,
+      confirm: :are_you_sure.l
+    )
   end
 end

--- a/app/views/controllers/occurrences/projects/form.rb
+++ b/app/views/controllers/occurrences/projects/form.rb
@@ -132,12 +132,12 @@ module Views::Controllers::Occurrences::Projects
     end
 
     def render_buttons
-      render(Components::Button.new(
-               type: :get,
-               target: cancel_path,
-               name: :CANCEL.l,
-               data: { dismiss: "modal" }
-             ))
+      Button(
+        type: :get,
+        target: cancel_path,
+        name: :CANCEL.l,
+        data: { dismiss: "modal" }
+      )
       whitespace
       # Skip = proceed without backfilling projects. Both controllers
       # (`OccurrencesController#create` and

--- a/app/views/controllers/projects/admin/show.rb
+++ b/app/views/controllers/projects/admin/show.rb
@@ -53,12 +53,12 @@ module Views::Controllers::Projects::Admin
 
     def render_destroy
       p { plain(:show_project_admin_destroy_help.l) }
-      render(Components::Button.new(
-               type: :delete,
-               target: @project,
-               name: :destroy_object.t(type: :project),
-               size: :lg
-             ))
+      Button(
+        type: :delete,
+        target: @project,
+        name: :destroy_object.t(type: :project),
+        size: :lg
+      )
     end
   end
 end

--- a/app/views/controllers/projects/aliases/table.rb
+++ b/app/views/controllers/projects/aliases/table.rb
@@ -40,22 +40,22 @@ module Views::Controllers::Projects::Aliases
     end
 
     def render_actions_cell(alias_)
-      render(Components::Button.new(
-               type: :edit,
-               target: edit_project_alias_path(
-                 project_id: alias_.project_id, id: alias_.id
-               ),
-               name: :edit_object.t(type: :project_alias),
-               variant: :strip
-             ))
+      Button(
+        type: :edit,
+        target: edit_project_alias_path(
+          project_id: alias_.project_id, id: alias_.id
+        ),
+        name: :edit_object.t(type: :project_alias),
+        variant: :strip
+      )
       span(class: "mx-2")
-      render(Components::Button.new(
-               type: :delete,
-               target: project_alias_path(
-                 project_id: alias_.project_id, id: alias_.id
-               ),
-               variant: :strip
-             ))
+      Button(
+        type: :delete,
+        target: project_alias_path(
+          project_id: alias_.project_id, id: alias_.id
+        ),
+        variant: :strip
+      )
     end
   end
 end

--- a/app/views/controllers/projects/aliases/widget.rb
+++ b/app/views/controllers/projects/aliases/widget.rb
@@ -32,44 +32,44 @@ module Views::Controllers::Projects::Aliases
       alias_data.each do |name, id|
         render_edit_link(name, id)
         span(class: "mx-2")
-        render(Components::Button.new(
-                 type: :delete,
-                 target: project_alias_path(
-                   project_id: @project.id, id: id
-                 ),
-                 variant: :strip
-               ))
+        Button(
+          type: :delete,
+          target: project_alias_path(
+            project_id: @project.id, id: id
+          ),
+          variant: :strip
+        )
         br
       end
     end
 
     def render_edit_link(name, id)
       span(id: "project_alias_#{id}") do
-        render(Components::Button.new(
-                 type: :modal,
-                 name: name,
-                 target: edit_project_alias_path(
-                   project_id: @project.id, id: id
-                 ),
-                 modal_id: "project_alias_#{id}",
-                 variant: :strip
-               ))
+        Button(
+          type: :modal,
+          name: name,
+          target: edit_project_alias_path(
+            project_id: @project.id, id: id
+          ),
+          modal_id: "project_alias_#{id}",
+          variant: :strip
+        )
       end
     end
 
     def render_new_link
       span(id: "project_alias") do
-        render(Components::Button.new(
-                 type: :modal,
-                 name: :ADD.t,
-                 target: new_project_alias_path(
-                   project_id: @project.id,
-                   target_id: @target.id,
-                   target_type: @target.class
-                 ),
-                 modal_id: "project_alias",
-                 variant: :strip
-               ))
+        Button(
+          type: :modal,
+          name: :ADD.t,
+          target: new_project_alias_path(
+            project_id: @project.id,
+            target_id: @target.id,
+            target_type: @target.class
+          ),
+          modal_id: "project_alias",
+          variant: :strip
+        )
       end
     end
   end

--- a/app/views/controllers/projects/locations/tables.rb
+++ b/app/views/controllers/projects/locations/tables.rb
@@ -196,19 +196,19 @@ module Views::Controllers::Projects::Locations
     end
 
     def render_remove_button(loc)
-      render(Components::Button.new(
-               type: :delete,
-               name: :REMOVE.l,
-               target: project_target_location_path(
-                 project_id: @project.id, id: loc.id
-               ),
-               confirm: :project_target_location_confirm_remove.t(
-                 name: loc.display_name
-               ),
-               icon: :x,
-               variant: :btn_link,
-               class: "p-0"
-             ))
+      Button(
+        type: :delete,
+        name: :REMOVE.l,
+        target: project_target_location_path(
+          project_id: @project.id, id: loc.id
+        ),
+        confirm: :project_target_location_confirm_remove.t(
+          name: loc.display_name
+        ),
+        icon: :x,
+        variant: :btn_link,
+        class: "p-0"
+      )
     end
   end
 end

--- a/app/views/controllers/projects/members/add_obs_modal.rb
+++ b/app/views/controllers/projects/members/add_obs_modal.rb
@@ -37,26 +37,26 @@ module Views::Controllers::Projects::Members
     end
 
     def render_footer_buttons
-      render(::Components::Button.new(
-               name: :CANCEL.l,
-               data: { dismiss: "modal" }
-             ))
+      Button(
+        name: :CANCEL.l,
+        data: { dismiss: "modal" }
+      )
       whitespace
       render_submit_button if @count.positive?
     end
 
     def render_submit_button
-      render(Components::Button.new(
-               type: :put,
-               name: submit_label,
-               target: project_member_path(
-                 project_id: @project.id,
-                 candidate: @candidate.id,
-                 commit: :change_member_add_obs.l,
-                 target: :project_index
-               ),
-               variant: :primary
-             ))
+      Button(
+        type: :put,
+        name: submit_label,
+        target: project_member_path(
+          project_id: @project.id,
+          candidate: @candidate.id,
+          commit: :change_member_add_obs.l,
+          target: :project_index
+        ),
+        variant: :primary
+      )
     end
 
     def submit_label

--- a/app/views/controllers/projects/members/new.rb
+++ b/app/views/controllers/projects/members/new.rb
@@ -39,15 +39,15 @@ module Views::Controllers::Projects::Members
     end
 
     def render_add_button(user)
-      render(Components::Button.new(
-               type: :post,
-               variant: :strip,
-               name: :ADD.l,
-               target: project_members_path(
-                 project_id: @project.id,
-                 candidate: user.id
-               )
-             ))
+      Button(
+        type: :post,
+        variant: :strip,
+        name: :ADD.l,
+        target: project_members_path(
+          project_id: @project.id,
+          candidate: user.id
+        )
+      )
     end
   end
 end

--- a/app/views/controllers/projects/members/trust_settings.rb
+++ b/app/views/controllers/projects/members/trust_settings.rb
@@ -106,10 +106,10 @@ module Views::Controllers::Projects::Members
     end
 
     def render_footer_buttons
-      render(::Components::Button.new(
-               name: :CANCEL.l,
-               data: { dismiss: "modal" }
-             ))
+      Button(
+        name: :CANCEL.l,
+        data: { dismiss: "modal" }
+      )
       whitespace
       # `name: "save"` overrides Superform's default `name: "commit"`
       # to avoid colliding with the radio group's own `commit` name —

--- a/app/views/controllers/projects/observation_buttons.rb
+++ b/app/views/controllers/projects/observation_buttons.rb
@@ -47,7 +47,7 @@ module Views::Controllers::Projects
     end
 
     def project_button(name, target)
-      render(Components::Button.new(type: :project, name: name, target: target))
+      Button(type: :project, name: name, target: target)
     end
 
     def related_observation_images_url

--- a/app/views/controllers/projects/show.rb
+++ b/app/views/controllers/projects/show.rb
@@ -96,12 +96,12 @@ module Views::Controllers::Projects
     def render_administer_button
       return unless @user&.admin && !@project.is_admin?(@user)
 
-      render(Components::Button.new(
-               type: :post,
-               name: :show_project_administer.l,
-               target: project_administration_path(project_id: @project.id),
-               size: :lg, class: "my-2 mr-2"
-             ))
+      Button(
+        type: :post,
+        name: :show_project_administer.l,
+        target: project_administration_path(project_id: @project.id),
+        size: :lg, class: "my-2 mr-2"
+      )
     end
 
     def render_membership_buttons
@@ -113,16 +113,16 @@ module Views::Controllers::Projects
     end
 
     def render_join_button
-      render(Components::Button.new(
-               type: :post,
-               name: :show_project_join.l,
-               target: project_members_path(
-                 project_id: @project.id,
-                 candidate: @user.id,
-                 target: :project_index
-               ),
-               size: :lg, class: "my-2 mr-2"
-             ))
+      Button(
+        type: :post,
+        name: :show_project_join.l,
+        target: project_members_path(
+          project_id: @project.id,
+          candidate: @user.id,
+          target: :project_index
+        ),
+        size: :lg, class: "my-2 mr-2"
+      )
     end
 
     def render_member_buttons
@@ -132,53 +132,53 @@ module Views::Controllers::Projects
     end
 
     def render_trust_settings_button
-      render(Components::Button.new(
-               type: :modal,
-               name: :show_project_trust_settings.l,
-               target: trust_modal_project_member_path(
-                 project_id: @project.id, candidate: @user.id
-               ),
-               modal_id: "trust_settings",
-               size: :lg, class: "my-2 mr-2"
-             ))
+      Button(
+        type: :modal,
+        name: :show_project_trust_settings.l,
+        target: trust_modal_project_member_path(
+          project_id: @project.id, candidate: @user.id
+        ),
+        modal_id: "trust_settings",
+        size: :lg, class: "my-2 mr-2"
+      )
     end
 
     def render_leave_button
-      render(Components::Button.new(
-               type: :put,
-               name: :show_project_leave.t,
-               target: project_member_path(
-                 project_id: @project.id,
-                 candidate: @user.id,
-                 target: :project_index
-               ),
-               size: :lg, class: "my-2 mr-2"
-             ))
+      Button(
+        type: :put,
+        name: :show_project_leave.t,
+        target: project_member_path(
+          project_id: @project.id,
+          candidate: @user.id,
+          target: :project_index
+        ),
+        size: :lg, class: "my-2 mr-2"
+      )
     end
 
     def render_add_obs_button
-      render(Components::Button.new(
-               type: :modal,
-               name: :change_member_add_obs.t,
-               target: add_obs_modal_project_member_path(
-                 project_id: @project.id, candidate: @user.id
-               ),
-               modal_id: "add_obs",
-               size: :lg, class: "my-2 mr-2"
-             ))
+      Button(
+        type: :modal,
+        name: :change_member_add_obs.t,
+        target: add_obs_modal_project_member_path(
+          project_id: @project.id, candidate: @user.id
+        ),
+        modal_id: "add_obs",
+        size: :lg, class: "my-2 mr-2"
+      )
     end
 
     def render_admin_links
       return if permission?(@project)
 
-      render(Components::Button.new(
-               type: :get,
-               name: :show_project_admin_request.l,
-               target: new_project_admin_request_path(
-                 project_id: @project.id
-               ),
-               size: :lg, class: "my-2 mr-2"
-             ))
+      Button(
+        type: :get,
+        name: :show_project_admin_request.l,
+        target: new_project_admin_request_path(
+          project_id: @project.id
+        ),
+        size: :lg, class: "my-2 mr-2"
+      )
     end
 
     # Explicit String target because the violations route uses
@@ -189,14 +189,14 @@ module Views::Controllers::Projects
       return unless @project.constraints?
 
       count = @project.count_violations
-      render(Components::Button.new(
-               type: :get,
-               name: "#{count} #{:CONSTRAINT_VIOLATIONS.l}",
-               target: project_violations_path(project_id: @project.id),
-               variant: count.positive? ? :warning : nil,
-               size: :lg,
-               class: "my-2 mr-2"
-             ))
+      Button(
+        type: :get,
+        name: "#{count} #{:CONSTRAINT_VIOLATIONS.l}",
+        target: project_violations_path(project_id: @project.id),
+        variant: count.positive? ? :warning : nil,
+        size: :lg,
+        class: "my-2 mr-2"
+      )
     end
 
     def render_comments

--- a/app/views/controllers/projects/updates/index.rb
+++ b/app/views/controllers/projects/updates/index.rb
@@ -72,15 +72,15 @@ module Views::Controllers::Projects::Updates
     end
 
     def render_add_all_button
-      render(Components::Button.new(
-               type: :post,
-               name: :project_updates_add_all.t,
-               target: add_all_project_updates_path(
-                 project_id: @project.id,
-                 show_excluded: @show_excluded
-               ),
-               confirm: :project_updates_confirm_add_all.t
-             ))
+      Button(
+        type: :post,
+        name: :project_updates_add_all.t,
+        target: add_all_project_updates_path(
+          project_id: @project.id,
+          show_excluded: @show_excluded
+        ),
+        confirm: :project_updates_confirm_add_all.t
+      )
     end
 
     def render_pagination

--- a/app/views/controllers/projects/updates/obs_footer.rb
+++ b/app/views/controllers/projects/updates/obs_footer.rb
@@ -25,27 +25,27 @@ module Views::Controllers::Projects::Updates
     private
 
     def render_add_button
-      render(Components::Button.new(
-               type: :post,
-               name: :ADD.t,
-               target: add_observation_project_update_path(
-                 project_id: @project.id, id: @obs.id,
-                 show_excluded: @show_excluded
-               ),
-               size: :sm, class: "mx-1"
-             ))
+      Button(
+        type: :post,
+        name: :ADD.t,
+        target: add_observation_project_update_path(
+          project_id: @project.id, id: @obs.id,
+          show_excluded: @show_excluded
+        ),
+        size: :sm, class: "mx-1"
+      )
     end
 
     def render_exclude_button
-      render(Components::Button.new(
-               type: :post,
-               name: :EXCLUDE.t,
-               target: exclude_observation_project_update_path(
-                 project_id: @project.id, id: @obs.id,
-                 show_excluded: @show_excluded
-               ),
-               size: :sm, class: "mx-1"
-             ))
+      Button(
+        type: :post,
+        name: :EXCLUDE.t,
+        target: exclude_observation_project_update_path(
+          project_id: @project.id, id: @obs.id,
+          show_excluded: @show_excluded
+        ),
+        size: :sm, class: "mx-1"
+      )
     end
   end
 end

--- a/app/views/controllers/projects/violations/form.rb
+++ b/app/views/controllers/projects/violations/form.rb
@@ -122,33 +122,33 @@ module Views::Controllers::Projects::Violations
     end
 
     def render_exclude_button(obs)
-      render(::Components::Button.new(
-               type: :put,
-               name: :form_violations_action_exclude.l,
-               target: violations_path,
-               params: { project: { do: "exclude", obs_id: obs.id } },
-               size: :xs
-             ))
+      Button(
+        type: :put,
+        name: :form_violations_action_exclude.l,
+        target: violations_path,
+        params: { project: { do: "exclude", obs_id: obs.id } },
+        size: :xs
+      )
     end
 
     def render_extend_button(obs)
-      render(::Components::Button.new(
-               type: :put,
-               name: :form_violations_action_extend.l,
-               target: violations_path,
-               params: { project: { do: "extend", obs_id: obs.id } },
-               size: :xs
-             ))
+      Button(
+        type: :put,
+        name: :form_violations_action_extend.l,
+        target: violations_path,
+        params: { project: { do: "extend", obs_id: obs.id } },
+        size: :xs
+      )
     end
 
     def render_add_target_name_button(obs)
-      render(::Components::Button.new(
-               type: :put,
-               name: :form_violations_action_add_target_name.l,
-               target: violations_path,
-               params: { project: { do: "add_target_name", obs_id: obs.id } },
-               size: :xs
-             ))
+      Button(
+        type: :put,
+        name: :form_violations_action_add_target_name.l,
+        target: violations_path,
+        params: { project: { do: "add_target_name", obs_id: obs.id } },
+        size: :xs
+      )
     end
 
     # The modal markup itself is no longer rendered eagerly — each
@@ -161,21 +161,21 @@ module Views::Controllers::Projects::Violations
     # first so DB state from the other tab (a newly-created suffix
     # Location) is picked up on reopen (#4304).
     def render_add_target_location_trigger(obs)
-      render(::Components::Button.new(
-               type: :get,
-               name: :form_violations_action_add_target_location.l,
-               target: target_location_modal_project_violations_path(
-                 project_id: @project.id, obs_id: obs.id
-               ),
-               size: :xs,
-               data: {
-                 modal: Views::Controllers::Projects::Violations::
-                          TargetLocationForm.modal_id_for(obs),
-                 controller: "modal-toggle",
-                 action: "modal-toggle#showModal:prevent",
-                 modal_toggle_always_fresh_value: true
-               }
-             ))
+      Button(
+        type: :get,
+        name: :form_violations_action_add_target_location.l,
+        target: target_location_modal_project_violations_path(
+          project_id: @project.id, obs_id: obs.id
+        ),
+        size: :xs,
+        data: {
+          modal: Views::Controllers::Projects::Violations::
+                   TargetLocationForm.modal_id_for(obs),
+          controller: "modal-toggle",
+          action: "modal-toggle#showModal:prevent",
+          modal_toggle_always_fresh_value: true
+        }
+      )
     end
   end
 end

--- a/app/views/controllers/projects/violations/target_location_form.rb
+++ b/app/views/controllers/projects/violations/target_location_form.rb
@@ -128,10 +128,10 @@ module Views::Controllers::Projects::Violations
       submit(:form_violations_modal_target_location_submit.l,
              as: :button, variant: :primary)
       whitespace
-      render(::Components::Button.new(
-               name: :CANCEL.l,
-               data: { dismiss: "modal" }
-             ))
+      Button(
+        name: :CANCEL.l,
+        data: { dismiss: "modal" }
+      )
     end
 
     def render_suffix_radios
@@ -188,14 +188,14 @@ module Views::Controllers::Projects::Violations
       # tab opens *and* the modal closes.
       capture do
         whitespace
-        render(::Components::Button.new(
-                 type: :get,
-                 name: :form_violations_modal_target_location_create.l,
-                 target: new_location_path(where: suffix),
-                 size: :xs,
-                 new_tab: true,
-                 data: { action: "click->modal#hide" }
-               ))
+        Button(
+          type: :get,
+          name: :form_violations_modal_target_location_create.l,
+          target: new_location_path(where: suffix),
+          size: :xs,
+          new_tab: true,
+          data: { action: "click->modal#hide" }
+        )
       end
     end
 

--- a/app/views/controllers/projects/violations/target_location_modal.rb
+++ b/app/views/controllers/projects/violations/target_location_modal.rb
@@ -50,10 +50,10 @@ module Views::Controllers::Projects::Violations
         p { :form_violations_modal_target_location_no_suffixes.l }
       end
       modal.with_footer do
-        render(::Components::Button.new(
-                 name: :CANCEL.l,
-                 data: { dismiss: "modal" }
-               ))
+        Button(
+          name: :CANCEL.l,
+          data: { dismiss: "modal" }
+        )
       end
     end
   end

--- a/app/views/controllers/rss_logs/type_filters.rb
+++ b/app/views/controllers/rss_logs/type_filters.rb
@@ -53,12 +53,12 @@ module Views::Controllers::RssLogs
     end
 
     def render_everything_button
-      render(::Components::Button.new(
-               tag: :span,
-               variant: :outline,
-               size: :sm,
-               class: ("active" if @types == ["all"])
-             )) { filter_for_everything }
+      Button(
+        tag: :span,
+        variant: :outline,
+        size: :sm,
+        class: ("active" if @types == ["all"])
+      ) { filter_for_everything }
     end
 
     def render_type_buttons
@@ -73,7 +73,7 @@ module Views::Controllers::RssLogs
     # style); the Apply button uses the solid `.btn-default` so it
     # stands out as the commit action.
     def render_submit_button
-      render(::Components::Button.new(type: :submit, name: :APPLY.t, size: :sm))
+      Button(type: :submit, name: :APPLY.t, size: :sm)
     end
 
     # Individual type checkbox styled as a Bootstrap button. Routes

--- a/app/views/controllers/sequences/show.rb
+++ b/app/views/controllers/sequences/show.rb
@@ -104,15 +104,15 @@ module Views::Controllers::Sequences
     def render_blast_link
       blast_tab = ::Tab::Sequence::Blast.new(sequence: @sequence)
       p do
-        render(::Components::Button.new(type: :external,
-                                        name: blast_tab.title,
-                                        url: blast_tab.path))
+        Button(type: :external,
+               name: blast_tab.title,
+               url: blast_tab.path)
         whitespace
-        render(::Components::Button.new(
-                 type: :external,
-                 name: :show_observation_mycoblast_link.l,
-                 url: ::Sequence.mycoblast_url
-               ))
+        Button(
+          type: :external,
+          name: :show_observation_mycoblast_link.l,
+          url: ::Sequence.mycoblast_url
+        )
       end
     end
 

--- a/app/views/controllers/species_lists/details.rb
+++ b/app/views/controllers/species_lists/details.rb
@@ -48,11 +48,11 @@ module Views::Controllers::SpeciesLists
     # so build the path explicitly and pass it to `Button::Download`
     # as a String target.
     def render_download_button
-      render(Components::Button.new(
-               type: :download,
-               target: new_download_species_list_path(id: @species_list.id),
-               variant: :strip
-             ))
+      Button(
+        type: :download,
+        target: new_download_species_list_path(id: @species_list.id),
+        variant: :strip
+      )
     end
 
     def render_observation_count

--- a/app/views/controllers/species_lists/listing.rb
+++ b/app/views/controllers/species_lists/listing.rb
@@ -92,29 +92,29 @@ module Views::Controllers::SpeciesLists
     end
 
     def render_remove_obs_button
-      render(Components::Button.new(
-               type: :put,
-               variant: :strip,
-               name: :REMOVE.t,
-               target: observation_species_list_path(
-                 id: @observation.id,
-                 species_list_id: @species_list.id,
-                 commit: "remove"
-               ),
-               confirm: :are_you_sure.l
-             ))
+      Button(
+        type: :put,
+        variant: :strip,
+        name: :REMOVE.t,
+        target: observation_species_list_path(
+          id: @observation.id,
+          species_list_id: @species_list.id,
+          commit: "remove"
+        ),
+        confirm: :are_you_sure.l
+      )
     end
 
     def render_add_obs_button
-      render(Components::Button.new(
-               type: :put,
-               name: :ADD.t,
-               target: observation_species_list_path(
-                 id: @observation.id,
-                 species_list_id: @species_list.id,
-                 commit: "add"
-               )
-             ))
+      Button(
+        type: :put,
+        name: :ADD.t,
+        target: observation_species_list_path(
+          id: @observation.id,
+          species_list_id: @species_list.id,
+          commit: "add"
+        )
+      )
     end
   end
 end

--- a/app/views/controllers/species_lists/observation.rb
+++ b/app/views/controllers/species_lists/observation.rb
@@ -84,17 +84,17 @@ module Views::Controllers::SpeciesLists
     # `confirm:` is the Turbo-confirm kwarg; `data: { confirm: … }` is
     # a no-op under Turbo (rails-ujs is not wired).
     def render_remove_obs_button
-      render(Components::Button.new(
-               type: :put,
-               variant: :strip,
-               name: :REMOVE.t,
-               target: observation_species_list_path(
-                 id: @observation.id,
-                 species_list_id: @species_list.id,
-                 commit: "remove"
-               ),
-               confirm: :are_you_sure.l
-             ))
+      Button(
+        type: :put,
+        variant: :strip,
+        name: :REMOVE.t,
+        target: observation_species_list_path(
+          id: @observation.id,
+          species_list_id: @species_list.id,
+          commit: "remove"
+        ),
+        confirm: :are_you_sure.l
+      )
     end
   end
 end

--- a/app/views/controllers/species_lists/show.rb
+++ b/app/views/controllers/species_lists/show.rb
@@ -112,7 +112,7 @@ module Views::Controllers::SpeciesLists
     end
 
     def project_button(name, target)
-      render(Components::Button.new(type: :project, name: name, target: target))
+      Button(type: :project, name: name, target: target)
     end
 
     def render_list_search

--- a/app/views/controllers/translations/form.rb
+++ b/app/views/controllers/translations/form.rb
@@ -210,11 +210,11 @@ module Views::Controllers::Translations
     end
 
     def render_cancel_button
-      render(::Components::Button.new(
-               name: :CANCEL.l,
-               id: "cancel_button",
-               data: cancel_button_data
-             ))
+      Button(
+        name: :CANCEL.l,
+        id: "cancel_button",
+        data: cancel_button_data
+      )
     end
 
     def cancel_button_data
@@ -225,15 +225,15 @@ module Views::Controllers::Translations
     end
 
     def render_reload_link
-      render(::Components::Button.new(
-               type: :get,
-               name: :RELOAD.l,
-               target: edit_translation_path(
-                 id: @tag, locale: @lang.locale
-               ),
-               id: "reload_button",
-               data: reload_link_data
-             ))
+      Button(
+        type: :get,
+        name: :RELOAD.l,
+        target: edit_translation_path(
+          id: @tag, locale: @lang.locale
+        ),
+        id: "reload_button",
+        data: reload_link_data
+      )
     end
 
     def reload_link_data

--- a/app/views/controllers/users/show/profile.rb
+++ b/app/views/controllers/users/show/profile.rb
@@ -35,15 +35,15 @@ module Views::Controllers::Users
         return if @show_user == @user || @show_user.no_emails
         return unless @show_user.email_general_question
 
-        render(::Components::Button.new(
-                 type: :modal,
-                 name: :show_user_email_to.t(
-                   name: @show_user.unique_text_name
-                 ),
-                 target: new_question_for_user_path(@show_user.id),
-                 modal_id: "user_question_email",
-                 variant: :strip, icon: :email
-               ))
+        Button(
+          type: :modal,
+          name: :show_user_email_to.t(
+            name: @show_user.unique_text_name
+          ),
+          target: new_question_for_user_path(@show_user.id),
+          modal_id: "user_question_email",
+          variant: :strip, icon: :email
+        )
       end
 
       def render_body

--- a/app/views/controllers/visual_groups/edit.rb
+++ b/app/views/controllers/visual_groups/edit.rb
@@ -120,19 +120,19 @@ module Views::Controllers::VisualGroups
 
     def render_status_button(value, label)
       if @status == value
-        render(Components::Button.new(
-                 name: label, variant: :outline,
-                 tag: :span, aria_disabled: "true",
-                 class: "active disabled"
-               ))
+        Button(
+          name: label, variant: :outline,
+          tag: :span, aria_disabled: "true",
+          class: "active disabled"
+        )
       else
-        render(Components::Button.new(
-                 type: :submit,
-                 name: label,
-                 html_name: "status",
-                 value: value,
-                 variant: :outline
-               ))
+        Button(
+          type: :submit,
+          name: label,
+          html_name: "status",
+          value: value,
+          variant: :outline
+        )
       end
     end
 
@@ -144,11 +144,11 @@ module Views::Controllers::VisualGroups
     # native `a` strips `javascript:` hrefs as a safety measure, but
     # the registered Rails `link_to` helper keeps them.
     def render_reload_link
-      render(Components::Button.new(
-               name: :RELOAD.t,
-               class: "ml-2",
-               onclick: "window.location.reload(true)"
-             ))
+      Button(
+        name: :RELOAD.t,
+        class: "ml-2",
+        onclick: "window.location.reload(true)"
+      )
     end
 
     def render_filter_text_row
@@ -158,11 +158,11 @@ module Views::Controllers::VisualGroups
           input(type: "text", name: "filter", id: "filter",
                 value: @filter, size: 40, class: "form-control")
         end
-        render(::Components::Button.new(
-                 type: :submit,
-                 name: :edit_visual_group_update_filter.t,
-                 html_name: "commit"
-               ))
+        Button(
+          type: :submit,
+          name: :edit_visual_group_update_filter.t,
+          html_name: "commit"
+        )
       end
     end
 

--- a/app/views/controllers/visual_groups/status_links.rb
+++ b/app/views/controllers/visual_groups/status_links.rb
@@ -50,17 +50,17 @@ module Views::Controllers::VisualGroups
     end
 
     def render_status_patch_button(link, link_text)
-      render(Components::Button.new(
-               type: :patch,
-               variant: :strip,
-               name: link_text,
-               target: visual_group_image_path(
-                 id: @image_id, visual_group_id: @visual_group.id,
-                 status: link
-               ),
-               title: link_text,
-               data: { turbo: true }
-             ))
+      Button(
+        type: :patch,
+        variant: :strip,
+        name: link_text,
+        target: visual_group_image_path(
+          id: @image_id, visual_group_id: @visual_group.id,
+          status: link
+        ),
+        title: link_text,
+        data: { turbo: true }
+      )
     end
 
     def render_image_id_line

--- a/app/views/controllers/visual_models/index.rb
+++ b/app/views/controllers/visual_models/index.rb
@@ -26,11 +26,11 @@ module Views::Controllers::VisualModels
     private
 
     def render_destroy_link(visual_model)
-      render(Components::Button.new(
-               type: :delete,
-               target: visual_model_path(visual_model),
-               variant: :outline
-             ))
+      Button(
+        type: :delete,
+        target: visual_model_path(visual_model),
+        variant: :outline
+      )
     end
   end
 end

--- a/app/views/controllers/visual_models/visual_group_table.rb
+++ b/app/views/controllers/visual_models/visual_group_table.rb
@@ -77,11 +77,11 @@ module Views::Controllers::VisualModels
     end
 
     def render_destroy_link(group)
-      render(Components::Button.new(
-               type: :delete,
-               target: visual_group_path(group),
-               variant: :outline
-             ))
+      Button(
+        type: :delete,
+        target: visual_group_path(group),
+        variant: :outline
+      )
     end
 
     def groups

--- a/app/views/layouts/app/banners.rb
+++ b/app/views/layouts/app/banners.rb
@@ -50,14 +50,14 @@ module Views::Layouts::App
     end
 
     def render_alert_contents(banner)
-      render(::Components::Button.new(
-               variant: :strip,
-               id: "dismiss-banner",
-               class: "close",
-               data: { banner_target: "dismissButton",
-                       version: banner.version },
-               aria: { label: :CLOSE.l }
-             )) do
+      Button(
+        variant: :strip,
+        id: "dismiss-banner",
+        class: "close",
+        data: { banner_target: "dismissButton",
+                version: banner.version },
+        aria: { label: :CLOSE.l }
+      ) do
         render(::Components::Icon.new(type: :chevron_up,
                                       title: :CLOSE.l))
       end

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -78,18 +78,18 @@ module Views::Layouts
     def render_toggle_button(truncate:)
       action = truncate ? "showFull" : "showTruncated"
       direction = truncate ? "down" : "up"
-      render(::Components::Button.new(
-               variant: :btn_link,
-               class: "top-right toggle",
-               title: if truncate
-                        :filter_caption_expand.l
-                      else
-                        :filter_caption_collapse.l
-                      end,
-               data: { filter_caption_target: action,
-                       action: "filter-caption##{action}",
-                       toggle: "tooltip" }
-             )) do
+      Button(
+        variant: :btn_link,
+        class: "top-right toggle",
+        title: if truncate
+                 :filter_caption_expand.l
+               else
+                 :filter_caption_collapse.l
+               end,
+        data: { filter_caption_target: action,
+                action: "filter-caption##{action}",
+                toggle: "tooltip" }
+      ) do
         # aria-hidden as a string — Phlex 2 renders boolean `true`
         # as an empty-string attr, not "true".
         render(::Components::Icon.new(

--- a/app/views/layouts/header/index_pagination_nav.rb
+++ b/app/views/layouts/header/index_pagination_nav.rb
@@ -157,11 +157,11 @@ module Views::Layouts
 
     def render_goto_button
       span(class: "input-group-btn") do
-        render(::Components::Button.new(
-                 type: :submit,
-                 variant: :outline,
-                 class: "px-2"
-               )) { render(::Components::Icon.new(type: :goto, title: :GOTO.l)) }
+        Button(
+          type: :submit,
+          variant: :outline,
+          class: "px-2"
+        ) { render(::Components::Icon.new(type: :goto, title: :GOTO.l)) }
       end
     end
 

--- a/app/views/layouts/sidebar/admin.rb
+++ b/app/views/layouts/sidebar/admin.rb
@@ -22,14 +22,14 @@ class Views::Layouts::Sidebar
         render_nav_link(link, link_class: @classes[:admin])
       end
 
-      render(::Components::Button.new(
-               type: :post,
-               name: :app_turn_admin_off.t,
-               target: admin_mode_path(turn_off: true),
-               variant: :btn_link,
-               id: "nav_admin_off_link",
-               class: @classes[:admin]
-             ))
+      Button(
+        type: :post,
+        name: :app_turn_admin_off.t,
+        target: admin_mode_path(turn_off: true),
+        variant: :btn_link,
+        id: "nav_admin_off_link",
+        class: @classes[:admin]
+      )
     end
   end
 end

--- a/app/views/layouts/sidebar/user.rb
+++ b/app/views/layouts/sidebar/user.rb
@@ -33,14 +33,14 @@ class Views::Layouts::Sidebar
     end
 
     def render_logout_button
-      render(::Components::Button.new(
-               type: :post,
-               name: :app_logout.t,
-               target: account_logout_path,
-               variant: :btn_link,
-               id: "nav_user_logout_link",
-               class: class_names(@classes[:indent], @classes[:mobile_only])
-             ))
+      Button(
+        type: :post,
+        name: :app_logout.t,
+        target: account_logout_path,
+        variant: :btn_link,
+        id: "nav_user_logout_link",
+        class: class_names(@classes[:indent], @classes[:mobile_only])
+      )
     end
 
     def render_tabs
@@ -64,14 +64,14 @@ class Views::Layouts::Sidebar
     end
 
     def render_admin_button
-      render(::Components::Button.new(
-               type: :post,
-               name: :app_turn_admin_on.t,
-               target: admin_mode_path(turn_on: true),
-               variant: :btn_link,
-               id: "nav_mobile_admin_link",
-               class: class_names(@classes[:indent], @classes[:mobile_only])
-             ))
+      Button(
+        type: :post,
+        name: :app_turn_admin_on.t,
+        target: admin_mode_path(turn_on: true),
+        variant: :btn_link,
+        id: "nav_mobile_admin_link",
+        class: class_names(@classes[:indent], @classes[:mobile_only])
+      )
     end
 
     def show_admin_button?

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -129,14 +129,14 @@ class Views::Layouts::TopNav < Views::Base
   # small-tablet widths. Uses the MO favicon as the glyph.
   def render_left_nav_toggle
     div(class: "visible-xs visible-sm pr-3 pr-sm-4") do
-      render(::Components::Button.new(
-               variant: :outline,
-               class: "rounded-circle overflow-hidden p-0",
-               id: "left_nav_toggle",
-               data: { toggle: "offcanvas", nav_target: "toggle",
-                       action: "nav#toggleOffcanvas" },
-               aria: { expanded: "false", controls: "search_nav" }
-             )) do
+      Button(
+        variant: :outline,
+        class: "rounded-circle overflow-hidden p-0",
+        id: "left_nav_toggle",
+        data: { toggle: "offcanvas", nav_target: "toggle",
+                action: "nav#toggleOffcanvas" },
+        aria: { expanded: "false", controls: "search_nav" }
+      ) do
         img(src: asset_path("mo_icon_bg.svg"),
             width: "30px", alt: :MENU.t, title: :MENU.t)
       end
@@ -147,12 +147,12 @@ class Views::Layouts::TopNav < Views::Base
   # row below the top nav.
   def render_search_nav_toggle
     div(class: "navbar-form px-2 px-sm-3") do
-      render(::Components::Button.new(
-               variant: :outline, size: :sm,
-               class: "top_nav_button",
-               data: { toggle: "collapse", target: "#search_nav" },
-               aria: { expanded: "false", controls: "search_nav" }
-             )) { render(::Components::Icon.new(type: :search, title: :SEARCH.l)) }
+      Button(
+        variant: :outline, size: :sm,
+        class: "top_nav_button",
+        data: { toggle: "collapse", target: "#search_nav" },
+        aria: { expanded: "false", controls: "search_nav" }
+      ) { render(::Components::Icon.new(type: :search, title: :SEARCH.l)) }
     end
   end
 
@@ -215,7 +215,7 @@ class Views::Layouts::TopNav < Views::Base
   def render_nav_create
     return unless nav_create_visible?
 
-    render(::Components::Button.new(**nav_create_button_options))
+    Button(**nav_create_button_options)
   end
 
   def nav_create_visible?
@@ -249,13 +249,13 @@ class Views::Layouts::TopNav < Views::Base
       controller.controller_name
     )
 
-    render(::Components::Button.new(
-             type: :get,
-             name: :app_qrcode.l,
-             icon: :qrcode,
-             target: field_slips_qr_reader_new_path,
-             variant: :outline, size: :sm,
-             class: "mx-0 mx-sm-2 top_nav_button"
-           ))
+    Button(
+      type: :get,
+      name: :app_qrcode.l,
+      icon: :qrcode,
+      target: field_slips_qr_reader_new_path,
+      variant: :outline, size: :sm,
+      class: "mx-0 mx-sm-2 top_nav_button"
+    )
   end
 end

--- a/app/views/layouts/top_nav/login.rb
+++ b/app/views/layouts/top_nav/login.rb
@@ -4,21 +4,21 @@
 # the top-nav when no user is logged in.
 class Views::Layouts::TopNav::Login < Views::Base
   def view_template
-    render(::Components::Button.new(
-             type: :get,
-             name: :app_login.t,
-             target: new_account_login_path,
-             variant: :outline, size: :sm,
-             class: "ml-3",
-             id: "user_nav_login_link"
-           ))
-    render(::Components::Button.new(
-             type: :get,
-             name: :app_create_account.t,
-             target: account_signup_path,
-             variant: :outline, size: :sm,
-             class: "ml-3",
-             id: "user_nav_signup_link"
-           ))
+    Button(
+      type: :get,
+      name: :app_login.t,
+      target: new_account_login_path,
+      variant: :outline, size: :sm,
+      class: "ml-3",
+      id: "user_nav_login_link"
+    )
+    Button(
+      type: :get,
+      name: :app_create_account.t,
+      target: account_signup_path,
+      variant: :outline, size: :sm,
+      class: "ml-3",
+      id: "user_nav_signup_link"
+    )
   end
 end


### PR DESCRIPTION
## Summary

Sweeps `render(Components::Button.new(...))` call sites over to the `Button(...)` Kit syntax that `Phlex::Kit` (see `config/initializers/phlex.rb`) already generates for every class under the `Components` namespace, following the same pattern as `Alert()` in #4652.

## Excluded on purpose

- `app/controllers/` — not Phlex render contexts.
- `app/components/button/` — the `Components::Button::*` subclasses themselves; converting their own internal `render(Components::Button.new(...))` dispatch calls isn't part of this sweep.
- `app/components/application_form/` and `test/` — reverted after an initial pass per review; left as `render(Components::Button.new(...))` for now.
- `app/views/controllers/images/exports/button.rb` — its own class is named `Button` (`Views::Controllers::Images::Exports::Button`), so calling the bare `Button(...)` Kit method inside its `view_template` collides with the enclosing class name and raises `ArgumentError: missing keyword: :image`. Caught by `Images::ExportsControllerTest#test_export_image`; left as `render(::Components::Button.new(...))`.

Also untouched: the handful of `Components::Button.new(...)` call sites that return an unrendered instance rather than calling `render` directly (e.g. `app/components/link/inline_mod.rb`, `app/components/description/mod_links.rb`) — these build a `Component` object for a caller to `render` later, so converting them to `Button(...)` would render-and-stringify immediately instead, changing behavior.

## Test plan

- [x] `ruby -c` on every changed file
- [x] `bundle exec rubocop` on every changed file — no offenses
- [ ] Full test suite (running separately)
