### PR TITLE
Flatten Components::ListGroup::Base to top-level ListGroup Kit component; sweep callers

### DIFF
--- a/app/components/carousel.rb
+++ b/app/components/carousel.rb
@@ -5,7 +5,7 @@
 # indicator strip) every carousel-shaped component in MO composes.
 # Items + thumbnails are registered via `c.item(...) { … }` /
 # `c.thumb(...) { … }` — same hybrid pattern as
-# `Components::ListGroup::Base`. The primitive owns the
+# `Components::ListGroup`. The primitive owns the
 # `<div class="item">` / `<li class="carousel-indicator">` wrappers
 # and the caller's block fills the inside.
 #
@@ -60,7 +60,7 @@ class Components::Carousel < Components::Base
   end
 
   # Register a slide. `class:` / `id:` / arbitrary attrs flow onto the
-  # wrapping `<div class="item …">` (mirroring `ListGroup::Base#item`).
+  # wrapping `<div class="item …">` (mirroring `ListGroup#item`).
   # `active: true` overrides the default first-slide-active behavior
   # (`Matrix::Carousel` uses this to active the slide matching its
   # `top_img`); when no slide is marked active, the first one gets it.

--- a/app/components/list_group.rb
+++ b/app/components/list_group.rb
@@ -38,9 +38,7 @@
 # handled elsewhere.
 #
 # @example Plain iteration with empty placeholder
-#   render(Components::ListGroup::Base.new(
-#            id: "comments", flush: true
-#          )) do |list|
+#   ListGroup(id: "comments", flush: true) do |list|
 #     @comments.each do |c|
 #       list.item(id: dom_id(c)) { render(Comment.new(comment: c)) }
 #     end
@@ -50,12 +48,12 @@
 # @example Flush variant inside a panel
 #   render(Components::Panel.new) do |panel|
 #     panel.with_body(wrapper: false) do
-#       render(Components::ListGroup::Base.new(flush: true)) do |list|
+#       ListGroup(flush: true) do |list|
 #         @items.each { |i| list.item { plain(i) } }
 #       end
 #     end
 #   end
-class Components::ListGroup::Base < Components::Base
+class Components::ListGroup < Components::Base
   # @param id [String] `id=` for the container element. Use to make
   #   the container a Turbo Stream target.
   # @param flush [Boolean] add `list-group-flush` for borderless

--- a/app/components/list_group/item.rb
+++ b/app/components/list_group/item.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# One Bootstrap `list-group-item` row. Used by `Components::ListGroup::Base`
+# One Bootstrap `list-group-item` row. Used by `Components::ListGroup`
 # for each item registered via `list.item(...)`, and rendered
 # directly elsewhere (notably the `Comment` model's
 # `after_create_commit` broadcast, which prepends a new comment row

--- a/app/views/controllers/articles/index.rb
+++ b/app/views/controllers/articles/index.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::Articles
   # Paginated articles index. Page chrome (title, sorter, context-nav,
-  # pagination) + a `Components::ListGroup::Base` of one article-summary
+  # pagination) + a `Components::ListGroup` of one article-summary
   # row per result.
   class Index < Views::FullPageBase
     prop :query, ::Query
@@ -22,7 +22,7 @@ module Views::Controllers::Articles
     private
 
     def render_list
-      render(::Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         @objects.each do |article|
           list.item { render(ArticleItem.new(article: article)) }
         end

--- a/app/views/controllers/comments/comment_row.rb
+++ b/app/views/controllers/comments/comment_row.rb
@@ -13,7 +13,7 @@
 #   so the wrapper has to live with the inner content.
 #
 # Inside the `CommentsForObject` panel, this composition is split:
-# `Components::ListGroup::Base#item` provides the wrapper (so the
+# `Components::ListGroup#item` provides the wrapper (so the
 # none-yet placeholder lives in the same list) and `CommentItem`
 # is rendered directly inside the block.
 module Views::Controllers::Comments

--- a/app/views/controllers/comments/comments_for_object.rb
+++ b/app/views/controllers/comments/comments_for_object.rb
@@ -6,7 +6,7 @@
 # `comments/new` / `comments/edit` pages (via `_object.rb`).
 #
 # Renders a `Components::Panel` whose body is a flush
-# `Components::ListGroup::Base` of `CommentItem`s — wired to an Action
+# `Components::ListGroup` of `CommentItem`s — wired to an Action
 # Cable Turbo Stream from `[object, :comments]` so the
 # `Comment` model's broadcast callbacks can prepend new rows,
 # replace edited rows, and remove deleted rows in place.
@@ -51,8 +51,7 @@ module Views::Controllers::Comments
     # `#comments` is the Action Cable broadcast target — the model
     # callbacks broadcast `[object, :comments]` with `target: "comments"`.
     def render_comments_list
-      render(Components::ListGroup::Base.new(id: "comments", flush: true,
-                                             class: "comments")) do |list|
+      ListGroup(id: "comments", flush: true, class: "comments") do |list|
         visible_comments.each do |comment|
           list.item(class: "comment", id: dom_id(comment)) do
             render(CommentItem.new(comment: comment, user: @user,

--- a/app/views/controllers/comments/index.rb
+++ b/app/views/controllers/comments/index.rb
@@ -28,7 +28,7 @@ module Views::Controllers::Comments
     def render_list
       return unless @objects.any?
 
-      render(::Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         @objects.each do |comment|
           # Editable on logged-out viewers matches the legacy
           # `controls: @user.nil?` semantics — leaving the

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -5,7 +5,7 @@
 # scoped to a single project: when `@project` is set, shows the
 # project's field-slip prefix (or a nudge for admins when none is
 # set); otherwise renders an inline filter form scoped to project.
-# Body is a `Components::ListGroup::Base` of `FieldSlipPanel`-rendered
+# Body is a `Components::ListGroup` of `FieldSlipPanel`-rendered
 # entries, one per `@object`, each with a per-row code-link heading
 # fed in via the panel's `:prepend` slot.
 module Views::Controllers::FieldSlips
@@ -97,7 +97,7 @@ module Views::Controllers::FieldSlips
 
     def render_list
       PaginatedResults do
-        render(Components::ListGroup::Base.new) do |list|
+        ListGroup do |list|
           @objects.each do |fs|
             list.item do
               render(FieldSlipPanel.new(

--- a/app/views/controllers/glossary_terms/index.rb
+++ b/app/views/controllers/glossary_terms/index.rb
@@ -2,7 +2,7 @@
 
 module Views::Controllers::GlossaryTerms
   # Paginated glossary terms index. Page chrome +
-  # a `Components::ListGroup::Base` of one `Index::Item` per term.
+  # a `Components::ListGroup` of one `Index::Item` per term.
   class Index < Views::FullPageBase
     prop :query, ::Query
     prop :pagination_data, ::PaginationData
@@ -29,7 +29,7 @@ module Views::Controllers::GlossaryTerms
     end
 
     def render_list
-      render(::Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         @objects.each do |term|
           list.item { render(Item.new(glossary_term: term)) }
         end

--- a/app/views/controllers/locations/descriptions/index.rb
+++ b/app/views/controllers/locations/descriptions/index.rb
@@ -31,7 +31,7 @@ module Views::Controllers::Locations
       end
 
       def render_list
-        render(::Components::ListGroup::Base.new) do |list|
+        ListGroup do |list|
           @descriptions.each do |desc|
             list.item do
               link_to(desc.show_link_args) { trusted_html(desc.format_name.t) }

--- a/app/views/controllers/locations/index.rb
+++ b/app/views/controllers/locations/index.rb
@@ -67,7 +67,7 @@ module Views::Controllers::Locations
     end
 
     def render_known_list(counts)
-      render(::Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         @locations.each { |loc| render_known_item(list, loc, counts) }
       end
     end
@@ -89,7 +89,7 @@ module Views::Controllers::Locations
     end
 
     def render_undefined_list
-      render(::Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         @undef_data.each do |obs, count|
           render_undefined_item(list, obs, count)
         end

--- a/app/views/controllers/names/index.rb
+++ b/app/views/controllers/names/index.rb
@@ -71,9 +71,7 @@ module Views::Controllers::Names
       return unless @objects.any?
 
       counts = Name.count_observations(@objects)
-      render(Components::ListGroup::Base.new(
-               class: "name-index mb-3"
-             )) do |list|
+      ListGroup(class: "name-index mb-3") do |list|
         @objects.each do |name|
           list.item do
             render(Row.new(

--- a/app/views/controllers/names/index/row.rb
+++ b/app/views/controllers/names/index/row.rb
@@ -19,7 +19,7 @@ class Views::Controllers::Names::Index::Row < Views::Base
   prop :has_descriptions, _Boolean, default: false
 
   # Row contents only — the surrounding `<div class="list-group-item">`
-  # is emitted by `Components::ListGroup::Base` in the Index view.
+  # is emitted by `Components::ListGroup` in the Index view.
   def view_template
     render_id_badge
     render_clipboard_wrapper

--- a/app/views/controllers/observations/locations/edit.rb
+++ b/app/views/controllers/observations/locations/edit.rb
@@ -28,7 +28,7 @@ module Views::Controllers::Observations::Locations
     def render_matches
       div(class: "h4") { plain(:list_merge_options_near_matches.t) }
       PaginatedResults do
-        render(::Components::ListGroup::Base.new) do |list|
+        ListGroup do |list|
           @matches.each { |location| render_match(list, location) }
         end
       end

--- a/app/views/controllers/observations/show/namings/row.rb
+++ b/app/views/controllers/observations/show/namings/row.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # One row of the obs-show namings sub-panel. Renders the content of a
-# `Components::ListGroup::Base` item — the wrapping `<div class="list-group-
+# `Components::ListGroup` item — the wrapping `<div class="list-group-
 # item">` is supplied by the parent `Show::Namings::Rows` via
 # `list.item(id: …) { render(Row.new(…)) }`.
 #

--- a/app/views/controllers/observations/show/namings/rows.rb
+++ b/app/views/controllers/observations/show/namings/rows.rb
@@ -19,8 +19,7 @@ class Views::Controllers::Observations::Show::Namings
     prop :consensus, ::Observation::NamingConsensus
 
     def view_template
-      render(Components::ListGroup::Base.new(id: "namings_table_rows",
-                                             flush: true)) do |list|
+      ListGroup(id: "namings_table_rows", flush: true) do |list|
         @consensus.merged_namings.each do |merged_naming|
           list.item do
             render(Row.new(naming: merged_naming, user: @user,

--- a/app/views/controllers/observations/species_lists/edit.rb
+++ b/app/views/controllers/observations/species_lists/edit.rb
@@ -2,7 +2,7 @@
 
 # Action template for `Observations::SpeciesListsController#edit` —
 # the "manage species lists for this observation" page.
-# Renders two `Components::ListGroup::Base`s of
+# Renders two `Components::ListGroup`s of
 # `SpeciesLists::Listing` rows: lists the observation already
 # belongs to (REMOVE button on each) and lists it doesn't (ADD
 # button on each).
@@ -59,7 +59,7 @@ module Views::Controllers::Observations::SpeciesLists
       return if lists.empty?
 
       h5(class: "mt-3") { plain("#{heading}:") }
-      render(Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         lists.each do |sl|
           list.item(
             class: "d-flex justify-content-between align-items-start"

--- a/app/views/controllers/projects/index.rb
+++ b/app/views/controllers/projects/index.rb
@@ -24,7 +24,7 @@ module Views::Controllers::Projects
     private
 
     def render_list_group
-      render(Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         @objects.each do |project|
           list.item(class: "d-flex align-items-start") do
             render(ListItem.new(project: project))

--- a/app/views/controllers/projects/list_item.rb
+++ b/app/views/controllers/projects/list_item.rb
@@ -2,7 +2,7 @@
 
 # Inner content of one row in the projects index list-group. The
 # `<div class="list-group-item …">` wrapper is supplied by the
-# caller (`Components::ListGroup::Base`);
+# caller (`Components::ListGroup`);
 # this class only emits the two-column body (id badge + title /
 # meta column).
 module Views::Controllers::Projects

--- a/app/views/controllers/sequences/index.rb
+++ b/app/views/controllers/sequences/index.rb
@@ -20,7 +20,7 @@ module Views::Controllers::Sequences
     private
 
     def render_list
-      render(::Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         @sequences.each { |seq| list.item { render_row(seq) } }
       end
     end

--- a/app/views/controllers/species_lists/index.rb
+++ b/app/views/controllers/species_lists/index.rb
@@ -31,9 +31,9 @@ module Views::Controllers::SpeciesLists
 
       # The d-flex / justify-content-between / align-items-start
       # classes used to live on `Listing`'s outer wrapper. After
-      # moving the row wrapping into `Components::ListGroup::Base#item`,
+      # moving the row wrapping into `Components::ListGroup#item`,
       # those layout classes ride on the item itself.
-      render(Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         @objects.each do |species_list|
           list.item(
             class: "d-flex justify-content-between align-items-start"

--- a/app/views/controllers/species_lists/listing.rb
+++ b/app/views/controllers/species_lists/listing.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # One species_list "listing" row, rendered inside a
-# `Components::ListGroup::Base#item`. Used by:
+# `Components::ListGroup#item`. Used by:
 #   - `Views::Controllers::SpeciesLists::Index#render_list` (the
 #     species_lists index page)
 #   - `observations/species_lists/edit.rb` (the
@@ -24,7 +24,7 @@ module Views::Controllers::SpeciesLists
 
     # Row contents only — the surrounding `<div class="list-group-item
     # d-flex justify-content-between align-items-start">` is emitted by
-    # `Components::ListGroup::Base#item` in the Index view.
+    # `Components::ListGroup#item` in the Index view.
     def view_template
       render_info
       render_manage_section if @remove || @add

--- a/app/views/controllers/species_lists/show.rb
+++ b/app/views/controllers/species_lists/show.rb
@@ -124,7 +124,7 @@ module Views::Controllers::SpeciesLists
     end
 
     def render_observations
-      render(Components::ListGroup::Base.new) do |list|
+      ListGroup do |list|
         if @objects.any?
           @objects.each { |obs| list.item { render_observation_row(obs) } }
         else

--- a/test/components/list_group_test.rb
+++ b/test/components/list_group_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 class ListGroupTest < ComponentTestCase
   def test_renders_plain_list_group_with_items
-    html = render(Components::ListGroup::Base.new) do |list|
+    html = render(Components::ListGroup.new) do |list|
       list.item { "one" }
       list.item { "two" }
     end
@@ -16,7 +16,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_flush_adds_list_group_flush_class
-    html = render(Components::ListGroup::Base.new(flush: true)) do |list|
+    html = render(Components::ListGroup.new(flush: true)) do |list|
       list.item { "x" }
     end
 
@@ -26,7 +26,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_ul_element_switches_items_to_li
-    html = render(Components::ListGroup::Base.new(element: :ul)) do |list|
+    html = render(Components::ListGroup.new(element: :ul)) do |list|
       list.item { "one" }
       list.item { "two" }
     end
@@ -38,7 +38,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_container_id_and_class_extras_flow_through
-    html = render(Components::ListGroup::Base.new(
+    html = render(Components::ListGroup.new(
                     id: "namings_table_rows",
                     flush: true, class: "namings"
                   )) do |list|
@@ -51,7 +51,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_container_data_attributes_pass_through
-    html = render(Components::ListGroup::Base.new(
+    html = render(Components::ListGroup.new(
                     attributes: { data: { controller: "section-update" } }
                   )) do |list|
       list.item { "x" }
@@ -63,7 +63,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_per_item_id_and_class_extras_flow_through
-    html = render(Components::ListGroup::Base.new) do |list|
+    html = render(Components::ListGroup.new) do |list|
       list.item(id: "naming_42", class: "consensus-row") { "x" }
     end
 
@@ -73,7 +73,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_per_item_arbitrary_attributes_pass_through
-    html = render(Components::ListGroup::Base.new) do |list|
+    html = render(Components::ListGroup.new) do |list|
       list.item(data: { foo: "bar" }) { "x" }
     end
 
@@ -87,7 +87,7 @@ class ListGroupTest < ComponentTestCase
     # `.list-group-item` child — so it shows iff no real rows
     # exist. Works seamlessly with Turbo Stream `append` / `remove`
     # broadcasts that only touch real items.
-    html = render(Components::ListGroup::Base.new) do |list|
+    html = render(Components::ListGroup.new) do |list|
       list.item { "real row" }
       list.empty { "nothing yet" }
     end
@@ -101,7 +101,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_empty_slot_renders_even_without_real_items
-    html = render(Components::ListGroup::Base.new) do |list|
+    html = render(Components::ListGroup.new) do |list|
       list.empty { "nothing yet" }
     end
 
@@ -115,7 +115,7 @@ class ListGroupTest < ComponentTestCase
     # Empty list with neither items nor placeholder: just the outer
     # container. Helpful for streamed-in content where items arrive
     # via Turbo later.
-    html = render(Components::ListGroup::Base.new) do |list|
+    html = render(Components::ListGroup.new) do |list|
       # intentionally empty — no list.item / list.empty calls
       _ = list
     end
@@ -128,7 +128,7 @@ class ListGroupTest < ComponentTestCase
     # Each block must close over its OWN value of `n` from the loop,
     # not a single shared one — proves the deferred-render pattern
     # captures iteration-local bindings correctly.
-    html = render(Components::ListGroup::Base.new) do |list|
+    html = render(Components::ListGroup.new) do |list|
       (1..3).each do |n|
         list.item { "row #{n}" }
       end

--- a/test/system/google_maps_api_smoke_test.rb
+++ b/test/system/google_maps_api_smoke_test.rb
@@ -52,7 +52,7 @@ class GoogleMapsApiSmokeTest < ApplicationSystemTestCase
   # failure message names the API surface so a developer running the
   # test locally knows which Google Cloud product needs enabling.
   def assert_no_gmaps_flash(api_label)
-    flash = find("#gmaps_flash", visible: :all)
+    flash = find_by_id("gmaps_flash", visible: :all)
     text = flash.text.strip
     assert_equal(
       "", text,

--- a/test/views/controllers/comments/index_test.rb
+++ b/test/views/controllers/comments/index_test.rb
@@ -11,8 +11,8 @@ module Views::Controllers::Comments
     end
 
     # Parity: the old raw `div.list-group { CommentRow }` and the new
-    # `Components::ListGroup::Base { list.item { CommentItem } }` must
-    # produce the same DOM. CommentRow itself wraps CommentItem in a
+    # `ListGroup { list.item { CommentItem } }` must produce the same
+    # DOM. CommentRow itself wraps CommentItem in a
     # `Components::ListGroup::Item`, so both paths delegate to the
     # same component for the `.list-group-item` wrapper.
     def test_list_group_parity_with_legacy_comment_row_render
@@ -72,7 +72,7 @@ module Views::Controllers::Comments
       render(NewCommentList.new(comments: objects, user: @user))
     end
 
-    # New list shape — Components::ListGroup::Base with list.item +
+    # New list shape — Components::ListGroup with list.item +
     # CommentItem. Mirrors what comments/index.rb#render_list now does.
     class NewCommentList < Components::Base
       include Phlex::Rails::Helpers::DOMID
@@ -81,7 +81,7 @@ module Views::Controllers::Comments
       prop :user, _Nilable(::User), default: nil
 
       def view_template
-        render(::Components::ListGroup::Base.new) do |list|
+        ListGroup do |list|
           @comments.each do |comment|
             list.item(class: "comment", id: dom_id(comment)) do
               render(CommentItem.new(comment: comment, user: @user,

--- a/test/views/controllers/species_lists/listing_test.rb
+++ b/test/views/controllers/species_lists/listing_test.rb
@@ -13,7 +13,7 @@ module Views::Controllers::SpeciesLists
     end
 
     # Listing renders contents only — the `list-group-item` wrapper
-    # comes from `Components::ListGroup::Base#item` in the Index view, so
+    # comes from `Components::ListGroup#item` in the Index view, so
     # standalone-render output should NOT have it.
     def test_renders_basic_row
       html = render_listing


### PR DESCRIPTION
## Summary

- Flattens `Components::ListGroup::Base` to a top-level `Components::ListGroup` (moves `app/components/list_group/base.rb` → `app/components/list_group.rb`) so it picks up `Phlex::Kit` sugar (`ListGroup(...)`) the same way `Panel`/`Table` already do. No dispatch table needed — unlike `Link`'s `type:` dispatch, `ListGroup` only has one shape, so a straight rename is the right amount of cleverness here.
- `Components::ListGroup::Item` stays nested and unchanged, mirroring the `Components::Link` + `Components::Link::Get` pattern (top-level dispatcher/component with nested helper classes).
- Sweeps all 16 real `render(Components::ListGroup::Base.new(...)) do |list| ... end` call sites to `ListGroup(...) do |list| ... end`, plus the one `Components::ListGroup::Item` caller inside a test-only Phlex stub in `comments/index_test.rb`.
- Updates doc-comment mentions of `ListGroup::Base` across the touched files for accuracy.
- `Components::ListGroup::Search` — an unrelated `ApplicationForm` component that happens to share the `list_group/` directory by loose historical association — is untouched; it has nothing to do with the list-group builder.
- **Out of scope, intentionally**: the sidebar's own list-group-item-styled rows (`Views::Layouts::Sidebar::CSS_CLASSES` consumed across `admin.rb`/`login.rb`/`user.rb`/`section.rb`/`languages.rb`, 10+ call sites) never went through this component and could arguably use `Components::ListGroup::Item` per-row. That's a separate, larger refactor — the sidebar's outer wrapper mixes `list-group` with navbar-specific classes and iterates over heterogeneous partial types rather than a uniform `list.item` loop, so it doesn't fit the builder pattern without restructuring the whole sidebar. Flagged for a follow-up PR.

## Test plan

- [x] `bin/rails test` — full suite green (run by @nimmo)
- [x] `bundle exec rubocop` clean on every touched file
- [x] Renamed `test/components/list_group/base_test.rb` → `test/components/list_group_test.rb`, updated to construct `Components::ListGroup` directly (component tests use explicit `render(Components::X.new(...))`, not Kit sugar, since Kit methods are only defined for Phlex view instances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
