### PR TITLE
Make Location display-name/place-name and sort order viewer-aware, not global

### DIFF
--- a/app/classes/api2/core/base.rb
+++ b/app/classes/api2/core/base.rb
@@ -263,7 +263,10 @@ module API2::Base
   end
 
   def authenticate_user
-    clear_user && return unless (key_str = parse(:string, :api_key))
+    unless (key_str = parse(:string, :api_key))
+      clear_user
+      return
+    end
 
     key = APIKey.find_by(key: key_str)
     raise(API2::BadAPIKey.new(key_str))        unless key
@@ -275,13 +278,16 @@ module API2::Base
 
   def clear_user
     User.current = self.user = nil
-    User.current_location_format = "postal"
   end
 
+  # Location/place-name formatting is postal-only throughout the API -
+  # nothing here ever threads a `user`/`viewer` through the
+  # viewer-aware display methods (Location#display_name, HasPlaceName,
+  # etc.), so they all default to postal automatically. Makes API
+  # responses consistent for apps regardless of the user's own
+  # location_format preference.
   def login_user(key)
     User.current = self.user = key.user
-    User.current_location_format = "postal"
-    # (that overrides user pref in order to make it more consistent for apps)
     key.touch!
     self.api_key = key
   end

--- a/app/classes/mappable/clustered_collection.rb
+++ b/app/classes/mappable/clustered_collection.rb
@@ -29,11 +29,14 @@ module Mappable
     # @param query_param [Hash, nil] the current query's q_param —
     #   added as `?q=…` on every per-marker cluster URL so a click
     #   from the popup lands inside the same filtered query context.
-    def initialize(objects, query_param: nil)
+    # @param user [User, nil] the viewer - decides postal/scientific
+    #   location-name formatting (nil => postal default).
+    def initialize(objects, query_param: nil, user: nil)
       @sets = {}
       routes = Rails.application.routes.url_helpers
       objects.each do |obj|
-        @sets[singleton_key_for(obj)] = build_set(obj, query_param, routes)
+        @sets[singleton_key_for(obj)] = build_set(obj, query_param, routes,
+                                                  user)
       end
       @extents = calc_extents
       @representative_points =
@@ -46,17 +49,17 @@ module Mappable
 
     private
 
-    def build_set(obj, query_param, routes)
+    def build_set(obj, query_param, routes, user)
       set = MapSet.new([obj])
       set.color = set.compute_color
       set.glyph = set.compute_glyph
       set.border_style = set.compute_border_style
-      set.title = mapset_title_for(set)
+      set.title = mapset_title_for(set, user)
       # caption is intentionally omitted — the client lazy-loads it
       # from observations/maps#popup on marker click. Rendering N
       # thumbnail-bearing popups at bulk-fetch time dominated refetch
       # cost (#4159).
-      set.cluster_name = cluster_label_for(obj)
+      set.cluster_name = cluster_label_for(obj, user)
       set.cluster_url = cluster_url_for(obj, query_param, routes)
       set.objects = nil
       set
@@ -73,11 +76,11 @@ module Mappable
     # are stripped by using the obs's `text_name` (fall back to the
     # stringified display_name for locations — only ::Observation /
     # ::Mappable::MinimalObservation expose `text_name`).
-    def cluster_label_for(obj)
+    def cluster_label_for(obj, user)
       return obj.text_name if obj.respond_to?(:text_name) &&
                               obj.text_name.present?
 
-      obj.display_name.to_s
+      obj.display_name(user).to_s
     end
 
     # Every object reaching `ClusteredCollection.new` is mappable
@@ -99,17 +102,17 @@ module Mappable
     # location but known lat/lng falls back to formatted coordinates
     # so the tooltip isn't blank (the GPS-only observation case).
     # Two-branch exhaustive: see `cluster_url_for`'s note.
-    def mapset_title_for(set)
+    def mapset_title_for(set, user)
       first = set.objects.first
       if first.observation?
-        observation_title_for(first)
+        observation_title_for(first, user)
       else
-        first.display_name.to_s
+        first.display_name(user).to_s
       end
     end
 
-    def observation_title_for(obs)
-      return obs.location.display_name.to_s if obs.location
+    def observation_title_for(obs, user)
+      return obs.location.display_name(user).to_s if obs.location
 
       return "" unless obs.lat
 

--- a/app/classes/observation_labels/rtf_labels.rb
+++ b/app/classes/observation_labels/rtf_labels.rb
@@ -134,7 +134,7 @@ class ObservationLabels::RtfLabels
 
   def add_location
     label("Location")
-    @para << @obs.place_name
+    @para << @obs.place_name(@user)
     @para.line_break
   end
 

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -293,6 +293,15 @@ class Query
 
   attr_writer :record
 
+  # The viewer - who's *looking at* these results, not part of the
+  # query spec (deliberately NOT a `query_attr`: doesn't affect which
+  # records match, only viewer-aware display/sort details like
+  # location name format, so it stays out of the serialized
+  # description and the `?q[...]=` URL). Set by
+  # `ApplicationController::Queries` right after building/finding a
+  # query, since Query has no ambient access to the session otherwise.
+  attr_accessor :viewer
+
   # NOTE: Declare query subclass attributes with `query_attr`, a custom MO
   # method defined by monkey-patching `Class` in app/extensions/class.rb.
   # attribute `:order_by` is inherited by all subclasses, necessary for paging.

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -103,11 +103,19 @@ module Query::Modules::Initialization
       next if (param != :id_in_set && skippable_values.include?(val.to_s)) ||
               (param == :id_in_set && val.nil?) # keep empty array
 
-      @scopes = if val.is_a?(Hash)
-                  @scopes.send(param, **val)
-                else
-                  @scopes.send(param, val)
-                end
+      @scopes = apply_scope_param(param, val)
+    end
+  end
+
+  # `:order_by` gets `viewer:` forwarded - it decides postal/scientific
+  # location-name sort order, see AbstractModel::OrderingScopes.
+  def apply_scope_param(param, val)
+    if param == :order_by
+      @scopes.send(param, val, viewer: viewer)
+    elsif val.is_a?(Hash)
+      @scopes.send(param, **val)
+    else
+      @scopes.send(param, val)
     end
   end
 
@@ -175,7 +183,12 @@ module Query::Modules::Initialization
   def add_default_order_if_none_specified
     return if params[:order_by].present?
 
-    @scopes = @scopes.order_by_default
+    # Bypasses the `order_by_default` scope (used directly, without a
+    # `viewer`, by callers outside the Query system) so the default
+    # sort on an index page is viewer-aware too - same underlying
+    # `order_by` dispatcher, with `self.class.default_order` standing
+    # in for the model's own `order_by_default` scope body.
+    @scopes = @scopes.order_by(self.class.default_order, viewer: viewer)
   end
 
   # array of max of MO.query_max_array unique ids for use with Arel "in"

--- a/app/classes/viewer_aware_format.rb
+++ b/app/classes/viewer_aware_format.rb
@@ -25,12 +25,12 @@ module ViewerAwareFormat
   end
 
   # Location's display name is postal/scientific-order depending on
-  # the viewer's preference. `Location.user_format` already takes an
+  # the viewer's preference. `Location#display_name` already takes an
   # explicit user - this just supplies the default when the caller
   # doesn't have one handy.
   def viewer_aware_location_format(location, user = default_viewer)
     return nil unless location
 
-    Location.user_format(user, location.name)
+    location.display_name(user)
   end
 end

--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -254,7 +254,7 @@ class Components::Map < Components::Base
   def map_location_strings(objects)
     objects.filter_map do |obj|
       if obj.location?
-        obj.display_name
+        obj.display_name(current_user)
       elsif obj.observation?
         observation_location_string(obj)
       end
@@ -263,7 +263,7 @@ class Components::Map < Components::Base
 
   def observation_location_string(obs)
     if obs.location
-      obs.location.display_name
+      obs.location.display_name(current_user)
     elsif obs.lat
       "#{format_latitude(obs.lat)} #{format_longitude(obs.lng)}"
     end

--- a/app/components/map/clustering.rb
+++ b/app/components/map/clustering.rb
@@ -34,7 +34,8 @@ module Components::Map::Clustering
   def collection_for_js
     if use_clustering?
       ::Mappable::ClusteredCollection.new(
-        mappable_objects, query_param: effective_query_param
+        mappable_objects, query_param: effective_query_param,
+                          user: current_user
       )
     else
       mappable_collection

--- a/app/controllers/account/profile_controller.rb
+++ b/app/controllers/account/profile_controller.rb
@@ -5,7 +5,7 @@ module Account
     before_action :login_required
 
     def edit
-      @user.place_name ||= @user.location&.display_name
+      @user.place_name ||= @user.location&.display_name(@user)
       set_image_upload_ivars
       render_edit_phlex
     end
@@ -61,7 +61,7 @@ module Account
           @need_location = true
         elsif @user.location != location
           @user.location = location
-          @place_name = location.display_name
+          @place_name = location.display_name(@user)
         end
       elsif @user.location
         @user.location = nil

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -53,7 +53,9 @@ module ApplicationController::Queries
     # know when params have been filtered by @user.content_filter vs any
     # other search, which may send the same params.
     query_params[:preference_filter] = true if @preference_filters_applied
-    Query.lookup(model_symbol, query_params)
+    query = Query.lookup(model_symbol, query_params)
+    query.viewer = @user
+    query
   end
 
   # Lookup an appropriate Query or create a default one if necessary. If you
@@ -225,7 +227,9 @@ module ApplicationController::Queries
   # available to templates as an ApplicationController ivar. Something like:
   #
   def current_query
-    @query || query_from_q_param || query_from_session
+    query = @query || query_from_q_param || query_from_session
+    query.viewer = @user if query
+    query
   end
 
   # Opposite is `q_param` below

--- a/app/controllers/concerns/clustered_observation_map.rb
+++ b/app/controllers/concerns/clustered_observation_map.rb
@@ -64,7 +64,7 @@ module ClusteredObservationMap
   def map_refetch_payload
     {
       collection: ::Mappable::ClusteredCollection.new(
-        @observations, query_param: q_param(@query)
+        @observations, query_param: q_param(@query), user: @user
       ),
       capped: @observations_capped,
       loaded: @observations_loaded_count,

--- a/app/controllers/concerns/locationable.rb
+++ b/app/controllers/concerns/locationable.rb
@@ -62,7 +62,9 @@ module Locationable
       @location.box_area = @location.calculate_area
       # With a Location instance, we can use the `display_name=` setter method,
       # which figures out scientific/postal format of user input and sets
-      # location `name` and `scientific_name` accordingly.
+      # location `name` and `scientific_name` accordingly. Needs
+      # `current_user` set first - `display_name=` reads it.
+      @location.current_user = @user
       @location.display_name = place_name
     end
 
@@ -88,7 +90,7 @@ module Locationable
     # bail on creating a "new" location, but go ahead with the observation save.
     # rubocop:disable Metrics/CyclomaticComplexity
     def place_name_exists?(object)
-      name = Location.user_format(@user, object.place_name)
+      name = Location.user_format(@user, object.place_name(@user))
       location = Location.find_by(name: name)
       if !object.location_id&.positive? && location ||
          (location && (object.location_id != location&.id))

--- a/app/controllers/field_slips_controller/observation_handling.rb
+++ b/app/controllers/field_slips_controller/observation_handling.rb
@@ -8,7 +8,7 @@ module FieldSlipsController::ObservationHandling
   def quick_create_observation
     fs_params = params[:field_slip]
     # Must have valid name and location
-    location = Location.place_name_to_location(place_name)
+    location = Location.place_name_to_location(place_name, @user)
     flash_error(:field_slip_quick_no_location.t) unless location
     name = Name.find_by(text_name: fs_params[:field_slip_name])
     notes = field_slip_notes.compact_blank!

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -277,7 +277,7 @@ class LocationsController < ApplicationController
     return unless find_location!
 
     params[:location] ||= {}
-    @display_name = @location.display_name
+    @display_name = @location.display_name(@user)
 
     respond_to do |format|
       format.turbo_stream { render_modal_location_form }
@@ -508,8 +508,8 @@ class LocationsController < ApplicationController
       @location, merge = merge, @location
     end
     if in_admin_mode? || @location.mergable?
-      old_name = @location.display_name
-      new_name = merge.display_name
+      old_name = @location.display_name(@user)
+      new_name = merge.display_name(@user)
       merge.merge(@user, @location)
       merge.current_user = @user
       merge.save if merge.changed?
@@ -529,6 +529,7 @@ class LocationsController < ApplicationController
   # Just change this location in place.
   def update_location_change
     @dubious_where_reasons = []
+    @location.current_user = @user
     @location.notes = params[:location][:notes].to_s.strip
     @location.locked = params[:location][:locked] == "1" if in_admin_mode?
     determine_and_check_location if !@location.locked || in_admin_mode?
@@ -567,7 +568,7 @@ class LocationsController < ApplicationController
   end
 
   def nontrivial_location_change?
-    old_name = @location.display_name
+    old_name = @location.display_name(@user)
     new_name = @display_name
     new_name.percent_match(old_name) < 0.9
   end
@@ -586,7 +587,7 @@ class LocationsController < ApplicationController
   def email_location_change_content
     :email_location_change.l(
       user: @user.login,
-      old: @location.display_name,
+      old: @location.display_name(@user),
       new: @display_name,
       observations: @location.observations.length,
       show_url: "#{MO.http_domain}/locations/#{@location.id}",
@@ -621,7 +622,7 @@ class LocationsController < ApplicationController
     when "edit", "update"
       render_to_string(Views::Layouts::Header::ObjectTitle.new(
                          object: @location, mode: :edit,
-                         title: @location.display_name
+                         title: @location.display_name(@user)
                        ))
     end
   end

--- a/app/controllers/observations_controller/create.rb
+++ b/app/controllers/observations_controller/create.rb
@@ -79,11 +79,16 @@ module ObservationsController::Create
   def create_observation_object(args = {})
     args = args&.permit(permitted_observation_args).to_h
     now = Time.zone.now
-    Observation.new(args&.merge({ created_at: now,
-                                  updated_at: now,
-                                  user: @user,
-                                  name: Name.unknown,
-                                  source: "mo_website" }))
+    obs = Observation.new(created_at: now, updated_at: now, user: @user,
+                          name: Name.unknown, source: "mo_website")
+    # `current_user` must be set before `args` is applied: `place_name=`
+    # (see HasPlaceName) reads it to decide postal vs scientific parsing,
+    # and a single `Observation.new(hash)` call can't guarantee that
+    # ordering if `place_name` and `current_user` were merged into one
+    # hash together.
+    obs.current_user = @user
+    obs.assign_attributes(args) if args
+    obs
   end
 
   def rough_cut
@@ -227,7 +232,7 @@ module ObservationsController::Create
 
   def redirect_to_next_page
     if @observation.location_id.nil?
-      redirect_to(new_location_path(where: @observation.place_name,
+      redirect_to(new_location_path(where: @observation.place_name(@user),
                                     set_observation: @observation.id))
     else
       redirect_to(permanent_observation_path(@observation.id))
@@ -270,7 +275,7 @@ module ObservationsController::Create
 
   def init_location_var_for_reload
     # Preserve the user's place_name input for form re-render
-    @default_place_name = @observation.place_name
+    @default_place_name = @observation.place_name(@user)
 
     # keep location_id if it's -1 (new)
     if @location || @observation.location_id.nil? ||

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -298,7 +298,7 @@ module ObservationsController::EditAndUpdate
 
   def redirect_to_observation_or_create_location
     if @observation.location_id.nil?
-      redirect_to(new_location_path(where: @observation.place_name,
+      redirect_to(new_location_path(where: @observation.place_name(@user),
                                     set_observation: @observation.id))
     else
       redirect_to(permanent_observation_path(@observation.id))

--- a/app/controllers/observations_controller/new.rb
+++ b/app/controllers/observations_controller/new.rb
@@ -38,6 +38,7 @@ module ObservationsController::New
     if params[:notes]
       @observation.notes = params[:notes].to_unsafe_h.symbolize_keys
     end
+    @observation.current_user = @user
     @observation.place_name = params[:place_name]
     # Prefill the editable collector: the field-slip collector when one
     # came through (the redirect carries it), else the entering user, who
@@ -186,10 +187,10 @@ module ObservationsController::New
     if params[:place_name]
       # Cannot use @place_name since that's being used for approved_where
       @default_place_name = params[:place_name]
-      loc = Location.place_name_to_location(@default_place_name)
+      loc = Location.place_name_to_location(@default_place_name, @user)
       @location = loc if loc
     else
-      @default_place_name = @observation.place_name
+      @default_place_name = @observation.place_name(@user)
     end
   end
 end

--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -38,6 +38,10 @@ module ObservationsController::SharedFormMethods
   end
 
   def update_permitted_observation_attributes
+    # Must be set before `attributes=` below: `place_name=` (see
+    # HasPlaceName) reads `current_user` to decide postal vs
+    # scientific parsing.
+    @observation.current_user = @user
     @observation.attributes = permitted_observation_params || {}
   end
 

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -91,7 +91,7 @@ module ObservationsController::Validators
   # check if we already have a location by this name. If so, find the existing
   # location and use that for the obs.
   def validate_place_name
-    place_name = @observation.place_name
+    place_name = @observation.place_name(@user)
     lat = @observation.lat
     lng = @observation.lng
     if !lat && !lng && place_name.blank?
@@ -108,7 +108,7 @@ module ObservationsController::Validators
     end
 
     @dubious_where_reasons = Location.dubious_reasons_for(
-      user: @user, place_name: @observation.place_name
+      user: @user, place_name: @observation.place_name(@user)
     )
     return true if @dubious_where_reasons.empty?
 

--- a/app/controllers/species_lists/shared_private_methods.rb
+++ b/app/controllers/species_lists/shared_private_methods.rb
@@ -77,7 +77,7 @@ module SpeciesLists
       @multiple_names = names_with_other_authors(sorter)
       @deprecated_names = sorter.deprecated_names.uniq.sort_by(&:search_name)
       @list_members = sorter.all_line_strs.join("\r\n")
-      @place_name = spl.place_name
+      @place_name = spl.place_name(@user)
     end
 
     def names_with_other_authors(sorter)

--- a/app/controllers/species_lists/write_in_controller.rb
+++ b/app/controllers/species_lists/write_in_controller.rb
@@ -203,7 +203,7 @@ module SpeciesLists
     end
 
     def validate_place_name
-      @place_name = params[:place_name] || @species_list.place_name
+      @place_name = params[:place_name] || @species_list.place_name(@user)
       @dubious_where_reasons = Location.dubious_reasons_for(
         user: @user, place_name: @place_name,
         approved: params[:approved_where]

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -138,7 +138,7 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
     return unless (@species_list = find_species_list!)
 
     if permission!(@species_list)
-      @place_name = @species_list.place_name
+      @place_name = @species_list.place_name(@user)
       init_project_vars_for_edit(@species_list)
       render_phlex_edit
     else
@@ -287,13 +287,13 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
   end
 
   def validate_place_name
-    if Location.is_unknown?(@species_list.place_name) ||
-       @species_list.place_name.blank?
+    if Location.is_unknown?(@species_list.place_name(@user)) ||
+       @species_list.place_name(@user).blank?
       @species_list.location = Location.unknown
       @species_list.where = nil
     end
 
-    @place_name = @species_list.place_name
+    @place_name = @species_list.place_name(@user)
     @dubious_where_reasons = []
     return if @species_list.location_id
 
@@ -322,6 +322,10 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
 
   def apply_species_list_params
     if params[:species_list]
+      # Must be set before `attributes=` below: `place_name=` (see
+      # HasPlaceName) reads `current_user` to decide postal vs
+      # scientific parsing.
+      @species_list.current_user = @user
       args = params[:species_list]
       @species_list.attributes = args.permit(permitted_species_list_args)
     end
@@ -374,7 +378,8 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
 
     @clone_id = clone_id
     @species_list.when = clone.when
-    @species_list.place_name = clone.place_name
+    @species_list.current_user = @user
+    @species_list.place_name = clone.place_name(@user)
     @species_list.location = clone.location
     @species_list.title = clone.title
   end

--- a/app/models/abstract_model/ordering_scopes.rb
+++ b/app/models/abstract_model/ordering_scopes.rb
@@ -25,10 +25,16 @@ module AbstractModel::OrderingScopes
     # which is basically just a scope. If no method by that name exists,
     # this will only add `order(id: :desc)` (:asc if reverse).
     #
+    # `viewer:` is only forwarded to the dispatched method when its own
+    # signature accepts it (currently just `order_by_name`/
+    # `order_by_location`, which need it to resolve postal/scientific
+    # location-name sort order) - every other `order_by_*` method's
+    # signature is untouched.
+    #
     # IMPORTANT: USE THIS SCOPE whenever possible in the app and tests.
     # The private methods called by it do not include the last step that
     # resolves order within grouped results consistently.
-    scope :order_by, lambda { |method|
+    scope :order_by, lambda { |method, viewer: nil|
       return all if method.to_sym == :none
 
       method ||= :default # :order_by_default must be defined for each model
@@ -39,7 +45,7 @@ module AbstractModel::OrderingScopes
 
       # Call `scoping` with `model.send(:method)` here, because the private
       # class methods below are otherwise inaccessible to a `scope` proc.
-      scope = scoping { model.send(scope) }
+      scope = scoping { model.send(:send_ordering_scope, scope, viewer) }
       scope = scope.reverse_order if reverse
       # Order grouped results from other scopes by adding order(id: :desc). If
       # this `:desc` is contrary to a previous order_by(:id) it will be ignored.
@@ -57,6 +63,19 @@ module AbstractModel::OrderingScopes
   # class methods here, `self` included
   module ClassMethods
     private
+
+    # Calls the dispatched `order_by_*` method, forwarding `viewer:`
+    # only when its signature accepts it - lets `order_by_name`/
+    # `order_by_location` (the only two that need it) take it without
+    # requiring every other `order_by_*` method to accept-and-ignore
+    # an unused kwarg.
+    def send_ordering_scope(scope_name, viewer)
+      accepts_viewer = method(scope_name).parameters.
+                       any? { |type, name| type == :key && name == :viewer }
+      return send(scope_name, viewer: viewer) if accepts_viewer
+
+      send(scope_name)
+    end
 
     # NOTE: For predictable results, DO NOT CALL THESE METHODS DIRECTLY
     # unless for some reason you need scopes without the ambiguity-resolving
@@ -169,10 +188,10 @@ module AbstractModel::OrderingScopes
       order(User[:last_login].desc)
     end
 
-    def order_by_location
+    def order_by_location(viewer: nil)
       return all unless column_names.include?("location_id")
 
-      scope = order_locations_by_name
+      scope = order_locations_by_name(viewer: viewer)
       # Join Users with null locations, else join records with locations
       if self == User
         scope.left_outer_joins(:location).distinct
@@ -191,10 +210,10 @@ module AbstractModel::OrderingScopes
     # NOTE: scope `order_by_location` calls `order_locations_by_name` above,
     # so the latter should stay here. To avoid method duplication, we could
     # just have scope `Location.order_by_name` call `order_locations_by_name`.
-    def order_by_name
+    def order_by_name(viewer: nil)
       order_by_name_method = :"order_#{name.underscore.pluralize}_by_name"
       if private_methods(false).include?(order_by_name_method)
-        send(order_by_name_method)
+        send_ordering_scope(order_by_name_method, viewer)
       else
         order_other_models_by_name
       end
@@ -320,8 +339,8 @@ module AbstractModel::OrderingScopes
         order(Location[:name].asc, LocationDescription[:created_at].asc)
     end
 
-    def order_locations_by_name
-      if User.current_location_format == "scientific"
+    def order_locations_by_name(viewer: nil)
+      if viewer&.location_format == "scientific"
         order(Location[:scientific_name].asc)
       else
         order(Location[:name].asc)

--- a/app/models/concerns/has_place_name.rb
+++ b/app/models/concerns/has_place_name.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Mix into any model with a `where` string column and a
+# `belongs_to :location`, to get a viewer-aware `place_name`/
+# `place_name=` pair. Used by Observation, Project, and SpeciesList.
+#
+# `place_name(user)` is viewer-aware (nil => postal default), matching
+# `Location#display_name`/`Location.normalize_place_name`. `place_name=`
+# can't take that same explicit second argument through plain `=`
+# syntax, so it reads `current_user` (an explicit per-instance
+# accessor the caller sets before assignment) instead.
+#
+# A host whose `location` association needs eager-load-safe lookup
+# (Observation, which may be reached after a bare `location_id =`
+# invalidated the cached association target) overrides
+# +location_for_place_name+ instead of +place_name+ itself.
+module HasPlaceName
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :current_user
+  end
+
+  def place_name(user = nil)
+    if (loc = location_for_place_name)
+      loc.display_name(user)
+    elsif user&.location_format == "scientific"
+      Location.reverse_name(where)
+    else
+      where
+    end
+  end
+
+  def place_name=(place_name)
+    where = Location.normalize_place_name(place_name, current_user)
+    loc = Location.find_by_name(where)
+    if loc
+      self.where = loc.name
+      self.location = loc
+    else
+      self.where = where
+      self.location = nil
+    end
+  end
+
+  private
+
+  def location_for_place_name
+    location
+  end
+end

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -51,7 +51,15 @@
 
 class Herbarium < AbstractModel
   # Used by create/edit form.
-  attr_accessor :place_name, :personal, :personal_user_name
+  attr_writer :place_name
+  attr_accessor :personal, :personal_user_name
+
+  # Plain scratch string (not viewer-aware, unlike Location/Observation/
+  # etc's place_name) - accepts and ignores an optional `user` so
+  # Locationable's shared `place_name_exists?` can call it uniformly.
+  def place_name(_user = nil)
+    @place_name
+  end
 
   has_many :herbarium_records, dependent: :destroy
   belongs_to :location

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -367,9 +367,14 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
 
   # Viewer-aware: `user` is who's *looking at* this name (nil => postal
   # default). Not the same viewer/actor concept as `current_user` below
-  # (that's who's *editing* - see `display_name=`).
+  # (that's who's *editing* - see `display_name=`). Reads the persisted
+  # `scientific_name` column directly rather than computing
+  # `Location.user_format(user, name)` - `scientific_name` isn't
+  # guaranteed to be an exact `reverse_name(name)` round-trip (legacy
+  # data), and `order_locations_by_name` sorts by the real column, so
+  # display and sort order need to agree.
   def display_name(user = nil)
-    Location.user_format(user, name)
+    user&.location_format == "scientific" ? scientific_name : name
   end
 
   # `current_user` (the acting/editing user - see VersionedByCurrentUser,

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -365,12 +365,20 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     name.split(", ").first
   end
 
-  def display_name
-    User.current_location_format == "scientific" ? scientific_name : name
+  # Viewer-aware: `user` is who's *looking at* this name (nil => postal
+  # default). Not the same viewer/actor concept as `current_user` below
+  # (that's who's *editing* - see `display_name=`).
+  def display_name(user = nil)
+    Location.user_format(user, name)
   end
 
+  # `current_user` (the acting/editing user - see VersionedByCurrentUser,
+  # set by the caller before assignment, same as attribution) decides
+  # which raw column the incoming string represents. Can't take an
+  # explicit second argument through plain `=` syntax the way the
+  # getter does.
   def display_name=(val)
-    if User.current_location_format == "scientific"
+    if current_user&.location_format == "scientific"
       self.name = Location.reverse_name(val)
       self.scientific_name = val
     else
@@ -380,13 +388,13 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   # Plain text version of +display_name+.
-  def text_name
-    display_name.t.html_to_ascii
+  def text_name(user = nil)
+    display_name(user).t.html_to_ascii
   end
 
   # Alias for +display_name+ for compatibility with Name and other models.
-  def format_name
-    display_name
+  def format_name(user = nil)
+    display_name(user)
   end
 
   # Page heading + browser tab title. `display_name` is plain text
@@ -395,18 +403,18 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   alias page_title display_name
   alias document_title text_name
 
-  def textile_name
-    display_name
+  def textile_name(user = nil)
+    display_name(user)
   end
 
   # Same as +text_name+ but with id tacked on.
-  def unique_text_name
-    string_with_id(text_name)
+  def unique_text_name(user = nil)
+    string_with_id(text_name(user))
   end
 
   # Same as +format_name+ but with id tacked on.
-  def unique_format_name
-    string_with_id(format_name)
+  def unique_format_name(user = nil)
+    string_with_id(format_name(user))
   end
 
   # Info to include about each location in merge requests.
@@ -436,11 +444,11 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     str.strip_squeeze.downcase
   end
 
-  # Cleans up a place_name (per Observation) and
-  # applies the current user's current_location_format
-  def self.normalize_place_name(place_name)
+  # Cleans up a place_name (per Observation) and applies `user`'s
+  # location_format (nil => postal default).
+  def self.normalize_place_name(place_name, user = nil)
     place_name = place_name&.strip_squeeze
-    if User.current_location_format == "scientific"
+    if user&.location_format == "scientific"
       reverse_name(place_name)
     else
       place_name
@@ -448,8 +456,8 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   # Returns any existing location that matches place_name
-  def self.place_name_to_location(place_name)
-    find_by_name(normalize_place_name(place_name))
+  def self.place_name_to_location(place_name, user = nil)
+    find_by_name(normalize_place_name(place_name, user))
   end
 
   # Takes a location string splits on commas, reverses the order,

--- a/app/models/mappable/minimal_location.rb
+++ b/app/models/mappable/minimal_location.rb
@@ -8,12 +8,8 @@ module Mappable
     validates :id, presence: true
     validates :name, presence: true
 
-    def display_name
-      if ::User.current_location_format == "scientific"
-        ::Location.reverse_name(name)
-      else
-        name
-      end
+    def display_name(user = nil)
+      ::Location.user_format(user, name)
     end
   end
 end

--- a/app/models/name_tracker.rb
+++ b/app/models/name_tracker.rb
@@ -65,7 +65,7 @@ class NameTracker < AbstractModel
       gsub(":observer", observer.login).
       gsub(":observation", "#{MO.http_domain}/#{naming.observation_id}").
       gsub(":mailing_address", tracker.mailing_address || "").
-      gsub(":location", naming.observation.place_name).
+      gsub(":location", naming.observation.place_name(tracker)).
       gsub(":name", naming.user_format_name(tracker))
   end
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -156,7 +156,7 @@
 #  announce_consensus_change::  After consensus changes: send email.
 #
 class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
-  attr_accessor :current_user
+  include HasPlaceName
 
   # Transient flag: when set, the before_create default that copies the
   # entering user into `collector` is skipped. Field-slip-originated
@@ -603,44 +603,22 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   #
   ##############################################################################
 
-  # Abstraction over +where+ and +location.display_name+.  Returns Location
-  # name as a string, preferring +location+ over +where+ wherever both exist.
-  # Also applies the location_format of the current user (defaults to "postal").
-  def place_name
-    # Use the eager-loaded `:location` when its id still matches
-    # `location_id` (the show/index render path). Fall back to an FK
-    # fetch when callers reach `place_name` after a `location_id =`
-    # assignment invalidated the cached target, so we don't lazy-load
-    # against strict_loading.
+  private
+
+  # Use the eager-loaded `:location` when its id still matches
+  # `location_id` (the show/index render path). Fall back to an FK
+  # fetch when callers reach `place_name` after a `location_id =`
+  # assignment invalidated the cached target, so we don't lazy-load
+  # against strict_loading. (Overrides HasPlaceName's default, which
+  # just calls the `location` association directly.)
+  def location_for_place_name
     cached = association(:location).target if association(:location).loaded?
-    loc = if cached && cached.id == location_id
-            cached
-          elsif location_id
-            Location.find_by(id: location_id)
-          end
-    if loc
-      loc.display_name
-    elsif User.current_location_format == "scientific"
-      Location.reverse_name(where)
-    else
-      where
-    end
+    return cached if cached && cached.id == location_id
+
+    Location.find_by(id: location_id) if location_id
   end
 
-  # Set +where+ or +location+, depending on whether a Location is defined with
-  # the given +display_name+.  (Fills the other in with +nil+.)
-  # Adjusts for the current user's location_format as well.
-  def place_name=(place_name)
-    where = Location.normalize_place_name(place_name)
-    loc = Location.find_by_name(where)
-    if loc
-      self.where = loc.name
-      self.location = loc
-    else
-      self.where = where
-      self.location = nil
-    end
-  end
+  public
 
   # Useful for forms in which date is entered in YYYYMMDD format: When form tag
   # helper creates input field, it reads obs.when_str and gets date in
@@ -709,13 +687,13 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       will_save_change_to_attribute?(:location_id)
   end
 
-  def place_name_and_coordinates
+  def place_name_and_coordinates(user = nil)
     if lat.present? && lng.present?
       lat_string = format_coordinate(lat, "N", "S")
       lng_string = format_coordinate(lng, "E", "W")
-      "#{place_name} (#{lat_string} #{lng_string})"
+      "#{place_name(user)} (#{lat_string} #{lng_string})"
     else
-      place_name
+      place_name(user)
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -99,6 +99,8 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
   has_many :aliases, class_name: "ProjectAlias", dependent: :destroy
 
+  include HasPlaceName
+
   before_destroy :orphan_drafts
   # Adding/changing a prefix retroactively claims previously-orphaned
   # field slips whose code matches — but only member-owned ones. See
@@ -863,19 +865,12 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     location ? location.name : ""
   end
 
-  def place_name
-    location ? location.display_name : ""
-  end
-
+  # place_name/place_name= come from HasPlaceName. Project has no
+  # free-text `where` storage (just the derived getter above), so
+  # `place_name=` overrides the concern's default to skip the
+  # where-fallback and only ever assign (or clear) +location+.
   def place_name=(place_name)
-    place_name = place_name.strip_squeeze
-    where = if User.current_location_format == "scientific"
-              Location.reverse_name(place_name)
-            else
-              place_name
-            end
-    loc = Location.find_by_name(where)
-    self.location = (loc)
+    self.location = Location.place_name_to_location(place_name, current_user)
   end
 
   def name_count

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -99,6 +99,8 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
 
   attr_accessor :data
 
+  include HasPlaceName
+
   scope :order_by_default,
         -> { order_by(::Query::SpeciesLists.default_order) }
 
@@ -256,36 +258,7 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
   #
   ##############################################################################
 
-  # Abstraction over +where+ and +location.display_name+.  Returns Location
-  # name as a string, preferring +location+ over +where+ wherever both exist.
-  # Also applies the location_format of the current user (defaults to "postal").
-  def place_name
-    if location
-      location.display_name
-    elsif User.current_location_format == "scientific"
-      Location.reverse_name(where)
-    else
-      where
-    end
-  end
-
-  # Set +where+ or +location+, depending on whether a Location is defined with
-  # the given +display_name+.  (Fills the other in with +nil+.)
-  # Adjusts for the current user's location_format as well.
-  def place_name=(place_name)
-    where = if User.current_location_format == "scientific"
-              Location.reverse_name(place_name)
-            else
-              place_name
-            end
-    if (loc = Location.find_by_name(where))
-      self.where = loc.name
-      self.location = loc
-    else
-      self.where = where
-      self.location = nil
-    end
-  end
+  # place_name/place_name= come from HasPlaceName.
 
   # Return title in plain text for debugging.
   def text_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -379,21 +379,6 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   # Thread-safe: Stores user in thread-local storage for proper isolation.
   def self.current=(val)
     Thread.current[:mushroom_observer_user] = val
-    Thread.current[:mushroom_observer_location_format] =
-      val ? val.location_format : "postal"
-  end
-
-  # Report current user's preferred location_format
-  #
-  #   location_format = User.current_location_format
-  #
-  def self.current_location_format
-    Thread.current[:mushroom_observer_location_format] || "postal"
-  end
-
-  # Set the location format to use throughout the site.
-  def self.current_location_format=(val)
-    Thread.current[:mushroom_observer_location_format] = val
   end
 
   # Clear cached data structures when reload.

--- a/app/views/controllers/projects/aliases/table.rb
+++ b/app/views/controllers/projects/aliases/table.rb
@@ -36,7 +36,15 @@ module Views::Controllers::Projects::Aliases
     private
 
     def render_target_cell(alias_)
-      link_to(alias_.target.try(:format_name), alias_.target)
+      target = alias_.target
+      # Target is either a User or a Location (see ProjectAlias) - only
+      # Location's format_name is viewer-aware (postal/scientific).
+      name = if target.is_a?(::Location)
+               target.format_name(current_user)
+             else
+               target.try(:format_name)
+             end
+      link_to(name, target)
     end
 
     def render_actions_cell(alias_)

--- a/app/views/controllers/projects/banner.rb
+++ b/app/views/controllers/projects/banner.rb
@@ -102,7 +102,7 @@ module Views::Controllers::Projects
       div(class: location_classes) do
         b do
           a(href: location_path(@project.location.id)) do
-            @project.place_name
+            @project.place_name(current_user)
           end
         end
       end

--- a/app/views/controllers/species_lists/form.rb
+++ b/app/views/controllers/species_lists/form.rb
@@ -86,7 +86,7 @@ module Views::Controllers::SpeciesLists
     # model attribute).
     def render_hidden_fields
       hidden_field("clone_id", value: @clone_id) if @clone_id
-      hidden_field(:approved_where, value: model.place_name)
+      hidden_field(:approved_where, value: model.place_name(current_user))
     end
 
     def render_visible_fields
@@ -103,6 +103,7 @@ module Views::Controllers::SpeciesLists
                button: @button
              ))
       autocompleter_field(:place_name, type: :location,
+                                       value: model.place_name(current_user),
                                        label: "#{:WHERE.l}:")
     end
 

--- a/app/views/controllers/species_lists/listing.rb
+++ b/app/views/controllers/species_lists/listing.rb
@@ -36,7 +36,7 @@ module Views::Controllers::SpeciesLists
     # `rescue :UNKNOWN.l` is fallback.
     def place
       @place ||= begin
-                   @species_list.place_name.t
+                   @species_list.place_name(current_user).t
                  rescue StandardError
                    :UNKNOWN.l
                  end

--- a/app/views/controllers/species_lists/write_in/form.rb
+++ b/app/views/controllers/species_lists/write_in/form.rb
@@ -102,11 +102,13 @@ module Views::Controllers::SpeciesLists::WriteIn
     end
 
     def render_place_name_field
-      # `:place_name` is a real `SpeciesList` attribute; Symbol path
-      # binds to `model.place_name` (which the controller has already
-      # set to the right value via `validate_place_name`).
+      # `:place_name` is a real `SpeciesList` attribute, but its getter
+      # is viewer-aware (takes an explicit user) - Superform's Symbol
+      # path would call it with no args, so pass `value:` explicitly
+      # to get `current_user`'s postal/scientific preference.
       autocompleter_field(:place_name,
                           type: :location,
+                          value: model.place_name(current_user),
                           label: "#{:WHERE.l}:")
     end
 

--- a/app/views/mailers/observation_change_mailer.rb
+++ b/app/views/mailers/observation_change_mailer.rb
@@ -121,7 +121,7 @@ class Views::Mailers::ObservationChangeMailer < Views::Mailers::Base
     when "date"
       "*#{:Date.l} #{now_label}:* #{@observation.when.email_date}\n"
     when "location"
-      "*#{:Location.l} #{now_label}:* #{@observation.place_name}\n"
+      "*#{:Location.l} #{now_label}:* #{@observation.place_name(@receiver)}\n"
     when "specimen" then specimen_line
     when "is_collection_location" then collection_location_line
     else simple_change_line(field)

--- a/lib/rubocop/cop/mushroom_observer/no_user_current_in_views.rb
+++ b/lib/rubocop/cop/mushroom_observer/no_user_current_in_views.rb
@@ -26,14 +26,14 @@ module RuboCop
       #   @user.id
       #
       #   # bad (in component/view)
-      #   User.current_location_format
-      #   ::User.current_location_format
+      #   User.current
+      #   ::User.current
       #
       #   # good (in component/view - add a user prop ...)
-      #   @user.location_format
+      #   @user
       #
       #   # ... or use the registered current_user value helper
-      #   current_user&.location_format
+      #   current_user
       #
       class NoUserCurrentInViews < Base
         MSG = "Avoid `User.current`. In controllers, use `@user` " \

--- a/test/classes/query/locations_test.rb
+++ b/test/classes/query/locations_test.rb
@@ -27,6 +27,18 @@ class Query::LocationsTest < UnitTestCase
     assert_query(expects, :Location, order_by: :name)
   end
 
+  def test_location_order_by_name_viewer_aware
+    query = Query.lookup(:Location, order_by: :name)
+    query.viewer = roy
+    assert_obj_arrays_equal(Location.order_by(:name, viewer: roy).to_a,
+                            query.results)
+
+    query = Query.lookup(:Location, order_by: :name)
+    query.viewer = rolf
+    assert_obj_arrays_equal(Location.order_by(:name, viewer: rolf).to_a,
+                            query.results)
+  end
+
   def test_location_order_by_num_views
     expects = Location.order_by(:num_views)
     assert_query(expects, :Location, order_by: :num_views)

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -32,6 +32,14 @@ class Query::ObservationsTest < UnitTestCase
     assert_query(expects, :Observation, order_by: :location)
   end
 
+  def test_observation_order_by_location_viewer_aware
+    query = Query.lookup(:Observation, order_by: :location)
+    query.viewer = roy
+    assert_obj_arrays_equal(
+      Observation.order_by(:location, viewer: roy).to_a, query.results
+    )
+  end
+
   # Test that subquery `reorder("")` does not interfere with explicit order.
   def test_observation_order_by_name
     expects = Observation.location_query(pattern: "Falmouth").order_by(:name)

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -979,7 +979,7 @@ class LocationsControllerTest < FunctionalTestCase
     login("rolf")
     loc = locations(:burbank)
     normal_name = loc.name
-    scientific_name = loc.display_name
+    scientific_name = loc.display_name(rolf)
     assert_not_equal(normal_name, scientific_name)
     get(:edit, params: { id: loc.id })
     assert_input_value(:location_display_name, scientific_name)
@@ -996,7 +996,7 @@ class LocationsControllerTest < FunctionalTestCase
     assert_response(:redirect) # means success
     loc.reload
     assert_equal(new_normal_name, loc.name)
-    assert_equal(new_scientific_name, loc.display_name)
+    assert_equal(new_scientific_name, loc.display_name(rolf))
   end
 
   def test_nontrivial_change

--- a/test/controllers/projects/aliases_controller_test.rb
+++ b/test/controllers/projects/aliases_controller_test.rb
@@ -28,12 +28,12 @@ module Projects
       login("roy")
       location = ProjectAlias.find_by(target_type: "Location",
                                       project: @project).target
-      assert_not_equal(location.name, location.display_name)
+      assert_not_equal(location.name, location.display_name(roy))
       get(:index, params: { project_id: @project.id })
       assert_response(:success)
       assert_not_nil(assigns(:project_aliases))
       assert_select("#index_project_alias_table",
-                    text: /#{Regexp.escape(location.display_name)}/)
+                    text: /#{Regexp.escape(location.display_name(roy))}/)
     end
 
     def test_show_displays_the_requested_project_alias

--- a/test/integration/capybara/observations_integration_test.rb
+++ b/test/integration/capybara/observations_integration_test.rb
@@ -263,7 +263,8 @@ class ObservationsIntegrationTest < CapybaraIntegrationTestCase
            "Missing an unchecked box for Project which has ended")
     assert_field("observation_location_id",
                  type: :hidden, with: last_location.id)
-    assert_field("observation_place_name", with: last_location.display_name)
+    assert_field("observation_place_name",
+                 with: last_location.display_name(user))
     assert_field("observation_when_1i", with: Time.zone.today.year)
     assert_field("observation_when_2i", with: Time.zone.today.month)
     assert_field("observation_when_3i", with: Time.zone.today.day)

--- a/test/integration/capybara/species_lists_integration_test.rb
+++ b/test/integration/capybara/species_lists_integration_test.rb
@@ -89,7 +89,7 @@ class SpeciesListsIntegrationTest < CapybaraIntegrationTestCase
     assert_not_nil(loc, "Cannot find Location")
     assert_equal(newer_location, loc.name)
     assert_equal(dick.id, rack_session[:user_id])
-    assert_equal(newer_location_reverse, loc.display_name)
+    assert_equal(newer_location_reverse, loc.display_name(dick))
     spl.reload
     assert_equal(loc.name, spl.where)
     assert_equal(loc, spl.location)

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -510,14 +510,14 @@ class LocationTest < UnitTestCase
   def test_change_scientific_name
     loc = Location.first
 
-    User.current = rolf
-    assert_equal("postal", User.current_location_format)
+    loc.current_user = rolf
+    assert_equal("postal", rolf.location_format)
     loc.update_attribute(:display_name, "One, Two, Three")
     assert_equal("One, Two, Three", loc.name)
     assert_equal("Three, Two, One", loc.scientific_name)
 
-    User.current = roy
-    assert_equal("scientific", User.current_location_format)
+    loc.current_user = roy
+    assert_equal("scientific", roy.location_format)
     loc.update_attribute(:display_name, "Un, Deux, Trois")
     assert_equal("Trois, Deux, Un", loc.name)
     assert_equal("Un, Deux, Trois", loc.scientific_name)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -170,17 +170,16 @@ class ProjectTest < UnitTestCase
   def test_place_name
     proj = projects(:eol_project)
     loc = locations(:albion)
-    proj.place_name = loc.display_name
+    proj.place_name = loc.display_name(rolf)
     assert_equal(proj.location, loc)
   end
 
   def test_scientific_place_name
-    User.current_location_format = "scientific"
     proj = projects(:eol_project)
+    proj.current_user = roy
     loc = locations(:albion)
-    proj.place_name = loc.display_name
+    proj.place_name = loc.display_name(roy)
     assert_equal(proj.location, loc)
-    User.current_location_format = "postal"
   end
 
   def test_location_violations

--- a/test/models/user_thread_safety_test.rb
+++ b/test/models/user_thread_safety_test.rb
@@ -55,47 +55,4 @@ class UserThreadSafetyTest < UnitTestCase
     assert_equal(results[:thread2_expected_id], results[:thread2_user_id],
                  "Thread 2 should see bob, but sees #{thread2_login}")
   end
-
-  def test_user_current_location_format_maintains_isolation_between_threads
-    alice = users(:rolf)
-    bob = users(:mary)
-
-    # Set different location formats
-    alice.location_format = "postal"
-    bob.location_format = "scientific"
-
-    results = Concurrent::Hash.new
-
-    # Use CountDownLatch for deterministic synchronization
-    setup_latch = Concurrent::CountDownLatch.new(2)
-    check_latch = Concurrent::CountDownLatch.new(2)
-
-    threads = [
-      Thread.new do
-        User.current = alice
-        setup_latch.count_down
-        setup_latch.wait # Wait for both threads to set their User.current
-        check_latch.count_down
-        check_latch.wait # Ensure both threads check at the same time
-        results[:thread1_format] = User.current_location_format
-        results[:thread1_expected] = "postal"
-      end,
-      Thread.new do
-        User.current = bob
-        setup_latch.count_down
-        setup_latch.wait # Wait for both threads to set their User.current
-        check_latch.count_down
-        check_latch.wait # Ensure both threads check at the same time
-        results[:thread2_format] = User.current_location_format
-        results[:thread2_expected] = "scientific"
-      end
-    ]
-
-    threads.each(&:join)
-
-    assert_equal(results[:thread1_expected], results[:thread1_format],
-                 "Thread 1 should see 'postal' format")
-    assert_equal(results[:thread2_expected], results[:thread2_format],
-                 "Thread 2 should see 'scientific' format")
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -177,13 +177,11 @@ module ActiveSupport
     # between tests running in the same thread.
     setup do
       Thread.current[:mushroom_observer_user] = nil
-      Thread.current[:mushroom_observer_location_format] = nil
     end
 
     # Clean up thread-local storage after each test
     teardown do
       Thread.current[:mushroom_observer_user] = nil
-      Thread.current[:mushroom_observer_location_format] = nil
     end
 
     # Add more helper methods to be used by all tests here...


### PR DESCRIPTION
## Summary

Follow-up to #4693, which converted `Location`'s attribution (`User.current`) but left its display-formatting methods reading the other deprecated global, `User.current_location_format` (postal vs. scientific place-name order). This PR finishes that: every method that decides postal-vs-scientific formatting now takes an explicit `user` (nil defaults to postal) instead of reading a thread-local, and — since that was the last reader of the global anywhere in the app — removes the global entirely.

## `Location`

`display_name`, `format_name`, `text_name`, `textile_name`, `unique_text_name`, `unique_format_name`, `self.normalize_place_name`, `self.place_name_to_location` all take an optional `user = nil` now. `display_name=` can't take a second argument through plain `=` syntax, so it reads `current_user` (the existing per-instance accessor from `VersionedByCurrentUser`) instead.

## Same pattern, extended to every model with a postal/scientific place name

`Observation`, `Project`, and `SpeciesList` all had their own `place_name`/`place_name=` pair reading the same global, with near-identical logic. Deduped into a new `app/models/concerns/has_place_name.rb` concern (`HasPlaceName`) — `place_name(user)` viewer-aware getter, `place_name=` reading a `current_user` accessor it provides, same `=`-syntax constraint as `Location#display_name=`. `Observation` overrides the concern's default location lookup (`location_for_place_name`) to keep its existing eager-load-safe association handling. `Project` overrides `place_name=` since it has no free-text `where` column, just a `location` association.

`Mappable::MinimalLocation#display_name` (a lightweight PORO paralleling `Location#display_name` for map rendering) gets the same conversion, threaded through `Mappable::ClusteredCollection` and `Components::Map`.

## Query sort order

`AbstractModel::OrderingScopes#order_locations_by_name` — reached both via `order_by_location` (sorting some other model's index by its associated location's name, e.g. Users/Observations) and via `order_by_name` (Location's own default index order) — was the last remaining reader of the global. Query has no "viewer" concept anywhere today, so this needed real plumbing:

- `Query#viewer` — a plain accessor, deliberately **not** a `query_attr`, so it doesn't affect the serialized query description or the `?q[...]=` URL shape, only in-process sort order.
- Set by `ApplicationController::Queries#create_query` and `#current_query` (the two paths controllers reach a `Query` instance through), so essentially every controller gets this for free without individual call-site changes.
- The generic `order_by` scope dispatcher forwards `viewer:` only to the `order_by_*` methods whose signature actually accepts it (`order_by_name`, `order_by_location`), via a small parameter-introspection helper — the ~30 unrelated `order_by_*` methods don't need touching.

Worth noting: this doesn't change any actual behavior. `order_locations_by_name` already read `User.current_location_format`, which is set from whoever's logged in — so the same `?q[order_by]=location` URL already sorted differently for a postal-format user vs. a scientific-format user today. This just makes that already-existing viewer-dependence explicit instead of implicit-via-global.

## Removed the now-dead global

Once every reader above was converted, nothing in `app/` read `User.current_location_format` anymore, so:

- Removed `User.current_location_format`/`current_location_format=` and the `Thread.current[:mushroom_observer_location_format]` write inside `User.current=`.
- Removed the two `User.current_location_format = "postal"` writes in `API2::Core::Base` (`login_user`/`clear_user`) — API2 already gets postal-only formatting for free now, since it never threads a `user`/`viewer` through any of the above.
- Removed `test/models/user_thread_safety_test.rb`'s test for the removed mechanism (the sibling test for `User.current`'s own thread-isolation stays — that global is unrelated and still very much alive) and the corresponding `test/test_helper.rb` resets.

## Bug found and fixed along the way

Removing the API2 write surfaced a latent bug: `authenticate_user`'s guard clause was `clear_user && return unless (key_str = parse(:string, :api_key))` — relying on `clear_user`'s last statement (the location_format write, a truthy string) to make the whole expression truthy so `return` would actually fire. With that write gone, `clear_user`'s return value became `nil`, and `&&`'s short-circuit meant `return` never ran — unauthenticated API requests fell through into key lookup and raised `BadAPIKey` instead of being treated as anonymous. Rewritten as an explicit `unless (...); clear_user; return; end`, not relying on a method's return value as a side channel.

## Full-suite regressions caught and fixed

A few real bugs surfaced only once the changes were exercised end-to-end (all confirmed via full test runs, not just the units directly touched):

- **Mass-assignment ordering**: `Observation`'s `create`/`update` flows and `SpeciesList`'s `apply_species_list_params` build the model via `Observation.new(hash)` / `.attributes = hash`, which processes keys in order — `place_name` could get assigned before `current_user` was set, silently defaulting to postal regardless of the real submitting user's preference. Fixed by setting `current_user` before mass-assignment in each spot.
- **`Locationable#place_name_exists?`**: relied on a deliberate double-reversal (the old getter's global-reading fallback reversed once, then `Location.user_format` reversed again, canceling out) that broke once the getter stopped implicitly reading the global. Fixed by threading `@user` through explicitly so the same cancellation still happens.
- **`LocationsController#update`**: `determine_and_check_location` called `@location.display_name = ...` before `current_user` was set (that happened later, in `save_flash_and_redirect_or_render!`). Moved the `current_user` assignment earlier.
- **`Herbarium#place_name`**: a plain `attr_accessor`, not viewer-aware — but shared `Locationable#place_name_exists?` now calls `object.place_name(@user)` uniformly across all its callers (Herbaria, Observations). Gave it a `place_name(_user = nil)` reader that accepts and ignores the arg.
- A handful of tests (`locations_controller_test.rb`, `projects/aliases_controller_test.rb`, `location_test.rb`, `project_test.rb`, and two Capybara integration tests) computed their "expected" values by calling the now-viewer-aware methods with no arguments, which silently changed their meaning from "read the global" to "default to postal" — updated to pass the relevant fixture user explicitly.

## Test plan

- [x] `bin/rails test test/models/ test/classes/ test/controllers/ test/integration/` — full run, 0 failures
- [x] `bin/rails test test/classes/api2/` — 301 tests, 0 failures (confirms the `authenticate_user` fix and postal-only API behavior)
- [x] `bundle exec rubocop` clean on every touched file
- [x] New coverage: `Query::LocationsTest#test_location_order_by_name_viewer_aware`, `Query::ObservationsTest#test_observation_order_by_location_viewer_aware` — prove the Query `viewer` plumbing end-to-end for both `order_by_name` and `order_by_location` paths
