### PR TITLE
DRY up observation field-slip handling; fix invalid-code path on create

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -6,6 +6,7 @@ class ObservationsController < ApplicationController
   include New
   include Create
   include EditAndUpdate
+  include FieldSlips
   include Destroy
 
   # Disable cop: all these methods are defined in files included above.

--- a/app/controllers/observations_controller/create.rb
+++ b/app/controllers/observations_controller/create.rb
@@ -61,7 +61,7 @@ module ObservationsController::Create
     save_collection_number
     save_herbarium_record
     strip_images! if @observation.gps_hidden
-    update_field_slip
+    update_field_slip_or_warn
     flash_notice(:runtime_observation_success.t(id: @observation.id))
     redirect_to_next_page
   end
@@ -259,23 +259,12 @@ module ObservationsController::Create
            location: new_observation_path)
   end
 
-  def update_field_slip
-    field_code = params[:field_code]
-    return if field_code.blank?
+  # The observation is already saved by the time the field slip is applied,
+  # so an invalid code can't abort creation — warn and keep the observation.
+  def update_field_slip_or_warn
+    return unless update_field_slip == :invalid
 
-    existed = FieldSlip.exists?(code: field_code.strip.upcase)
-    field_slip = FieldSlip.find_or_create_by_code(field_code, @user)
-    return unless field_slip
-
-    flash_notice(:field_slip_created.t(code: field_slip.code)) unless existed
-
-    occ = field_slip.occurrence
-    occ ||= Occurrence.create!(
-      user: @user, primary_observation: @observation,
-      field_slip: field_slip
-    )
-    @observation.update!(occurrence: occ)
-    field_slip.adopt_user_from(@observation)
+    flash_warning(:create_observation_field_slip_invalid.t(code: field_code))
   end
 
   def init_location_var_for_reload

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -83,7 +83,7 @@ module ObservationsController::EditAndUpdate
     apply_observation_changes
     reload_edit_form and return if @any_errors
 
-    update_field_slip
+    update_field_slip_or_flag_error
     reload_edit_form and return if @any_errors
 
     update_projects
@@ -201,50 +201,13 @@ module ObservationsController::EditAndUpdate
     end
   end
 
-  def update_field_slip
-    return unless params.key?(:field_code)
+  # On edit, an invalid field-slip code halts the save and re-renders the
+  # form so the user can correct it.
+  def update_field_slip_or_flag_error
+    return unless update_field_slip == :invalid
 
-    new_code = params[:field_code].to_s.strip.upcase
-    current_code = @observation.field_slip&.code.to_s
-
-    return if new_code == current_code
-
-    if new_code.blank?
-      clear_field_slip
-    else
-      assign_field_slip(new_code)
-    end
-  end
-
-  def clear_field_slip
-    occ = @observation.occurrence
-    return unless occ
-
-    if occ.primary_observation_id == @observation.id
-      @observation.send(:reassign_occurrence_primary, occ)
-    end
-    @observation.update!(occurrence: nil)
-    return unless Occurrence.exists?(occ.id)
-
-    occ.reload
-    occ.destroy_if_incomplete!
-  end
-
-  def assign_field_slip(code)
-    existed = FieldSlip.exists?(code: code)
-    field_slip = FieldSlip.find_or_create_by_code(code, @user)
-    unless field_slip
-      flash_error(
-        :edit_observation_field_slip_invalid.t(code: code)
-      )
-      @any_errors = true
-      return
-    end
-
-    flash_notice(:field_slip_created.t(code: field_slip.code)) unless existed
-    @observation.field_slip = field_slip
-    @observation.save!
-    field_slip.adopt_user_from(@observation)
+    flash_error(:edit_observation_field_slip_invalid.t(code: field_code))
+    @any_errors = true
   end
 
   def reload_edit_form

--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Shared field-slip handling for the observation create and update actions.
+#
+# `update_field_slip` applies the `params[:field_code]` change to
+# `@observation` and returns a status (:unchanged / :cleared / :assigned /
+# :invalid). It deliberately does NOT flash errors or set `@any_errors` —
+# create and update surface an invalid code differently: create warns and
+# continues (the observation is already saved by the time this runs), while
+# update flags `@any_errors` and re-renders the edit form so the user can
+# fix the code.
+module ObservationsController::FieldSlips
+  private
+
+  # The submitted field-slip code, normalized. Used both to apply the change
+  # and to build the caller's invalid-code message.
+  def field_code
+    params[:field_code].to_s.strip.upcase
+  end
+
+  def update_field_slip
+    return :unchanged unless params.key?(:field_code)
+
+    code = field_code
+    return :unchanged if code == @observation.field_slip&.code.to_s
+
+    code.blank? ? clear_field_slip : assign_field_slip(code)
+  end
+
+  def clear_field_slip
+    occ = @observation.occurrence
+    return :cleared unless occ
+
+    if occ.primary_observation_id == @observation.id
+      @observation.send(:reassign_occurrence_primary, occ)
+    end
+    @observation.update!(occurrence: nil)
+    if Occurrence.exists?(occ.id)
+      occ.reload
+      occ.destroy_if_incomplete!
+    end
+    :cleared
+  end
+
+  # Creates/reuses the field slip and links it to @observation via an
+  # occurrence (Observation#field_slip= creates the occurrence). Returns
+  # :invalid when the code fails FieldSlip validation.
+  def assign_field_slip(code)
+    existed = FieldSlip.exists?(code: code)
+    field_slip = FieldSlip.find_or_create_by_code(code, @user)
+    return :invalid unless field_slip
+
+    flash_notice(:field_slip_created.t(code: field_slip.code)) unless existed
+    @observation.field_slip = field_slip
+    @observation.save!
+    field_slip.adopt_user_from(@observation)
+    :assigned
+  end
+end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1847,6 +1847,7 @@
   form_observations_field_code: for field slip
   form_observations_field_slip_code: Field Slip Code
   edit_observation_field_slip_invalid: 'Invalid field slip code "[code]".'
+  create_observation_field_slip_invalid: 'Observation created, but the field slip code "[code]" was invalid and was not attached.'
   form_observations_specimen_available: Specimen Available
   form_observations_is_collection_location: Is this location where it was collected?
   form_observations_gps_hidden: Hide exact coordinates?

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -223,6 +223,22 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert(obs.field_slip.present?)
   end
 
+  # An invalid field-slip code cannot abort creation (the observation is
+  # already saved); it warns and keeps the observation without a field slip.
+  def test_create_observation_with_invalid_field_slip
+    generic_construct_observation(
+      { observation: { specimen: "1" },
+        field_code: "12345", # digits-only fails FieldSlip validation
+        naming: { name: "Coprinus comatus" } },
+      1, 1, 0, 0
+    )
+    obs = assigns(:observation)
+
+    assert_nil(obs.field_slip, "Invalid code must not attach a field slip")
+    assert_nil(obs.occurrence, "Invalid code must not create an occurrence")
+    assert_flash_warning
+  end
+
   def test_create_observation_with_collection_number
     generic_construct_observation(
       { observation: { specimen: "1" },

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -239,6 +239,18 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert_flash_warning
   end
 
+  # update_field_slip lives in the shared FieldSlips concern. It used to be
+  # defined in both Create and EditAndUpdate, where the later include
+  # silently shadowed the other. Pin the owner so a same-named method
+  # (re)introduced in another included module fails loudly here instead of
+  # quietly winning the module-resolution race again.
+  def test_update_field_slip_is_not_shadowed
+    assert_equal(
+      ObservationsController::FieldSlips,
+      ObservationsController.instance_method(:update_field_slip).owner
+    )
+  end
+
   def test_create_observation_with_collection_number
     generic_construct_observation(
       { observation: { specimen: "1" },


### PR DESCRIPTION
## Problem

`update_field_slip` was defined in **both** `ObservationsController::Create` and `ObservationsController::EditAndUpdate`. The controller does `include Create` then `include EditAndUpdate`, so Ruby resolved `update_field_slip` to the EditAndUpdate version — the `create.rb` copy was dead, and the `create` action silently ran edit semantics.

That's harmless on the happy path (both versions create the occurrence, since `Observation#field_slip=` does), but the **invalid-code path** was broken in create. The edit version's `assign_field_slip` sets `@any_errors = true` and flashes an edit-namespaced error. In the `update` action there's an `@any_errors` check immediately after `update_field_slip`, so that works. In the `create` action the only `@any_errors` check happens *before* `update_field_slip` runs, so on an invalid code create would:

- set `@any_errors` — a dead assignment, never checked;
- flash `:edit_observation_field_slip_invalid` — an edit message shown during create;
- then flash `:runtime_observation_success` and redirect anyway.

Net: a contradictory error + success flash pair, the code silently dropped, and no chance to fix it.

## Change

Move the shared logic into a new `ObservationsController::FieldSlips` concern. `update_field_slip` now **returns a status** (`:unchanged` / `:cleared` / `:assigned` / `:invalid`) and does no flashing or `@any_errors` — each action surfaces `:invalid` in the way that fits it:

- **update** — re-renders the edit form with an error so the user can correct the code (behavior unchanged; `test_update_invalid_field_slip_code` still passes).
- **create** — the observation is already saved by the time the field slip is applied, so an invalid code can't abort creation. It flashes a create-specific warning (`create_observation_field_slip_invalid`, "Observation created, but the field slip code … was invalid and was not attached") and keeps the observation without a field slip. No more contradictory error+success.

The dead `Create#update_field_slip` is deleted, and `update_field_slip` now resolves to a single definition — no more shadowing.

## Not addressed here

This is orthogonal to the orphaned-field-slip observation from the same investigation. On the normal path both flows create the occurrence correctly, so the shadowing was not the orphan cause; the orphans trace to the field-slip entry flow (`FieldSlipsController#create` saving a bare slip and redirecting to the new-observation form, which can be abandoned). That's a separate change if we decide to act on it.

## Tests

- `test/controllers/observations_controller_create_test.rb` — new `test_create_observation_with_invalid_field_slip`: obs created, no field slip, no occurrence, flash warning.
- Existing create/update field-slip tests unchanged and green: `bin/rails test test/controllers/observations_controller_create_test.rb test/controllers/observations_controller_update_test.rb` → 84 tests, 0 failures.
- Rubocop clean; method resolution verified to be the single `FieldSlips` definition.

## Adopted from #4710

@nimmolo's #4710 tackles the same shadowing by *renaming* `Create#update_field_slip` to `attach_new_field_slip` so it un-shadows. The one idea worth keeping from it is a **regression test pinning the method's owner**, so a future same-named method in another included module fails loudly rather than silently winning module resolution. Added here as `test_update_field_slip_is_not_shadowed` (asserting the owner is the `FieldSlips` concern).
