### PR TITLE
Cover uncovered app/models/image.rb lines; remove dead unique_format_name branch

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -316,13 +316,10 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   #   "**__Agaricus campestris__** L. & **__Agaricus californicus__** Peck. (3)"
   #
   def unique_format_name
-    title = format_name
-    id_format = if title == :image.l
-                  "##{id || "?"}"
-                else
-                  "(#{id || "?"})"
-                end
-    [title, id_format].safe_join(" ")
+    # format_name returns the joined subject titles, or "" when there are
+    # none — never the bare :image.l ("image") string — so the id always
+    # renders in the "(id)" form here.
+    [format_name, "(#{id || "?"})"].safe_join(" ")
   end
 
   # Do the same without the ID, for new page titles that generate an ID UI

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -181,6 +181,121 @@ class ImageTest < UnitTestCase
     assert_equal(0, img.num_votes(4))
   end
 
+  def test_other_subjects
+    img = images(:in_situ_image)
+
+    assert_not_empty(img.all_subjects)
+    # An unrelated object leaves the image's own subjects in place.
+    assert(img.other_subjects?(Object.new))
+  end
+
+  def test_original_extension_by_content_type
+    {
+      "image/jpeg" => "jpg", "image/gif" => "gif", "image/png" => "png",
+      "image/tiff" => "tiff", "image/bmp" => "bmp",
+      "image/x-ms-bmp" => "bmp", "application/octet-stream" => "raw"
+    }.each do |content_type, ext|
+      assert_equal(ext, Image.new(content_type: content_type).
+                        original_extension)
+    end
+  end
+
+  def test_image_dir_defaults_and_override
+    img = Image.new
+
+    assert_equal(MO.local_image_files, img.image_dir)
+
+    img.image_dir = "/custom/dir"
+
+    assert_equal("/custom/dir", img.image_dir)
+  end
+
+  def test_image_setter_rejects_unknown_type
+    assert_raises(RuntimeError) { Image.new.image = 42 }
+  end
+
+  def test_init_image_from_local_file_blank_path
+    file = Struct.new(:path).new("")
+
+    assert_raises(RuntimeError) do
+      Image.new.init_image_from_local_file(file)
+    end
+  end
+
+  def test_init_image_from_stream_content_length
+    img = Image.new
+    stream = Object.new
+    stream.define_singleton_method(:content_length) { "42\n" }
+
+    img.init_image_from_stream(stream)
+
+    assert_equal("42", img.upload_length)
+  end
+
+  def test_upload_from_url
+    img = Image.new
+    upload = Struct.new(:content, :content_length, :content_type,
+                        :content_md5).
+             new(StringIO.new("data"), 4, "image/jpeg", "abc123")
+    upload.define_singleton_method(:clean_up) { nil }
+
+    API2::UploadFromURL.stub(:new, ->(_url) { upload }) do
+      img.upload_from_url("https://example.org/x.jpg")
+    end
+
+    assert_equal(4, img.upload_length)
+    assert_equal("image/jpeg", img.upload_type)
+    assert_equal("abc123", img.upload_md5sum)
+    assert_respond_to(img.clean_up_proc, :call)
+  end
+
+  def test_validate_image_length_too_big
+    img = Image.new
+    img.upload_length = MO.image_upload_max_size + 1
+
+    assert_not(img.validate_image_length)
+    assert(img.errors[:image].any?)
+  end
+
+  def test_save_to_temp_file_rescues_copy_error
+    img = Image.new
+    img.upload_handle = StringIO.new("data")
+
+    Tempfile.stub(:new, ->(*) { raise("boom") }) do
+      assert_not(img.save_to_temp_file)
+    end
+    assert(img.errors[:image].any?)
+  end
+
+  def test_save_to_temp_file_rejects_invalid_upload_handle
+    img = Image.new
+    img.upload_handle = Object.new # not an IO/StringIO/TeeInput
+
+    assert_not(img.save_to_temp_file)
+    assert(img.errors[:image].any?)
+  end
+
+  def test_process_image_before_save
+    img = Image.new
+
+    assert_not(img.process_image)
+    assert(img.errors[:image].any?)
+  end
+
+  def test_process_image_command_failure
+    img = images(:in_situ_image)
+    img.upload_temp_file = "already-staged" # save_to_temp_file short-circuits
+
+    img.stub(:move_original, true) do
+      img.stub(:system, false) do
+        Rails.env.stub(:test?, false) do
+          assert_not(img.process_image)
+        end
+      end
+    end
+    assert(img.errors[:image].any?)
+  end
+
   def test_move_original_system_fail
     img = Image.new
     File.stub(:rename, false) do


### PR DESCRIPTION
## Summary

Brings `app/models/image.rb` to full line coverage on a set of previously-uncovered lines, and removes one dead branch. No behavior change beyond the dead-code removal.

Each flagged line was evaluated for reachability: reachable lines got tests (all the methods involved are public, so they're called directly; several are defensive/legacy upload paths reached with crafted inputs), and the one genuinely dead branch was removed.

## Reachable → tested

| Lines | Method / branch | How covered |
|---|---|---|
| 288 | `other_subjects?` | direct call |
| 464–467 | `original_extension` gif/png/tiff/bmp/raw arms | iterate content types |
| 534 | `image_dir` default + override | call both ways |
| 573 | `image=` rejects an unknown upload class | `assert_raises` on a non-file arg |
| 594–595 | `init_image_from_local_file` blank-path guard | struct double with `path == ""` |
| 609 | `init_image_from_stream` `content_length` arm | object responding to `content_length` |
| 625–630 | `upload_from_url` | `API2::UploadFromURL.new` stubbed |
| 648–653 | `validate_image_length` too-big arm | oversized `upload_length` |
| 745–757 | `save_to_temp_file` copy-error rescue **and** invalid-handle else | stub `Tempfile.new` to raise; pass a non-IO handle |
| 770–771 | `process_image` before-save | `Image.new.process_image` |
| 787–788 | `process_image` command failure | stub `move_original` / `system` / `Rails.env.test?` |

## Dead → removed

`unique_format_name` had an `if title == :image.l` branch that can never be true: `format_name` returns the joined subject titles, or `""` when there are none — never the bare `:image.l` (`"image"`) string — so the `else` arm was always taken. Collapsed the conditional to that arm.

Noted but **not** changed here (out of scope, and it changes output): this dead branch exists because `format_name` uses `title_subjects || :image.l` while the sibling `document_title` uses `title_subjects(:text_name).presence || :image.l`. The missing `.presence` is why `format_name` returns `""` rather than `:image.l` for a no-subject image.

## Verification

- Confirmed via SimpleCov's resultset (unioned across all parallel-worker keys) that every previously-uncovered fragment now registers hits.
- `bin/rails test test/models/image_test.rb` — 34 tests, green.
- `bin/rails test test/controllers/images_controller_test.rb test/classes/api2/images_test.rb` — green (the `process_image` / `save_to_temp_file` paths are exercised by real uploads).
- Rubocop clean on both files.

## Follow-up to #4677

The two `process_image` cases (770–771, 787–788) exercise the `ImageDhashJob` wiring that landed in #4677 (now merged), so this is a small coverage follow-up to that PR.
