### PR TITLE
Split Solid Queue into default + maintenance worker pools

### DIFF
--- a/app/jobs/discard_stale_jobs_job.rb
+++ b/app/jobs/discard_stale_jobs_job.rb
@@ -3,7 +3,7 @@
 require "mission_control/jobs"
 
 class DiscardStaleJobsJob < ApplicationJob
-  queue_as :default
+  queue_as :maintenance
 
   def perform(discard_date = 1.week.ago.in_time_zone("UTC"))
     discard_stale_failed_jobs(discard_date)

--- a/app/jobs/update_box_area_and_center_columns_job.rb
+++ b/app/jobs/update_box_area_and_center_columns_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
-  queue_as :default
+  queue_as :maintenance
 
   def perform(**args)
     args ||= {}

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,17 +1,20 @@
 # Two worker pools so periodic maintenance jobs (cache/data-integrity
 # repairs, recurring cleanup) can't starve user-facing jobs
-# (ImageDhashJob, ImageLoaderJob, FieldSlipJob, InatImportJob) of
-# threads, and vice versa. Both pools run under the same single
-# supervisor process (see config/puma.rb + config/etc/solidqueue.service
-# — issue #4639 / PR #4657 established that there must be exactly one
-# supervisor; this only splits its worker threads by queue, it doesn't
-# add a second supervisor).
+# (ImageDhashJob, ImageLoaderJob, FieldSlipJob, InatImportJob, and mail
+# delivery via ActionMailer's deliver_later, which defaults to the
+# "mailers" queue) of threads, and vice versa. Both worker processes run
+# under the same single supervisor (see config/puma.rb +
+# config/etc/solidqueue.service — issue #4639 / PR #4657 established
+# that there must be exactly one *supervisor*; this config still starts
+# two worker processes/thread-pools under it, one per queue group, which
+# is the intended way to split capacity - it doesn't add a second
+# supervisor).
 default: &default
   dispatchers:
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: default
+    - queues: [default, mailers]
       threads: 4
       processes: 1
       polling_interval: 0.1

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,18 +1,30 @@
-# default: &default
-#   dispatchers:
-#     - polling_interval: 1
-#       batch_size: 500
-#   workers:
-#     - queues: "*"
-#       threads: 5
-#       processes: 1
-#       polling_interval: 0.1
-#
-# development:
-#  <<: *default
-#
-# test:
-#  <<: *default
-#
-# production:
-#  <<: *default
+# Two worker pools so periodic maintenance jobs (cache/data-integrity
+# repairs, recurring cleanup) can't starve user-facing jobs
+# (ImageDhashJob, ImageLoaderJob, FieldSlipJob, InatImportJob) of
+# threads, and vice versa. Both pools run under the same single
+# supervisor process (see config/puma.rb + config/etc/solidqueue.service
+# — issue #4639 / PR #4657 established that there must be exactly one
+# supervisor; this only splits its worker threads by queue, it doesn't
+# add a second supervisor).
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: default
+      threads: 4
+      processes: 1
+      polling_interval: 0.1
+    - queues: maintenance
+      threads: 2
+      processes: 1
+      polling_interval: 1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/test/jobs/queue_config_test.rb
+++ b/test/jobs/queue_config_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Regression guard for the bug Copilot caught on PR #4727: config/queue.yml
+# restricting workers to specific queues can silently starve a queue nobody
+# declared a worker for - e.g. ActionMailer's deliver_later jobs (queue
+# "mailers" by default) went unclaimed until a worker was added for it.
+class QueueConfigTest < UnitTestCase
+  def test_every_job_queue_is_covered_by_a_worker
+    skip if all_queues_covered?
+
+    job_queue_names.each do |queue|
+      assert_includes(configured_worker_queues, queue,
+                      "No worker in config/queue.yml listens to queue " \
+                      "#{queue.inspect} - jobs on it would never run")
+    end
+  end
+
+  def test_actionmailer_deliver_later_queue_is_covered_by_a_worker
+    skip if all_queues_covered?
+
+    mailer_queue = ActionMailer::Base.deliver_later_queue_name.to_s
+    assert_includes(configured_worker_queues, mailer_queue,
+                    "No worker in config/queue.yml listens to the " \
+                    "ActionMailer deliver_later queue " \
+                    "(#{mailer_queue.inspect}) - mail sent via " \
+                    "deliver_later would never send in production")
+  end
+
+  private
+
+  def all_queues_covered?
+    configured_worker_queues.include?("*")
+  end
+
+  def configured_worker_queues
+    return @configured_worker_queues if @configured_worker_queues
+
+    path = Rails.root.join("config/queue.yml")
+    workers = YAML.load_file(path, aliases: true)["production"]["workers"]
+    @configured_worker_queues = workers.flat_map { |w| Array(w["queues"]) }
+  end
+
+  def job_queue_names
+    Rails.root.glob("app/jobs/*.rb").filter_map do |path|
+      match = File.read(path).match(/queue_as[\s(]*[:'"](\w+)/)
+      match && match[1]
+    end.uniq
+  end
+end


### PR DESCRIPTION
Allows for separate priority job runs: `default` for user-facing, `maintenance` for lower priority.

This means a multi-minute maintenance job run (e.g. the future `RefreshCachesJob`/`CheckForBrokenReferencesJob`) can't starve user-facing work of threads, and vice versa.

Setup for PRs bringing some cron jobs into SolidQueue - only the ones that boot Rails and seem like they would benefit from having a job supervisor.

## Summary

First PR from #4726 (crontab → Solid Queue recurring-job audit). `config/queue.yml` was fully commented out — Solid Queue was running on gem defaults (one process, 5 threads, `queues: "*"`). Splits that into two worker pools:

- `default` (4 threads) — user-facing jobs: `ImageDhashJob`, `ImageLoaderJob`, `FieldSlipJob`, `InatImportJob`, `InatImportRecoveryJob`, and (as of the Copilot-review fix below) ActionMailer's `deliver_later` mail delivery.
- `maintenance` (2 threads) — periodic background housekeeping: `DiscardStaleJobsJob`, `UpdateBoxAreaAndCenterColumnsJob`, and the future Bucket A jobs from #4726.

Both pools run under the same single supervisor process — issue #4639/PR #4657 established there must be exactly one supervisor in production (systemd, not the Puma plugin); this PR starts two worker processes/thread-pools under that one supervisor, split by queue — it doesn't add a second supervisor.

`InatImportRecoveryJob` stays on `default` even though it runs on a recurring schedule — it finalizes user-visible import status (tells the user their import crashed and needs restarting), so it's user-facing work, not background housekeeping, despite the recurring trigger.

## Copilot review fix

Copilot's review caught a critical gap: restricting workers to `default`/`maintenance` only left no worker listening to the `mailers` queue, which is where every `deliver_later` call in the app (dozens of call sites — account verification, password reset, name/location change notifications, etc.) enqueues its `ActionMailer::MailDeliveryJob`. In production this would have silently stopped all `deliver_later`-based mail from ever sending. Fixed by adding `mailers` to the `default` worker's `queues:` (as a YAML array — Solid Queue's `queues:` just wraps the raw value in `Array()`, no comma-splitting, so a comma-joined string wouldn't have worked). Added `test/jobs/queue_config_test.rb` as a standing regression guard, verified it fails against the pre-fix config and passes with the fix.

## Test plan

- [x] `bundle exec rubocop` clean on the touched `.rb` files.
- [x] `ruby -ryaml -e "YAML.load_file('config/queue.yml', aliases: true)"` — confirms the YAML (with merge-key anchors and the new array value) is valid.
- [x] `bin/rails test test/jobs/` — 83 tests, all green.
