### PR TITLE
Sweep PaginatedResults callers to Kit syntax

### DIFF
--- a/app/views/controllers/articles/index.rb
+++ b/app/views/controllers/articles/index.rb
@@ -16,7 +16,7 @@ module Views::Controllers::Articles
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      render(::Components::PaginatedResults.new) { render_list }
+      PaginatedResults { render_list }
     end
 
     private

--- a/app/views/controllers/collection_numbers/index.rb
+++ b/app/views/controllers/collection_numbers/index.rb
@@ -22,7 +22,7 @@ module Views::Controllers::CollectionNumbers
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render_rows_table if @objects.any?
       end
     end

--- a/app/views/controllers/comments/index.rb
+++ b/app/views/controllers/comments/index.rb
@@ -20,7 +20,7 @@ module Views::Controllers::Comments
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      render(::Components::PaginatedResults.new) { render_list }
+      PaginatedResults { render_list }
     end
 
     private

--- a/app/views/controllers/contributors/index.rb
+++ b/app/views/controllers/contributors/index.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Contributors
       add_pagination(@pagination_data)
 
       render_legend_row
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render(::Components::Matrix::Table.new(objects: @objects))
       end
     end

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -96,7 +96,7 @@ module Views::Controllers::FieldSlips
     end
 
     def render_list
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render(Components::ListGroup::Base.new) do |list|
           @objects.each do |fs|
             list.item do

--- a/app/views/controllers/glossary_terms/index.rb
+++ b/app/views/controllers/glossary_terms/index.rb
@@ -15,7 +15,7 @@ module Views::Controllers::GlossaryTerms
 
       content_for(:filters) { documentation_link }
 
-      render(::Components::PaginatedResults.new) { render_list }
+      PaginatedResults { render_list }
     end
 
     private

--- a/app/views/controllers/herbaria/index.rb
+++ b/app/views/controllers/herbaria/index.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Herbaria
 
       render_merge_alert if @merge
 
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render_table if @objects.any?
       end
     end
@@ -30,9 +30,7 @@ module Views::Controllers::Herbaria
     end
 
     def render_merge_alert
-      render(::Components::Alert.new(
-               level: :warning, class: "container-text mt-3"
-             )) do
+      Alert(level: :warning, class: "container-text mt-3") do
         trusted_html(
           :herbarium_index_merge_help.tp(
             name: @merge.format_name,

--- a/app/views/controllers/herbarium_records/index.rb
+++ b/app/views/controllers/herbarium_records/index.rb
@@ -24,7 +24,7 @@ module Views::Controllers::HerbariumRecords
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render_rows_table if @objects.any?
       end
     end

--- a/app/views/controllers/images/index.rb
+++ b/app/views/controllers/images/index.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Images
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render(::Components::Matrix::Table.new(
                  objects: @objects, user: current_user
                ))

--- a/app/views/controllers/interests/index.rb
+++ b/app/views/controllers/interests/index.rb
@@ -15,7 +15,7 @@ module Views::Controllers::Interests
       container_class(:wide)
 
       render_type_filter if show_type_filter?
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render_interests_table if @interests.any?(&:target)
       end
     end

--- a/app/views/controllers/locations/descriptions/index.rb
+++ b/app/views/controllers/locations/descriptions/index.rb
@@ -12,7 +12,7 @@ module Views::Controllers::Locations
       def view_template
         register_chrome
 
-        render(::Components::PaginatedResults.new) do
+        PaginatedResults do
           render_list if @descriptions.any?
         end
       end

--- a/app/views/controllers/locations/index.rb
+++ b/app/views/controllers/locations/index.rb
@@ -63,7 +63,7 @@ module Views::Controllers::Locations
       render(::Components::ContentPadded.new) do
         small { plain(:list_place_names_parenthetical.l) }
       end
-      render(::Components::PaginatedResults.new) { render_known_list(counts) }
+      PaginatedResults { render_known_list(counts) }
     end
 
     def render_known_list(counts)

--- a/app/views/controllers/names/descriptions/index.rb
+++ b/app/views/controllers/names/descriptions/index.rb
@@ -11,7 +11,7 @@ module Views::Controllers::Names::Descriptions
     def view_template
       register_chrome
 
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render_table if @descriptions.any?
       end
     end

--- a/app/views/controllers/names/index.rb
+++ b/app/views/controllers/names/index.rb
@@ -48,7 +48,7 @@ module Views::Controllers::Names
       render_suggestions_alert if suggest_alternates?
       render_help_blurb if @help
 
-      render(::Components::PaginatedResults.new) { render_name_rows }
+      PaginatedResults { render_name_rows }
     end
 
     private

--- a/app/views/controllers/observations/identify/index.rb
+++ b/app/views/controllers/observations/identify/index.rb
@@ -28,7 +28,7 @@ module Views::Controllers::Observations::Identify
         p { trusted_html(:obs_needing_id_intro.tp) }
       end
 
-      render(::Components::PaginatedResults.new) { render_matrix }
+      PaginatedResults { render_matrix }
     end
 
     private

--- a/app/views/controllers/observations/index.rb
+++ b/app/views/controllers/observations/index.rb
@@ -36,7 +36,7 @@ module Views::Controllers::Observations
 
       render_suggestions_alert if suggest_alternates?
 
-      render(::Components::PaginatedResults.new) { render_matrix }
+      PaginatedResults { render_matrix }
     end
 
     private

--- a/app/views/controllers/observations/locations/edit.rb
+++ b/app/views/controllers/observations/locations/edit.rb
@@ -27,7 +27,7 @@ module Views::Controllers::Observations::Locations
 
     def render_matches
       div(class: "h4") { plain(:list_merge_options_near_matches.t) }
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render(::Components::ListGroup::Base.new) do |list|
           @matches.each { |location| render_match(list, location) }
         end

--- a/app/views/controllers/projects/index.rb
+++ b/app/views/controllers/projects/index.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Projects
       add_pagination(@pagination_data)
       container_class(:text_image)
 
-      render(::Components::PaginatedResults.new) { render_list_group }
+      PaginatedResults { render_list_group }
     end
 
     private

--- a/app/views/controllers/rss_logs/index.rb
+++ b/app/views/controllers/rss_logs/index.rb
@@ -13,7 +13,7 @@ module Views::Controllers::RssLogs
     def view_template
       register_chrome
 
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render(::Components::Matrix::Table.new(
                  objects: @rss_logs, user: current_user, cached: true
                ))

--- a/app/views/controllers/sequences/index.rb
+++ b/app/views/controllers/sequences/index.rb
@@ -14,7 +14,7 @@ module Views::Controllers::Sequences
       add_sorter(@query, controller.index_sort_options)
       add_pagination(@pagination_data)
 
-      render(::Components::PaginatedResults.new) { render_list }
+      PaginatedResults { render_list }
     end
 
     private

--- a/app/views/controllers/shared/images_to_reuse_form.rb
+++ b/app/views/controllers/shared/images_to_reuse_form.rb
@@ -35,7 +35,7 @@ module Views::Controllers::Shared
     private
 
     def render_image_matrix
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render(::Components::Matrix::Table.new) do
           @objects.each { |image| render_image_card(image) }
         end

--- a/app/views/controllers/species_lists/index.rb
+++ b/app/views/controllers/species_lists/index.rb
@@ -21,7 +21,7 @@ module Views::Controllers::SpeciesLists
       add_pagination(@pagination_data)
       container_class(:wide)
 
-      render(::Components::PaginatedResults.new) { render_list }
+      PaginatedResults { render_list }
     end
 
     private

--- a/app/views/controllers/species_lists/show.rb
+++ b/app/views/controllers/species_lists/show.rb
@@ -60,7 +60,7 @@ module Views::Controllers::SpeciesLists
              ))
       render_project_buttons
       render_list_search
-      render(::Components::PaginatedResults.new) { render_observations }
+      PaginatedResults { render_observations }
       render_comments
       render(Views::Layouts::ObjectFooter.new(
                user: @user, obj: @species_list

--- a/app/views/controllers/users/index.rb
+++ b/app/views/controllers/users/index.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Users
       if in_admin_mode?
         render_admin_table
       else
-        render(::Components::PaginatedResults.new) do
+        PaginatedResults do
           render(::Components::Matrix::Table.new(objects: @users))
         end
       end
@@ -27,7 +27,7 @@ module Views::Controllers::Users
 
     def render_admin_table
       style { ".permissions td { padding: 3px 5px 3px 5px }" }
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render(Components::Table.new(
                  @users,
                  variant: :striped,

--- a/app/views/controllers/visual_groups/image_matrix.rb
+++ b/app/views/controllers/visual_groups/image_matrix.rb
@@ -13,7 +13,7 @@ module Views::Controllers::VisualGroups
     prop :pagination_data, _Nilable(PaginationData)
 
     def view_template
-      render(::Components::PaginatedResults.new) do
+      PaginatedResults do
         render(Components::Matrix::Table.new) do
           @subset.each { |row| render_matrix_box(row) }
         end

--- a/app/views/layouts/app/banners.rb
+++ b/app/views/layouts/app/banners.rb
@@ -40,11 +40,11 @@ module Views::Layouts::App
 
     def render_site_banner(banner)
       div(data: { controller: "banner" }) do
-        render(::Components::Alert.new(
-                 level: :success,
-                 class: "message-banner",
-                 data: { banner_target: "banner" }
-               )) { render_alert_contents(banner) }
+        Alert(
+          level: :success,
+          class: "message-banner",
+          data: { banner_target: "banner" }
+        ) { render_alert_contents(banner) }
         render_show_button_row
       end
     end

--- a/app/views/layouts/app/flash_notices.rb
+++ b/app/views/layouts/app/flash_notices.rb
@@ -27,9 +27,9 @@ module Views::Layouts
       severity = severity_for(flash_notice_level)
       flash_clear
 
-      render(::Components::Alert.new(
-               level: severity, id: "flash_notices", class: "mt-3"
-             )) { trusted_html(notices) }
+      Alert(level: severity, id: "flash_notices", class: "mt-3") do
+        trusted_html(notices)
+      end
     end
 
     private


### PR DESCRIPTION
## Summary

Continues the Kit-syntax sweep (see #4667 for the previous batch of 8 small components). Converts `render(Components::PaginatedResults.new(...))` callers to the bare `PaginatedResults(...)` Kit syntax across all 24 real call sites (25 counting `users/index.rb`'s two branches — the admin table and the regular matrix both wrap in `PaginatedResults`).

`Phlex::Kit` is extended on `Components`/`Views` at the module level (`config/initializers/phlex.rb`), so `PaginatedResults` already has this bare-call method — no per-component registration needed, purely a call-site rewrite. No namespace collisions found (no caller view is literally named `PaginatedResults`).

Also picks up two stray `render(Components::Alert.new(...))` leftovers from the earlier `Alert()` sweep (`herbaria/index.rb`, `app/views/layouts/app/banners.rb`) that got autocorrected while editing nearby code in those same files.

## Test plan

- [x] `bin/rails test test/components/ test/views/` — 1928 tests, 0 failures.
- [x] `bin/rails test test/system/observation_show_system_test.rb` — real-browser coverage of a page using the converted component, 5/5 pass.
- [x] `bundle exec rubocop` — clean on all 26 touched files.
