### PR TITLE
Sweep 8 small top-level components to Kit syntax

### DIFF
--- a/app/components/accordion.rb
+++ b/app/components/accordion.rb
@@ -27,9 +27,9 @@ class Components::Accordion < Components::Base
   prop :id, String
 
   slot :pane, lambda { |id:, expanded: false, &content|
-    render(::Components::CollapseDiv.new(
-             id: id, expanded: expanded, html_class: "no-transition"
-           )) { content&.call }
+    CollapseDiv(
+      id: id, expanded: expanded, html_class: "no-transition"
+    ) { content&.call }
   }, collection: true
 
   def view_template

--- a/app/components/form/location_map.rb
+++ b/app/components/form/location_map.rb
@@ -22,11 +22,11 @@ class Components::Form::LocationMap < Components::Base
   private
 
   def render_map_div
-    render(::Components::CollapseDiv.new(
-             id: @id,
-             html_class: "form-map",
-             attributes: { data: map_data_attributes }
-           ))
+    CollapseDiv(
+      id: @id,
+      html_class: "form-map",
+      attributes: { data: map_data_attributes }
+    )
   end
 
   def map_data_attributes

--- a/app/components/form/region_with_box_fields.rb
+++ b/app/components/form/region_with_box_fields.rb
@@ -116,11 +116,11 @@ class Components::Form::RegionWithBoxFields < Components::Base
   end
 
   def render_editable_map
-    render(::Components::Map.new(
-             objects: [build_minimal_location],
-             editable: true, map_type: "location",
-             map_open: true, controller: nil
-           ))
+    Map(
+      objects: [build_minimal_location],
+      editable: true, map_type: "location",
+      map_open: true, controller: nil
+    )
   end
 
   def build_minimal_location

--- a/app/components/help/collapse_block.rb
+++ b/app/components/help/collapse_block.rb
@@ -18,7 +18,7 @@ class Components::Help::CollapseBlock < Components::Base
     div_class = "well well-sm mb-3 help-block position-relative"
     div_class += " mt-3" if @direction == "up"
 
-    render(::Components::CollapseDiv.new(id: @target_id)) do
+    CollapseDiv(id: @target_id) do
       div(class: div_class) do
         yield if block
         if @direction

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -147,7 +147,7 @@ class Components::Matrix::Box < Components::Base
 
   def render_id_badge(obj)
     whitespace
-    render(Components::IdBadge.new(object: obj, extra_class: "rss-id"))
+    IdBadge(object: obj, extra_class: "rss-id")
   end
 
   def render_occurrence_link

--- a/app/components/panel.rb
+++ b/app/components/panel.rb
@@ -206,12 +206,12 @@ class Components::Panel < Components::Base
   end
 
   def render_collapse_body(classes:, id:, wrapper:, &content)
-    render(::Components::CollapseDiv.new(
-             id: @collapse_id,
-             expanded: @expanded,
-             panel: true,
-             html_class: @collapse_class
-           )) { render_plain_body(classes:, id:, wrapper:, &content) }
+    CollapseDiv(
+      id: @collapse_id,
+      expanded: @expanded,
+      panel: true,
+      html_class: @collapse_class
+    ) { render_plain_body(classes:, id:, wrapper:, &content) }
   end
 
   def render_footer(classes:)

--- a/app/views/controllers/articles/show.rb
+++ b/app/views/controllers/articles/show.rb
@@ -22,7 +22,7 @@ module Views::Controllers::Articles
     private
 
     def render_byline
-      render(::Components::ContentPadded.new) do
+      ContentPadded do
         plain(:BY.t)
         whitespace
         Link(type: :user, user: @article.user)

--- a/app/views/controllers/collection_numbers/show.rb
+++ b/app/views/controllers/collection_numbers/show.rb
@@ -28,7 +28,7 @@ module Views::Controllers::CollectionNumbers
     private
 
     def render_details
-      render(Components::ContentPadded.new) do
+      ContentPadded do
         render_field(:collection_number_name.t, @collection_number.name)
         render_field(:collection_number_number.t, @collection_number.number)
         render_user_field

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -83,9 +83,9 @@ module Views::Controllers::FieldSlips
       project_field = Components::ApplicationForm::FieldProxy.new(
         nil, :project_name, project_title
       )
-      render(Components::IndexFilter.new(
-               to: field_slips_path, submit_text: "Filter"
-             )) do
+      IndexFilter(
+        to: field_slips_path, submit_text: "Filter"
+      ) do
         render(Components::ApplicationForm::AutocompleterField.new(
                  project_field,
                  type: :project, hidden_name: :project, inline: true,

--- a/app/views/controllers/field_slips/show.rb
+++ b/app/views/controllers/field_slips/show.rb
@@ -16,7 +16,7 @@ module Views::Controllers::FieldSlips
 
       Alert(message: @notice, level: :success) if @notice
 
-      render(Components::ContentPadded.new) do
+      ContentPadded do
         render(FieldSlipPanel.new(field_slip: @field_slip))
       end
 

--- a/app/views/controllers/herbaria/show.rb
+++ b/app/views/controllers/herbaria/show.rb
@@ -131,7 +131,7 @@ module Views::Controllers::Herbaria
     def render_right_column
       div(class: "col-xs-12 col-sm-4 mt-3", style: "max-width:320px") do
         div(class: "mb-3") do
-          render(::Components::Map.new(objects: [@herbarium.location]))
+          Map(objects: [@herbarium.location])
         end
         p(id: "herbarium_location") do
           plain("#{:LOCATION.l}: #{@herbarium.location.text_name}")

--- a/app/views/controllers/herbarium_records/show.rb
+++ b/app/views/controllers/herbarium_records/show.rb
@@ -31,7 +31,7 @@ module Views::Controllers::HerbariumRecords
     private
 
     def render_details
-      render(Components::ContentPadded.new(id: "herbarium_record_details")) do
+      ContentPadded(id: "herbarium_record_details") do
         p do
           render_field_lines
           render_collection_link if herbarium&.web_searchable?

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -28,11 +28,11 @@ module Views::Controllers::InatImports
     private
 
     def render_content
-      render(::Components::ContentPadded.new do
+      ContentPadded do
         render_summary_paragraph
         render_actions
         render_timing_details
-      end)
+      end
     end
 
     def render_actions

--- a/app/views/controllers/locations/index.rb
+++ b/app/views/controllers/locations/index.rb
@@ -60,7 +60,7 @@ module Views::Controllers::Locations
       render_section_heading(:list_place_names_known,
                              :list_place_names_known_order,
                              css: "h4 px-3 mb-0")
-      render(::Components::ContentPadded.new) do
+      ContentPadded do
         small { plain(:list_place_names_parenthetical.l) }
       end
       render(::Components::PaginatedResults.new) { render_known_list(counts) }

--- a/app/views/controllers/locations/maps/show.rb
+++ b/app/views/controllers/locations/maps/show.rb
@@ -18,11 +18,11 @@ module Views::Controllers::Locations::Maps
         )
       )
 
-      render(::Components::Map.new(
-               objects: @locations,
-               zoom: 2,
-               map_type: "location"
-             ))
+      Map(
+        objects: @locations,
+        zoom: 2,
+        map_type: "location"
+      )
     end
   end
 end

--- a/app/views/controllers/locations/show.rb
+++ b/app/views/controllers/locations/show.rb
@@ -44,7 +44,7 @@ module Views::Controllers::Locations
 
     def render_left_column
       div(class: "mb-5") do
-        render(::Components::Map.new(objects: [@location]))
+        Map(objects: [@location])
       end
       render(Show::GeneralDescriptionPanel.new(
                location: @location, description: @description

--- a/app/views/controllers/locations/versions/show.rb
+++ b/app/views/controllers/locations/versions/show.rb
@@ -35,7 +35,7 @@ module Views::Controllers::Locations
       def render_columns
         div(class: content_for(:left_columns)) do
           div(class: "mb-5") do
-            render(::Components::Map.new(objects: [@location]))
+            Map(objects: [@location])
           end
         end
         div(class: content_for(:right_columns)) do

--- a/app/views/controllers/names/index/row.rb
+++ b/app/views/controllers/names/index/row.rb
@@ -31,9 +31,7 @@ class Views::Controllers::Names::Index::Row < Views::Base
 
   def render_id_badge
     span do
-      render(Components::IdBadge.new(
-               object: @name, extra_class: "rss-id mr-4"
-             ))
+      IdBadge(object: @name, extra_class: "rss-id mr-4")
     end
   end
 

--- a/app/views/controllers/names/maps/show.rb
+++ b/app/views/controllers/names/maps/show.rb
@@ -22,16 +22,16 @@ class Views::Controllers::Names::Maps::Show < Views::FullPageBase
       )
     )
 
-    render(::Components::Map.new(
-             objects: @observations.to_a,
-             clustering: true,
-             capped: @observations_capped,
-             observations_loaded_count: @observations_loaded_count,
-             observations_total_count: @observations_total_count,
-             cluster_query_string: @cluster_query_string,
-             zoom: 2,
-             map_type: "info",
-             nothing_to_map: :name_map_no_maps.tp(name: @name.display_name)
-           ))
+    Map(
+      objects: @observations.to_a,
+      clustering: true,
+      capped: @observations_capped,
+      observations_loaded_count: @observations_loaded_count,
+      observations_total_count: @observations_total_count,
+      cluster_query_string: @cluster_query_string,
+      zoom: 2,
+      map_type: "info",
+      nothing_to_map: :name_map_no_maps.tp(name: @name.display_name)
+    )
   end
 end

--- a/app/views/controllers/names/show.rb
+++ b/app/views/controllers/names/show.rb
@@ -96,13 +96,13 @@ module Views::Controllers::Names
     end
 
     def render_best_images_carousel
-      render(Components::ImageGallery.new(
-               object: @name,
-               images: @best_images,
-               title: :show_name_most_confident.l,
-               links: "",
-               panel_id: "name_confident_observations"
-             ))
+      ImageGallery(
+        object: @name,
+        images: @best_images,
+        title: :show_name_most_confident.l,
+        links: "",
+        panel_id: "name_confident_observations"
+      )
     end
 
     # --- Right column -------------------------------------------------

--- a/app/views/controllers/names/synonyms/form.rb
+++ b/app/views/controllers/names/synonyms/form.rb
@@ -97,7 +97,7 @@ module Views::Controllers::Names::Synonyms
         end
       end
       badge = capture do
-        render(Components::IdBadge.new(object: name_obj, extra_class: ""))
+        IdBadge(object: name_obj, extra_class: "")
       end
       [link, badge].safe_join(" ")
     end

--- a/app/views/controllers/observations/form/details.rb
+++ b/app/views/controllers/observations/form/details.rb
@@ -165,11 +165,11 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   end
 
   def render_geolocation_fields
-    render(::Components::CollapseDiv.new(
-             id: "observation_geolocation",
-             expanded: @observation.lat.present?,
-             attributes: { data: { form_exif_target: "collapseFields" } }
-           )) do
+    CollapseDiv(
+      id: "observation_geolocation",
+      expanded: @observation.lat.present?,
+      attributes: { data: { form_exif_target: "collapseFields" } }
+    ) do
       p { :form_observations_click_point.l }
       render_lat_lng_alt_row
       render_gps_hidden_checkbox

--- a/app/views/controllers/observations/maps/index.rb
+++ b/app/views/controllers/observations/maps/index.rb
@@ -27,16 +27,16 @@ module Views::Controllers::Observations::Maps
       # built from the obs's .location, so the locations are already
       # implicitly represented. Unioning @locations in addition produced
       # duplicate box overlays on top of obs points (#4131 follow-up).
-      render(::Components::Map.new(
-               objects: @observations,
-               clustering: true,
-               capped: @observations_capped,
-               observations_loaded_count: @observations_loaded_count,
-               observations_total_count: @observations_total_count,
-               cluster_query_string: @cluster_query_string,
-               zoom: 2,
-               map_type: "info"
-             ))
+      Map(
+        objects: @observations,
+        clustering: true,
+        capped: @observations_capped,
+        observations_loaded_count: @observations_loaded_count,
+        observations_total_count: @observations_total_count,
+        cluster_query_string: @cluster_query_string,
+        zoom: 2,
+        map_type: "info"
+      )
     end
   end
 end

--- a/app/views/controllers/observations/maps/show.rb
+++ b/app/views/controllers/observations/maps/show.rb
@@ -17,11 +17,11 @@ module Views::Controllers::Observations::Maps
         )
       )
 
-      render(::Components::Map.new(
-               objects: @observations,
-               zoom: 2,
-               map_type: "observation"
-             ))
+      Map(
+        objects: @observations,
+        zoom: 2,
+        map_type: "observation"
+      )
     end
   end
 end

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -75,11 +75,11 @@ module Views::Controllers::Observations
     end
 
     def render_carousel
-      render(Components::ImageGallery.new(
-               object: @observation, images: @images,
-               carousel_id: "observation_images", user: @user,
-               title: :IMAGES.t, links: carousel_links
-             ))
+      ImageGallery(
+        object: @observation, images: @images,
+        carousel_id: "observation_images", user: @user,
+        title: :IMAGES.t, links: carousel_links
+      )
     end
 
     def carousel_links

--- a/app/views/controllers/occurrences/projects/form.rb
+++ b/app/views/controllers/occurrences/projects/form.rb
@@ -96,9 +96,7 @@ module Views::Controllers::Occurrences::Projects
       ul(class: "list-unstyled mt-2") do
         projects.each do |project|
           li(class: "d-flex align-items-center mb-1") do
-            render(Components::IdBadge.new(
-                     object: project, extra_class: "rss-id mr-3"
-                   ))
+            IdBadge(object: project, extra_class: "rss-id mr-3")
             a(href: project_path(project)) { plain(project.title) }
           end
         end

--- a/app/views/controllers/projects/admin_subtabs.rb
+++ b/app/views/controllers/projects/admin_subtabs.rb
@@ -20,10 +20,10 @@ module Views::Controllers::Projects
       div(class: "row") do
         div(class: "col-xs-12 pl-4 mt-2 mb-3",
             id: "project_admin_subtabs") do
-          render(Components::NavTabs.new(
-                   current: @current_subtab,
-                   tabs: ::Tab::Project::AdminSubtabs.new(project: @project)
-                 ))
+          NavTabs(
+            current: @current_subtab,
+            tabs: ::Tab::Project::AdminSubtabs.new(project: @project)
+          )
         end
       end
     end

--- a/app/views/controllers/projects/banner.rb
+++ b/app/views/controllers/projects/banner.rb
@@ -29,12 +29,12 @@ module Views::Controllers::Projects
 
       div(class: "row") do
         div(class: Grid::FULL, id: "project_tabs") do
-          render(Components::NavTabs.new(
-                   current: @current_tab, link_class: "mt-3",
-                   tabs: ::Tab::Project::Banner.new(
-                     project: @project, user: @user
-                   )
-                 ))
+          NavTabs(
+            current: @current_tab, link_class: "mt-3",
+            tabs: ::Tab::Project::Banner.new(
+              project: @project, user: @user
+            )
+          )
         end
       end
     end
@@ -79,7 +79,7 @@ module Views::Controllers::Projects
 
       h1(class: title_classes, id: "title") do
         div(class: "d-flex align-items-center") do
-          render(Components::IdBadge.new(object: @project))
+          IdBadge(object: @project)
           whitespace
           Link(type: :object, object: @project)
         end

--- a/app/views/controllers/projects/list_item.rb
+++ b/app/views/controllers/projects/list_item.rb
@@ -14,9 +14,7 @@ module Views::Controllers::Projects
 
     def view_template
       div(class: "text-larger") do
-        render(Components::IdBadge.new(
-                 object: @project, extra_class: "rss-id mr-4"
-               ))
+        IdBadge(object: @project, extra_class: "rss-id mr-4")
       end
       div do
         render_title_row

--- a/app/views/controllers/publications/index.rb
+++ b/app/views/controllers/publications/index.rb
@@ -33,7 +33,7 @@ module Views::Controllers::Publications
 
       div(class: "container-text") { render_intro }
       render_publications_table
-      render(::Components::ContentPadded.new) do
+      ContentPadded do
         trusted_html(:publication_legend.tp)
       end
     end
@@ -41,7 +41,7 @@ module Views::Controllers::Publications
     private
 
     def render_intro
-      render(::Components::ContentPadded.new) do
+      ContentPadded do
         trusted_html(:publication_index_intro.tp)
         trusted_html(:publication_citation.tp)
         a(href: INTRO_CITATION_URL) { plain(INTRO_CITATION_TEXT) }

--- a/app/views/controllers/sequences/show.rb
+++ b/app/views/controllers/sequences/show.rb
@@ -9,7 +9,7 @@ module Views::Controllers::Sequences
 
     def view_template
       register_chrome
-      render(::Components::ContentPadded.new(class: "container-text")) do
+      ContentPadded(class: "container-text") do
         render_fields
       end
       render(::Views::Layouts::ObjectFooter.new(

--- a/app/views/controllers/species_lists/listing.rb
+++ b/app/views/controllers/species_lists/listing.rb
@@ -45,9 +45,7 @@ module Views::Controllers::SpeciesLists
     def render_info
       div(class: "list_info d-flex align-items-start") do
         div(class: "text-larger") do
-          render(Components::IdBadge.new(
-                   object: @species_list, extra_class: "rss-id mr-4"
-                 ))
+          IdBadge(object: @species_list, extra_class: "rss-id mr-4")
         end
         div do
           render_title_row

--- a/app/views/controllers/users/show.rb
+++ b/app/views/controllers/users/show.rb
@@ -42,12 +42,12 @@ module Views::Controllers::Users
     def render_right_column
       return unless @best_images.length.positive?
 
-      render(::Components::ImageGallery.new(
-               object: @show_user,
-               images: @best_images,
-               title: :show_user_observations_by.t(name: @show_user.login),
-               panel_id: "user_best_images"
-             ))
+      ImageGallery(
+        object: @show_user,
+        images: @best_images,
+        title: :show_user_observations_by.t(name: @show_user.login),
+        panel_id: "user_best_images"
+      )
     end
   end
 end

--- a/app/views/layouts/header/object_title.rb
+++ b/app/views/layouts/header/object_title.rb
@@ -27,8 +27,7 @@ module Views::Layouts
 
     def view_template
       div(class: "d-flex align-items-center") do
-        render(::Components::IdBadge.new(object: @object,
-                                         extra_class: "mr-4"))
+        IdBadge(object: @object, extra_class: "mr-4")
         whitespace
         span { render_title_span }
       end

--- a/app/views/layouts/header/sorter.rb
+++ b/app/views/layouts/header/sorter.rb
@@ -28,16 +28,16 @@ module Views::Layouts
         li(class: "navbar-text mx-0 hidden-xs") do
           plain("#{:sort_by_header.l}:")
         end
-        render(::Components::Dropdown.new(
-                 id: "sort_nav_toggle",
-                 menu_id: "sort_nav_menu",
-                 label: toggle_title.to_s,
-                 wrapper_class: "navbar-form px-2",
-                 toggle_variant: :outline, toggle_size: :sm,
-                 toggle_class: "font-weight-normal",
-                 menu_class: "sorts",
-                 menu_header: mobile_header_html
-               )) do |menu|
+        Dropdown(
+          id: "sort_nav_toggle",
+          menu_id: "sort_nav_menu",
+          label: toggle_title.to_s,
+          wrapper_class: "navbar-form px-2",
+          toggle_variant: :outline, toggle_size: :sm,
+          toggle_class: "font-weight-normal",
+          menu_class: "sorts",
+          menu_header: mobile_header_html
+        ) do |menu|
           menu.section(sort_tuples)
         end
       end

--- a/app/views/layouts/object_footer.rb
+++ b/app/views/layouts/object_footer.rb
@@ -37,9 +37,9 @@ module Views::Layouts
 
       num_versions = @versions.length
 
-      render(::Components::ContentPadded.new(
-               class: "small footer-view-stats"
-             )) do
+      ContentPadded(
+        class: "small footer-view-stats"
+      ) do
         if num_versions.positive? && @obj.version < num_versions
           render_old_version_metadata(num_versions)
         else
@@ -57,7 +57,7 @@ module Views::Layouts
     # of the optional chunks. Renders for `herbarium_records/show`
     # and `collection_numbers/show`.
     def render_minimal
-      render(::Components::ContentPadded.new(class: "small")) do
+      ContentPadded(class: "small") do
         p do
           plain("#{:CREATED_AT.l}: #{@obj.created_at.web_date}")
           br

--- a/app/views/layouts/top_nav/context_nav.rb
+++ b/app/views/layouts/top_nav/context_nav.rb
@@ -20,11 +20,11 @@ class Views::Layouts::TopNav::ContextNav < Views::Base
   prop :links, _Union(Array, ::Tab::Base, ::Tab::Collection)
 
   def view_template
-    render(Components::Dropdown.new(
-             id: "context_nav_toggle",
-             menu_id: "context_nav",
-             label: :app_context_actions.l
-           )) do |menu|
+    Dropdown(
+      id: "context_nav_toggle",
+      menu_id: "context_nav",
+      label: :app_context_actions.l
+    ) do |menu|
       menu.section(@links)
     end
   end

--- a/app/views/layouts/top_nav/user_nav.rb
+++ b/app/views/layouts/top_nav/user_nav.rb
@@ -14,11 +14,11 @@ class Views::Layouts::TopNav::UserNav < Views::Base
   prop :user, ::User
 
   def view_template
-    render(Components::Dropdown.new(
-             id: "user_nav_toggle",
-             menu_id: "user_drop_down",
-             label: @user.login
-           )) do |menu|
+    Dropdown(
+      id: "user_nav_toggle",
+      menu_id: "user_drop_down",
+      label: @user.login
+    ) do |menu|
       menu.section(::Tab::UserNav::LoggedIn.new(user: @user))
       menu.section(::Tab::UserNav::LogOut.new(
                      user: @user, in_admin_mode: in_admin_mode?


### PR DESCRIPTION
## Summary

Continues the Kit-syntax sweep (see the recent `Button()`/`Alert()`/`Link()`/`Table()` conversions) for the remaining top-level components living directly in `app/components/` (not a subdirectory). Converts `render(Components::X.new(...))` callers to the bare `X(...)` Kit syntax for:

- `CollapseDiv` (5 sites)
- `ContentPadded` (9 sites)
- `Dropdown` (3 sites)
- `ImageGallery` (3 sites — the other 3 files matched on `ImageGallery::Item`/`ImageGallery::Thumbnail` prefix, not the bare class, and were left alone)
- `IdBadge` (8 sites)
- `IndexFilter` (1 site)
- `Map` (8 sites)
- `NavTabs` (2 sites)

`Phlex::Kit` is extended on `Components`/`Views` at the module level (`config/initializers/phlex.rb`), so every component already has this bare-call method — no per-component registration needed, purely a call-site rewrite.

Excluded per the sweep's scope: `test/`, `app/components/application_form/`, and each component's own file (doc-comment `@example` blocks referencing themselves). Audited for namespace collisions (a caller view literally named the same as the component) — found none; the closest cases are `Maps` namespace modules (plural), which don't collide with singular `Map`.

`Icon` (26+ sites) and `PaginatedResults` (25 sites) are intentionally excluded — split into their own PRs given their much larger caller counts.

## Test plan

- [x] `bin/rails test test/components/ test/views/` — 1928 tests, 0 failures.
- [x] `bin/rails test test/system/herbarium_form_system_test.rb test/system/location_form_system_test.rb test/system/observation_show_system_test.rb test/system/admin_mode_system_test.rb` — real-browser coverage of pages using the converted `Map`/`Dropdown`/`IdBadge` components, 14/14 pass.
- [x] `bundle exec rubocop` — clean on all 38 touched files.
