### PR TITLE
Fix 2 failing system tests: missing help id, stale .d-none selector

### DIFF
--- a/app/components/application_form/field_with_help.rb
+++ b/app/components/application_form/field_with_help.rb
@@ -37,8 +37,11 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     private
 
+    def help_id
+      "#{field.dom.id}_help"
+    end
+
     def render_help_icon
-      help_id = "#{field.dom.id}_help"
       span(class: between_class) do
         render(::Components::Link.new(
                  type: :collapse_toggle,
@@ -49,14 +52,13 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def render_collapsed_help_text
-      help_id = "#{field.dom.id}_help"
       render(::Components::CollapseDiv.new(id: help_id)) do
         render(::Components::Help::Block.new(well: true)) { render(help_slot) }
       end
     end
 
     def render_plain_help_text
-      render(::Components::Help::Block.new) { render(help_slot) }
+      render(::Components::Help::Block.new(id: help_id)) { render(help_slot) }
     end
   end
 end

--- a/test/system/project_alias_form_system_test.rb
+++ b/test/system/project_alias_form_system_test.rb
@@ -15,22 +15,27 @@ class ProjectAliasFormSystemTest < ApplicationSystemTestCase
 
     # By default, location type is selected (first option alphabetically
     # is "Location" in our select)
-    # Location autocompleter should be visible, user autocompleter hidden
-    assert_selector("[data-type-switch-type='location']:not(.d-none)")
-    assert_selector("[data-type-switch-type='user'].d-none", visible: :all)
+    # Location autocompleter should be visible, user autocompleter hidden.
+    # Panels toggle via Bootstrap .collapse/.collapse.in (type-switch
+    # controller), not .d-none.
+    assert_selector("[data-type-switch-type='location'].collapse.in")
+    assert_selector("[data-type-switch-type='user'].collapse:not(.in)",
+                    visible: :all)
 
     # Switch to User type
     select(:USER.l, from: "project_alias[target_type]")
 
     # Now user autocompleter should be visible, location hidden
-    assert_selector("[data-type-switch-type='user']:not(.d-none)")
-    assert_selector("[data-type-switch-type='location'].d-none", visible: :all)
+    assert_selector("[data-type-switch-type='user'].collapse.in")
+    assert_selector("[data-type-switch-type='location'].collapse:not(.in)",
+                    visible: :all)
 
     # Switch back to Location
     select(:LOCATION.l, from: "project_alias[target_type]")
 
     # Location visible again, user hidden
-    assert_selector("[data-type-switch-type='location']:not(.d-none)")
-    assert_selector("[data-type-switch-type='user'].d-none", visible: :all)
+    assert_selector("[data-type-switch-type='location'].collapse.in")
+    assert_selector("[data-type-switch-type='user'].collapse:not(.in)",
+                    visible: :all)
   end
 end


### PR DESCRIPTION
## Summary

Two pre-existing failures on `main`, fixed to get a clean baseline before further Turbo work:

- `ObservationFormSystemTest#test_create_minimal_observation` expected `#observation_place_name_help` to exist. `render_plain_help_text` (added in `05f14b23`, "Refactor iNat import form... plain help") never passed an `id` to `Components::Help::Block`, unlike the collapse/icon help variants — a regression from that commit. Fixed by extracting the shared `help_id` computation and passing it through all three render paths (icon trigger, collapsed well, plain).
- `ProjectAliasFormSystemTest#test_type_switch_shows_correct_autocompleter` asserted `.d-none` on type-switch panels, but `panel_class` (`app/views/controllers/projects/aliases/form.rb`) and the `type-switch` Stimulus controller only ever use Bootstrap `.collapse`/`.collapse.in` — `.d-none` was never actually a supported scheme for this controller. `git log -p` on `panel_class` shows the implementation flip-flopped between `.d-none` and `.collapse` a few times over its history; the test never got updated after the most recent flip back to `.collapse`.

## Test plan

- [x] `bin/rails test test/system/project_alias_form_system_test.rb test/system/observation_form_system_test.rb` — both previously-failing tests pass, 10/10 total.
- [x] `bin/rails test test/components/ test/views/controllers/inat_imports/ test/system/` — 937 tests, 0 failures (confirms the new help `id` doesn't collide with or break the iNat import form that introduced the plain-help path).
- [x] `bundle exec rubocop` — clean on both touched files.
