### PR TITLE
Defer field-slip creation in the add-images flow (prevent orphans)

### DIFF
--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -44,11 +44,14 @@ class FieldSlipsController < ApplicationController
 
   # POST /field_slips or /field_slips.json
   def create
+    @field_slip = FieldSlip.new(field_slip_params)
+    @field_slip.current_user = @user
+    @field_slip.update_project
+    check_project_membership
+
+    return create_deferred_for_add_images if adding_images?
+
     respond_to do |format|
-      @field_slip = FieldSlip.new(field_slip_params)
-      @field_slip.current_user = @user
-      @field_slip.update_project
-      check_project_membership
       if check_last_obs && @field_slip.save
         format.html do
           html_create
@@ -61,6 +64,29 @@ class FieldSlipsController < ApplicationController
         end
       end
     end
+  end
+
+  def adding_images?
+    params[:commit] == :field_slip_add_images.t
+  end
+
+  # "Add images" defers field-slip creation: redirect to the observation
+  # form carrying the code, and stop. observations#create creates the slip —
+  # with its project (from the code prefix) and its occurrence — only when
+  # the observation is saved, so abandoning the form leaves no orphan slip.
+  # An invalid code is rejected here rather than after the whole obs form.
+  def create_deferred_for_add_images
+    return render_new_phlex(status: :unprocessable_content) unless
+      @field_slip.valid?
+
+    redirect_to(new_observation_url(
+                  field_code: @field_slip.code,
+                  place_name: place_name,
+                  date: extract_date,
+                  notes: field_slip_notes.compact_blank!,
+                  species_list: params[:species_list],
+                  collector: field_slip_collector_string
+                ))
   end
 
   # PATCH/PUT /field_slips/1 or /field_slips/1.json
@@ -181,15 +207,6 @@ class FieldSlipsController < ApplicationController
   def html_create
     if params[:commit] == :field_slip_quick_create_obs.t
       quick_create_observation
-    elsif params[:commit] == :field_slip_add_images.t
-      redirect_to(new_observation_url(
-                    field_code: @field_slip.code,
-                    place_name: place_name,
-                    date: extract_date,
-                    notes: field_slip_notes.compact_blank!,
-                    species_list: params[:species_list],
-                    collector: field_slip_collector_string
-                  ))
     else
       attach_selected_observations
       update_observation_fields

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -66,29 +66,6 @@ class FieldSlipsController < ApplicationController
     end
   end
 
-  def adding_images?
-    params[:commit] == :field_slip_add_images.t
-  end
-
-  # "Add images" defers field-slip creation: redirect to the observation
-  # form carrying the code, and stop. observations#create creates the slip —
-  # with its project (from the code prefix) and its occurrence — only when
-  # the observation is saved, so abandoning the form leaves no orphan slip.
-  # An invalid code is rejected here rather than after the whole obs form.
-  def create_deferred_for_add_images
-    return render_new_phlex(status: :unprocessable_content) unless
-      @field_slip.valid?
-
-    redirect_to(new_observation_url(
-                  field_code: @field_slip.code,
-                  place_name: place_name,
-                  date: extract_date,
-                  notes: field_slip_notes.compact_blank!,
-                  species_list: params[:species_list],
-                  collector: field_slip_collector_string
-                ))
-  end
-
   # PATCH/PUT /field_slips/1 or /field_slips/1.json
   def update
     respond_to do |format|
@@ -118,6 +95,29 @@ class FieldSlipsController < ApplicationController
   end
 
   private
+
+  def adding_images?
+    params[:commit] == :field_slip_add_images.t
+  end
+
+  # "Add images" defers field-slip creation: redirect to the observation
+  # form carrying the code, and stop. observations#create creates the slip —
+  # with its project (from the code prefix) and its occurrence — only when
+  # the observation is saved, so abandoning the form leaves no orphan slip.
+  # An invalid code is rejected here rather than after the whole obs form.
+  def create_deferred_for_add_images
+    return render_new_phlex(status: :unprocessable_content) unless
+      @field_slip.valid?
+
+    redirect_to(new_observation_url(
+                  field_code: @field_slip.code,
+                  place_name: place_name,
+                  date: extract_date,
+                  notes: field_slip_notes.compact_blank!,
+                  species_list: params[:species_list],
+                  collector: field_slip_collector_string
+                ))
+  end
 
   def render_new_phlex(**render_opts)
     # The `:new` action populates these; the `:create` validation-

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -36,12 +36,12 @@ class FieldSlip < AbstractModel
 
     slip = new
     slip.current_user = user
+    # `code=` derives the project from the code prefix (e.g. "RINHS-00108"
+    # -> the RINHS project); current_user is set first so that lookup can
+    # check membership. This is what makes a lazily-created slip — one built
+    # when an observation with a field_code is saved, rather than up front
+    # in the field-slip form — still land in its project.
     slip.code = code
-    # Derive the project from the code prefix (e.g. "RINHS-00108" ->
-    # the RINHS project). This is what FieldSlipsController#create does
-    # before saving, and matters when a slip is created lazily here — when
-    # an observation with a field_code is saved — rather than up front.
-    slip.update_project
     slip.save ? slip : nil
   end
 

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -37,6 +37,11 @@ class FieldSlip < AbstractModel
     slip = new
     slip.current_user = user
     slip.code = code
+    # Derive the project from the code prefix (e.g. "RINHS-00108" ->
+    # the RINHS project). This is what FieldSlipsController#create does
+    # before saving, and matters when a slip is created lazily here — when
+    # an observation with a field_code is saved — rather than up front.
+    slip.update_project
     slip.save ? slip : nil
   end
 

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -250,7 +250,10 @@ class FieldSlipsControllerTest < FunctionalTestCase
   def test_should_create_field_slip_and_redirect_to_create_obs
     login(@field_slip.user.login)
     code = "Z#{@field_slip.code}"
-    assert_difference("FieldSlip.count") do
+    # "Add images" defers creation — the field slip is not persisted here;
+    # it is created when the observation is saved, so an abandoned form
+    # leaves no orphan. It still redirects to the observation form.
+    assert_difference("FieldSlip.count", 0) do
       post(:create,
            params: {
              commit: :field_slip_add_images.t,

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -223,6 +223,29 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert(obs.field_slip.present?)
   end
 
+  # A brand-new field code (no slip yet) is created lazily when the
+  # observation is saved — with its project (from the code prefix) and an
+  # occurrence. This is what lets the field-slip "add images" flow defer
+  # slip creation until the observation exists, avoiding orphans.
+  def test_create_observation_creates_new_field_slip_with_project
+    code = "OPEN-77777"
+    assert_nil(FieldSlip.find_by(code: code))
+
+    generic_construct_observation(
+      { observation: { specimen: "1" },
+        field_code: code,
+        naming: { name: "Coprinus comatus" } },
+      1, 1, 0, 0
+    )
+    obs = assigns(:observation)
+    slip = FieldSlip.find_by(code: code)
+
+    assert_not_nil(slip, "field slip created on observation save")
+    assert_equal(projects(:open_membership_project), slip.project)
+    assert_not_nil(obs.occurrence)
+    assert_equal(slip, obs.field_slip)
+  end
+
   def test_create_observation_with_collection_number
     generic_construct_observation(
       { observation: { specimen: "1" },

--- a/test/models/field_slip_test.rb
+++ b/test/models/field_slip_test.rb
@@ -11,6 +11,23 @@ class FieldSlipTest < UnitTestCase
     assert_nil(FieldSlip.prefix_for_code(""))
   end
 
+  # find_or_create_by_code derives the project from the code prefix, so a
+  # slip created lazily (when an observation with a field_code is saved,
+  # rather than up front in the field-slip form) still lands in its project.
+  def test_find_or_create_by_code_derives_project_from_prefix
+    # open_membership_project has prefix OPEN and lets anyone join, so
+    # can_add_field_slip? holds for any user.
+    slip = FieldSlip.find_or_create_by_code("OPEN-99999", rolf)
+
+    assert_predicate(slip, :persisted?)
+    assert_equal(projects(:open_membership_project), slip.project)
+  end
+
+  def test_find_or_create_by_code_returns_nil_for_invalid_code
+    assert_nil(FieldSlip.find_or_create_by_code("12345", rolf),
+               "digits-only code fails validation")
+  end
+
   # eol_project: admins rolf + mary; members rolf, mary (editing),
   # katrina (no_trust); dick is not a member. See #4436.
   def test_admin_can_edit_trusting_members_slip


### PR DESCRIPTION
## Summary

Prevents orphaned field slips at the dominant source: the field-slip "add images" flow.

`FieldSlipsController#create` used to save a bare field slip and then, for the `field_slip_add_images` commit, redirect to the new-observation form. If the user abandoned that form, the slip was left with no occurrence — an orphan. (This is where most of the 35 orphans cleaned up in #4716 came from — NAMA/RINHS/BLITZ project slips scanned to add photos, then not finished.)

Now the add-images path **does not persist the slip**. It redirects to the observation form carrying the code and stops; `observations#create` creates the slip — with its occurrence — only when the observation is actually saved. An abandoned form leaves nothing behind.

## The project is not lost by deferring

The concern with deferring was that a slip's `project` might not be set when it's created lazily by `observations#create` (via `find_or_create_by_code`). It turns out it already is: `FieldSlip#code=` derives the project from the code prefix — `RINHS-00108` → the project whose `field_slip_prefix` is `RINHS` — every time the code is assigned. `find_or_create_by_code` sets `current_user` before the code, so that membership-checked lookup succeeds. So a lazily-created slip lands in its project with no extra work.

Verified end to end (new test): creating an observation with a brand-new field code produces the field slip **with its project and an occurrence**.

## Changes

- `FieldSlipsController#create` intercepts the add-images commit before saving and redirects (deferred creation); an invalid code is rejected here rather than after the whole observation form. The two new helpers are private (not controller actions).
- Removed the now-dead add-images branch from `html_create`.
- `find_or_create_by_code` is unchanged in behavior — a comment documents that `code=` derives the project, since the deferred flow depends on it, and tests pin it.

## Scope / follow-up

This is the **prevention** half of addressing orphans; #4716 is the one-time cleanup of existing ones. It fixes the dominant source (add-images abandonment). One rarer path remains: the attach-existing-observations branch when no observations are selected still saves a slip with no occurrence. That's a smaller, separate change — noted here, not fixed in this PR.

## Tests

- `test/controllers/field_slips_controller_test.rb` — the add-images test now asserts the slip is **not** created (`FieldSlip.count, 0`) and still redirects.
- `test/models/field_slip_test.rb` — `find_or_create_by_code` derives the project from the prefix; returns nil for an invalid code.
- `test/controllers/observations_controller_create_test.rb` — a new field code creates the slip with project + occurrence when the observation is saved.
- Full suites green: field_slips controller (78), field_slip model, observations create (65).
