### PR TITLE
Drop User.current fallback in Name::Notify#notify_users

### DIFF
--- a/app/models/name/merge.rb
+++ b/app/models/name/merge.rb
@@ -30,7 +30,7 @@ class Name
 
       move_observations(old_name)
       move_namings(old_name)
-      move_mispellings(old_name)
+      move_mispellings(user, old_name)
       move_followings(old_name) # move Interest and Tracking
       move_descriptions(user, old_name)
       move_versions(old_name)
@@ -58,9 +58,15 @@ class Name
       end
     end
 
-    def move_mispellings(old_name)
+    def move_mispellings(user, old_name)
       old_name.misspellings.each do |name|
         name.correct_spelling = (name == self ? nil : self)
+        # `name` (a misspelling of old_name) is a different record from
+        # `self`/old_name, so it never gets a `current_user` from
+        # anywhere else in `merge` - without this, Name::Notify#notify_users
+        # would attribute the resulting change-notification email to
+        # no one instead of the user performing the merge.
+        name.current_user = user
         name.save
       end
     end

--- a/app/models/name/notify.rb
+++ b/app/models/name/notify.rb
@@ -36,8 +36,7 @@ module Name::Notify
     # column that changed.
     return if classification_only_change?
 
-    # debugger unless @current_user
-    sender = @current_user || User.current
+    sender = @current_user
     recipients = []
 
     notify_admins(recipients)

--- a/test/models/name_test.rb
+++ b/test/models/name_test.rb
@@ -2324,6 +2324,7 @@ class NameTest < UnitTestCase
       }
     ) do
       name.citation = "Rolf added this."
+      name.current_user = rolf
       name.save
     end
     assert_equal(name_version + 1, name.version)
@@ -2358,13 +2359,14 @@ class NameTest < UnitTestCase
     Interest.create!(user: dick, target: name, state: false)
 
     # Katrina makes a change - should notify mary and rolf, but NOT dick
-    User.current = katrina
     name.reload
 
     # Should enqueue 2 emails (mary and rolf), not 3 (dick was removed
-    # because of Interest with state=false)
+    # because of Interest with state=false, and Katrina is excluded
+    # from her own notification as `current_user`/sender)
     assert_enqueued_jobs(2) do
       name.citation = "Katrina added citation."
+      name.current_user = katrina
       name.save
     end
 


### PR DESCRIPTION
## Summary

First step of removing `User.current` (a thread-local global) from the `Name` model layer, replacing it with the already-established `current_user` accessor pattern (`attr_accessor :current_user` on `Name`, set explicitly by `save_with_log` and every real controller/model call site that saves a `Name`).

`Name::Notify#notify_users` had a `sender = @current_user || User.current` fallback. Investigating what actually depends on that fallback turned up more than the single bypass I originally expected:

- **`Name::Merge#move_mispellings`** saves each reassigned misspelling directly during a merge, without ever setting `current_user` on it — it relied entirely on `User.current` still being correctly populated by the ambient request context. Threaded `user` through `move_mispellings` (`merge` already receives it) and set `current_user` explicitly there.
- **Two tests** in `test/models/name_test.rb` (`test_email_notification`, `test_notify_interest_state_false`) relied on `User.current = <user>` followed by a direct `name.save` (not `save_with_log`) to attribute the notification sender, with assertions on `mailer_args[:sender]` and on self-notification exclusion (`recipients.uniq - [sender]`). Updated both to set `name.current_user` explicitly instead.
- The `descriptions_controller.rb:206` bypass I'd originally flagged (`@name.save if @name.changed?`) turned out to be a non-issue — `description`/`description_id` isn't in `Name::VERSIONED_COLUMNS`, so `saved_version_changes?` is false there and `notify_users` returns early before ever reaching the sender line.

## Test plan

- [x] `bundle exec rubocop` on touched files — no offenses
- [x] `bin/rails test test/models/name_test.rb` — 175 tests, 0 failures
- [x] `bin/rails test test/controllers/names_controller_show_test.rb test/controllers/names_controller_update_test.rb test/controllers/names_controller_update_merge_test.rb test/controllers/names_controller_destroy_test.rb test/controllers/names_controller_index_test.rb test/controllers/names_controller_create_test.rb test/controllers/names/synonyms/ test/controllers/names/versions_controller_test.rb test/controllers/names/descriptions_controller_test.rb test/controllers/names/descriptions/merges_controller_test.rb` — 183 tests, 0 failures

## Note

This branch is off `main`, independent of #4689 (`Name::Merge#merge` transaction-safety fix, not yet merged) — both touch `merge.rb`'s `move_mispellings`, so whichever lands second will need a small rebase.
