### PR TITLE
Remove dead `@@last_update` class variable from Language

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -437,7 +437,6 @@ Style/ClassVars:
     - 'app/classes/textile.rb'
     - 'app/extensions/symbol.rb'
     - 'app/models/concerns/language_tracking.rb'
-    - 'app/models/language.rb'
     - 'app/models/location.rb'
     - 'app/models/user_group.rb'
     - 'test/controllers/locations_controller_test.rb'

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -134,9 +134,4 @@ class Language < AbstractModel
     end
     score
   end
-
-  # Be generous to ensure that we don't accidentally miss anything that is
-  # changed while the Rails app is booting.
-  # We need a class variable here
-  @@last_update = 1.minute.ago
 end

--- a/test/language_extensions.rb
+++ b/test/language_extensions.rb
@@ -19,10 +19,6 @@ class Language
     @@export_files = nil
   end
 
-  def self.last_update=(val)
-    @@last_update = val
-  end
-
   def self.clear_verbose_messages
     @@verbose_messages = []
   end


### PR DESCRIPTION
## Summary

Part of the #3589 thread-safety cleanup. `Language`'s `@@last_update` class variable had no live reader left — its only user, `self.update_recent_translations`, was already fully removed/commented out in the source. Rather than convert this to a thread-safe mechanism, it's just dead weight to delete.

Also removes `test/language_extensions.rb`'s `last_update=` setter, which existed only to support this dead mechanism and has no callers.

## Test plan

- [x] `bundle exec rubocop app/models/language.rb test/language_extensions.rb` — no offenses
- [x] `bin/rails test test/models/language_test.rb test/classes/language_exporter_test.rb test/integration/capybara/language_tracking_integration_test.rb` — 25 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
