### PR TITLE
.claude hooks: Run git commit before blocking a behind-branch push

### DIFF
--- a/.claude/hooks/check_branch_up_to_date.sh
+++ b/.claude/hooks/check_branch_up_to_date.sh
@@ -4,6 +4,18 @@
 # `gh pr create`, verifies the current branch has incorporated all
 # commits from origin/main. Exits 2 (blocking) if the branch is behind.
 #
+# PreToolUse hooks block the ENTIRE Bash call, not just the risky
+# part - so a compound command like `git commit -m "..." && git push`
+# would otherwise lose the commit too when only the push should be
+# blocked. To avoid that, when blocking we first run whatever precedes
+# the `git push`/`gh pr create` invocation (split on the first literal
+# occurrence of either) as its own step, so a bundled commit still
+# lands. This is a plain substring split, not real shell parsing - it
+# can misfire if "git push"/"gh pr create" appears as literal text
+# earlier in the command (e.g. inside a commit message body); in that
+# case the extracted prefix will typically just fail safely (e.g. an
+# unterminated heredoc) rather than doing anything silently wrong.
+#
 # Skips when already on main/master.
 set -euo pipefail
 
@@ -25,8 +37,41 @@ git fetch origin main --quiet 2>/dev/null || true
 # If origin/main is not an ancestor of HEAD, we're behind main.
 if ! git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
   BEHIND="$(git rev-list --count HEAD..origin/main 2>/dev/null || echo "?")"
+
+  # Split on whichever of the two risky invocations occurs first.
+  PREFIX_PUSH="${COMMAND%%git push*}"
+  PREFIX_GHPR="${COMMAND%%gh pr create*}"
+  if [ "$PREFIX_PUSH" != "$COMMAND" ] && [ "$PREFIX_GHPR" != "$COMMAND" ]; then
+    if [ "${#PREFIX_PUSH}" -le "${#PREFIX_GHPR}" ]; then
+      PREFIX="$PREFIX_PUSH"
+    else
+      PREFIX="$PREFIX_GHPR"
+    fi
+  elif [ "$PREFIX_PUSH" != "$COMMAND" ]; then
+    PREFIX="$PREFIX_PUSH"
+  else
+    PREFIX="$PREFIX_GHPR"
+  fi
+  # Trim a trailing statement separator and whitespace left dangling
+  # by the split (e.g. "git commit -m 'x' && " -> "git commit -m 'x'").
+  PREFIX="$(printf '%s' "$PREFIX" | sed -E 's/[[:space:]]*(&&|\|\||;)[[:space:]]*$//')"
+
+  RAN_MSG="(nothing preceded the push/PR-create step)"
+  if [ -n "$(printf '%s' "$PREFIX" | tr -d '[:space:]')" ]; then
+    echo "▶ Running the portion of the command before push/PR-create:" >&2
+    printf '%s\n' "$PREFIX" >&2
+    if bash -c "$PREFIX" >&2 2>&1; then
+      RAN_MSG="✅ that portion ran successfully - only the push/PR-create below was blocked."
+    else
+      RAN_MSG="⚠️  that portion FAILED (see output above) - nothing further ran, including the push/PR-create."
+    fi
+  fi
+
   cat >&2 <<EOF
+
 🚫 Branch '$BRANCH' is behind origin/main by ${BEHIND} commit(s) — blocking push/PR.
+
+$RAN_MSG
 
 Merge main before pushing:
   git fetch origin main


### PR DESCRIPTION
## Summary

`.claude/hooks/check_branch_up_to_date.sh` is a `PreToolUse` hook that blocks any Bash call containing `git push`/`gh pr create` when the current branch is behind `origin/main`. Since `PreToolUse` hooks block the whole tool call, not just the offending sub-command, a compound command like `git commit -m "..." && git push` would lose the commit too — the block message only mentioned the push, so it was easy to believe the commit had gone through when it hadn't. This happened twice in one session.

Rather than relying on remembering to never combine `git commit` with `git push`/`gh pr create` in one call, this makes the hook itself run whatever precedes the first literal `git push`/`gh pr create` occurrence in the command before blocking, so a bundled commit still lands. The block message now says explicitly whether that portion ran successfully.

This is a substring split, not real shell parsing — documented in the script's own comments, along with the (rare) failure mode where "git push"/"gh pr create" text appearing earlier in the command (e.g. inside a commit message body) could cause the split to happen in the wrong place. In that case the extracted prefix would typically just fail safely (e.g. an unterminated heredoc) rather than doing anything silently wrong.

## Test plan

- [x] `bash -n .claude/hooks/check_branch_up_to_date.sh` — syntax valid
- [x] Isolated dry-run of the prefix-splitting logic against representative command shapes (`&&`-joined, newline-joined, push-only, `gh pr create`-only) — all split correctly
- [x] Live-exercised during this session's own PR rebase batch (#4728/#4729/#4730/#4732/#4733/#4734) — no regressions, existing behavior (block when behind) still fires correctly when not bundled with a commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
