### PR TITLE
Fix 2 remaining pre-existing system test failures

### DIFF
--- a/test/fixtures/inat_import_job_trackers.yml
+++ b/test/fixtures/inat_import_job_trackers.yml
@@ -8,3 +8,6 @@ lone_wolf_tracker:
 
 ollie_tracker:
   inat_import: <%= ActiveRecord::FixtureSet.identify(:ollie_inat_import) %>
+
+rolf_tracker:
+  inat_import: <%= ActiveRecord::FixtureSet.identify(:rolf_inat_import) %>

--- a/test/system/admin_mode_system_test.rb
+++ b/test/system/admin_mode_system_test.rb
@@ -18,7 +18,9 @@ class AdminModeSystemTest < ApplicationSystemTestCase
   # iNat import pages use a Turbo Frame — regression reported by Nathan
   # where the admin mode button failed to apply on those pages.
   def test_admin_mode_toggle_from_inat_import_page
-    visit(inat_import_path(inat_imports(:rolf_inat_import)))
+    tracker = inat_import_job_trackers(:rolf_tracker)
+    visit(inat_import_path(inat_imports(:rolf_inat_import),
+                           params: { tracker_id: tracker.id }))
     assert_admin_toggle_works
   end
 

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -115,7 +115,7 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     assert_selector("body.search__new")
 
     # Expand the Location panel to reveal the region field
-    find("[data-target='#observations_location']").click
+    find("[aria-controls='observations_location']").click
     assert_selector("#observations_location.in", wait: 3)
 
     # Region autocompleter should show matches as user types


### PR DESCRIPTION
## Summary

Fixes the last 2 pre-existing, unrelated system test failures found while investigating the confirm-modal Turbo regression in #4655, so the full system test suite can go green and be turned on in CI.

- **`AdminModeSystemTest#test_admin_mode_toggle_from_inat_import_page`**: `InatImportsController#show` does `InatImportJobTracker.find(params[:tracker_id])` unconditionally, but neither the test nor the `rolf_inat_import` fixture supplied a `tracker_id`. Added a `rolf_tracker` fixture and pass its id explicitly in the test's `visit(...)` URL, matching the pattern already used in `test/controllers/inat_imports_controller_test.rb`.
- **`AutocompleterSystemTest#test_observation_search_region_autocompleter`**: stale selector. `Components::Panel` deliberately omits `data-target` for id-based collapse targets — see the comment at `app/components/panel.rb:152` — so Bootstrap reads the trigger's `href="#id"` and calls `preventDefault()`, avoiding a Turbo-frame navigation bug. The test was never updated to the `aria-controls` selector that replaced it; `search_bar_collapse_system_test.rb` already uses the correct pattern.

## Test plan

- [x] `bundle exec rubocop` on both touched Ruby files — no offenses
- [x] `test/system/admin_mode_system_test.rb` — 2/2 pass
- [x] `test/system/autocompleter_system_test.rb` — 14/14 pass
