### PR TITLE
Fix block_python.sh false positives; document the per-line coveralls endpoint

### DIFF
--- a/.claude/hooks/block_python.sh
+++ b/.claude/hooks/block_python.sh
@@ -17,12 +17,16 @@ set -euo pipefail
 INPUT="$(cat)"
 COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')"
 
-# `\bpython3?\b` — match `python` or `python3` as a whole word so
-# names like `mypython` or `python2-config` don't trip it. Common
-# call shapes: `python3 -c "..."`, `python3 <<EOF`, `python3 script.py`.
-# All of those start with `python` / `python3` as a whole word
-# somewhere in the command.
-if printf '%s' "$COMMAND" | grep -qE '(^|[^A-Za-z0-9_])python3?($|[^A-Za-z0-9_])'; then
+# Match `python`/`python3` only when it's actually the command being
+# invoked — immediately preceded (modulo whitespace) by a command-start
+# boundary: start of string, `;`, `|`, `&`, a backtick, or `$(`. This
+# deliberately does NOT match `python3` appearing inside a quoted
+# argument to some other command (e.g. `grep -n "python3" file.md`,
+# `echo "avoid python3 here"`) — a bare substring match blocked those
+# too, which is a false positive: nothing is actually invoking Python
+# there. Common real call shapes this still catches: `python3 -c "..."`,
+# `python3 <<EOF`, `foo && python3 bar`, `cmd | python3`.
+if printf '%s' "$COMMAND" | grep -qE '(^|[;|&`]|\$\()[[:space:]]*python3?([^A-Za-z0-9_]|$)'; then
   cat >&2 <<'EOF'
 🚫 Write Ruby, not Python.
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -189,7 +189,9 @@ What to do, after the coveralls bot comments on the PR:
    multiple pages, and **Phlex views (`app/views/**/*.rb`) consistently
    land on page 2**. A single-page fetch will report them as
    `<not instrumented>` — a false negative. Fetch every page first,
-   then look up:
+   then look up. Use `ruby -rjson -e` for the JSON munging, not
+   Python — the project's `.claude/settings.local.json` allowlists
+   the former as a wildcard, so it runs without a permission prompt:
 
     ```bash
     BUILD_ID=$(gh pr view <PR> --json comments \
@@ -199,17 +201,16 @@ What to do, after the coveralls bot comments on the PR:
 
     # Paginate. per_page=2000 covers MO's current build in two pages;
     # the loop walks until a page returns 0 source_files, so it scales.
-    rm -f /tmp/cov_files.json
+    rm -f /tmp/cov_page_*.json
     page=1
     while : ; do
       curl -s "https://coveralls.io/builds/${BUILD_ID}/source_files.json?per_page=2000&page=${page}" \
         > "/tmp/cov_page_${page}.json"
-      count=$(python3 -c "
-import json
-with open('/tmp/cov_page_${page}.json') as f: d = json.load(f)
-src = json.loads(d['source_files']) if isinstance(d['source_files'], str) else d['source_files']
-print(len(src))
-")
+      count=$(ruby -rjson -e "
+        d = JSON.parse(File.read('/tmp/cov_page_${page}.json'))
+        src = d['source_files'].is_a?(String) ? JSON.parse(d['source_files']) : d['source_files']
+        puts src.length
+      ")
       [ "$count" = "0" ] && break
       page=$((page + 1))
       [ "$page" -gt 10 ] && break  # safety
@@ -219,26 +220,26 @@ print(len(src))
       --jq '.files[] | select(.changeType!="DELETED") | .path' |
       grep -E '\.rb$' > /tmp/touched_files.txt
 
-    python3 <<'PY'
-import json, glob, os
-files = []
-for path in sorted(glob.glob('/tmp/cov_page_*.json')):
-    with open(path) as f: d = json.load(f)
-    src = json.loads(d['source_files']) if isinstance(d['source_files'], str) else d['source_files']
-    files.extend(src)
-by_name = {x['name']: x for x in files}
-with open('/tmp/touched_files.txt') as f:
-    paths = [p.strip() for p in f if p.strip()]
-for p in paths:
-    f = by_name.get(p)
-    if f:
-        cov, rel, miss = f['covered_line_count'], f['relevant_line_count'], f['missed_line_count']
-        pct = 100.0 * cov / rel if rel else 0
-        flag = '' if miss == 0 else f'  MISSED {miss}'
-        print(f"{p}: {cov}/{rel} ({pct:.1f}%){flag}")
-    else:
-        print(f"{p}: <not instrumented>")
-PY
+    ruby -rjson -e '
+      files = []
+      Dir.glob("/tmp/cov_page_*.json").sort.each do |path|
+        d = JSON.parse(File.read(path))
+        src = d["source_files"].is_a?(String) ? JSON.parse(d["source_files"]) : d["source_files"]
+        files.concat(src)
+      end
+      by_name = files.each_with_object({}) { |f, h| h[f["name"]] = f }
+      File.readlines("/tmp/touched_files.txt").map(&:strip).reject(&:empty?).each do |p|
+        f = by_name[p]
+        if f
+          cov, rel, miss = f["covered_line_count"], f["relevant_line_count"], f["missed_line_count"]
+          pct = rel.to_i.zero? ? 100.0 : (100.0 * cov / rel)
+          flag = miss.to_i.zero? ? "" : "  MISSED #{miss}"
+          puts format("%s: %d/%d (%.1f%%)%s", p, cov, rel, pct, flag)
+        else
+          puts "#{p}: <not instrumented>"
+        end
+      end
+    '
     ```
 
 2. **Every Ruby file in the PR should report 100% coverage.** ERB,
@@ -247,7 +248,32 @@ PY
    tracked elsewhere (a Phlex view, a model) shows `<not instrumented>`,
    suspect pagination — re-check that every page got fetched.
 
-3. **Every PR should lever coverage upward.** If a touched file is
+3. **Once a file is known to be below 100%, find the exact missing
+   line numbers straight from Coveralls** — don't reach for a local
+   SimpleCov run to pin them down. A local run of just the file's own
+   test(s) is a *lower bound*: many lines only get covered by other
+   tests elsewhere in the suite (controller/integration tests that
+   render the same view through a real request, for instance), so a
+   narrow local run reports far more "missed" lines than are actually
+   missing, and chasing that down wastes cycles on a false picture.
+   Coveralls exposes a per-file endpoint with one entry per source
+   line — `null` for non-coverable lines, a hit count otherwise:
+
+    ```bash
+    curl -s "https://coveralls.io/builds/${BUILD_ID}/source.json?filename=<path/to/file.rb>"
+    ```
+
+    ```ruby
+    # Map the array back onto the source so 0-hit lines are obvious:
+    arr = JSON.parse(<paste the curl output>)
+    source = File.readlines("<path/to/file.rb>")
+    arr.each_with_index do |hits, idx|
+      next if hits.nil?
+      puts format("%4d %-8s %s", idx + 1, hits.zero? ? "MISSED" : "hit=#{hits}", source[idx]&.chomp)
+    end
+    ```
+
+4. **Every PR should lever coverage upward.** If a touched file is
    below 100%, fix the gap in the same PR — even if the uncovered
    lines were already missed on `main` before your edit. Either add
    tests that exercise the uncovered branches, or remove the dead


### PR DESCRIPTION
`block_python.sh` did a blanket substring match for "python"/"python3" anywhere in the command, so it blocked innocent mentions too -- a grep search for the word, an echo message, even a git branch name containing "python". Narrowed it to only match when python/python3 is actually the invoked command (immediately after a command-start boundary: start of string, ;, |, &, a backtick, or $(), not merely present somewhere in the string.

Also rewrites `testing.md`'s "Verify per-file coverage" recipe in Ruby instead of Python -- following that doc's own Python examples is what triggered the hook in the first place. Documents the per-file source.json?filename= coveralls endpoint (exact per-line hit counts) as the way to pin down missing lines once a file is known to be under 100%, replacing any implied "check locally with SimpleCov" approach, which only reports a lower bound unless the full suite runs.