### PR TITLE
Fix UserStats per-field counter sign on delete

### DIFF
--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -148,7 +148,8 @@ class UserStats < ApplicationRecord
       User.find(user_id).increment!(:contribution, impact)
       return unless (user_stat = UserStats.find_by(user_id: user_id))
 
-      user_stat.increment!(field, num)
+      # Sign the per-field delta like `impact`: a delete must decrement.
+      user_stat.increment!(field, mode == :del ? -num : num)
     end
 
     # impact can be positive or negative

--- a/test/models/user_stats_test.rb
+++ b/test/models/user_stats_test.rb
@@ -80,6 +80,37 @@ class UserStatsTest < UnitTestCase
     assert_equal(mary.votes.size, mary_stats.votes)
   end
 
+  # Regression test for the sign bug where a :del incremented the
+  # per-field user_stats counter instead of decrementing it (issue #4638).
+  # users.contribution was correctly signed all along; both must move
+  # together.
+  def test_update_contribution_add_and_del_sign
+    stats = user_stats(:rolf)
+    contribution = rolf.contribution
+    weight = UserStats::ALL_FIELDS[:observations][:weight]
+
+    UserStats.update_contribution(:add, :observations, rolf.id)
+    assert_equal(1, stats.reload.observations)
+    assert_equal(contribution + weight, rolf.reload.contribution)
+
+    UserStats.update_contribution(:del, :observations, rolf.id)
+    assert_equal(0, stats.reload.observations)
+    assert_equal(contribution, rolf.reload.contribution)
+  end
+
+  # Same bug via the real path: the generic before_destroy callback in
+  # AbstractModel calls update_contribution(:del, self).
+  def test_destroying_counted_object_decrements_field_counter
+    comment = comments(:minimal_unknown_obs_comment_1)
+    stats = UserStats.find_by(user_id: comment.user_id)
+    assert_not_nil(stats, "Comment owner needs a user_stats fixture")
+    count_before = stats.comments
+
+    comment.destroy
+
+    assert_equal(count_before - 1, stats.reload.comments)
+  end
+
   def test_refresh_all_user_stats_dry_run
     old_rolf_stats = user_stats(:rolf)
     assert_equal(0, old_rolf_stats.comments)


### PR DESCRIPTION
## Summary

`UserStats.update_contribution` bumped the per-field `user_stats` counter (e.g. `observations`, `images`, `comments`, …) by the raw unsigned `num` on every destroy, so deleting a counted record pushed its category count up by 1 instead of down by 1. `users.contribution` was correctly signed all along via `calc_impact`; this signs the per-field delta the same way (`mode == :del ? -num : num`).

Affects every incrementally-maintained positive-weight counter since the caching layer landed in March 2024 (PR #1988) — see the issue for the full per-field trace.

Fixes #4638

## Regression tests

- `test_update_contribution_add_and_del_sign` — direct field-name mode: `:add` increments and `:del` decrements both the per-field counter and `users.contribution`, symmetrically.
- `test_destroying_counted_object_decrements_field_counter` — the real path: `AbstractModel`'s generic `before_destroy` → `update_contribution(:del, self)` on a comment destroy.

## Backfill: already covered by the nightly cron

The issue planned a one-off backfill runner script. It turns out no new mechanism is needed: `config/etc/crontab` runs `script/refresh_caches` nightly at 5:13, which already calls `UserStats.refresh_all_user_stats` — a blanket recompute of every per-field counter from the source tables via `upsert_all`. All accumulated drift is wiped the night after this fix deploys, and the fix stops new drift from accruing.

The only thing that mechanism does not provide is a durable per-user report of what had drifted (it just recomputes and reports a user count). If that forensic record is wanted before the next nightly run overwrites the evidence, it needs a read-only diff script run before deploy — flagging here rather than including one speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
