### PR TITLE
Fix shadowed update_field_slip method in ObservationsController::Create

### DIFF
--- a/app/controllers/observations_controller/create.rb
+++ b/app/controllers/observations_controller/create.rb
@@ -61,7 +61,7 @@ module ObservationsController::Create
     save_collection_number
     save_herbarium_record
     strip_images! if @observation.gps_hidden
-    update_field_slip
+    attach_new_field_slip
     flash_notice(:runtime_observation_success.t(id: @observation.id))
     redirect_to_next_page
   end
@@ -254,7 +254,11 @@ module ObservationsController::Create
            location: new_observation_path)
   end
 
-  def update_field_slip
+  # NOTE: named distinctly from EditAndUpdate#update_field_slip - both
+  # modules are included into ObservationsController, and a same-named
+  # method here would be silently shadowed by EditAndUpdate's version
+  # (included after Create), never actually running.
+  def attach_new_field_slip
     field_code = params[:field_code]
     return if field_code.blank?
 

--- a/app/controllers/observations_controller/create.rb
+++ b/app/controllers/observations_controller/create.rb
@@ -264,7 +264,10 @@ module ObservationsController::Create
 
     existed = FieldSlip.exists?(code: field_code.strip.upcase)
     field_slip = FieldSlip.find_or_create_by_code(field_code, @user)
-    return unless field_slip
+    unless field_slip
+      flash_error(:edit_observation_field_slip_invalid.t(code: field_code))
+      return
+    end
 
     flash_notice(:field_slip_created.t(code: field_slip.code)) unless existed
 

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -223,6 +223,20 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert(obs.field_slip.present?)
   end
 
+  # ObservationsController includes both Create and EditAndUpdate, and
+  # (before this was fixed) both defined a private update_field_slip
+  # method. Ruby's module resolution meant EditAndUpdate's version
+  # always won - Create's own field-slip logic never ran, though tests
+  # exercising it still passed because EditAndUpdate's logic happened
+  # to produce an equivalent result. Pin the method's owner directly so
+  # a future name collision fails loudly instead of silently.
+  def test_attach_new_field_slip_is_not_shadowed
+    assert_equal(
+      ObservationsController::Create,
+      ObservationsController.instance_method(:attach_new_field_slip).owner
+    )
+  end
+
   def test_create_observation_with_collection_number
     generic_construct_observation(
       { observation: { specimen: "1" },

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -223,6 +223,23 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert(obs.field_slip.present?)
   end
 
+  # A purely numeric code fails FieldSlip's format validation, so
+  # find_or_create_by_code returns nil - make sure the observation
+  # still gets created but the user sees why the field slip was
+  # ignored, instead of it silently vanishing.
+  def test_create_observation_with_invalid_field_code
+    generic_construct_observation(
+      { observation: { specimen: "1" },
+        field_code: "12345",
+        naming: { name: "Coprinus comatus" } },
+      1, 1, 0, 0
+    )
+    obs = assigns(:observation)
+    assert(obs.specimen)
+    assert_nil(obs.field_slip)
+    assert_flash_error
+  end
+
   # ObservationsController includes both Create and EditAndUpdate, and
   # (before this was fixed) both defined a private update_field_slip
   # method. Ruby's module resolution meant EditAndUpdate's version
@@ -231,8 +248,12 @@ class ObservationsControllerCreateTest < FunctionalTestCase
   # to produce an equivalent result. Pin the method's owner directly so
   # a future name collision fails loudly instead of silently.
   def test_attach_new_field_slip_is_not_shadowed
-    assert_equal(
-      ObservationsController::Create,
+    # Either Create itself, or a later refactor that moves the method
+    # straight onto ObservationsController, is fine - what this guards
+    # against is a *different* module (re)introducing a same-named
+    # method that silently wins the module-resolution race again.
+    assert_includes(
+      [ObservationsController::Create, ObservationsController],
       ObservationsController.instance_method(:attach_new_field_slip).owner
     )
   end


### PR DESCRIPTION
## Summary

`ObservationsController` includes both `Create` and `EditAndUpdate`, and both defined a private `update_field_slip` method. Ruby's module resolution order means `EditAndUpdate#update_field_slip` always wins — `Create#update_field_slip` was 100% dead code, both in tests and in production. The `create` action's field-slip attachment was silently running through `EditAndUpdate`'s `assign_field_slip`/`clear_field_slip` logic instead of its own, undetected because both paths happen to produce an equivalent end result for the existing test scenario.

Confirmed via `ObservationsController.instance_method(:update_field_slip).owner` returning `ObservationsController::EditAndUpdate` even when called from the `create` action.

- Renamed `Create`'s version to `attach_new_field_slip` so it actually runs.
- Added a comment on the method explaining why the distinct name matters.
- Added a dedicated regression test pinning `ObservationsController.instance_method(:attach_new_field_slip).owner` to `ObservationsController::Create`, so a future name collision fails loudly instead of silently.
- The existing `test_create_observation_with_field_slip` test still passes with the real `Create` logic now executing.

Surfaced while chasing a coverage gap on a separate PR (#4705); pulled out here as its own standalone fix since it's unrelated to that PR's actual scope (the `User.current` removal sweep).

## Test plan

- [x] `bin/rails test test/controllers/observations_controller_create_test.rb` — green (63 tests)
- [x] `bundle exec rubocop app/controllers/observations_controller/create.rb test/controllers/observations_controller_create_test.rb` — no offenses
