### PR TITLE
Gate iNat imports on ExternalLinks; add recheck-all checkbox

### DIFF
--- a/app/classes/form_object/inat_import.rb
+++ b/app/classes/form_object/inat_import.rb
@@ -9,6 +9,7 @@ class FormObject::InatImport < FormObject::Base
   attribute :consent, :string
   attribute :import_others, :string
   attribute :inat_url, :string
+  attribute :recheck_all, :string
   attribute :skip_inat_writeback, :string
   attribute :choose_method, :string
 end

--- a/app/classes/form_object/inat_import_confirm.rb
+++ b/app/classes/form_object/inat_import_confirm.rb
@@ -10,5 +10,6 @@ class FormObject::InatImportConfirm < FormObject::Base
   attribute :import_others, :string
   attribute :inat_url, :string
   attribute :original_inat_url, :string
+  attribute :recheck_all, :string
   attribute :skip_inat_writeback, :string
 end

--- a/app/classes/inat/confirm_url_builder.rb
+++ b/app/classes/inat/confirm_url_builder.rb
@@ -56,10 +56,19 @@ class Inat::ConfirmURLBuilder
   def expected_obs_args(query_str)
     args = Rack::Utils.parse_query(query_str.to_s)
     args["iconic_taxa"] ||= "Fungi,Protozoa" unless args.key?("taxon_id")
-    args["without_field"] = BASE_FILTER_PARAMS[:without_field]
+    unless skip_without_field?
+      args["without_field"] = BASE_FILTER_PARAMS[:without_field]
+    end
     filter = LICENSED_FILTER.stringify_keys.transform_values(&:to_s)
     args.merge!(filter) if import_others?
     args
+  end
+
+  # Id lists always re-check obs already carrying the MO URL field, and
+  # query modes re-check when the user opted in — so the expected-obs link
+  # must not filter them out (#4565).
+  def skip_without_field?
+    @model.inat_ids.present? || @model.recheck_all == "1"
   end
 
   def translate_api_to_ui_params(query_str)

--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -55,6 +55,13 @@ class Inat
     # id of iNat's "Mushroom Observer URL" observation field
     MO_URL_OBSERVATION_FIELD_ID = 5005
 
+    # Extracts the MO observation id from a "Mushroom Observer URL" field
+    # value, tolerating the URL variants that appear in the wild (current,
+    # /obs/, legacy /observer/show_observation/) and prefixes like
+    # "DEAD LINK: " (#4565).
+    MO_URL_FIELD_VALUE_ID_RE = %r{mushroomobserver\.org/
+      (?:observations/|obs/|observer/show_observation/)?(\d+)}x
+
     # Filter params added to every iNat observation API request
     # to restrict results to observations eligible for import:
     BASE_FILTER_PARAMS = {

--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -81,6 +81,14 @@ class Inat
       inat_obs_fields.find { |field| field[:name] == name }
     end
 
+    # Value of the "Mushroom Observer URL" observation field, or nil.
+    # Looked up by field id — the display name is localizable on iNat.
+    def mo_url_field_value
+      inat_obs_fields&.find do |field|
+        field[:field_id] == MO_URL_OBSERVATION_FIELD_ID
+      end&.dig(:value)
+    end
+
     # NOTE: Fixes ABC count of `snapshot` because
     # inat_taxon_name is one fewer Branch than self[:taxon][:name]
     def inat_taxon_name = @obs_taxon[:name]

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -31,7 +31,8 @@ class Inat
       @observation = nil
       return if unimportable?
       return if date_missing?
-      return if already_imported?
+      return if already_linked?
+      return if crosslinked_to_live_mo_obs?
 
       builder = create_mo_observation
       return unless @observation
@@ -60,24 +61,64 @@ class Inat
       true
     end
 
-    # Last-line-of-defense check against duplicate imports.
-    # Upstream filters (iNat-side `without_field` and the controller's
-    # `clean_inat_ids`) miss observations whose back-link write to iNat
-    # failed silently after a prior import, and the controller filter
-    # is bypassed entirely on import-all runs. The import ExternalLink's
-    # unique index (one import per target) is the actual race-safety
-    # guarantee; this pre-check just keeps benign duplicates from emitting
-    # noisy RecordNotUnique exceptions.
-    def already_imported?
-      return false unless ExternalLink.import.exists?(
+    # The primary duplicate gate: any typed iNat ExternalLink for this iNat
+    # obs (import / mirror / copy / remote_manual / manual) means it already
+    # corresponds to an MO observation, so importing it would create a
+    # duplicate. With #4565's materialization the link set is complete, so
+    # this MO-side check is authoritative — the iNat-side `without_field`
+    # filter is only a fetch-volume optimization (skipped for explicit id
+    # lists and recheck_all runs). The import ExternalLink's unique index
+    # (one import per target) remains the race-safety guarantee; this
+    # pre-check keeps benign duplicates from emitting noisy RecordNotUnique
+    # exceptions.
+    def already_linked?
+      return false unless ExternalLink.exists?(
         target_type: "Observation",
         external_site_id: inat_site.id,
         external_id: @inat_obs[:id].to_s
       )
 
-      log("Skipped #{@inat_obs[:id]} already imported")
+      log("Skipped #{@inat_obs[:id]} already linked to an MO observation")
       inat_import.add_ignored_obs(:already_imported)
       true
+    end
+
+    # The iNat obs carries an MO URL (field 5005) with no MO-side link — a
+    # cross-reference hand-set on iNat. When the MO obs is alive,
+    # materialize the missing remote_manual link (#4565) and skip the
+    # import. A blank, dead (MO obs deleted), or unparseable value blocks
+    # nothing: the obs is importable again.
+    def crosslinked_to_live_mo_obs?
+      mo_obs = live_crosslinked_mo_obs
+      return false unless mo_obs
+
+      create_crosslink(mo_obs)
+      log("Skipped #{@inat_obs[:id]} cross-referenced on iNat " \
+          "to MO #{mo_obs.id}; recorded the link")
+      inat_import.add_ignored_obs(:already_imported)
+      true
+    end
+
+    def live_crosslinked_mo_obs
+      value = @inat_obs.mo_url_field_value
+      return nil if value.blank?
+
+      mo_obs_id = value[MO_URL_FIELD_VALUE_ID_RE, 1]
+      return nil unless mo_obs_id
+
+      Observation.find_by(id: mo_obs_id)
+    end
+
+    def create_crosslink(mo_obs)
+      ExternalLink.create!(
+        user: @user, target: mo_obs, external_site: inat_site,
+        external_id: @inat_obs[:id].to_s, relationship: :remote_manual
+      )
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.warn(
+        "InatImport: failed to create remote_manual ExternalLink for " \
+        "Observation #{mo_obs.id} (iNat #{@inat_obs[:id]}): #{e.message}"
+      )
     end
 
     # Cached iNaturalist ExternalSite for this importer instance — avoids

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -92,9 +92,10 @@ class Inat
       mo_obs = live_crosslinked_mo_obs
       return false unless mo_obs
 
-      create_crosslink(mo_obs)
+      link = create_crosslink(mo_obs)
+      outcome = link ? "recorded the link" : "failed to record the link"
       log("Skipped #{@inat_obs[:id]} cross-referenced on iNat " \
-          "to MO #{mo_obs.id}; recorded the link")
+          "to MO #{mo_obs.id}; #{outcome}")
       inat_import.add_ignored_obs(:already_imported)
       true
     end
@@ -109,6 +110,7 @@ class Inat
       Observation.find_by(id: mo_obs_id)
     end
 
+    # Returns the created link, or nil when validation failed.
     def create_crosslink(mo_obs)
       ExternalLink.create!(
         user: @user, target: mo_obs, external_site: inat_site,
@@ -119,6 +121,7 @@ class Inat
         "InatImport: failed to create remote_manual ExternalLink for " \
         "Observation #{mo_obs.id} (iNat #{@inat_obs[:id]}): #{e.message}"
       )
+      nil
     end
 
     # Cached iNaturalist ExternalSite for this importer instance — avoids

--- a/app/classes/inat/page_parser.rb
+++ b/app/classes/inat/page_parser.rb
@@ -97,7 +97,7 @@ class Inat
       # field, bypassing URLNormalizer. Strip MO-controlled keys defensively.
       strip_keys = Inat::URLNormalizer::STRIP_PARAMS.map(&:to_sym) + [:id]
       args.except!(*strip_keys)
-      args.merge!(BASE_FILTER_PARAMS)
+      args.merge!(without_field_filter(ids_mode: false))
       args[:taxon_id] ||= IMPORTABLE_TAXON_IDS_ARG
       args.merge!(id_above: effective_id_above, per_page: @per_page,
                   order: "asc", order_by: "id")
@@ -109,7 +109,18 @@ class Inat
         id: nil, id_above: nil, only_id: false, per_page: @per_page,
         order: "asc", order_by: "id",
         taxon_id: IMPORTABLE_TAXON_IDS_ARG
-      }.merge(BASE_FILTER_PARAMS)
+      }.merge(without_field_filter(ids_mode: inat_ids.present?))
+    end
+
+    # without_field excludes obs already carrying iNat's "Mushroom Observer
+    # URL" field. Explicit id lists always re-check (the user pointed at
+    # specific obs, and the importer's ExternalLink gate decides); query
+    # modes re-check only when the user opted in via the recheck_all
+    # checkbox (#4565 orphan reimport).
+    def without_field_filter(ids_mode:)
+      return {} if ids_mode || @import.recheck_all?
+
+      BASE_FILTER_PARAMS
     end
 
     # When importing own observations: scope by user_login, no licensed filter.

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -26,6 +26,7 @@ class InatImportsController < ApplicationController
   include Validators
   include Estimators
   include FormBuilders
+  include PreviousImports
   include Inat::Constants
 
   before_action :login_required
@@ -246,28 +247,6 @@ class InatImportsController < ApplicationController
     flash_warning(:inat_taxon_id_not_importable.l)
   end
 
-  # Were any listed iNat IDs previously imported?
-  def warn_about_listed_previous_imports
-    return if importing_all? || !listing_ids?
-
-    previous_imports = previously_imported_links
-    return if previous_imports.none?
-
-    flash_warning(:inat_previous_import.t(count: previous_imports.count))
-  end
-
-  def previously_imported_links
-    return ExternalLink.none if inat_id_list.blank?
-
-    ExternalLink.import.where(target_type: "Observation",
-                              external_site: inat_site,
-                              external_id: inat_id_list.map(&:to_s))
-  end
-
-  def inat_site
-    @inat_site ||= ExternalSite.inaturalist
-  end
-
   def assure_user_has_inat_import_api_key
     key = APIKey.find_by(user: @user, notes: MO_API_KEY_NOTES)
     key = APIKey.create(user: @user, notes: MO_API_KEY_NOTES) if key.nil?
@@ -275,28 +254,41 @@ class InatImportsController < ApplicationController
   end
 
   # A new persistent record per import, so each import's results are kept.
-  # avg_import_time derives from the user's prior records (a throwaway
-  # instance computes it since the new one isn't saved yet).
   def init_ivars
     @inat_import = InatImport.create!(
+      new_import_scope_attrs.merge(new_import_bookkeeping_attrs)
+    )
+  end
+
+  # What to import, from the submitted form params.
+  def new_import_scope_attrs
+    {
       user: @user,
-      state: "Authorizing",
       import_all: params[:all],
-      importables: importables_count,
-      total_importables: importables_count,
-      imported_count: 0,
-      avg_import_time: InatImport.new(user: @user).initial_avg_import_seconds,
       inat_username: params[:inat_username]&.strip,
       inat_ids: clean_inat_ids,
       inat_url: params[:inat_url].presence,
       import_others: import_others?,
-      writeback: writeback_policy,
+      recheck_all: recheck_all?,
+      writeback: writeback_policy
+    }
+  end
+
+  # Fresh-run state. avg_import_time derives from the user's prior records
+  # (a throwaway instance computes it since the new one isn't saved yet).
+  def new_import_bookkeeping_attrs
+    {
+      state: "Authorizing",
+      importables: importables_count,
+      total_importables: importables_count,
+      imported_count: 0,
+      avg_import_time: InatImport.new(user: @user).initial_avg_import_seconds,
       response_errors: "",
       token: "",
       log: [],
       ended_at: nil,
       cancel: false
-    )
+    }
   end
 
   def importables_count
@@ -313,6 +305,13 @@ class InatImportsController < ApplicationController
     params[:import_others] == "1"
   end
 
+  # Whether an import-all / URL run should re-check observations already
+  # carrying iNat's "Mushroom Observer URL" field (#4565 orphan reimport).
+  # Explicit id lists always re-check regardless of this flag.
+  def recheck_all?
+    params[:recheck_all] == "1"
+  end
+
   # Admins can toggle the iNat write-back per import via a form checkbox
   # (checked = skip, unchecked = force it on). Everyone else gets `default`
   # so the importer applies its environment default (skip in development,
@@ -321,25 +320,6 @@ class InatImportsController < ApplicationController
     return :default unless in_admin_mode?
 
     params[:skip_inat_writeback] == "1" ? :skip : :force
-  end
-
-  def clean_inat_ids
-    inat_ids = normalize_inat_ids(params[:inat_ids])
-    previous_imports = previously_imported_links
-    return inat_ids if previous_imports.none?
-
-    remove_previously_imported_ids(inat_ids, previous_imports)
-  end
-
-  # Remove previously imported ids in case the iNat user deleted the
-  # Mushroom_Observer_URL field.
-  # NOTE: Also useful in manual testing when writes of iNat obss are
-  # commented out temporarily. jdc 2026-01-15
-  def remove_previously_imported_ids(inat_ids, previous_imports)
-    previous_ids = previous_imports.pluck(:external_id)
-    remaining_ids =
-      inat_ids.split(",").map(&:strip).reject { |id| previous_ids.include?(id) }
-    remaining_ids.join(",")
   end
 
   # Pass the new record's id through the OAuth `state` param; iNat echoes it

--- a/app/controllers/inat_imports_controller/estimators.rb
+++ b/app/controllers/inat_imports_controller/estimators.rb
@@ -90,15 +90,28 @@ module InatImportsController::Estimators
   # + licensed (for import-others) + user scope.
   def import_estimate_query_args
     args = listing_url? ? url_query_args : {}
-    args.merge!(BASE_FILTER_PARAMS, only_id: true)
+    args.merge!(estimate_without_field_filter, ownership_filter_args,
+                only_id: true)
     args[:taxon_id] ||= IMPORTABLE_TAXON_IDS_ARG
-    if import_others?
-      args.merge!(LICENSED_FILTER)
-    else
-      args[:user_login] = params[:inat_username]&.strip
-    end
     args[:id] = params[:inat_ids] if listing_ids?
     args
+  end
+
+  # Id lists always re-check obs already carrying the MO URL field, and
+  # query modes re-check when the user opted in — the estimate must
+  # match actual import behavior (#4565).
+  def estimate_without_field_filter
+    return {} if listing_ids? || recheck_all?
+
+    BASE_FILTER_PARAMS
+  end
+
+  def ownership_filter_args
+    if import_others?
+      LICENSED_FILTER
+    else
+      { user_login: params[:inat_username]&.strip }
+    end
   end
 
   # Strip MO-controlled params so estimates match actual import behavior.

--- a/app/controllers/inat_imports_controller/form_builders.rb
+++ b/app/controllers/inat_imports_controller/form_builders.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
 module InatImportsController::FormBuilders
+  # Params carried verbatim from the new form through the confirm page.
+  PASSTHROUGH_PARAM_KEYS = [
+    :inat_username, :inat_ids, :inat_url, :original_inat_url, :consent,
+    :recheck_all, :skip_inat_writeback
+  ].freeze
+
   private
 
   def build_confirm_form
     FormObject::InatImportConfirm.new(
-      inat_username: params[:inat_username],
-      inat_ids: params[:inat_ids],
-      inat_url: params[:inat_url],
-      original_inat_url: params[:original_inat_url],
+      **PASSTHROUGH_PARAM_KEYS.index_with { |key| params[key] },
       import_all: params[:all],
-      consent: params[:consent],
-      import_others: (import_others? ? "1" : nil),
-      skip_inat_writeback: params[:skip_inat_writeback]
+      import_others: (import_others? ? "1" : nil)
     )
   end
 
@@ -29,6 +30,7 @@ module InatImportsController::FormBuilders
       username: params[:inat_username],
       consent: params[:consent],
       import_others: params[:import_others],
+      recheck_all: params[:recheck_all],
       skip_writeback: params[:skip_inat_writeback]
     }
   end
@@ -63,6 +65,7 @@ module InatImportsController::FormBuilders
                      derive_choose_method(submitted),
       consent: ("1" if submitted[:consent] == "1"),
       import_others: ("1" if submitted[:import_others] == "1"),
+      recheck_all: ("1" if submitted[:recheck_all] == "1"),
       skip_inat_writeback: initial_skip_writeback(submitted)
     )
   end
@@ -92,13 +95,9 @@ module InatImportsController::FormBuilders
     confirm = params[:inat_import_confirm]
     return unless confirm
 
-    merge_form_param(confirm, :inat_username)
-    merge_form_param(confirm, :inat_ids)
-    merge_form_param(confirm, :inat_url)
-    merge_form_param(confirm, :original_inat_url)
-    merge_form_param(confirm, :consent)
-    merge_form_param(confirm, :import_others)
-    merge_form_param(confirm, :skip_inat_writeback)
+    (PASSTHROUGH_PARAM_KEYS + [:import_others]).each do |key|
+      merge_form_param(confirm, key)
+    end
     params[:all] ||= confirm[:import_all]
   end
 
@@ -112,13 +111,9 @@ module InatImportsController::FormBuilders
     new_form = params[:inat_import]
     return unless new_form
 
-    merge_form_param(new_form, :inat_username)
-    merge_form_param(new_form, :inat_ids)
-    merge_form_param(new_form, :inat_url)
-    merge_form_param(new_form, :consent)
-    merge_form_param(new_form, :import_others)
-    merge_form_param(new_form, :skip_inat_writeback)
-    merge_form_param(new_form, :choose_method)
+    keys = PASSTHROUGH_PARAM_KEYS - [:original_inat_url] +
+           [:import_others, :choose_method]
+    keys.each { |key| merge_form_param(new_form, key) }
     params[:all] = "1" if params[:choose_method] == "all"
     params[:all] ||= new_form[:all]
   end

--- a/app/controllers/inat_imports_controller/previous_imports.rb
+++ b/app/controllers/inat_imports_controller/previous_imports.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Handling for listed iNat ids that were already imported to MO:
+# warn about them and drop them from the id list before the import runs.
+module InatImportsController::PreviousImports
+  private
+
+  # Were any listed iNat IDs previously imported?
+  def warn_about_listed_previous_imports
+    return if importing_all? || !listing_ids?
+
+    previous_imports = previously_imported_links
+    return if previous_imports.none?
+
+    flash_warning(:inat_previous_import.t(count: previous_imports.count))
+  end
+
+  def previously_imported_links
+    return ExternalLink.none if inat_id_list.blank?
+
+    ExternalLink.import.where(target_type: "Observation",
+                              external_site: inat_site,
+                              external_id: inat_id_list.map(&:to_s))
+  end
+
+  def inat_site
+    @inat_site ||= ExternalSite.inaturalist
+  end
+
+  def clean_inat_ids
+    inat_ids = normalize_inat_ids(params[:inat_ids])
+    previous_imports = previously_imported_links
+    return inat_ids if previous_imports.none?
+
+    remove_previously_imported_ids(inat_ids, previous_imports)
+  end
+
+  # Remove previously imported ids in case the iNat user deleted the
+  # Mushroom_Observer_URL field.
+  # NOTE: Also useful in manual testing when writes of iNat obss are
+  # commented out temporarily. jdc 2026-01-15
+  def remove_previously_imported_ids(inat_ids, previous_imports)
+    previous_ids = previous_imports.pluck(:external_id)
+    remaining_ids =
+      inat_ids.split(",").map(&:strip).reject { |id| previous_ids.include?(id) }
+    remaining_ids.join(",")
+  end
+end

--- a/app/controllers/inat_imports_controller/previous_imports.rb
+++ b/app/controllers/inat_imports_controller/previous_imports.rb
@@ -30,15 +30,18 @@ module InatImportsController::PreviousImports
   def clean_inat_ids
     inat_ids = normalize_inat_ids(params[:inat_ids])
     previous_imports = previously_imported_links
-    return inat_ids if previous_imports.none?
-
-    remove_previously_imported_ids(inat_ids, previous_imports)
+    unless previous_imports.none?
+      inat_ids = remove_previously_imported_ids(inat_ids, previous_imports)
+    end
+    # Write the cleaned list back so downstream readers in the same request
+    # (importables_count via inat_id_list) count what will actually import.
+    params[:inat_ids] = inat_ids
   end
 
   # Remove previously imported ids in case the iNat user deleted the
   # Mushroom_Observer_URL field.
-  # NOTE: Also useful in manual testing when writes of iNat obss are
-  # commented out temporarily. jdc 2026-01-15
+  # NOTE: Also useful in manual testing when writes of iNat observations
+  # are commented out temporarily. jdc 2026-01-15
   def remove_previously_imported_ids(inat_ids, previous_imports)
     previous_ids = previous_imports.pluck(:external_id)
     remaining_ids =

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -234,7 +234,8 @@ module Views::Controllers::InatImports
 
     def render_hidden_fields
       [:inat_username, :inat_ids, :import_all, :consent, :import_others,
-       :inat_url, :original_inat_url, :skip_inat_writeback].each do |f|
+       :inat_url, :original_inat_url, :recheck_all,
+       :skip_inat_writeback].each do |f|
         hidden_field(f)
       end
     end

--- a/app/views/controllers/inat_imports/form.rb
+++ b/app/views/controllers/inat_imports/form.rb
@@ -56,6 +56,7 @@ module Views::Controllers::InatImports
             render_ids_panel
             render_method_radio("url", :inat_url_label.l)
             render_url_panel
+            render_recheck_all_field
           end
         end
       end
@@ -104,6 +105,14 @@ module Views::Controllers::InatImports
 
     def current_method
       model.choose_method.presence || "all"
+    end
+
+    # Applies to "all" and URL imports; id lists always re-check (#4565).
+    def render_recheck_all_field
+      checkbox_field(:recheck_all,
+                     label: :inat_recheck_all.l,
+                     help: :inat_recheck_all_help.l,
+                     wrap_class: "mt-4")
     end
 
     def render_consent_checkbox

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3253,7 +3253,7 @@
   inat_import_list: A list of observations
   inat_import_list_help: "List of up to about 384 observation #s (comma- or whitespace-separated; a header row like \"id\" is ignored)"
   inat_import_all: All my iNat observations
-  inat_recheck_all: "Re-check observations already marked as imported"
+  inat_recheck_all: "Re-check observations already linked to Mushroom Observer"
   inat_recheck_all_help: "\"All\" and URL imports normally skip iNat observations that already have a \"Mushroom Observer URL\" field. Check this to re-examine them — for example, to re-import observations whose MO observation was deleted. Slower for large accounts. Observations listed by ID are always re-checked."
   inat_import_others: "Import other users' observations"
   inat_skip_writeback: "Skip writing the MO link back to iNaturalist (admin)"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3253,6 +3253,8 @@
   inat_import_list: A list of observations
   inat_import_list_help: "List of up to about 384 observation #s (comma- or whitespace-separated; a header row like \"id\" is ignored)"
   inat_import_all: All my iNat observations
+  inat_recheck_all: "Re-check observations already marked as imported"
+  inat_recheck_all_help: "\"All\" and URL imports normally skip iNat observations that already have a \"Mushroom Observer URL\" field. Check this to re-examine them — for example, to re-import observations whose MO observation was deleted. Slower for large accounts. Observations listed by ID are always re-checked."
   inat_import_others: "Import other users' observations"
   inat_skip_writeback: "Skip writing the MO link back to iNaturalist (admin)"
   inat_import_consent: "(Required) I consent to importing my iNaturalist observations into Mushroom Observer, including any unlicensed observations and images, with my default MO license applied to any unlicensed images."

--- a/db/migrate/20260703204051_add_recheck_all_to_inat_imports.rb
+++ b/db/migrate/20260703204051_add_recheck_all_to_inat_imports.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Whether an import-all / URL-mode run should re-check observations that
+# already carry iNat's "Mushroom Observer URL" field instead of filtering
+# them out server-side with without_field. Lets users re-import
+# observations whose MO link is dead (MO observation deleted).
+class AddRecheckAllToInatImports < ActiveRecord::Migration[7.2]
+  def change
+    add_column(:inat_imports, :recheck_all, :boolean,
+               default: false, null: false)
+  end
+end

--- a/db/migrate/20260703210852_add_site_target_extid_index_to_external_links.rb
+++ b/db/migrate/20260703210852_add_site_target_extid_index_to_external_links.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# The importer's any-relationship duplicate gate looks links up by
+# (external_site_id, target_type, external_id). The existing
+# index_external_links_on_site_rel_target_extid has `relationship` second,
+# so that lookup can only use its first column — a large per-observation
+# scan across ~360k iNaturalist links. Index the exact lookup.
+class AddSiteTargetExtidIndexToExternalLinks < ActiveRecord::Migration[7.2]
+  def change
+    add_index(:external_links, [:external_site_id, :target_type, :external_id],
+              name: "index_external_links_on_site_target_extid")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_03_204051) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_03_210852) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -92,6 +92,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_03_204051) do
     t.virtual "import_target", type: :string, as: "(case when (`relationship` = 1) then concat(`target_type`,_utf8mb3':',`target_id`) end)", stored: true
     t.date "external_created_on"
     t.index ["external_site_id", "relationship", "target_type", "external_id"], name: "index_external_links_on_site_rel_target_extid"
+    t.index ["external_site_id", "target_type", "external_id"], name: "index_external_links_on_site_target_extid"
     t.index ["import_target"], name: "index_external_links_on_import_target", unique: true
     t.index ["target_type", "target_id"], name: "index_external_links_on_target"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_02_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_03_204051) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -239,6 +239,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_02_000000) do
     t.integer "ignored_already_imported_count", default: 0, null: false
     t.text "date_missing_inat_ids"
     t.text "license_added_inat_ids"
+    t.boolean "recheck_all", default: false, null: false
   end
 
   create_table "interests", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/test/classes/inat/page_parser_test.rb
+++ b/test/classes/inat/page_parser_test.rb
@@ -167,6 +167,60 @@ class Inat
                    "order_by should be id for pagination")
     end
 
+    def test_base_query_args_import_all_includes_without_field
+      import = inat_imports(:dick_inat_import).tap do |i|
+        i.inat_username = "some_user"
+        i.inat_ids = ""
+      end
+      parser = PageParser.new(import)
+
+      args = parser.send(:base_query_args)
+
+      assert_equal("Mushroom Observer URL", args[:without_field],
+                   "Import-all should filter by without_field by default")
+    end
+
+    def test_base_query_args_import_all_recheck_drops_without_field
+      import = inat_imports(:dick_inat_import).tap do |i|
+        i.inat_username = "some_user"
+        i.inat_ids = ""
+        i.recheck_all = true
+      end
+      parser = PageParser.new(import)
+
+      args = parser.send(:base_query_args)
+
+      assert_nil(args[:without_field],
+                 "recheck_all import-all must not filter by without_field")
+    end
+
+    def test_base_query_args_ids_mode_drops_without_field
+      import = inat_imports(:dick_inat_import).tap do |i|
+        i.inat_username = "some_user"
+        i.inat_ids = "123,456"
+      end
+      parser = PageParser.new(import)
+
+      args = parser.send(:base_query_args)
+
+      assert_nil(args[:without_field],
+                 "Explicit id lists always re-check: no without_field filter")
+    end
+
+    def test_url_request_query_args_recheck_drops_without_field
+      import = inat_imports(:dick_inat_import).tap do |i|
+        i.inat_url = "project_id=291058&without_field=foo"
+        i.recheck_all = true
+      end
+      parser = PageParser.new(import)
+
+      args = parser.send(:url_request_query_args, id_above: 0)
+
+      assert_nil(args[:without_field],
+                 "recheck_all URL mode must not filter by without_field, " \
+                 "and the user's own without_field is still stripped")
+    end
+
     def test_next_page_url_mode_returns_parsed_json
       import = inat_imports(:dick_inat_import).tap do |i|
         i.inat_url = "project_id=291058"

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -482,7 +482,9 @@ class InatImportsControllerTest < FunctionalTestCase
       url: "#{site.base_url}#{inat_id}"
     )
 
-    params = { inat_username: "anything", inat_ids: inat_id,
+    fresh_id = "1123457"
+    params = { inat_username: "anything",
+               inat_ids: "#{inat_id},#{fresh_id}",
                consent: 1, confirmed: 1 }
     login
     assert_no_difference("Observation.count",
@@ -491,11 +493,16 @@ class InatImportsControllerTest < FunctionalTestCase
     end
 
     assert_flash_text(/#{Regexp.escape(:inat_previous_import.l(count: 1))}/)
-    # It should continue even if some ids were previously imported
-    # The job will exclude previous imports via the iNat API
-    # `without_field: "Mushroom Observer URL"` param.
+    # It should continue even if some ids were previously imported: the
+    # previously imported id is dropped from the list, and the counts
+    # reflect the cleaned list.
+    import = created_import(user)
+    assert_equal(fresh_id, import.inat_ids,
+                 "Previously imported id should be dropped from inat_ids")
+    assert_equal(1, import.total_importables,
+                 "total_importables should count only the cleaned id list")
     assert_redirected_to(
-      "#{INAT_AUTHORIZATION_URL}&state=#{created_import(user).id}"
+      "#{INAT_AUTHORIZATION_URL}&state=#{import.id}"
     )
   end
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -645,6 +645,37 @@ class InatImportsControllerTest < FunctionalTestCase
                  "Should flatten inat_username from namespaced params")
   end
 
+  def test_create_recheck_all_persists
+    user = users(:rolf)
+    login(user.login)
+
+    post(:create,
+         params: { all: "1", inat_username: "rolf",
+                   consent: 1, confirmed: 1, recheck_all: "1" })
+
+    import = created_import(user)
+    assert(import.recheck_all,
+           "Failed to save InatImport.recheck_all from the form checkbox")
+  end
+
+  def test_create_recheck_all_survives_confirm_round_trip
+    user = users(:rolf)
+    login(user.login)
+
+    post(:create,
+         params: {
+           confirmed: 1,
+           inat_import_confirm: {
+             inat_username: "rolf", inat_ids: "123,456",
+             import_all: "", consent: "1", recheck_all: "1"
+           }
+         })
+
+    import = created_import(user)
+    assert(import.recheck_all,
+           "recheck_all should flatten from namespaced confirm params")
+  end
+
   def test_skip_writeback_checkbox_admin_only
     login(users(:rolf).login)
     get(:new)

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -129,6 +129,76 @@ class InatImportJobTest < ActiveJob::TestCase
     assert_equal(@user.unique_text_name, obs.collector)
   end
 
+  # The duplicate gate is any-relationship (#4565): an iNat obs already
+  # linked to an MO obs via a non-import link (mirror/copy/etc.) must be
+  # skipped, not re-imported as a duplicate.
+  def test_import_skips_inat_obs_with_non_import_link
+    create_ivars_from_filename("calostoma_lutescens")
+    @user.update(inat_username: @inat_import.inat_username)
+    ExternalLink.create!(
+      user: @user, target: observations(:minimal_unknown_obs),
+      external_site: ExternalSite.inaturalist,
+      external_id: @parsed_results.first[:id].to_s, relationship: :mirror
+    )
+
+    stub_inat_interactions
+    assert_no_difference(
+      "Observation.count",
+      "A mirror-linked iNat obs must not be re-imported"
+    ) do
+      InatImportJob.perform_now(@inat_import)
+    end
+    assert_equal(1, @inat_import.reload.ignored_already_imported_count)
+  end
+
+  # Self-heal (#4565): an iNat obs whose MO URL field points at a LIVE MO
+  # obs that has no link yet gets the missing remote_manual link
+  # materialized, and is skipped rather than imported as a duplicate.
+  def test_import_materializes_crosslink_to_live_mo_obs
+    create_ivars_from_filename("calostoma_lutescens")
+    @user.update(inat_username: @inat_import.inat_username)
+    mo_obs = observations(:minimal_unknown_obs)
+    inject_mo_url_field("https://mushroomobserver.org/#{mo_obs.id}")
+
+    stub_inat_interactions
+    assert_no_difference(
+      "Observation.count",
+      "An iNat obs cross-referenced to a live MO obs must not be imported"
+    ) do
+      InatImportJob.perform_now(@inat_import)
+    end
+
+    link = ExternalLink.find_by(
+      external_id: @parsed_results.first[:id].to_s, relationship: :remote_manual
+    )
+    assert_not_nil(link, "Cannot find the self-healed remote_manual link")
+    assert_equal(mo_obs, link.target)
+    assert_equal(1, @inat_import.reload.ignored_already_imported_count)
+  end
+
+  # A dead MO URL field value (the MO obs was deleted) blocks nothing:
+  # the obs is importable again (#4565 orphan reimport). Pins the
+  # "DEAD LINK:" annotation form used by the iNat-side cleanup sweep.
+  def test_import_imports_inat_obs_with_dead_mo_url_field
+    create_ivars_from_filename("calostoma_lutescens")
+    @user.update(inat_username: @inat_import.inat_username)
+    dead_id = Observation.maximum(:id).to_i + 1_000_000
+    inject_mo_url_field("DEAD LINK: https://mushroomobserver.org/#{dead_id}")
+
+    Location.create(user: @user,
+                    name: "Sevier Co., Tennessee, USA",
+                    north: 36.043571, south: 35.561849,
+                    east: -83.253046, west: -83.794123)
+
+    stub_inat_interactions
+    assert_difference(
+      "Observation.count", 1,
+      "An iNat obs whose MO URL points at a deleted MO obs is importable"
+    ) do
+      InatImportJob.perform_now(@inat_import)
+    end
+  end
+
   # Prove (inter alia) that the MO Naming.user differs from the importing user
   # when the iNat user who made the 1st iNat id is another MO user
   def test_import_job_inat_id_suggested_by_another_by_mo_user
@@ -809,7 +879,7 @@ class InatImportJobTest < ActiveJob::TestCase
       InatImportJob.perform_now(@inat_import)
     end
 
-    assert_match(/Skipped #{inat_id} already imported/, job_log_file.read,
+    assert_match(/Skipped #{inat_id} already linked/, job_log_file.read,
                  "Should log a skip message when the obs is already imported")
   end
 
@@ -1217,7 +1287,7 @@ class InatImportJobTest < ActiveJob::TestCase
       only_id: false,
       order: "asc",
       order_by: "id",
-      **BASE_FILTER_PARAMS,
+      # no without_field: id-list imports always re-check (#4565)
       user_login: @inat_import.inat_username
     }
     error = "Unauthorized"
@@ -1337,6 +1407,19 @@ class InatImportJobTest < ActiveJob::TestCase
       JSON.parse(@mock_inat_response, symbolize_names: true)[:results]
 
     @inat_import = create_inat_import(**attrs)
+  end
+
+  # Add a "Mushroom Observer URL" observation field (5005) to the mocked
+  # iNat response. Call after create_ivars_from_filename, before stubbing.
+  def inject_mo_url_field(value)
+    parsed = JSON.parse(@mock_inat_response, symbolize_names: true)
+    parsed[:results].first[:ofvs] << {
+      field_id: MO_URL_OBSERVATION_FIELD_ID,
+      name: "Mushroom Observer URL",
+      value: value
+    }
+    @mock_inat_response = JSON.generate(parsed)
+    @parsed_results = parsed[:results]
   end
 
   # On the app side, the Job is created by InatImportsController#create,

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -151,6 +151,37 @@ class InatImportJobTest < ActiveJob::TestCase
     assert_equal(1, @inat_import.reload.ignored_already_imported_count)
   end
 
+  # When the self-heal link fails validation, the obs is still skipped
+  # (it IS cross-referenced to a live MO obs) but the job log must report
+  # the failure instead of claiming the link was recorded.
+  def test_import_crosslink_creation_failure_logged_and_still_skipped
+    create_ivars_from_filename("calostoma_lutescens")
+    @user.update(inat_username: @inat_import.inat_username)
+    mo_obs = observations(:minimal_unknown_obs)
+    inject_mo_url_field("https://mushroomobserver.org/#{mo_obs.id}")
+
+    stub_inat_interactions
+    raiser = ->(*) { raise(ActiveRecord::RecordInvalid.new(ExternalLink.new)) }
+    ExternalLink.stub(:create!, raiser) do
+      assert_no_difference(
+        "Observation.count",
+        "A cross-referenced iNat obs is skipped even when the " \
+        "self-heal link fails"
+      ) do
+        InatImportJob.perform_now(@inat_import)
+      end
+    end
+
+    assert_nil(
+      ExternalLink.find_by(external_id: @parsed_results.first[:id].to_s,
+                           relationship: :remote_manual),
+      "No link should exist after the stubbed validation failure"
+    )
+    assert_equal(1, @inat_import.reload.ignored_already_imported_count)
+    assert_match(/failed to record the link/, job_log_file.read,
+                 "Job log must report the link-creation failure")
+  end
+
   # Self-heal (#4565): an iNat obs whose MO URL field points at a LIVE MO
   # obs that has no link yet gets the missing remote_manual link
   # materialized, and is skipped rather than imported as a duplicate.

--- a/test/jobs/inat_import_job_test_doubles.rb
+++ b/test/jobs/inat_import_job_test_doubles.rb
@@ -78,9 +78,13 @@ module InatImportJobTestDoubles
       per_page: InatImportJob::BATCH_SIZE,
       only_id: false,
       order: "asc",
-      order_by: "id",
-      **BASE_FILTER_PARAMS
+      order_by: "id"
     }
+    # Mirrors PageParser#without_field_filter: id lists always re-check,
+    # query modes filter unless recheck_all (#4565).
+    unless @inat_import.inat_ids.present? || @inat_import.recheck_all?
+      query_args.merge!(BASE_FILTER_PARAMS)
+    end
     if @inat_import.import_others
       query_args.merge!(LICENSED_FILTER)
     else

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -34,6 +34,14 @@ module Views::Controllers::InatImports
                   "[name='inat_import_confirm[inat_username]']")
     end
 
+    def test_carries_recheck_all_through_hidden_field
+      html = render_form
+
+      assert_html(html,
+                  "input[type='hidden']" \
+                  "[name='inat_import_confirm[recheck_all]']")
+    end
+
     def test_staleness_note_absent_when_result_set_is_stable
       stable_model = FormObject::InatImportConfirm.new(
         inat_username: "rolf_inat_username", inat_ids: "123,456"

--- a/test/views/controllers/inat_imports/form_test.rb
+++ b/test/views/controllers/inat_imports/form_test.rb
@@ -91,6 +91,14 @@ module Views::Controllers::InatImports
                   "[name='inat_import[consent]']")
     end
 
+    def test_recheck_all_checkbox
+      html = render_form
+
+      assert_html(html,
+                  "input[type='checkbox'][name='inat_import[recheck_all]']")
+      assert_includes(html, :inat_recheck_all.l)
+    end
+
     def test_super_importer_field_hidden_by_default
       html = render_form(super_importer: false)
 


### PR DESCRIPTION
## Summary

Makes MO's typed `ExternalLink` set — complete since #4565's materialization — the authoritative duplicate gate for iNat imports, and demotes iNat's field-presence `without_field` filter to a fetch-volume optimization. This unblocks re-import of the ~2,506 orphaned iNat observations whose "Mushroom Observer URL" field points at a deleted MO observation: the presence-based filter excluded them from every fetch regardless of the field's value (verified against the live API — a blanked value still counts as present).

Part of #4565 / #4208.

## The gate (per fetched iNat obs, in order)

1. **Any iNat `ExternalLink` for that iNat id** (import / mirror / copy / remote_manual / manual) → skip. Previously only `import` links were checked (`already_imported?`); mirrors and copies were excluded solely by the iNat-side filter. Renamed to `already_linked?`.
2. **No link, but the MO URL field points at a live MO obs** → materialize the missing `remote_manual` link and skip. This makes the importer self-healing: manual field-5005 cross-references made on iNat after the June-18 materialization snapshot get linked on contact instead of imported as duplicates.
3. **Field absent, blank, dead (MO obs deleted), or unparseable** → import normally. A `"DEAD LINK: <url>"` annotated value (planned iNat-side cleanup sweep) parses to a deleted obs and imports — pinned by a test.

## When `without_field` is still sent

| Request mode | Filter |
|---|---|
| Explicit id list | never (user pointed at specific obs; silently skipping them looks like a bug) |
| Import-all / URL | sent, unless the new **"Re-check observations already marked as imported"** checkbox is checked |

The checkbox keeps the default import-all fast for users who re-import regularly to pull in new obs; checking it re-examines everything, at fetch-volume cost, to pick up orphans. `recheck_all` is a new boolean on `inat_imports`, carried through the confirm round-trip like the other form params.

Confirm-page estimates (`import_estimate_query_args`) and the expected-obs link (`Inat::ConfirmURLBuilder`) follow the same rules, so the numbers shown match what the import will do.

## Refactors in passing

- `InatImportsController`: previous-imports handling extracted to a `PreviousImports` concern; `init_ivars` split into scope/bookkeeping attr builders (Metrics).
- `FormBuilders`: the passthrough param lists are now driven by one `PASSTHROUGH_PARAM_KEYS` constant.

## Test plan

- [x] PageParser: `without_field` present on default import-all, absent for id lists, absent with `recheck_all`, absent in URL mode with `recheck_all` (user-supplied `without_field` still stripped).
- [x] Job: mirror-linked iNat obs skipped (not re-imported); live cross-reference self-heals a `remote_manual` link and skips; `DEAD LINK:` value imports.
- [x] Controller: `recheck_all` persists from the form and survives the namespaced confirm round-trip.
- [x] Form/confirm views: checkbox renders; hidden field carries the value.
- [x] Full files green: job (56), controller (33), inat classes, inat_imports views — 260 tests, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
