### PR TITLE
Persist inat_username before building imported observations

### DIFF
--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -15,9 +15,7 @@ class InatImportJob < ApplicationJob
   BATCH_SIZE = 10
 
   delegate :canceled?, to: :inat_import
-  delegate :imported_count, to: :inat_import
   delegate :inat_username, to: :inat_import
-  delegate :response_errors, to: :inat_import
   delegate :token, to: :inat_import
   delegate :user, to: :inat_import
 
@@ -26,10 +24,7 @@ class InatImportJob < ApplicationJob
   # continuation: true skips auth + state init (already done by first job).
   def perform(inat_import, id_above: 0, continuation: false)
     create_ivars(inat_import)
-    unless continuation
-      authenticate
-      ensure_not_importing_others
-    end
+    prepare_first_job unless continuation
     import_requested_observations(id_above: id_above,
                                   continuation: continuation)
   rescue StandardError => e
@@ -60,6 +55,14 @@ class InatImportJob < ApplicationJob
     log(
       "InatImportJob #{inat_import.id} started, user: #{user.id}"
     )
+  end
+
+  # Auth, own-obs verification, and username persist — first job only;
+  # continuations inherit all three from the job that enqueued them.
+  def prepare_first_job
+    authenticate
+    ensure_not_importing_others
+    update_user_inat_username
   end
 
   def authenticate
@@ -248,27 +251,20 @@ class InatImportJob < ApplicationJob
   def done
     log("Updating inat_import state to Done")
     inat_import.update(state: "Done", ended_at: Time.zone.now)
-    update_user_inat_username
   end
 
-  # A convenience to let a user to create/update their iNat username
-  # simply by entering it in the import form.
+  # A convenience to let a user create/update their iNat username simply
+  # by entering it in the import form. Runs after ensure_not_importing_others
+  # has proven the logged-in iNat account matches the entered username, and
+  # BEFORE any observations are built, so collector resolution (match_inat)
+  # can link the importing user's own obs during their first import.
   def update_user_inat_username
-    return unless inat_username_updateable?
+    # Don't update a SuperImporter's inat_username because
+    # InatImport.inat_username could be someone else's inat_username
+    # (they also skip the own-obs verification above).
+    return if super_importer?
 
     user.update(inat_username: inat_username)
     log("Updated user inat_username")
-  end
-
-  def inat_username_updateable?
-    # Don't update a SuperImporter's inat_username because
-    # InatImport.inat_username could be someone else's inat_username.
-    return false if InatImport.super_importer?(user)
-
-    # Prevent changing inat_username to a non-existent iNat login
-    # No errors or any imports means that iNat accepted the inat_username,
-    # so it's real inat_username.
-    response_errors.empty? ||
-      imported_count.to_i.positive?
   end
 end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -97,6 +97,38 @@ class InatImportJobTest < ActiveJob::TestCase
     )
   end
 
+  # Regression: a first-time importer has no persisted inat_username when
+  # the job starts. The job must persist it BEFORE building observations —
+  # collector resolution (match_inat) matches User#inat_username, so a
+  # too-late persist left every obs of a first import with an unlinked
+  # free-text collector.
+  def test_import_first_import_links_collector
+    create_ivars_from_filename("calostoma_lutescens")
+    assert_nil(@user.inat_username,
+               "Test needs a user without a persisted inat_username")
+
+    Location.create(user: @user,
+                    name: "Sevier Co., Tennessee, USA",
+                    north: 36.043571, south: 35.561849,
+                    east: -83.253046, west: -83.794123)
+
+    stub_inat_interactions
+    assert_difference("Observation.count", 1,
+                      "Failed to create observation") do
+      InatImportJob.perform_now(@inat_import)
+    end
+
+    assert_equal(@inat_import.inat_username, @user.reload.inat_username,
+                 "Username should be persisted during the import")
+    link = ExternalLink.find_by(external_id: @parsed_results.first[:id],
+                                relationship: "import")
+    assert_not_nil(link, "Cannot find import ExternalLink for the new obs")
+    obs = link.target
+    assert_equal(@user.id, obs.collector_user_id,
+                 "A first import should link the collector to the importer")
+    assert_equal(@user.unique_text_name, obs.collector)
+  end
+
   # Prove (inter alia) that the MO Naming.user differs from the importing user
   # when the iNat user who made the 1st iNat id is another MO user
   def test_import_job_inat_id_suggested_by_another_by_mo_user
@@ -1008,6 +1040,9 @@ class InatImportJobTest < ActiveJob::TestCase
       @inat_import.response_errors, expect,
       "It should warn if a user tries to import another's iNat obs"
     )
+    assert_nil(@user.reload.inat_username,
+               "A username that failed the own-obs verification " \
+               "must not be persisted")
   end
 
   def test_super_importer_anothers_observation


### PR DESCRIPTION
## Summary

`InatImportJob` persisted `users.inat_username` only in `#done`, after the batch's observations were built. During a first-time importer's run, `Observation.resolve_collector(match_inat: true)` therefore had nothing to match, and the iNat login was stored as an unlinked free-text collector for the **entire first batch**. Production has 2,541 such self-owned rows from two recent first imports (2,505 from a 2026-06-21 batch, 36 from 2026-06-12), plus 13 older cross-owned rows.

## Change

- Move the persist from `#done` to `#prepare_first_job`, right after `ensure_not_importing_others` — which proves the logged-in iNat account matches the entered username. That is a stronger validity check than the post-hoc `inat_username_updateable?` heuristic ("no errors or imported something") it replaces, so that heuristic and its now-unused `imported_count`/`response_errors` delegates are removed.
- SuperImporters are still excluded from the persist: their entered username can be someone else's, and they skip the own-obs verification.
- Continuation jobs are unaffected (they already skipped auth/verification; the first job has persisted the username by the time they run).

## Behavior notes

- A username that fails the own-obs verification is still never persisted (the verification raises before the persist runs) — now pinned by an assertion in `test_import_anothers_observation`.
- One deliberate change: previously a verified username was not persisted if the import later errored out with zero imports. Now it is — the OAuth match already proved the username is real and belongs to the importer, so import success is irrelevant to its validity.

## Cleanup of existing rows

The 2,554 already-unlinked rows in production are healed by a one-time runner script (kept out of the repo): it re-runs the exact save-path resolver over every `collector_user_id IS NULL` row whose collector string matches a `users.inat_username`, writing like `CollectorNotesSeeder`. Dry run against a 2026-07-03 prod copy resolves all 2,554 with zero unresolved. To be run after this merges/deploys.

## Test plan

- [x] New regression test `test_import_first_import_links_collector`: user with no persisted `inat_username` imports their own obs → username persisted during the run, collector linked to the importer, display string normalized to `unique_text_name`.
- [x] Wrong-user path now also asserts the failed username is not persisted.
- [x] `bin/rails test test/jobs/inat_import_job_test.rb` — 53 tests, 612 assertions, 0 failures.
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
