### PR TITLE
Add admin-mode toggle regression test from observation show page (#4659)

### DIFF
--- a/test/system/admin_mode_system_test.rb
+++ b/test/system/admin_mode_system_test.rb
@@ -22,6 +22,24 @@ class AdminModeSystemTest < ApplicationSystemTestCase
     assert_admin_toggle_works
   end
 
+  # Observation show also holds an open Turbo Stream subscription
+  # (comments, via Views::Controllers::Comments::CommentsForObject's
+  # `turbo_stream_from(@object, :comments)`) — same class of page as
+  # the iNat import show test above, added to scope how far #4659's
+  # finding reaches. Verified locally by temporarily removing
+  # Tab::UserNav::AdminMode's `data: { turbo: false }` opt-out: unlike
+  # the iNat import page (where the post-toggle redirect is never
+  # followed — turbo:submit-end fires, then nothing), THIS page's
+  # toggle still works fine without the opt-out. So the "redirect
+  # never followed" failure isn't universal to any page with an open
+  # Turbo Stream subscription — something more specific to the iNat
+  # import page's subscription is involved. Passes today regardless,
+  # since the opt-out is in place either way.
+  def test_admin_mode_toggle_from_observation_show_page
+    visit(observation_path(observations(:minimal_unknown_obs).id))
+    assert_admin_toggle_works
+  end
+
   private
 
   def assert_admin_toggle_works


### PR DESCRIPTION
## Summary

Part of the #4659 investigation (flash notice missing after Turbo-driven observation destroy redirect). Adds a regression test scoping how far that investigation's findings reach, stacked on #4662 since it depends on that branch's system-test baseline being clean.

`AdminModeSystemTest` already has `test_admin_mode_toggle_from_inat_import_page`, added because the iNat import show page holds an open Turbo Stream subscription and previously failed to apply admin mode at all. This PR adds the same shape of test for the observation show page, which also holds an open Turbo Stream subscription (comments, via `Views::Controllers::Comments::CommentsForObject#turbo_stream_from(@object, :comments)`).

Verified locally (not committed, since it would break `main`) that temporarily removing `Tab::UserNav::AdminMode`'s `data: { turbo: false }` opt-out reproduces the iNat import page's "redirect never followed" failure exactly, but does **not** reproduce it on the observation show page — that toggle still works fine without the opt-out there. So the underlying issue isn't universal to "any page with an open Turbo Stream subscription"; something more specific to the iNat import page's subscription is involved. This test documents that scope and guards against a regression if the observation-show case ever breaks too.

This test passes today regardless, since the opt-out is in place either way — it's forward-looking coverage, not a fix.

## Related finding (not shipped here)

While investigating #4659 further, tried the `data-turbo-track: reload` stylesheet fix (previously tested and reverted out of #4655) as a way to drop the per-button Turbo opt-outs entirely. It does fix the admin-mode stylesheet corruption, but it directly *causes* the destroy-flash bug — confirmed by isolating the change: revert it and `test_post_edit_and_destroy_with_details_and_location` passes; add it back and even the simplest possible destroy (fresh observation, fresh session) fails the same way, with the browser doing a genuine full reload (confirmed via injected JS state getting wiped) instead of a normal Turbo render. Likely mechanism: Turbo fetches the redirected page, detects the tracked stylesheet doesn't match, discards that response (which already rendered and cleared the flash's `session[:notice]` server-side) and does a fresh `location.reload()` — so the page the user actually sees comes from a second request that finds the flash already consumed. Full write-up on #4659; that fix is not included in this PR since it's not safe to ship as-is.

## Test plan

- [x] `bin/rails test test/system/admin_mode_system_test.rb` — 3/3 pass.
- [x] `bundle exec rubocop test/system/admin_mode_system_test.rb` — clean.
