### PR TITLE
Remove User.current attribution from Observation, Occurrence, Naming, Vote, Image

### DIFF
--- a/app/classes/api2/occurrence_api.rb
+++ b/app/classes/api2/occurrence_api.rb
@@ -114,10 +114,10 @@ class API2
 
     def add_one_observation(occ, obs)
       if obs.occurrence && obs.occurrence != occ
-        Occurrence.merge!(occ, obs.occurrence)
+        Occurrence.merge!(occ, obs.occurrence, @user)
       elsif obs.occurrence_id != occ.id
         obs.update!(occurrence: occ)
-        Occurrence.log_observation_added([obs])
+        Occurrence.log_observation_added([obs], @user)
       end
     end
 
@@ -130,7 +130,7 @@ class API2
 
         occ.reassign_thumbnails_from(obs)
         obs.update!(occurrence: nil)
-        Occurrence.log_observation_removed(obs, occ)
+        Occurrence.log_observation_removed(obs, occ, @user)
       end
       occ.reload
       occ.destroy_if_incomplete!

--- a/app/controllers/field_slips_controller/observation_handling.rb
+++ b/app/controllers/field_slips_controller/observation_handling.rb
@@ -183,7 +183,7 @@ module FieldSlipsController::ObservationHandling
 
       occ.reassign_thumbnails_from(obs)
       obs.update!(occurrence: nil)
-      Occurrence.log_field_slip_removed(obs, occ)
+      Occurrence.log_field_slip_removed(obs, occ, @user)
       Observation::NamingConsensus.new(obs).calc_consensus
     end
   end
@@ -197,7 +197,7 @@ module FieldSlipsController::ObservationHandling
       obs.update!(occurrence: occ)
       added << obs
     end
-    Occurrence.log_field_slip_added(added) if added.any?
+    Occurrence.log_field_slip_added(added, @user) if added.any?
   end
 
   def update_occurrence_primary(occ)
@@ -224,7 +224,7 @@ module FieldSlipsController::ObservationHandling
       selected.each { |obs| obs.update!(occurrence: occ) }
       newly_added = selected
     end
-    Occurrence.log_field_slip_added(newly_added) if newly_added&.any?
+    Occurrence.log_field_slip_added(newly_added, @user) if newly_added&.any?
     occ.recompute_has_specimen!
     occ.recalculate_consensus!
     check_field_slip_project_gaps(occ)

--- a/app/controllers/observations/images_controller.rb
+++ b/app/controllers/observations/images_controller.rb
@@ -35,6 +35,7 @@ module Observations
       @licenses = current_license_names_and_ids
       return unless check_image_permission?
 
+      @image.current_user = @user
       @image.attributes = permitted_image_params
 
       if image_or_projects_updated

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -74,7 +74,9 @@ module Observations
     def update
       init_ivars
       @observation = Observation.show_includes.find(params[:observation_id])
+      @observation.current_user = @user
       @naming = naming_from_params
+      @naming.current_user = @user
       # N+1: What is this doing? Watch out for permission!
       return redirect_to_obs(@observation) unless permission!(@naming)
 
@@ -92,7 +94,9 @@ module Observations
 
     def destroy
       naming = Naming.show_includes.find(params[:id].to_s)
+      naming.current_user = @user
       @observation = Observation.naming_includes.find(params[:observation_id])
+      @observation.current_user = @user
       @consensus = Observation::NamingConsensus.new(@observation)
       if destroy_if_we_can(naming) # needs to know consensus before deleting
         flash_notice(:runtime_destroy_naming_success.t(id: params[:id].to_s))
@@ -114,6 +118,11 @@ module Observations
       fill_in_reference_for_suggestions if params[:naming].present?
 
       @observation = Observation.show_includes.find(params[:observation_id])
+      # `Naming.construct`/`Vote.construct` read this off the observation
+      # for attribution - set here since `@observation` is an existing,
+      # already-saved record, not one built fresh with `current_user`
+      # already populated.
+      @observation.current_user = @user
     end
 
     # `params[:id]` is guaranteed by the `:edit`/`:update`/`:destroy`

--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -219,6 +219,7 @@ module ObservationsController::SharedFormMethods
       args = params.dig(:observation, :good_image, image.id.to_s)
       next unless args
 
+      image.current_user = @user
       image.attributes = args.permit(permitted_image_args)
       next unless image.when_changed? ||
                   image.notes_changed? ||

--- a/app/controllers/occurrences_controller/edit.rb
+++ b/app/controllers/occurrences_controller/edit.rb
@@ -76,7 +76,7 @@ module OccurrencesController::Edit
 
       @occurrence.reassign_thumbnails_from(obs)
       obs.update!(occurrence: nil)
-      Occurrence.log_observation_removed(obs, @occurrence)
+      Occurrence.log_observation_removed(obs, @occurrence, @user)
       recalculate_standalone_consensus(obs)
     end
     @occurrence.reload
@@ -102,10 +102,10 @@ module OccurrencesController::Edit
 
   def add_single_observation(obs)
     if obs.occurrence && obs.occurrence != @occurrence
-      Occurrence.merge!(@occurrence, obs.occurrence)
+      Occurrence.merge!(@occurrence, obs.occurrence, @user)
     else
       obs.update!(occurrence: @occurrence)
-      Occurrence.log_observation_added([obs])
+      Occurrence.log_observation_added([obs], @user)
     end
   end
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -250,6 +250,10 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
 
   has_many :profile_users, class_name: "User"
 
+  # The acting/editing user - attribution for track_copyright_changes'
+  # CopyrightChange record, set by the caller before save.
+  attr_accessor :current_user
+
   belongs_to :user
   belongs_to :license
 
@@ -1133,7 +1137,7 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
                          license_id
                        end
       CopyrightChange.create!(
-        user: User.current,
+        user: current_user,
         updated_at: updated_at,
         target: self,
         year: old_year,
@@ -1267,7 +1271,7 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     validate_upload if upload_handle && new_record?
 
     # I guess this is kind of serious -- uploading with no one logged in??!
-    errors.add(:user, :validate_image_user_missing.t) if !user && !User.current
+    errors.add(:user, :validate_image_user_missing.t) if !user && !current_user
 
     # Try everything in our power to make uploads succeed.  Let the user worry
     # about correcting the date later if need be.

--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -104,7 +104,7 @@ class Naming < AbstractModel
     naming.created_at = now
     naming.updated_at = now
     naming.current_user = observation.current_user
-    naming.user = naming.current_user || User.current
+    naming.user = naming.current_user
     naming.observation = observation
     naming
   end
@@ -272,8 +272,7 @@ class Naming < AbstractModel
   # clear naming.observation -- otherwise it will recalculate the consensus for
   # each deleted naming, and send a bunch of bogus emails.)
   def log_destruction
-    if (@current_user || User.current) &&
-       (obs = observation)
+    if current_user && (obs = observation)
       obs.log(:log_naming_destroyed, name: format_name)
       obs = Observation.naming_includes.find(obs.id) # get a fresh eager-load
       consensus = Observation::NamingConsensus.new(obs)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -158,6 +158,13 @@
 class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   include HasPlaceName
 
+  # The acting/editing user - who's *doing* this (attribution), not who's
+  # looking (see place_name's `user` args). HasPlaceName's `included do`
+  # already declares this same accessor for its own purpose; declared
+  # again here explicitly so attribution doesn't depend on that
+  # unrelated concern staying included.
+  attr_accessor :current_user
+
   # Transient flag: when set, the before_create default that copies the
   # entering user into `collector` is skipped. Field-slip-originated
   # observations set this so a foray recorder is never auto-claimed as
@@ -228,7 +235,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     old_occ = occurrence
     occ = slip.occurrence
     occ ||= Occurrence.create!(
-      user: user || User.current,
+      user: user || current_user,
       primary_observation: self,
       field_slip: slip
     )
@@ -328,16 +335,17 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # never auto-claimed as collector. The caller assigns the resolved
   # field-slip collector to the column afterward; a blank one stays blank
   # (suppressed on the show page). See #4211.
-  def self.build_observation(location, name, notes, date, current_user = nil)
+  def self.build_observation(location, name, notes, date, user = nil)
     return nil unless location
 
     name ||= Name.find_by(text_name: "Fungi")
     now = Time.zone.now
-    user = current_user || User.current
     obs = new({ created_at: now, updated_at: now, source: "mo_website",
                 when: date, user:, location:, name:, notes:,
                 skip_collector_default: true })
     return nil unless obs
+
+    obs.current_user = user
 
     obs.user_log(user, :log_observation_created)
     naming = Naming.user_construct({ name: }, obs, user)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -335,7 +335,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # never auto-claimed as collector. The caller assigns the resolved
   # field-slip collector to the column afterward; a blank one stays blank
   # (suppressed on the show page). See #4211.
-  def self.build_observation(location, name, notes, date, user = nil)
+  def self.build_observation(location, name, notes, date, user)
     return nil unless location
 
     name ||= Name.find_by(text_name: "Fungi")

--- a/app/models/observation/naming_consensus.rb
+++ b/app/models/observation/naming_consensus.rb
@@ -257,6 +257,13 @@ class Observation
     # Returns true if something was changed.
     # Called from outside.
     def change_vote(naming, value, user = naming.current_user)
+      if user.nil?
+        raise(ArgumentError.new(
+                "change_vote needs a user - either pass one explicitly, " \
+                "or set naming.current_user first."
+              ))
+      end
+
       result = false
       vote = users_vote(naming, user)
       value = value.to_f

--- a/app/models/observation/naming_consensus.rb
+++ b/app/models/observation/naming_consensus.rb
@@ -256,7 +256,7 @@ class Observation
     # consensus for the Observation in question if anything is changed.
     # Returns true if something was changed.
     # Called from outside.
-    def change_vote(naming, value, user = User.current)
+    def change_vote(naming, value, user = naming.current_user)
       result = false
       vote = users_vote(naming, user)
       value = value.to_f
@@ -459,6 +459,7 @@ class Observation
     def delete_vote(naming, vote, user)
       return false unless vote
 
+      vote.current_user = user
       naming.votes.delete(vote)
       reload_namings_and_votes!
       find_new_favorite(user) if vote.favorite
@@ -492,12 +493,14 @@ class Observation
         vote.favorite = favorite
         vote.save
       else
-        naming.votes.create!(
+        new_vote = naming.votes.build(
           user: user,
           observation: @observation,
           value: value,
           favorite: favorite
         )
+        new_vote.current_user = user
+        new_vote.save!
       end
     end
 

--- a/app/models/occurrence.rb
+++ b/app/models/occurrence.rb
@@ -87,11 +87,11 @@ class Occurrence < AbstractModel
   # Dissolve the occurrence: detach all non-primary observations.
   # If a field slip is linked, keep the occurrence with just the
   # primary. Otherwise destroy it entirely.
-  def dissolve!
+  def dissolve!(user = nil)
     non_primary = observations.where.not(id: primary_observation_id).to_a
     reset_cross_observation_thumbnails
     dissolve_transaction(non_primary)
-    dissolve_log_and_recalculate(non_primary)
+    dissolve_log_and_recalculate(non_primary, user)
   end
 
   # Reset any thumbnail that points to an image belonging to a
@@ -148,7 +148,7 @@ class Occurrence < AbstractModel
 
   # Merge +absorbed+ occurrence into +keeper+. All observations from
   # +absorbed+ move to +keeper+, then +absorbed+ is destroyed.
-  def self.merge!(keeper, absorbed)
+  def self.merge!(keeper, absorbed, user = nil)
     merged_obs = absorbed.observations.to_a
     transaction do
       merged_obs.each do |obs|
@@ -157,7 +157,7 @@ class Occurrence < AbstractModel
       absorbed.reload.destroy!
       keeper.recompute_has_specimen!
     end
-    log_observation_added(merged_obs)
+    log_observation_added(merged_obs, user)
     keeper
   end
 
@@ -184,9 +184,9 @@ class Occurrence < AbstractModel
   end
 
   # Merge existing occurrences and add remaining observations.
-  def self.merge_into_manual(occurrences, primary_obs, all_obs, _user)
+  def self.merge_into_manual(occurrences, primary_obs, all_obs, user)
     keeper = occurrences.shift
-    occurrences.each { |occ| merge!(keeper, occ) }
+    occurrences.each { |occ| merge!(keeper, occ, user) }
     newly_added = []
     all_obs.each do |obs|
       next if obs.occurrence_id == keeper.id
@@ -194,7 +194,7 @@ class Occurrence < AbstractModel
       obs.update!(occurrence: keeper)
       newly_added << obs
     end
-    log_observation_added(newly_added) if newly_added.any?
+    log_observation_added(newly_added, user) if newly_added.any?
     keeper.update!(primary_observation: primary_obs)
     keeper.recompute_has_specimen!
     keeper
@@ -251,11 +251,11 @@ class Occurrence < AbstractModel
     end
   end
 
-  def dissolve_log_and_recalculate(non_primary)
+  def dissolve_log_and_recalculate(non_primary, user = nil)
     detached = non_primary
     detached += [primary_observation] if field_slip_id.blank?
     detached.each do |obs|
-      Occurrence.log_observation_removed(obs)
+      Occurrence.log_observation_removed(obs, nil, user)
       Observation::NamingConsensus.new(obs).calc_consensus
     end
   end

--- a/app/models/occurrence/logging.rb
+++ b/app/models/occurrence/logging.rb
@@ -72,6 +72,10 @@ module Occurrence::Logging
       occ&.field_slip&.code
     end
 
+    # `user` may be nil (e.g. dissolve! has no caller-supplied actor
+    # today) - OccurrenceChangeMailer's view already handles a nil
+    # `sender` deliberately, attributing the change to the site itself
+    # rather than a person (see Views::Mailers::OccurrenceChangeMailer#intro).
     def notify_observation_owner(obs, action, user)
       owner = obs.user
       return if owner == user || owner.no_emails

--- a/app/models/occurrence/logging.rb
+++ b/app/models/occurrence/logging.rb
@@ -7,24 +7,24 @@ module Occurrence::Logging
 
   class_methods do
     # Log and notify when observations are added to an occurrence.
-    def log_observation_added(obs_list, user = User.current)
+    def log_observation_added(obs_list, user = nil)
       log_obs_event(obs_list, :log_occurrence_added, user)
     end
 
     # Field slip variant — includes field slip code in log entry.
-    def log_field_slip_added(obs_list, user = User.current)
+    def log_field_slip_added(obs_list, user = nil)
       code = field_slip_code_for(obs_list)
       log_obs_event(obs_list, :log_field_slip_added, user,
                     touch_tag: :log_field_slip_updated, name: code)
     end
 
     # Log and notify when an observation is removed.
-    def log_observation_removed(obs, occ = nil, user = User.current)
+    def log_observation_removed(obs, occ = nil, user = nil)
       log_obs_removal(obs, occ, :log_occurrence_removed, user)
     end
 
     # Field slip variant.
-    def log_field_slip_removed(obs, occ = nil, user = User.current)
+    def log_field_slip_removed(obs, occ = nil, user = nil)
       resolved = occ || obs.occurrence
       code = resolved&.field_slip&.code
       log_obs_removal(obs, occ, :log_field_slip_removed, user,

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -134,10 +134,9 @@ class UserStats < ApplicationRecord
         field = get_applicable_field(obj)
         user_id ||= obj&.user_id
       else
-        return unless user_id || User.current_id
+        return unless user_id
 
         field = obj
-        user_id ||= User.current_id
       end
       weight = ALL_FIELDS.key?(field) ? ALL_FIELDS[field.to_sym][:weight] : 0
       return unless weight&.positive? && user_id&.positive?

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -52,6 +52,11 @@ class Vote < AbstractModel
   belongs_to :naming
   belongs_to :observation
 
+  # The acting/editing user - see Naming#current_user for the same
+  # pattern (Vote follows Naming's lead, reading current_user off its
+  # naming instead of taking a separate param).
+  attr_accessor :current_user
+
   # scope :not_by_user, lambda { |user|
   #   user_id = user.is_a?(Integer) ? user : user&.id
   #   where.not(user_id: user_id)
@@ -74,7 +79,8 @@ class Vote < AbstractModel
     vote.assign_attributes(args.permit(:favorite, :value)) if args
     vote.created_at = now
     vote.updated_at = now
-    vote.user = User.current
+    vote.current_user = naming.current_user
+    vote.user = vote.current_user
     vote.naming = naming
     vote.observation = naming.observation
     vote
@@ -283,7 +289,7 @@ class Vote < AbstractModel
   validate :check_requirements
   def check_requirements # :nodoc:
     errors.add(:naming, :validate_vote_naming_missing.t) unless naming
-    errors.add(:user, :validate_vote_user_missing.t) if !user && !User.current
+    errors.add(:user, :validate_vote_user_missing.t) if !user && !current_user
 
     if value.nil?
       errors.add(:value, :validate_vote_value_missing.t)

--- a/test/controllers/images/licenses_controller_test.rb
+++ b/test/controllers/images/licenses_controller_test.rb
@@ -72,6 +72,7 @@ module Images
 
       # This empty string caused it to crash in the wild.
       example_image.reload
+      example_image.current_user = rolf
       example_image.copyright_holder = ""
       example_image.save
       # (note: the above creates a new entry in copyright_changes!!)

--- a/test/controllers/observations/identify_controller_test.rb
+++ b/test/controllers/observations/identify_controller_test.rb
@@ -99,7 +99,7 @@ module Observations
       end
       vote_on_obs = not_confident[with_naming]
       consensus = ::Observation::NamingConsensus.new(vote_on_obs)
-      consensus.change_vote(vote_on_obs.namings.first, 1)
+      consensus.change_vote(vote_on_obs.namings.first, 1, mary)
 
       # q = @controller.q_param(QueryRecord.last.query)
       # get(:index, params: { q: })

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -37,8 +37,6 @@ class ImageTest < UnitTestCase
   end
 
   def test_copyright_logging
-    User.current = mary
-
     license_one = licenses(:ccnc25)
     license_two = licenses(:ccwiki30)
     name_one = "Bobby Singer"
@@ -52,6 +50,7 @@ class ImageTest < UnitTestCase
       license: license_one,
       copyright_holder: name_one
     )
+    img.current_user = mary
     assert_equal(date_one.year, img.when.year)
     assert_equal(license_one, img.license)
     assert_equal(name_one, img.copyright_holder)

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -323,7 +323,6 @@ class ImageTest < UnitTestCase
     assert_not_nil(thumb)
     assert_empty(other_images)
 
-    User.current = thumb.user
     thumb.destroy!
 
     assert_nil(term.reload.thumb_image,
@@ -342,7 +341,6 @@ class ImageTest < UnitTestCase
     thumb_id = thumb.id
     other_image_ids = other_images.map(&:id)
 
-    User.current = thumb.user
     thumb.destroy!
 
     assert_false(term.reload.image_ids.include?(thumb_id),
@@ -358,7 +356,6 @@ class ImageTest < UnitTestCase
     assert_not_nil(thumb)
     assert_empty(other_images)
 
-    User.current = thumb.user
     thumb.destroy!
 
     assert_nil(obs.reload.thumb_image,
@@ -377,7 +374,6 @@ class ImageTest < UnitTestCase
     thumb_id = thumb.id
     other_image_ids = other_images.map(&:id)
 
-    User.current = thumb.user
     thumb.destroy!
 
     assert_false(obs.reload.image_ids.include?(thumb_id),
@@ -389,7 +385,6 @@ class ImageTest < UnitTestCase
   def test_delete_user_profile_image
     assert_not_nil(rolf.image)
 
-    User.current = rolf.image.user
     rolf.image.destroy!
 
     assert_nil(rolf.reload.image_id,
@@ -402,7 +397,6 @@ class ImageTest < UnitTestCase
     assert_not_nil(image)
     image_id = image.id
 
-    User.current = image.user
     image.destroy!
 
     assert_false(project.reload.image_ids.include?(image_id),
@@ -415,7 +409,6 @@ class ImageTest < UnitTestCase
     assert_not_nil(image)
     image_id = image.id
 
-    User.current = image.user
     image.destroy!
 
     assert_false(group.reload.image_ids.include?(image_id),
@@ -427,7 +420,6 @@ class ImageTest < UnitTestCase
     image_id = image.id
     assert_not_empty(ImageVote.where(image_id: image_id))
 
-    User.current = image.user
     image.destroy!
 
     assert_empty(ImageVote.where(image_id: image_id),

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -56,7 +56,6 @@ class ObservationTest < UnitTestCase
 
   def test_destroy
     create_new_objects
-    User.current = rolf
     assert_save(@cc_obs)
     assert_save(@cc_nam)
     @cc_obs.destroy
@@ -532,7 +531,6 @@ class ObservationTest < UnitTestCase
     marys_interest.state = true
     assert_save(marys_interest)
 
-    User.current = rolf
     assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
       observations(:coprinus_comatus_obs).
         notes = "I have new information on this observation."
@@ -544,7 +542,6 @@ class ObservationTest < UnitTestCase
     assert_save(marys_interest)
     dicks_interest.state = true
     assert_save(dicks_interest)
-    User.current = rolf
     assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
       obs.reload.add_image(images(:disconnected_coprinus_comatus_image))
     end
@@ -555,7 +552,6 @@ class ObservationTest < UnitTestCase
     katrinas_interest.state = true
     assert_save(katrinas_interest)
 
-    User.current = rolf
     assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
       obs.reload.destroy
     end
@@ -567,7 +563,6 @@ class ObservationTest < UnitTestCase
     obs = observations(:coprinus_comatus_obs)
     Interest.create(target: obs, user: mary, state: true)
 
-    User.current = rolf
     assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
       obs.update(is_collection_location: !obs.is_collection_location)
     end
@@ -579,7 +574,6 @@ class ObservationTest < UnitTestCase
     @name2 = names(:coprinus_comatus)
     @name3 = names(:conocybe_filaris)
 
-    User.current = rolf
     obs = Observation.create!(
       when: Time.zone.today,
       where: "anywhere",
@@ -588,21 +582,18 @@ class ObservationTest < UnitTestCase
       user: rolf
     )
 
-    User.current = rolf
     namg1 = Naming.create!(
       observation_id: obs.id,
       name_id: @name1.id,
       user: rolf
     )
 
-    User.current = mary
     namg2 = Naming.create!(
       observation_id: obs.id,
       name_id: @name2.id,
       user: mary
     )
 
-    User.current = dick
     namg3 = Naming.create!(
       observation_id: obs.id,
       name_id: @name3.id,
@@ -642,7 +633,6 @@ class ObservationTest < UnitTestCase
     assert_nil(dov)
 
     # Play with Rolf's vote for his naming (first naming).
-    User.current = rolf # necessary for ov creation in naming_consensus
     consensus.change_vote(namg1, 2, rolf)
     namg1.reload
     obs.reload
@@ -720,7 +710,6 @@ class ObservationTest < UnitTestCase
     assert_equal(namg3, consensus.consensus_naming)
 
     # Play with Mary's vote. Make votes:
-    User.current = mary # necessary for ov creation in naming_consensus
     # namg1 Agaricus campestris L.: rolf=1.0, mary=1.0
     # namg2 Coprinus comatus (O.F. Müll.) Pers.: rolf=1.0, mary=2.0(*)
     # namg3 Conocybe filaris: rolf=2.0(*), mary=-1.0
@@ -780,7 +769,6 @@ class ObservationTest < UnitTestCase
   # Test that a "Promising" vote boosts consensus when it's
   # the user's highest vote (no "I'd Call It That" elsewhere).
   def test_consensus_boost_promising_increases_consensus
-    User.current = rolf
     obs = Observation.create!(
       when: Time.zone.today, where: "anywhere",
       name_id: names(:fungi).id, needs_naming: true, user: rolf
@@ -798,7 +786,6 @@ class ObservationTest < UnitTestCase
     cache_with_one_vote = namg.vote_cache
 
     # Mary votes "Promising" (2.0) - should boost, not penalize
-    User.current = mary
     consensus.change_vote(namg, 2, mary)
     obs.reload
     namg.reload
@@ -813,7 +800,6 @@ class ObservationTest < UnitTestCase
   # Test that boost does NOT apply when user has a higher vote
   # on another naming (regular algorithm should penalize).
   def test_consensus_no_boost_when_higher_vote_elsewhere
-    User.current = rolf
     obs = Observation.create!(
       when: Time.zone.today, where: "anywhere",
       name_id: names(:fungi).id, needs_naming: true, user: rolf
@@ -837,7 +823,6 @@ class ObservationTest < UnitTestCase
     # Mary votes "I'd Call It That" on namg2, then
     # "Promising" on namg1. Since her max is 3.0,
     # her "Promising" on namg1 should use regular algorithm.
-    User.current = mary
     consensus.change_vote(namg2, 3, mary)
     consensus.change_vote(namg1, 2, mary)
     obs.reload
@@ -852,7 +837,6 @@ class ObservationTest < UnitTestCase
 
   # Test that "Could Be" also boosts when it's the user's max.
   def test_consensus_boost_could_be
-    User.current = rolf
     obs = Observation.create!(
       when: Time.zone.today, where: "anywhere",
       name_id: names(:fungi).id, needs_naming: true, user: rolf
@@ -870,7 +854,6 @@ class ObservationTest < UnitTestCase
     cache_before = namg.vote_cache
 
     # Mary votes "Could Be" (1.0) as her only vote
-    User.current = mary
     consensus.change_vote(namg, 1, mary)
     obs.reload
     namg.reload
@@ -885,7 +868,6 @@ class ObservationTest < UnitTestCase
   # vote "Could Be" on another name, only "Promising" gets
   # the boost - "Could Be" uses regular algorithm.
   def test_consensus_boost_only_applies_to_max_vote
-    User.current = rolf
     obs = Observation.create!(
       when: Time.zone.today, where: "anywhere",
       name_id: names(:fungi).id, needs_naming: true, user: rolf
@@ -909,7 +891,6 @@ class ObservationTest < UnitTestCase
 
     # Mary votes "Promising" on namg1 (boosted), and
     # "Could Be" on namg2 (regular - not her max).
-    User.current = mary
     consensus.change_vote(namg1, 2, mary)
     consensus.change_vote(namg2, 1, mary)
     obs.reload
@@ -927,7 +908,6 @@ class ObservationTest < UnitTestCase
   # Test that a single "Promising" vote with no higher vote
   # on the naming uses the regular algorithm (no boost).
   def test_consensus_no_boost_without_higher_vote_on_naming
-    User.current = mary
     obs = Observation.create!(
       when: Time.zone.today, where: "anywhere",
       name_id: names(:fungi).id, needs_naming: true, user: mary
@@ -954,7 +934,6 @@ class ObservationTest < UnitTestCase
 
   # Test that negative-only voters use regular algorithm.
   def test_consensus_no_boost_for_negative_only_voter
-    User.current = rolf
     obs = Observation.create!(
       when: Time.zone.today, where: "anywhere",
       name_id: names(:fungi).id, needs_naming: true, user: rolf
@@ -972,7 +951,6 @@ class ObservationTest < UnitTestCase
     cache_before = namg.vote_cache
 
     # Mary votes "Doubtful" (-1.0) - negative vote, no boost
-    User.current = mary
     consensus.change_vote(namg, -1, mary)
     obs.reload
     namg.reload
@@ -1160,7 +1138,6 @@ class ObservationTest < UnitTestCase
 
   # nil notes were seen in the wild
   def test_notes_nil
-    User.current = mary
     obs = Observation.create!(name_id: names(:fungi).id, when_str: "2020-07-05",
                               notes: nil, user: mary)
 
@@ -1175,7 +1152,6 @@ class ObservationTest < UnitTestCase
 
   # empty string notes were seen in the wild
   def test_notes_empty_string
-    User.current = mary
     obs = Observation.create!(name_id: names(:fungi).id,
                               when_str: "2020-07-05", notes: "",
                               user: mary)
@@ -1239,7 +1215,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_future_date
-    User.current = mary
     fungi = names(:fungi)
     exception = assert_raise(ActiveRecord::RecordInvalid) do
       Observation.create!(name_id: fungi.id, when: Time.zone.today + 2.days,
@@ -1249,7 +1224,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_future_time
-    User.current = mary
     fungi = names(:fungi)
     exception = assert_raise(ActiveRecord::RecordInvalid) do
       # Note that 'when' gets automagically converted to Date
@@ -1260,7 +1234,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_invalid_year
-    User.current = mary
     fungi = names(:fungi)
     exception = assert_raise(ActiveRecord::RecordInvalid) do
       Observation.create!(name_id: fungi.id, when: Date.new(1499, 1, 1),
@@ -1270,7 +1243,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_where_too_long
-    User.current = mary
     fungi = names(:fungi)
     exception = assert_raise(ActiveRecord::RecordInvalid) do
       Observation.create!(name_id: fungi.id, where: "X" * 1025,
@@ -1280,7 +1252,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_where_no_latitude
-    User.current = mary
     fungi = names(:fungi)
     exception = assert_raise(ActiveRecord::RecordInvalid) do
       Observation.create!(name_id: fungi.id, lng: 90.0, user: mary)
@@ -1289,7 +1260,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_where_no_longitude
-    User.current = mary
     fungi = names(:fungi)
     exception = assert_raise(ActiveRecord::RecordInvalid) do
       Observation.create!(name_id: fungi.id, lat: 90.0, user: mary)
@@ -1298,7 +1268,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_where_bad_altitude
-    User.current = mary
     fungi = names(:fungi)
     # Currently all strings are parsable as altitude
     assert_nothing_raised do
@@ -1308,7 +1277,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_with_valid_when_str
-    User.current = mary
     fungi = names(:fungi)
     assert_nothing_raised do
       Observation.create!(name_id: fungi.id, when_str: "2020-07-05",
@@ -1317,7 +1285,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_with_invalid_when_str_date
-    User.current = mary
     fungi = names(:fungi)
     exception = assert_raise(ActiveRecord::RecordInvalid) do
       Observation.create!(name_id: fungi.id, when_str: "0000-00-00",
@@ -1327,7 +1294,6 @@ class ObservationTest < UnitTestCase
   end
 
   def test_check_requirements_with_invalid_when_str
-    User.current = mary
     fungi = names(:fungi)
     exception = assert_raise(ActiveRecord::RecordInvalid) do
       Observation.create!(name_id: fungi.id, when_str: "This is not a date",

--- a/test/models/occurrence_test.rb
+++ b/test/models/occurrence_test.rb
@@ -14,7 +14,6 @@ class OccurrenceTest < UnitTestCase
     [@obs1, @obs2, @obs3, @obs4].each do |obs|
       obs.update_column(:occurrence_id, nil)
     end
-    User.current = rolf
   end
 
   def test_create_occurrence
@@ -488,7 +487,6 @@ class OccurrenceTest < UnitTestCase
   # == Phase 10: Logging and Notifications ==
 
   def test_create_manual_logs_observations
-    User.current = rolf
     all_obs = [@obs1, @obs2]
     occ = Occurrence.create_manual(@obs1, all_obs, rolf)
 
@@ -502,7 +500,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_create_manual_notifies_other_owner
-    User.current = rolf
     # obs3 is owned by mary, not rolf
     all_obs = [@obs1, @obs3]
     assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
@@ -511,7 +508,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_log_observation_removed
-    User.current = rolf
     create_occurrence(@obs1, @obs2, @obs3)
     Occurrence.log_observation_removed(@obs3)
     @obs3.reload
@@ -522,7 +518,6 @@ class OccurrenceTest < UnitTestCase
   # == Coverage: dissolve! ==
 
   def test_dissolve_with_field_slip_keeps_occurrence
-    User.current = rolf
     fs = field_slips(:field_slip_no_obs)
     occ = create_occurrence(@obs1, @obs2, @obs3)
     occ.update!(field_slip: fs)
@@ -540,7 +535,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_dissolve_without_field_slip_destroys
-    User.current = rolf
     occ = create_occurrence(@obs1, @obs2, @obs3)
 
     occ.dissolve!
@@ -553,7 +547,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_dissolve_logs_removed_observations
-    User.current = rolf
     occ = create_occurrence(@obs1, @obs2)
 
     occ.dissolve!
@@ -567,7 +560,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_dissolve_with_field_slip_logs_only_non_primary
-    User.current = rolf
     fs = field_slips(:field_slip_no_obs)
     occ = create_occurrence(@obs1, @obs2)
     occ.update!(field_slip: fs)
@@ -587,7 +579,6 @@ class OccurrenceTest < UnitTestCase
   # == Coverage: refresh_has_specimen_cache ==
 
   def test_refresh_has_specimen_cache_dry_run
-    User.current = rolf
     occ = create_occurrence(@obs1, @obs2)
     @obs1.update!(specimen: true)
     # Force incorrect cached value
@@ -603,7 +594,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_refresh_has_specimen_cache_fixes_mismatch
-    User.current = rolf
     occ = create_occurrence(@obs1, @obs2)
     @obs1.update!(specimen: true)
     occ.update_column(:has_specimen, false)
@@ -616,7 +606,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_refresh_has_specimen_cache_no_change_needed
-    User.current = rolf
     occ = create_occurrence(@obs1, @obs2)
     @obs1.update!(specimen: false)
     @obs2.update!(specimen: false)
@@ -633,7 +622,6 @@ class OccurrenceTest < UnitTestCase
   # == Coverage: check_multiple_occurrences! ==
 
   def test_check_multiple_occurrences_passes_with_one
-    User.current = rolf
     occ = create_occurrence(@obs1, @obs2)
     # Should not raise
     Occurrence.check_multiple_occurrences!([occ])
@@ -644,7 +632,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_check_multiple_occurrences_raises_with_two
-    User.current = rolf
     occ1 = create_occurrence(@obs1, @obs2)
     occ2 = create_occurrence(@obs3, @obs4)
 
@@ -657,7 +644,6 @@ class OccurrenceTest < UnitTestCase
   # == Coverage: merge_into_manual ==
 
   def test_merge_into_manual_with_additional_obs
-    User.current = rolf
     occ = create_occurrence(@obs1, @obs2)
     all = [@obs1, @obs2, @obs3, @obs4]
     result = Occurrence.create_manual(@obs3, all, rolf)
@@ -672,7 +658,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_merge_into_manual_two_existing_occurrences
-    User.current = rolf
     occ1 = create_occurrence(@obs1, @obs2)
     occ2 = create_occurrence(@obs3, @obs4)
     all = [@obs1, @obs2, @obs3, @obs4]
@@ -1010,7 +995,6 @@ class OccurrenceTest < UnitTestCase
   # == Coverage: observation_count_within_limits (289-290) ==
 
   def test_observation_count_within_limits_validation
-    User.current = rolf
     occ = create_occurrence(@obs1, @obs2)
     # Attach more observations to exceed limit
     extras = Observation.where.not(
@@ -1027,7 +1011,6 @@ class OccurrenceTest < UnitTestCase
   # == Coverage: dissolve_transaction field_slip branch ==
 
   def test_dissolve_field_slip_reloads_and_keeps_occ
-    User.current = rolf
     fs = field_slips(:field_slip_no_obs)
     occ = create_occurrence(@obs1, @obs2, @obs3)
     occ.update!(field_slip: fs)
@@ -1044,7 +1027,6 @@ class OccurrenceTest < UnitTestCase
   # == Coverage: dissolve_log_and_recalculate (306-310) ==
 
   def test_dissolve_recalculates_consensus_for_detached
-    User.current = rolf
     # Create occurrence first, then add a naming
     occ = create_occurrence(@obs1, @obs2)
     name = names(:agaricus_campestris)
@@ -1070,7 +1052,6 @@ class OccurrenceTest < UnitTestCase
   end
 
   def test_dissolve_without_field_slip_logs_all
-    User.current = rolf
     occ = create_occurrence(@obs1, @obs2, @obs3)
     clear_logs(@obs1, @obs2, @obs3)
 


### PR DESCRIPTION
## Summary

Continues the `User.current` removal sweep (Name/NameDescription/Location/LocationDescription/Description/Interest already done in #4693) for the five remaining models: Observation, Occurrence, Naming, Vote, Image. Scoped to **actor attribution only** ("who did this") — each of these models also has separate viewer-aware display-formatting reads of `User.current` (`Observation#format_name`, `Image#users_vote`, `NamingConsensus#calc_consensus`'s display string, etc.) that are a different concern, left alone here as a follow-up.

None of these five models are `acts_as_versioned`, so `VersionedByCurrentUser` (built for Name/Location) doesn't apply — this is a simpler `attr_accessor :current_user` pattern per model instead.

## Key mechanism already in place

`AbstractModel#set_user_and_autolog` (`before_create`) and `UserStats.update_contribution`'s object-mode branch both already prefer a model's own `current_user` accessor over the global, if the model responds to it. So for most of these models, adding `attr_accessor :current_user` and having callers set it before save was enough — no changes needed to those two generic hooks.

`UserStats.update_contribution`'s *field-mode* branch (passed a Symbol like `:location_versions` instead of an AR instance) still had a `User.current_id` fallback. Every real caller already passes an explicit `user_id`, so that fallback was dead — removed.

## Per-model changes

- **Naming** — already had `current_user`; just dropped two `|| User.current` fallbacks that were dead once callers were fixed. Surfaced two controller gaps where `current_user` was never set on an *existing* naming/observation at all (`Observations::NamingsController#update`/`#destroy` re-fetch after `init_ivars`, clobbering it).
- **Observation** — added an explicit `current_user` accessor (previously only a side effect of including `HasPlaceName`, meant for `place_name=`), dropped dead fallbacks in `field_slip=` and `self.build_observation`.
- **Occurrence** — `Occurrence::Logging`'s four methods (`log_observation_added`/`log_field_slip_added`/`log_observation_removed`/`log_field_slip_removed`) default to `user = nil` instead of the global; threaded an explicit user through every real call site (`Occurrence.merge!`/`merge_into_manual` had an already-passed-but-silently-unused `_user` param, now wired up).
- **Vote** — new `current_user` accessor, following Naming's pattern (`Vote.construct` reads it off `naming.current_user`). `NamingConsensus#change_vote` defaults its `user` param to `naming.current_user` instead of `User.current`; `process_real_vote`/`delete_vote` thread `current_user` onto the vote before save/destroy.
- **Image** — new `current_user` accessor, attributing the `CopyrightChange` record that `track_copyright_changes` (`after_update`) creates when year/license/copyright_holder change. Set at the two real update paths that trigger it (`Observations::ImagesController#update`, `shared_form_methods.rb`'s inline edit of already-uploaded images) — new-image upload flows never hit this, since `after_update` doesn't fire on create.

Both Vote and Image also had a `!user && !User.current` validation-guard pattern, swapped for `!user && !current_user`.

## Test cleanup

`test/models/{observation,occurrence,image}_test.rb` had 49/19/8 `User.current = someone` setup lines respectively — almost all dead ambient state left over from before these models stopped reading the global (every real save/vote/destroy in those spots already passes an explicit `user`). Verified empirically per file: stripped every `User.current = ` line, ran the suite, and only restored the handful that were genuinely load-bearing for reasons *outside* this sweep's scope (`Comment`'s own still-global-reading attribution in the email-notification tests, `Observation#update_view_stats`'s out-of-scope default param, `NamingConsensus#calc_consensus`'s out-of-scope viewer-formatting read). This also resolved two "necessary for ov creation in naming_consensus" comments on lines that, it turns out, weren't.

## Bugs found and fixed via full-suite runs (not caught by narrow test runs)

- `Observations::NamingsController#update`/`#destroy` re-fetch `@observation`/`@naming` after `init_ivars` already set `current_user`, silently clobbering it — added explicit assignment after each re-fetch.
- `test_identify_observations_index` calls `change_vote` directly on a Naming loaded independently (not built via `Naming.construct` in the same flow, so no `current_user`) with no explicit user — crashed in `mark_obs_reviewed`. Real controller call sites all pass an explicit user already; only this test's direct JS-flow simulation needed one added.
- `Images::LicensesControllerTest#test_update_licenses`: a direct `image.copyright_holder = ""; image.save` (not the bulk `update_all` path used elsewhere in that controller, which never triggers `after_update`) hit `track_copyright_changes` with no `current_user` set. `CopyrightChange.create!`'s own user-presence validation failed inside the callback and silently rolled back the whole save — the next step of the test then found no image matching the (never-actually-blanked) old copyright_holder, so nothing got updated.

## Test plan

- [x] `bundle exec rubocop` clean on every touched file
- [x] `bin/rails test` — full suite, 7187 tests, 0 failures, 0 errors
- [x] Targeted runs of `test/models/{observation,occurrence,naming,vote,image,user_stats}_test.rb`, the relevant controller tests, and `test/classes/api2/` along the way, to isolate each change before the final full run
