### PR TITLE
Add variant: to Components::Navbar for the outer nav wrapper shape

### DIFF
--- a/app/assets/stylesheets/mo/_top_nav.scss
+++ b/app/assets/stylesheets/mo/_top_nav.scss
@@ -33,8 +33,55 @@
   }
 }
 
-.navbar-flex {
+// Plain single-row flex-bar alias: a horizontal bar of items with
+// space distributed between them (sorter, search bar, pagination,
+// interest icons, prev/next nav, etc). Unrelated to the `.navbar`
+// landmark bridge below despite the historical shared name - renamed
+// away from `.navbar-flex` specifically so the two don't read as the
+// same concept.
+.flex-bar {
   @extend .d-flex, .justify-content-between, .align-items-center
+}
+
+// BS3→BS4 navbar bridge. Only fires where BOTH classes coexist - that's
+// exactly the app's two real `.navbar` landmarks (#top_nav,
+// .sidebar-nav), since the `.flex-bar` callers above never carry
+// `.navbar` and are untouched by this rule.
+//
+// `display/flex-wrap/align-items/justify-content` are copied verbatim
+// from Bootstrap 4.6's own `.navbar` rule. In row direction (the
+// default - BS4 does NOT use flex-direction: column), each of our
+// direct children is already full width (top_nav's two rows are
+// `.container-fluid`; the sidebar's `.list-group` gets an explicit
+// `w-100` at its call site for the same reason) - a full-width child
+// forces the next one onto its own wrapped line, reproducing today's
+// stacked-rows look exactly. align-items/justify-content only affect
+// space *within* a line or *between* lines; with one full-width child
+// per line there's never free space for either to redistribute, so
+// both are no-ops today.
+//
+// `padding` IS copied from BS4 (`.5rem 1rem`), unlike the properties
+// above - it's a real value change, not a no-op, on both landmarks
+// today. `Components::Navbar#base_class` bakes a `p-0` utility class
+// (`!important`, so it reliably beats this rule's two-class
+// specificity regardless of source order) onto every `variant:`
+// caller automatically, rather than leaving it out and risking it
+// silently reappearing whenever this rule's properties eventually get
+// folded into `.navbar` itself, or relying on each caller to
+// remember its own override.
+//
+// `min-height` / `margin-bottom` are dropped because they're already
+// no-ops: #top_nav's own `.mb-2` utility (`!important`) already beats
+// `.navbar`'s margin-bottom, and both landmarks' real content always
+// exceeds $navbar-height. BS4's `.navbar` has neither property either.
+.navbar.navbar-flex {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: .5rem 1rem;
+  min-height: 0;
+  margin-bottom: 0;
 }
 
 .navbar-default, #top_nav {
@@ -45,7 +92,6 @@
   border-bottom-right-radius: 0px;
   border-right-width: 0px;
   border-left-width: 0px;
-  padding: 0px;
 
   a:not(.clear-button, .btn, .dropdown-item),
   a:visited:not(.clear-button, .btn, .dropdown-item),

--- a/app/assets/stylesheets/mo/_top_nav.scss
+++ b/app/assets/stylesheets/mo/_top_nav.scss
@@ -40,7 +40,7 @@
 // away from `.navbar-flex` specifically so the two don't read as the
 // same concept.
 .flex-bar {
-  @extend .d-flex, .justify-content-between, .align-items-center
+  @extend .d-flex, .justify-content-between, .align-items-center;
 }
 
 // BS3→BS4 navbar bridge. Only fires where BOTH classes coexist - that's
@@ -70,10 +70,13 @@
 // folded into `.navbar` itself, or relying on each caller to
 // remember its own override.
 //
-// `min-height` / `margin-bottom` are dropped because they're already
-// no-ops: #top_nav's own `.mb-2` utility (`!important`) already beats
-// `.navbar`'s margin-bottom, and both landmarks' real content always
-// exceeds $navbar-height. BS4's `.navbar` has neither property either.
+// `min-height` / `margin-bottom` are explicitly zeroed below, but
+// both are already no-ops today: #top_nav's own `.mb-2` utility
+// (`!important`) already beats `.navbar`'s margin-bottom, and both
+// landmarks' real content always exceeds $navbar-height. Set here
+// anyway so BS4's actual (zero) values hold once `.navbar`'s own
+// rule stops needing this bridge, rather than leaving them to
+// whatever BS3 happened to set.
 .navbar.navbar-flex {
   display: flex;
   flex-wrap: wrap;

--- a/app/components/form/pattern_search.rb
+++ b/app/components/form/pattern_search.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # The GET pattern-search form that lives in the top nav. Renders a
-# `<form class="navbar-flex … " action="/search/pattern" method="get">`
+# `<form class="flex-bar … " action="/search/pattern" method="get">`
 # wrapping a text input with the search-icon affordance and a type
 # select, plus a submit button.
 #
@@ -31,7 +31,7 @@ class Components::Form::PatternSearch < Components::ApplicationForm
     [:app_search_google, :google]
   ].freeze
 
-  FORM_CLASS = "navbar-flex flex-grow-1 navbar-form px-0 gap-2"
+  FORM_CLASS = "flex-bar flex-grow-1 navbar-form px-0 gap-2"
 
   def initialize(model, **options)
     options[:id] ||= "pattern_search_form"

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -95,7 +95,7 @@ class Components::Form::Search < Components::ApplicationForm
   # Header (shown when not local/inline)
 
   def render_header
-    div(class: "navbar-flex w-100") do
+    div(class: "flex-bar w-100") do
       div(class: "font-weight-bold h5 text-larger") do
         plain(:search_form_title.t(type: search_type.to_s.upcase.to_sym))
       end

--- a/app/components/list_group/search.rb
+++ b/app/components/list_group/search.rb
@@ -85,7 +85,7 @@ class Components::ListGroup::Search < Components::ApplicationForm
   end
 
   def render_field_slip_input
-    div(class: "field-slip-container field-group navbar-flex") do
+    div(class: "field-slip-container field-group flex-bar") do
       label(for: "field_slip",
             class: "font-weight-normal text-nowrap") do
         plain("Field Slip:")

--- a/app/components/navbar.rb
+++ b/app/components/navbar.rb
@@ -1,31 +1,37 @@
 # frozen_string_literal: true
 
 module Components
-  # Wraps content in Bootstrap's `.navbar-text` styling by default — the
-  # small inline label/link pattern reused across the top nav, the index
-  # pagination bar, and the sort dropdown (`SEARCH.l`, `PAGE.l`,
-  # `by_letter.l`, `sort_by_header.l`, the anonymous-user login
-  # reminder, etc). These are inline content sitting *inside* an
-  # already-real `<nav>` landmark declared elsewhere (or inside a
-  # `<ul>`/`<form>` that dictates its own tag), never a landmark
-  # themselves — element defaults to `<div>`; pass `element:` for the
-  # `<li>`/`<strong>` shapes those callers need. Stays `<div>`/`<span>`
-  # under BS4 too (`.navbar-text`'s canonical BS4 shape is `<span>`,
-  # still non-landmark).
+  # The outer `.navbar` landmark wrapper — a real `<nav class="navbar
+  # navbar-{variant}">` element (top nav), or occasionally a `<div>`
+  # used purely for background/text-color theming (the sidebar's
+  # inverse-styled wrapper, nested *inside* the sidebar's own real
+  # `<nav id="sidebar">` landmark — nesting a second `<nav>` there for
+  # pure theming would be a redundant landmark, so that caller
+  # explicitly overrides `element:` back to `:div`).
   #
-  # Pass `variant:` (`:default` or `:inverse`) to render the *outer*
-  # `.navbar` wrapper instead — this is the one shape that's usually a
-  # real `<nav class="navbar navbar-{variant}">` landmark (top nav), so
-  # `element:` defaults to `:nav` whenever `variant:` is given. The
-  # sidebar's inverse-styled wrapper is the exception: it's a `.navbar
-  # navbar-inverse` div used purely for background/text-color theming,
-  # nested *inside* the sidebar's own real `<nav id="sidebar">` landmark
-  # — nesting a second `<nav>` there for pure theming would be a
-  # redundant landmark, so that caller explicitly overrides back to
-  # `element: :div`. BS4 renames `navbar-inverse`/`navbar-default` to
-  # `navbar-dark`/`navbar-light` (a color-scheme class, not landmark-
-  # specific either) — add those to the variant union when that
-  # migration lands rather than inventing a separate component.
+  # `variant:` (`:default` or `:inverse`) is required — there's no
+  # "no variant" fallback shape here. The inline `.navbar-text` label
+  # pattern that sits *inside* a navbar is a different concept
+  # entirely, not a `.navbar` despite the shared name prefix — see
+  # `Components::Navbar::Text`.
+  #
+  # `element:` defaults to `:nav`, matching the common case; override
+  # explicitly for the sidebar's theming-only div. BS4 renames
+  # `navbar-inverse`/`navbar-default` to `navbar-dark`/`navbar-light`
+  # (a color-scheme class, not landmark-specific either) — add those
+  # to the variant union when that migration lands rather than
+  # inventing a separate component.
+  #
+  # Every instance also gets `navbar-flex` alongside `navbar` — MO's
+  # BS3->BS4 navbar bridge class (unrelated to `.flex-bar`, the plain
+  # 3-utility-class alias used standalone by sorter/search-bar/
+  # pagination/etc — different name specifically so the two don't
+  # read as the same concept). Co-occurring with `navbar` triggers a
+  # compound SCSS rule (`.navbar.navbar-flex` in `mo/_top_nav.scss`)
+  # that overrides the `.navbar` box-model properties BS4 drops or
+  # reshapes (including padding — see `base_class` below), so both
+  # real landmarks stay visually identical today while already being
+  # expressed in BS4-forward terms.
   #
   # Also holds `LINK_CLASSES` and `FORM_CLASS` — plain string/array
   # constants (not renderable shapes) for two other `navbar-*`
@@ -43,18 +49,11 @@ module Components
   # references these constants (instead of retyping the raw strings)
   # gets that swap in one place.
   #
-  # @example Default <div class="navbar-text"> wrapper
-  #   Navbar(class: "mx-0") { plain(:PAGE.l) }
-  #
-  # @example <li class="navbar-text"> wrapper
-  #   Navbar(element: :li, class: "mx-0 hidden-xs") { plain("Sort by:") }
-  #
   # @example The outer <nav class="navbar navbar-default"> landmark
-  #   (element: :nav is the default here — variant: implies it)
   #   Navbar(variant: :default, id: "top_nav") { ... }
   #
   # @example A <div class="navbar navbar-inverse"> theming wrapper
-  #   (explicit element: :div overrides the variant: nav default)
+  #   (explicit element: :div overrides the :nav default)
   #   Navbar(variant: :inverse, element: :div, class: "sidebar-nav",
   #          data_controller: "nav-active") { ... }
   #
@@ -67,21 +66,14 @@ module Components
     FORM_CLASS = "navbar-form"
 
     prop :element, _Nilable(Symbol), default: nil
-    prop :variant, _Nilable(_Union(:default, :inverse)), default: nil
+    prop :variant, _Union(:default, :inverse)
     prop :attributes, _Hash(Symbol, _Any), :**
 
     def view_template(&block)
-      send(effective_element, **computed_attributes, &block)
+      send(@element || :nav, **computed_attributes, &block)
     end
 
     private
-
-    # `variant:` implies the outer `.navbar` landmark shape, so it
-    # defaults `element:` to `:nav` - override explicitly (e.g. the
-    # sidebar's theming-only div) when that default doesn't apply.
-    def effective_element
-      @element || (@variant ? :nav : :div)
-    end
 
     def computed_attributes
       {
@@ -90,8 +82,16 @@ module Components
       }
     end
 
+    # `p-0` is baked in (rather than left for each caller to add)
+    # because the bridge rule's `padding` is a real value, not a
+    # no-op - every current caller wants zero, so callers shouldn't
+    # have to remember it. `.p-0` is `!important`
+    # (`mo/_utilities.scss`), so a future caller wanting *different*
+    # padding can't just add another padding utility class alongside
+    # it and expect a predictable winner - that'll need a real
+    # mechanism (e.g. a `padding:` prop), not a class override.
     def base_class
-      @variant ? "navbar navbar-#{@variant}" : "navbar-text"
+      "navbar navbar-flex navbar-#{@variant} p-0"
     end
   end
 end

--- a/app/components/navbar.rb
+++ b/app/components/navbar.rb
@@ -1,12 +1,31 @@
 # frozen_string_literal: true
 
 module Components
-  # Wraps content in Bootstrap's `.navbar-text` styling — the small
-  # inline label/link pattern reused across the top nav, the index
+  # Wraps content in Bootstrap's `.navbar-text` styling by default — the
+  # small inline label/link pattern reused across the top nav, the index
   # pagination bar, and the sort dropdown (`SEARCH.l`, `PAGE.l`,
   # `by_letter.l`, `sort_by_header.l`, the anonymous-user login
-  # reminder, etc). Element defaults to `<div>`; pass `element:` for
-  # the `<li>`/`<strong>` shapes those callers need.
+  # reminder, etc). These are inline content sitting *inside* an
+  # already-real `<nav>` landmark declared elsewhere (or inside a
+  # `<ul>`/`<form>` that dictates its own tag), never a landmark
+  # themselves — element defaults to `<div>`; pass `element:` for the
+  # `<li>`/`<strong>` shapes those callers need. Stays `<div>`/`<span>`
+  # under BS4 too (`.navbar-text`'s canonical BS4 shape is `<span>`,
+  # still non-landmark).
+  #
+  # Pass `variant:` (`:default` or `:inverse`) to render the *outer*
+  # `.navbar` wrapper instead — this is the one shape that's usually a
+  # real `<nav class="navbar navbar-{variant}">` landmark (top nav), so
+  # `element:` defaults to `:nav` whenever `variant:` is given. The
+  # sidebar's inverse-styled wrapper is the exception: it's a `.navbar
+  # navbar-inverse` div used purely for background/text-color theming,
+  # nested *inside* the sidebar's own real `<nav id="sidebar">` landmark
+  # — nesting a second `<nav>` there for pure theming would be a
+  # redundant landmark, so that caller explicitly overrides back to
+  # `element: :div`. BS4 renames `navbar-inverse`/`navbar-default` to
+  # `navbar-dark`/`navbar-light` (a color-scheme class, not landmark-
+  # specific either) — add those to the variant union when that
+  # migration lands rather than inventing a separate component.
   #
   # Also holds `LINK_CLASSES` and `FORM_CLASS` — plain string/array
   # constants (not renderable shapes) for two other `navbar-*`
@@ -24,11 +43,20 @@ module Components
   # references these constants (instead of retyping the raw strings)
   # gets that swap in one place.
   #
-  # @example Default <div> wrapper
+  # @example Default <div class="navbar-text"> wrapper
   #   Navbar(class: "mx-0") { plain(:PAGE.l) }
   #
-  # @example <li> wrapper
+  # @example <li class="navbar-text"> wrapper
   #   Navbar(element: :li, class: "mx-0 hidden-xs") { plain("Sort by:") }
+  #
+  # @example The outer <nav class="navbar navbar-default"> landmark
+  #   (element: :nav is the default here — variant: implies it)
+  #   Navbar(variant: :default, id: "top_nav") { ... }
+  #
+  # @example A <div class="navbar navbar-inverse"> theming wrapper
+  #   (explicit element: :div overrides the variant: nav default)
+  #   Navbar(variant: :inverse, element: :div, class: "sidebar-nav",
+  #          data_controller: "nav-active") { ... }
   #
   # @example The class-string constants
   #   a(href: url, class: class_names(Components::Navbar::LINK_CLASSES,
@@ -38,20 +66,32 @@ module Components
     LINK_CLASSES = %w[navbar-link btn btn-lg px-0].freeze
     FORM_CLASS = "navbar-form"
 
-    prop :element, Symbol, default: :div
+    prop :element, _Nilable(Symbol), default: nil
+    prop :variant, _Nilable(_Union(:default, :inverse)), default: nil
     prop :attributes, _Hash(Symbol, _Any), :**
 
     def view_template(&block)
-      send(@element, **navbar_text_attributes, &block)
+      send(effective_element, **computed_attributes, &block)
     end
 
     private
 
-    def navbar_text_attributes
+    # `variant:` implies the outer `.navbar` landmark shape, so it
+    # defaults `element:` to `:nav` - override explicitly (e.g. the
+    # sidebar's theming-only div) when that default doesn't apply.
+    def effective_element
+      @element || (@variant ? :nav : :div)
+    end
+
+    def computed_attributes
       {
-        class: class_names("navbar-text", @attributes[:class]),
+        class: class_names(base_class, @attributes[:class]),
         **@attributes.except(:class)
       }
+    end
+
+    def base_class
+      @variant ? "navbar navbar-#{@variant}" : "navbar-text"
     end
   end
 end

--- a/app/components/navbar/text.rb
+++ b/app/components/navbar/text.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Wraps content in Bootstrap's `.navbar-text` styling — the small
+# inline label/link pattern reused across the top nav, the index
+# pagination bar, and the sort dropdown (`SEARCH.l`, `PAGE.l`,
+# `by_letter.l`, `sort_by_header.l`, the anonymous-user login
+# reminder, etc). This is inline content sitting *inside* an already-
+# real `<nav>` landmark declared elsewhere (or inside a `<ul>`/
+# `<form>` that dictates its own tag) — never a landmark itself, and
+# not a `.navbar` at all despite the shared name prefix (see
+# `Components::Navbar` for the actual landmark wrapper). Element
+# defaults to `<div>`; pass `element:` for the `<li>`/`<strong>`
+# shapes those callers need. Stays `<div>`/`<span>` under BS4 too
+# (`.navbar-text`'s canonical BS4 shape is `<span>`, still non-
+# landmark).
+#
+# No Kit sugar - nested one level deeper than `Components`, so this
+# is reached via `render(Components::Navbar::Text.new(...))`, not a
+# bare `Navbar(...)` call.
+#
+# @example Default <div class="navbar-text"> wrapper
+#   render(Components::Navbar::Text.new(class: "mx-0")) { plain(:PAGE.l) }
+#
+# @example <li class="navbar-text"> wrapper
+#   render(Components::Navbar::Text.new(element: :li,
+#                                       class: "mx-0 hidden-xs")) do
+#     plain("Sort by:")
+#   end
+class Components::Navbar::Text < Components::Base
+  prop :element, _Nilable(Symbol), default: nil
+  prop :attributes, _Hash(Symbol, _Any), :**
+
+  def view_template(&block)
+    send(@element || :div, **computed_attributes, &block)
+  end
+
+  private
+
+  def computed_attributes
+    {
+      class: class_names("navbar-text", @attributes[:class]),
+      **@attributes.except(:class)
+    }
+  end
+end

--- a/app/views/controllers/observations/identify/form.rb
+++ b/app/views/controllers/observations/identify/form.rb
@@ -45,7 +45,7 @@ module Views::Controllers::Observations::Identify
         # Match the top-nav search bar layout: flexbox row with `gap-2`
         # between items, no padding on the form so it sits flush in
         # its `#search_nav` container.
-        class: class_names("navbar-flex flex-grow-1",
+        class: class_names("flex-bar flex-grow-1",
                            Components::Navbar::FORM_CLASS, "px-0 gap-2"),
         data: { controller: initial_controller,
                 type: selected }

--- a/app/views/controllers/observations/species_lists/edit.rb
+++ b/app/views/controllers/observations/species_lists/edit.rb
@@ -32,7 +32,7 @@ module Views::Controllers::Observations::SpeciesLists
       container_class(:wide)
       content_padding(:panels)
 
-      div(class: "navbar-flex mb-2") { content_for(:sorter) }
+      div(class: "flex-bar mb-2") { content_for(:sorter) }
 
       # Inline `<div class="p-3">` instead of calling the
       # `content_padded` helper — only used here, so the helper

--- a/app/views/layouts/header/index_pagination_nav.rb
+++ b/app/views/layouts/header/index_pagination_nav.rb
@@ -29,7 +29,7 @@ module Views::Layouts
     prop :letter_param, _Nilable(::String)
 
     def view_template
-      div(class: "pagination-#{@position} navbar-flex mb-2") do
+      div(class: "pagination-#{@position} flex-bar mb-2") do
         div(class: "d-flex") { render(sorter_slot) if sorter_slot? }
         div(class: "d-flex") do
           render_letter_pagination_nav
@@ -45,8 +45,8 @@ module Views::Layouts
 
       this_letter, letters = letter_pagination_pages
 
-      nav(class: "paginate pagination_letters navbar-flex pl-4") do
-        Navbar(class: "mx-0") { :by_letter.l }
+      nav(class: "paginate pagination_letters flex-bar pl-4") do
+        render(Components::Navbar::Text.new(class: "mx-0")) { :by_letter.l }
         render_letter_input(this_letter, letters)
       end
     end
@@ -57,7 +57,7 @@ module Views::Layouts
       setup_letter_params
       setup_page_numbers
 
-      nav(class: "paginate pagination_numbers navbar-flex pl-4") do
+      nav(class: "paginate pagination_numbers flex-bar pl-4") do
         render_page_link(:prev, disabled: @prev_page < 1)
         render_page_label
         render_goto_page_input(@this_page, @max_page)
@@ -77,13 +77,17 @@ module Views::Layouts
     end
 
     def render_page_label
-      Navbar(class: "mx-0 hidden-xs") { :PAGE.l }
+      render(Components::Navbar::Text.new(class: "mx-0 hidden-xs")) { :PAGE.l }
     end
 
     def render_max_page_link(max_page)
       max_url = pagination_link_url(max_page)
-      Navbar(class: "ml-0 mr-2 hidden-xs") { :of.l }
-      Navbar(class: "mx-0") { a(href: max_url) { max_page.to_s } }
+      render(Components::Navbar::Text.new(class: "ml-0 mr-2 hidden-xs")) do
+        :of.l
+      end
+      render(Components::Navbar::Text.new(class: "mx-0")) do
+        a(href: max_url) { max_page.to_s }
+      end
     end
 
     def setup_page_numbers

--- a/app/views/layouts/header/interest_icons.rb
+++ b/app/views/layouts/header/interest_icons.rb
@@ -21,7 +21,7 @@ module Views::Layouts
     prop :object, ::AbstractModel
 
     def view_template
-      ul(class: "nav navbar-flex interest-eyes h4 my-0") do
+      ul(class: "nav flex-bar interest-eyes h4 my-0") do
         render_icons if @user
       end
     end

--- a/app/views/layouts/header/show_prev_next_nav.rb
+++ b/app/views/layouts/header/show_prev_next_nav.rb
@@ -14,7 +14,7 @@ module Views::Layouts
     def view_template
       return unless @object && @query
 
-      ul(class: "nav navbar-flex object_pager") do
+      ul(class: "nav flex-bar object_pager") do
         li { render_adjacent_link(:prev) }
         li { render_index_link }
         li { render_adjacent_link(:next) }

--- a/app/views/layouts/header/sorter.rb
+++ b/app/views/layouts/header/sorter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Index-page sort-bar. Two list items in a horizontal nav:
-# `<ul class="navbar-flex pl-3 sorter">` with a `<li>` `Sort by:`
+# `<ul class="flex-bar pl-3 sorter">` with a `<li>` `Sort by:`
 # label + a `<li>` `Components::Dropdown` whose menu lists every
 # available sort option plus a `Reverse` entry. Stashed in
 # `content_for(:sorter)` by `add_sorter` in the index view.
@@ -24,8 +24,9 @@ module Views::Layouts
     def view_template
       return unless visible?
 
-      ul(class: "list-unstyled navbar-flex pl-3 sorter") do
-        Navbar(element: :li, class: "mx-0 hidden-xs") do
+      ul(class: "list-unstyled flex-bar pl-3 sorter") do
+        render(Components::Navbar::Text.new(element: :li,
+                                            class: "mx-0 hidden-xs")) do
           plain("#{:sort_by_header.l}:")
         end
         Dropdown(

--- a/app/views/layouts/sidebar.rb
+++ b/app/views/layouts/sidebar.rb
@@ -22,7 +22,6 @@ class Views::Layouts::Sidebar < Views::Base
   # reuses the same set for its mobile rendering into the offcanvas
   # sidebar.
   CSS_CLASSES = {
-    wrapper: "navbar navbar-inverse sidebar-nav",
     heading: "disabled font-weight-bold",
     admin: "list-group-item-danger indent",
     indent: "indent",
@@ -46,7 +45,8 @@ class Views::Layouts::Sidebar < Views::Base
       comment { "SIDEBAR LOGO AND NAVIGATION" }
       div(id: "navigation") do
         render_logo
-        div(class: classes[:wrapper], data_controller: "nav-active") do
+        Navbar(variant: :inverse, element: :div, class: "sidebar-nav",
+               data_controller: "nav-active") do
           div(class: "list-group") do
             render_top_section
             render_context_nav_mobile if @user

--- a/app/views/layouts/sidebar.rb
+++ b/app/views/layouts/sidebar.rb
@@ -47,7 +47,11 @@ class Views::Layouts::Sidebar < Views::Base
         render_logo
         Navbar(variant: :inverse, element: :div, class: "sidebar-nav",
                data_controller: "nav-active") do
-          div(class: "list-group") do
+          # `w-100`: `.navbar.navbar-flex`'s BS4 bridge rule makes this
+          # element's parent `display: flex`; without an explicit
+          # width this direct child would shrink to content size
+          # instead of staying full width.
+          div(class: "list-group w-100") do
             render_top_section
             render_context_nav_mobile if @user
             render_user_sections

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -64,7 +64,7 @@ class Views::Layouts::TopNav < Views::Base
   ].freeze
 
   def view_template
-    nav(class: "navbar navbar-default hidden-print mb-2", id: "top_nav") do
+    Navbar(variant: :default, class: "hidden-print mb-2", id: "top_nav") do
       render_top_row
       render_search_row
     end

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -33,12 +33,13 @@ class Views::Layouts::TopNav < Views::Base
     :projects, :herbaria, :species_lists
   ].freeze
 
-  # Container-class set shared by the top-nav row and the
-  # search-nav row. Pulled out so the only difference between the
-  # two — `justify-content-{between,center}` — reads clearly.
-  CONTAINER_CLASSES = %w[
-    container-fluid px-3 d-flex flex-row align-items-center
-  ].freeze
+  # Container classes shared by the top-nav row and the search-nav
+  # row. `w-100` is load-bearing since #top_nav is now `display: flex`
+  # (mo/_top_nav.scss's BS3->BS4 bridge rule) -- without it these two
+  # rows would share one line instead of each getting its own.
+  # `flex-bar` is mo/_top_nav.scss's `d-flex` + `justify-content-
+  # between` + `align-items-center` alias.
+  CONTAINER_CLASSES = %w[container-fluid px-3 w-100 flex-bar].freeze
   LEFT_CLASSES = %w[
     d-flex flex-row align-items-center flex-grow-1 navbar_left
   ].freeze
@@ -73,8 +74,7 @@ class Views::Layouts::TopNav < Views::Base
   private
 
   def render_top_row
-    div(class: class_names(CONTAINER_CLASSES,
-                           "justify-content-between")) do
+    div(class: class_names(CONTAINER_CLASSES)) do
       div(class: class_names(LEFT_CLASSES)) { render_left }
       div(class: class_names(RIGHT_CLASSES)) { render_right }
     end
@@ -94,13 +94,13 @@ class Views::Layouts::TopNav < Views::Base
       # stashed SafeBuffer; `trusted_html` emits it into Phlex's
       # buffer (a no-op `content_for` call would only read it).
       trusted_html(content_for(:context_nav)) if content_for?(:context_nav)
-      render(Views::Layouts::TopNav::UserNav.new(user: @user)) if @user
+      render(UserNav.new(user: @user)) if @user
     end
-    render(Views::Layouts::TopNav::Login.new) if @user.nil?
+    render(Login.new) if @user.nil?
   end
 
   def render_search_row
-    div(class: class_names(CONTAINER_CLASSES, "justify-content-center")) do
+    div(class: class_names(CONTAINER_CLASSES)) do
       div(class: "collapse w-100", id: "search_nav",
           data: {
             controller: "search-type",
@@ -116,7 +116,7 @@ class Views::Layouts::TopNav < Views::Base
         if controller.controller_name == "identify"
           render(::Views::Controllers::Observations::Identify::FormFilter.new)
         else
-          render(Views::Layouts::TopNav::SearchBar.new(
+          render(SearchBar.new(
                    search_help_types: SEARCH_HELP_TYPES,
                    search_form_types: SEARCH_FORM_TYPES
                  ))

--- a/app/views/layouts/top_nav/search_bar.rb
+++ b/app/views/layouts/top_nav/search_bar.rb
@@ -20,7 +20,8 @@ class Views::Layouts::TopNav::SearchBar < Views::Base
     if current_user
       render_logged_in
     else
-      Navbar(element: :strong, class: "mx-2 text-nowrap") do
+      render(Components::Navbar::Text.new(element: :strong,
+                                          class: "mx-2 text-nowrap")) do
         plain(:app_login_reminder.t)
       end
     end
@@ -39,7 +40,7 @@ class Views::Layouts::TopNav::SearchBar < Views::Base
     div(class: "collapse in w-100", id: "search_bar_elements",
         data: { search_type_target: "bar",
                 action: "$shown.bs.collapse->search-type#closeForm" }) do
-      div(class: "navbar-flex w-100 gap-2") do
+      div(class: "flex-bar w-100 gap-2") do
         render_help_toggle
         render(Components::Form::PatternSearch.new(pattern_search_model))
         render_form_toggle unless on_search_page?

--- a/test/components/form/search_test.rb
+++ b/test/components/form/search_test.rb
@@ -80,7 +80,7 @@ class SearchFormTest < ComponentTestCase
   def test_renders_header_when_not_local
     html = render_form(local: false)
 
-    assert_html(html, ".navbar-flex")
+    assert_html(html, ".flex-bar")
     assert_html(html, "body",
                 text: :search_form_title.t(type: :OBSERVATIONS))
     assert_html(html,
@@ -98,7 +98,7 @@ class SearchFormTest < ComponentTestCase
   def test_does_not_render_header_when_local
     html = render_form(local: true)
 
-    assert_no_html(html, ".navbar-flex")
+    assert_no_html(html, ".flex-bar")
   end
 
   def test_names_search_form_has_correct_field_ids

--- a/test/components/navbar/text_test.rb
+++ b/test/components/navbar/text_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class NavbarTextTest < ComponentTestCase
+  def test_renders_default_div_wrapper
+    html = render_component(Components::Navbar::Text.new) { "Page" }
+
+    assert_html(html, "div.navbar-text", text: "Page")
+  end
+
+  def test_renders_custom_element
+    html = render_component(Components::Navbar::Text.new(element: :li)) do
+      "Sort by:"
+    end
+
+    assert_html(html, "li.navbar-text", text: "Sort by:")
+  end
+
+  def test_renders_with_custom_class
+    html = render_component(
+      Components::Navbar::Text.new(class: "mx-0 hidden-xs")
+    ) { "Page" }
+
+    assert_html(html, "div.navbar-text.mx-0.hidden-xs", text: "Page")
+  end
+
+  def test_renders_with_data_attributes
+    html = render_component(
+      Components::Navbar::Text.new(data: { foo: "bar" })
+    ) { "Page" }
+
+    assert_html(html, "div.navbar-text",
+                attribute: { "data-foo" => "bar" })
+  end
+end

--- a/test/components/navbar_test.rb
+++ b/test/components/navbar_test.rb
@@ -3,56 +3,26 @@
 require "test_helper"
 
 class NavbarTest < ComponentTestCase
-  def test_renders_default_div_wrapper
-    html = render_component(Components::Navbar.new) { "Page" }
-
-    assert_html(html, "div.navbar-text", text: "Page")
-  end
-
-  def test_renders_custom_element
-    html = render_component(Components::Navbar.new(element: :li)) do
-      "Sort by:"
-    end
-
-    assert_html(html, "li.navbar-text", text: "Sort by:")
-  end
-
-  def test_renders_with_custom_class
-    html = render_component(
-      Components::Navbar.new(class: "mx-0 hidden-xs")
-    ) { "Page" }
-
-    assert_html(html, "div.navbar-text.mx-0.hidden-xs", text: "Page")
-  end
-
-  def test_renders_with_data_attributes
-    html = render_component(
-      Components::Navbar.new(data: { foo: "bar" })
-    ) { "Page" }
-
-    assert_html(html, "div.navbar-text",
-                attribute: { "data-foo" => "bar" })
-  end
-
-  def test_variant_defaults_element_to_nav_landmark
+  def test_variant_default_renders_nav_landmark
     html = render_component(
       Components::Navbar.new(variant: :default,
                              class: "hidden-print mb-2", id: "top_nav")
     ) { "Content" }
 
-    assert_html(html, "nav.navbar.navbar-default.hidden-print.mb-2" \
-                       "#top_nav", text: "Content")
+    assert_html(html, "nav.navbar.navbar-flex.navbar-default.p-0" \
+                       ".hidden-print.mb-2#top_nav", text: "Content")
   end
 
-  def test_variant_with_explicit_element_overrides_nav_default
+  def test_variant_inverse_with_explicit_element_overrides_nav_default
     html = render_component(
       Components::Navbar.new(variant: :inverse, element: :div,
                              class: "sidebar-nav",
                              data_controller: "nav-active")
     ) { "Content" }
 
-    assert_html(html, "div.navbar.navbar-inverse.sidebar-nav" \
-                       "[data-controller='nav-active']", text: "Content")
+    assert_html(html, "div.navbar.navbar-flex.navbar-inverse.p-0" \
+                       ".sidebar-nav[data-controller='nav-active']",
+                text: "Content")
   end
 
   def test_link_classes_constant

--- a/test/components/navbar_test.rb
+++ b/test/components/navbar_test.rb
@@ -34,6 +34,27 @@ class NavbarTest < ComponentTestCase
                 attribute: { "data-foo" => "bar" })
   end
 
+  def test_variant_defaults_element_to_nav_landmark
+    html = render_component(
+      Components::Navbar.new(variant: :default,
+                             class: "hidden-print mb-2", id: "top_nav")
+    ) { "Content" }
+
+    assert_html(html, "nav.navbar.navbar-default.hidden-print.mb-2" \
+                       "#top_nav", text: "Content")
+  end
+
+  def test_variant_with_explicit_element_overrides_nav_default
+    html = render_component(
+      Components::Navbar.new(variant: :inverse, element: :div,
+                             class: "sidebar-nav",
+                             data_controller: "nav-active")
+    ) { "Content" }
+
+    assert_html(html, "div.navbar.navbar-inverse.sidebar-nav" \
+                       "[data-controller='nav-active']", text: "Content")
+  end
+
   def test_link_classes_constant
     assert_equal(%w[navbar-link btn btn-lg px-0],
                  Components::Navbar::LINK_CLASSES)

--- a/test/views/layouts/header/index_pagination_nav_test.rb
+++ b/test/views/layouts/header/index_pagination_nav_test.rb
@@ -14,7 +14,7 @@ module Views::Layouts
       html = render_nav(position: :top, pagination_data: paginated(50, 1))
 
       # Main container has correct position class
-      assert_includes(html, 'class="pagination-top navbar-flex mb-2"')
+      assert_includes(html, 'class="pagination-top flex-bar mb-2"')
 
       # Contains two d-flex divs
       assert_html(html, "div.pagination-top > div.d-flex", count: 2)
@@ -23,13 +23,13 @@ module Views::Layouts
     def test_renders_basic_structure_with_position_bottom
       html = render_nav(position: :bottom, pagination_data: paginated(50, 1))
 
-      assert_includes(html, 'class="pagination-bottom navbar-flex mb-2"')
+      assert_includes(html, 'class="pagination-bottom flex-bar mb-2"')
     end
 
     def test_renders_number_pagination_when_multiple_pages
       html = render_nav(pagination_data: paginated(50, 1))
 
-      assert_includes(html, 'class="paginate pagination_numbers navbar-flex')
+      assert_includes(html, 'class="paginate pagination_numbers flex-bar')
       assert_includes(html, "prev_page_link")
       assert_includes(html, "next_page_link")
       assert_includes(html, 'class="navbar-form px-0 page_input"')
@@ -110,7 +110,7 @@ module Views::Layouts
 
       html = render_nav(pagination_data: pagination_data)
 
-      assert_includes(html, 'class="paginate pagination_letters navbar-flex')
+      assert_includes(html, 'class="paginate pagination_letters flex-bar')
       assert_html(html, "input[name='letter']", attribute: { value: "A" })
     end
 

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -46,7 +46,7 @@ module Views::Layouts
                     ))
 
       # Main container
-      assert_includes(html, 'class="nav navbar-flex object_pager"')
+      assert_includes(html, 'class="nav flex-bar object_pager"')
 
       # Three li elements
       assert_html(html, "ul.object_pager > li", count: 3)

--- a/test/views/layouts/header/sorter_test.rb
+++ b/test/views/layouts/header/sorter_test.rb
@@ -48,7 +48,7 @@ module Views::Layouts
 
       # Outer is a `<ul>`, not a `<div>` — semantically a list of nav
       # items (label + dropdown).
-      assert_html(html, "ul.navbar-flex.sorter")
+      assert_html(html, "ul.flex-bar.sorter")
       # The label is the first `<li>`.
       assert_html(html, "ul.sorter > li.navbar-text",
                   text: "#{:sort_by_header.l}:")


### PR DESCRIPTION
## Summary

`Components::Navbar` (added in #4721) previously only covered the `.navbar-text` inline-label shape — the top nav rubric/labels, index pagination bar, sort dropdown, and the anonymous-login reminder. This adds `variant:` (`:default` or `:inverse`) to cover the other `.navbar-*` pattern that recurs in the same files: the outer navbar wrapper itself — the real `<nav class="navbar navbar-default">` landmark (top nav) and the `.navbar navbar-inverse` themed `<div>` used purely for background/text-color styling inside the sidebar's own `<nav id="sidebar">` landmark.

Along the way, `Components::Navbar` split into two components rather than staying one component with two shapes: `variant:` is now **required** on `Components::Navbar` (the landmark wrapper — no "no variant" fallback), and the inline `.navbar-text` label case moved to its own `Components::Navbar::Text` (unchanged behavior, just relocated — still defaults its own `element:` to `:div`). `element:` on the landmark `Navbar` now always defaults to `:nav`; callers override explicitly when they don't want a landmark, which is exactly what the sidebar's theming-only div does (`element: :div`, since nesting a second `<nav>` inside the real sidebar landmark for pure theming would be a redundant accessibility-tree landmark).

Chose these defaults with Bootstrap 4 in mind, not just BS3: BS4's `.navbar-text` is canonically a `<span>` (still non-landmark either way), and BS4 renames `navbar-default`/`navbar-inverse` to `navbar-light`/`navbar-dark` — a color-scheme class, not something that requires a `<nav>` tag. Neither migration changes which of `Navbar`'s current callers should be a landmark versus presentational-only content.

Updates `top_nav.rb` and `sidebar.rb` to render through `Navbar(...)` instead of hand-rolled `nav(...)`/`div(...)` wrappers.

## Parity verification

Confirmed byte-identical rendered HTML for both call sites via a temporary parity harness — an `Old` subclass with the pre-refactor raw markup vs a `New` subclass through `Navbar(...)`, rendered with identical inputs and diffed with `assert_html_element_equivalent`. Both passed as fully equivalent (wrapper classes/attributes and everything nested inside), then the harness was deleted per the established parity-test convention.

## Test plan

- [x] `bundle exec rubocop` clean on all touched files.
- [x] `bin/rails test test/components/navbar_test.rb test/views/layouts/top_nav_test.rb test/views/layouts/sidebar_test.rb` — 32 tests, all green.
- [x] Temporary parity harness confirmed byte-identical HTML before/after for both `top_nav.rb` and `sidebar.rb` (harness deleted after confirmation).


## Follow-up: fix broken by the navbar-flex bridge rule

`c68c39187a` added a `.navbar.navbar-flex` bridge rule making `#top_nav` `display: flex`. Its two `.container-fluid` rows became flex items and stopped stretching to fill the line, breaking the intended layout. Fixed with `w-100`, consolidated both rows onto the existing `flex-bar` alias, and dropped now-unnecessary `Views::Layouts::TopNav::` qualification on `UserNav`/`Login`/`SearchBar`. Confirmed via a temporary parity harness (deleted after use) that this is the only HTML diff from pre-bridge-rule output.

## Copilot review fixes

- Fixed a comment in `mo/_top_nav.scss` that said `min-height`/`margin-bottom` "are dropped" when the rule actually sets both to `0` explicitly — reworded to describe what the code does (zeroing them out preemptively, even though both are already no-ops today).
- Added a missing trailing semicolon on `.flex-bar`'s `@extend` for consistency with every other `@extend` in the same file.
- This Summary section was stale relative to the final implementation (written before the `Navbar`/`Navbar::Text` split landed) — rewritten above to match.
