### PR TITLE
Gate SolidQueue Puma plugin to non-production

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -29,7 +29,12 @@ state_path  "#{app_path}/tmp/pids/puma.state"
 # and manage it. With this you don't have to `bin/rails solid_queue:start`,
 # but there's a lot of queue chatter in the console, even when debugging.
 # https://github.com/rails/solid_queue?tab=readme-ov-file#puma-plugin
-plugin :solid_queue
+#
+# Not in production: there the dedicated solidqueue.service is the sole
+# supervisor. Running the plugin there too would start a second supervisor
+# that also claims jobs, doubling the worker footprint and complicating
+# the deploy lifecycle (see issue #4639).
+plugin :solid_queue unless rails_env == "production"
 
 activate_control_app
 


### PR DESCRIPTION
## Summary

Gates `plugin :solid_queue` in `config/puma.rb` to non-production. In production the dedicated `solidqueue.service` (`bundle exec rake solid_queue:start`) is the sole supervisor; the unconditional plugin made `service puma start` boot a second supervisor inside Puma that also registered in `solid_queue_processes` and claimed jobs — doubling the worker footprint and complicating the deploy lifecycle (`service solidqueue stop` didn't stop the Puma-hosted supervisor).

The plugin remains active in development and test, where SolidQueue running inside `rails s` is convenient.

Kept as its own small PR (separate from the graceful-drain deploy work) so it can be reverted independently if it has any unexpected effect on production job processing.

Fixes #4639

## Verification after deploy

- [ ] `service puma start` alone should NOT create a `SolidQueue::Process` supervisor row; only `solidqueue.service` should.
- [ ] Confirm jobs still get claimed and run in production with a single supervisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
