### PR TITLE
Rewrite Vote's `observation_views` joins in Arel

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -227,8 +227,7 @@ class Vote < AbstractModel
   # This fixes existing entries in observation_views which correspond to a vote
   # but are not currently marked as "reviewed".
   def self.update_existing_views_corresponding_to_votes(dry_run: false)
-    join = "JOIN `votes` ON #{votes_views_join_condition}"
-    query = ObservationView.where(reviewed: 0).joins(join)
+    query = ObservationView.where(reviewed: 0).joins(votes_join)
     msgs = query.map do |ov|
       "User #{ov.user_id} has reviewed observation #{ov.observation_id} " \
         "(update)"
@@ -241,14 +240,13 @@ class Vote < AbstractModel
   # correspond to an entry in obseration_views yet.
   def self.add_missing_views_corresponding_to_votes(dry_run: false)
     # This is really expensive, but AN and JH can't think of any better way.
-    join = "LEFT OUTER JOIN `observation_views` ON " \
-           "#{votes_views_join_condition}"
     # (user 0 is used for anonymous votes, ignore those; observation_id nil
     # means the naming was never attached to an observation, so there's
     # nothing to create an ObservationView for. Without this exclusion these
     # votes never match the LEFT JOIN - NULL never equals NULL in SQL - so
     # they'd generate a fresh junk ObservationView every night forever.)
-    Vote.where.not(user_id: 0).where.not(observation_id: nil).joins(join).
+    Vote.where.not(user_id: 0).where.not(observation_id: nil).
+      joins(missing_views_join).
       where(observation_views: { id: nil }).
       select(arel_table[:observation_id],
              arel_table[:user_id],
@@ -267,9 +265,26 @@ class Vote < AbstractModel
       end
   end
 
-  def self.votes_views_join_condition
-    "`votes`.`observation_id` = `observation_views`.`observation_id` " \
-      "AND `votes`.`user_id` = `observation_views`.`user_id`"
+  # `votes.observation_id = observation_views.observation_id AND
+  #  votes.user_id = observation_views.user_id` - shared by both join
+  # directions below.
+  def self.votes_observation_views_condition(votes, views)
+    votes[:observation_id].eq(views[:observation_id]).
+      and(votes[:user_id].eq(views[:user_id]))
+  end
+
+  def self.votes_join
+    views = ObservationView.arel_table
+    votes = Vote.arel_table
+    views.join(votes).
+      on(votes_observation_views_condition(votes, views)).join_sources
+  end
+
+  def self.missing_views_join
+    votes = Vote.arel_table
+    views = ObservationView.arel_table
+    votes.join(views, Arel::Nodes::OuterJoin).
+      on(votes_observation_views_condition(votes, views)).join_sources
   end
 
   ##############################################################################

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -136,52 +136,6 @@
         77
       ],
       "note": "False positive: `id` is this Image record's integer primary key (never a user-supplied string) and the operator is one of three string literals set by the case statement immediately above (unknown operators raise before this line). Neither interpolated value can carry shell metacharacters. The shell-string form is kept because the trailing '&' backgrounds the rotate script."
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "a6e091d1b880b1bf981ac1fe1b928105a62e8f0f3b71bea926142ccd08d1cc97",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/vote.rb",
-      "line": 251,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Vote.where.not(:user_id => 0).where.not(:observation_id => nil).joins(\"LEFT OUTER JOIN `observation_views` ON #{votes_views_join_condition}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Vote",
-        "method": "Vote.add_missing_views_corresponding_to_votes"
-      },
-      "user_input": "votes_views_join_condition",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "False positive: `votes_views_join_condition` takes no arguments and returns a hardcoded literal string comparing two backtick-quoted column names; it contains no user- or database-supplied input. The method exists only to share the join condition between this method and update_existing_views_corresponding_to_votes."
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "e6b20056c30031cf2a6a33a65a29432ad7e9cfdd21f9d9168b443023bc95bfc5",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/vote.rb",
-      "line": 231,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ObservationView.where(:reviewed => 0).joins(\"JOIN `votes` ON #{votes_views_join_condition}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Vote",
-        "method": "Vote.update_existing_views_corresponding_to_votes"
-      },
-      "user_input": "votes_views_join_condition",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": "False positive: same `votes_views_join_condition` helper as the sibling warning in add_missing_views_corresponding_to_votes -- a hardcoded literal string with no user- or database-supplied input."
     }
   ],
   "brakeman_version": "7.1.1"


### PR DESCRIPTION
## Summary

Stacked on #4702 (`jdc-votes-for-nil-observations`), at Joe's request — a separate PR rather than folding into his, so he can review/merge on his own timeline.

`Vote.update_existing_views_corresponding_to_votes` and `add_missing_views_corresponding_to_votes` (both called via `Vote.update_observation_views_reviewed_column`, part of `script/refresh_caches` → the in-progress `RefreshCachesJob` conversion in #4730) built their SQL joins from a raw string (`votes_views_join_condition`) — a violation of `.claude/rules/no_raw_sql.md`. Rewrites both using Arel table joins, sharing the join condition via `votes_observation_views_condition`.

The raw SQL originated in `035015f60b` (Jason Hollinger, 2024-02-01), which replaced an earlier pure-ActiveRecord implementation (mine, `acf4590f98`, 2024-01-29) specifically for performance — loading the full `Votes`/`ObservationViews` tables into Ruby memory to do the matching by hand was too expensive. This rewrite keeps that same query-level performance profile (still two targeted SQL joins, no full-table Ruby-side loads) while eliminating the raw string.

**Verified behavioral equivalence directly**, not just by eyeballing the generated SQL (which differs cosmetically — `JOIN` vs `INNER JOIN`, and Arel wraps each `AND`-term in parens — but is semantically identical): ran both the old raw-SQL and new Arel versions of both queries against real test-DB data and diffed the result sets. Identical, including a duplicate-row artifact from the join fan-out in `update_existing_views_corresponding_to_votes` — proof the rewrite reproduces even that quirk, not just the happy path.

Also removes the two `config/brakeman.ignore` entries suppressing SQL-injection false-positives on the now-deleted raw-SQL lines — a fresh Brakeman run confirms `vote.rb` produces zero warnings without them.

## Test plan

- [x] `bundle exec rubocop` clean.
- [x] Directly compared old-vs-new query result sets against test-DB data (see commit message) — identical.
- [x] `bundle exec brakeman` — zero warnings on `vote.rb`.
- [x] `bin/rails test test/models/vote_test.rb` — 14 tests, all green (including this branch's own `test_add_missing_views_skips_votes_with_nil_observation_id`).
