### PR TITLE
Make lang-tag test failures self-explanatory

### DIFF
--- a/test/classes/localization_files_test.rb
+++ b/test/classes/localization_files_test.rb
@@ -65,7 +65,9 @@ class LocalizationFilesTest < UnitTestCase
     end
     assert_true(missing_tags.empty?,
                 "Found #{missing_tags.length} undefined tag reference(s) " \
-                "in source files:\n #{missing_tags.join}")
+                "in source files (run `bin/rails lang:update` and re-run " \
+                "before concluding this is a pre-existing/unrelated " \
+                "failure):\n #{missing_tags.join}")
     assert_true(
       duplicate_function_defs.empty?,
       "Found #{duplicate_function_defs.length} duplicate method " \

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -204,7 +204,10 @@ module ActiveSupport
     # Standard teardown to run after every test.  Just makes sure any
     # images that might have been uploaded are cleared out.
     def teardown
-      assert_equal([], Symbol.missing_tags, "Language tag(s) are missing.")
+      assert_equal([], Symbol.missing_tags,
+                   "Language tag(s) are missing. Run `bin/rails " \
+                   "lang:update` and re-run this test before concluding " \
+                   "this is a pre-existing/unrelated failure.")
       FileUtils.rm_rf(MO.local_image_files)
       UserGroup.clear_cache_for_unit_tests
     end


### PR DESCRIPTION
CC gets tripped up when `lang:update` hasn't run, and things there are "preexisting errors on main". I finally realized the error message could be more helpful.

## Summary

Neither assertion message told the reader what to do about it: the generic per-test teardown check in `test_helper.rb` and the dedicated source-scan test in `localization_files_test.rb` both just said a tag was missing, with no instruction to run `bin/rails lang:update` before concluding the failure is pre-existing/unrelated to the current branch.

Verified live: a real "Language tag(s) are missing" failure on `main` (missing `:create_observation_field_slip_invalid` key) flipped to passing after running `bin/rails lang:update` and re-running the test, with no other file changes needed — exactly the misdiagnosis this message fix targets.

## Test plan

- [x] `bundle exec rubocop test/test_helper.rb test/classes/localization_files_test.rb` — clean
- [x] `bin/rails test test/classes/localization_files_test.rb` — confirmed the new message text renders correctly on a real failure, then confirmed it resolves after `bin/rails lang:update`
