### PR TITLE
Port image processing to Ruby: Image::Processor (#4735 PR 1/4)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,16 @@ gem("xmlrpc")
 gem("fastimage")
 # for detecting file type of uploaded images
 gem("mimemagic")
+# An interface between Ruby and ImageMagick/Vips, used to resize/reorient
+# uploaded images
+gem("image_processing")
+gem("mini_magick", "~> 5.0")
+# Reads and writes EXIF/GPS data; "vendors" a recent exiftool so we don't
+# depend on a system install
+gem("mini_exiftool_vendored")
+# Wraps the rsync binary, used to transfer processed images to the image
+# server(s)
+gem("rsync")
 
 # Gems used for iNat import
 gem("oauth2")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    image_processing (2.0.2)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -285,6 +286,13 @@ GEM
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
+    mini_exiftool (2.14.0)
+      ostruct (>= 0.6.0)
+      pstore (>= 0.1.3)
+    mini_exiftool_vendored (9.2.7.v1)
+      mini_exiftool (>= 1.6.0)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     mini_racer (0.21.0)
       libv8-node (~> 24.12.0.1)
@@ -346,6 +354,7 @@ GEM
       snaky_hash (~> 2.0, >= 2.0.4)
       version_gem (~> 1.1, >= 1.1.9)
     os (1.1.4)
+    ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -375,6 +384,7 @@ GEM
       rexml (>= 3.4.2, < 4)
     prettyprint (0.2.0)
     prism (1.9.0)
+    pstore (0.2.1)
     psych (5.3.1)
       date
       stringio
@@ -442,6 +452,7 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 2.0)
     rqrcode_core (2.1.0)
+    rsync (1.0.9)
     rtf (0.3.3)
     rubocop (1.88.2)
       json (~> 2.3)
@@ -639,10 +650,13 @@ DEPENDENCIES
   google-cloud-storage
   haversine
   i18n
+  image_processing
   importmap-rails
   jbuilder
   literal
   mimemagic
+  mini_exiftool_vendored
+  mini_magick (~> 5.0)
   mini_racer
   minitest (< 6)
   minitest-reporters
@@ -660,6 +674,7 @@ DEPENDENCIES
   requestjs-rails
   rest-client
   rqrcode
+  rsync
   rtf
   rubocop
   rubocop-capybara

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -769,29 +769,31 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     elsif save_to_temp_file
       ext = original_extension
       set_image_size(upload_temp_file) if ext == "jpg"
-      set = width.nil? ? "1" : "0"
+      set_size = width.nil?
       update_attribute(:gps_stripped, true) if strip
-      strip = strip ? "1" : "0"
       # move_original returns true or raises — never false — so there is no
       # reachable else branch here.
-      if move_original
-        cmd = MO.process_image_command.
-              gsub("<id>", id.to_s).
-              gsub("<ext>", ext).
-              gsub("<set>", set).
-              gsub("<strip>", strip)
-        if !Rails.env.test? && !system(cmd)
-          errors.add(:image, :runtime_image_process_failed.t(id: id))
-          result = false
-        else
-          # Only after processing has succeeded (or been skipped in test):
-          # enqueueing earlier would hash an image whose upload ultimately
-          # failed, and could race the resize/strip command writing files.
-          ImageDhashJob.perform_later(id)
-        end
-      end
+      result = process_and_enqueue_dhash(ext, set_size, strip) if move_original
     end
     result
+  end
+
+  # Runs Image::Processor synchronously (skipped in test, see
+  # test/models/image/processor_test.rb for direct coverage), then enqueues
+  # the perceptual-hash job. Only after processing has succeeded: enqueueing
+  # earlier would hash an image whose upload ultimately failed, and could
+  # race the resize/strip command writing files.
+  def process_and_enqueue_dhash(ext, set_size, strip)
+    unless Rails.env.test?
+      Image::Processor.new(image: self, ext: ext, set_size: set_size,
+                           strip_gps: strip).process
+    end
+    ImageDhashJob.perform_later(id)
+    true
+  rescue StandardError => e
+    Rails.logger.error("Image::Processor failed for image #{id}: #{e}")
+    errors.add(:image, :runtime_image_process_failed.t(id: id))
+    false
   end
 
   # Move temp file into its final position.  Adds any errors to the :image

--- a/app/models/image/processor.rb
+++ b/app/models/image/processor.rb
@@ -250,11 +250,12 @@ class Image
 
     # Email webmaster if there were any errors
     def email_webmaster
-      QueuedEmail::Webmaster.create_email(
+      message = WebmasterMailer.prepend_user(@user, @errors.join("\n"))
+      WebmasterMailer.build(
         sender_email: @user.email,
         subject: "[MO] process_image",
-        content: @errors.join("\n")
-      )
+        message: message
+      ).deliver_later
     end
 
     def image_server_has_subdir?(server, subdir)

--- a/app/models/image/processor.rb
+++ b/app/models/image/processor.rb
@@ -22,7 +22,6 @@ class Image
     require "open-uri"
 
     IMAGE_SUBDIRS = Image::URL::SUBDIRECTORIES.values.freeze
-    LOCAL_IMAGES_PATH = MO.local_image_files
 
     # Store Exiftool's database in a temporary directory.
     MiniExiftool.pstore_dir = Rails.root.join("tmp").to_s
@@ -36,12 +35,30 @@ class Image
       ["small", "thumbnail", 160, 95]
     ].freeze
 
+    # MO.local_image_files/MO.image_sources are worker-suffix-aware lazy
+    # methods (config/consts.rb) so parallel test workers get distinct
+    # directories. Recompute per call rather than caching at class-load
+    # time -- if this class autoloads in a forked test worker before that
+    # worker's own TEST_ENV_NUMBER is set, a frozen constant would lock in
+    # the wrong (unsuffixed) path for the rest of that worker's process
+    # lifetime, colliding with every other worker on the same directory.
+    def self.local_images_path
+      MO.local_image_files
+    end
+
     # Data (type/path/subdirs) for every configured image server, keyed by
     # server name. Includes :local (the filesystem MO itself runs on).
-    IMAGE_SERVER_DATA = ServerData.build(LOCAL_IMAGES_PATH, IMAGE_SUBDIRS)
+    # Recomputed per call for the same reason local_images_path is above --
+    # see ServerData for the actual construction.
+    def self.image_server_data
+      ServerData.build(local_images_path, IMAGE_SUBDIRS)
+    end
+
     # Servers we transfer files *to* -- excludes :local, which is where the
     # files already live, not a transfer destination.
-    IMAGE_SERVERS = (IMAGE_SERVER_DATA.keys - [:local]).freeze
+    def self.image_servers
+      image_server_data.keys - [:local]
+    end
 
     attr_reader :transferred_any
 
@@ -83,7 +100,7 @@ class Image
     def transfer_files_to_image_servers
       return if Rails.env.development?
 
-      IMAGE_SERVERS.each do |server|
+      self.class.image_servers.each do |server|
         transfer_all_sizes_to_server_subdirectories(server)
       end
     end
@@ -124,7 +141,7 @@ class Image
     def make_sure_we_have_full_size_locally
       return if File.exist?(full_size_filepath)
 
-      IMAGE_SERVERS.each do |server|
+      self.class.image_servers.each do |server|
         next unless image_server_has_subdir?(server, "orig")
 
         copy_file_from_server(server, "orig/#{@id}.jpg")
@@ -177,7 +194,7 @@ class Image
     def salvage_first_layer_if_multilayer
       return if File.exist?(full_size_filepath)
 
-      layers = Dir.glob("#{LOCAL_IMAGES_PATH}/orig/#{@id}-*.jpg")
+      layers = Dir.glob("#{self.class.local_images_path}/orig/#{@id}-*.jpg")
       biggest_layer = layers.first
       return unless biggest_layer && File.exist?(biggest_layer)
 
@@ -219,7 +236,7 @@ class Image
     end
 
     def transfer_all_sizes_to_server_subdirectories(server)
-      subdirs = IMAGE_SERVER_DATA[server][:subdirs]
+      subdirs = self.class.image_server_data[server][:subdirs]
       IMAGE_SUBDIRS.each do |subdir|
         next unless subdirs.include?(subdir)
 
@@ -241,54 +258,55 @@ class Image
     end
 
     def image_server_has_subdir?(server, subdir)
-      IMAGE_SERVER_DATA[server][:subdirs].include?(subdir)
+      self.class.image_server_data[server][:subdirs].include?(subdir)
     end
 
     # Original file location
     def original_filepath
-      "#{LOCAL_IMAGES_PATH}/orig/#{@id}.#{@ext}"
+      "#{self.class.local_images_path}/orig/#{@id}.#{@ext}"
     end
 
     # full_size, huge, large, medium, small, thumbnail
     Image::URL::SUBDIRECTORIES.each do |size, subdir|
       define_method(:"#{size}_filepath") do
-        "#{LOCAL_IMAGES_PATH}/#{subdir}/#{@id}.jpg"
+        "#{self.class.local_images_path}/#{subdir}/#{@id}.jpg"
       end
     end
 
     ############################################################
 
     def copy_file_to_server(server, local_file, remote_file = local_file)
-      case IMAGE_SERVER_DATA[server][:type]
+      case self.class.image_server_data[server][:type]
       when "file"
         copy_file_to_local_server(server, local_file, remote_file)
       when "ssh"
         copy_file_to_remote_server(server, local_file, remote_file)
       else
-        raise("Unknown image server type: #{IMAGE_SERVER_DATA[server][:type]}")
+        raise("Unknown image server type: " \
+              "#{self.class.image_server_data[server][:type]}")
       end
     end
 
     def copy_file_to_local_server(server, local_file, remote_file)
-      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+      return unless (remote_path = self.class.image_server_data[server][:path])
 
       FileUtils.mkpath(File.dirname("#{remote_path}/#{remote_file}"))
-      FileUtils.cp("#{LOCAL_IMAGES_PATH}/#{local_file}",
+      FileUtils.cp("#{self.class.local_images_path}/#{local_file}",
                    "#{remote_path}/#{remote_file}")
     end
 
     # Rsync is used to copy files to the image server(s).
     def copy_file_to_remote_server(server, local_file, remote_file)
-      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+      return unless (remote_path = self.class.image_server_data[server][:path])
 
-      Rsync.run("#{LOCAL_IMAGES_PATH}/#{local_file}",
+      Rsync.run("#{self.class.local_images_path}/#{local_file}",
                 "#{remote_path}/#{remote_file}") do |result|
         @errors << result.error unless result.success?
       end
     end
 
     def copy_file_from_server(server, remote_file)
-      case IMAGE_SERVER_DATA[server][:type]
+      case self.class.image_server_data[server][:type]
       when "file"
         copy_file_from_local_server(server, remote_file)
       when "ssh"
@@ -297,33 +315,33 @@ class Image
         copy_file_from_http_server(server, remote_file)
       else
         raise("Don't know how to get #{remote_file} from #{server} via: " \
-              "#{IMAGE_SERVER_DATA[server][:type]}")
+              "#{self.class.image_server_data[server][:type]}")
       end
     end
 
     def copy_file_from_local_server(server, remote_file)
-      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+      return unless (remote_path = self.class.image_server_data[server][:path])
 
       FileUtils.cp("#{remote_path}/#{remote_file}",
-                   "#{LOCAL_IMAGES_PATH}/#{remote_file}")
+                   "#{self.class.local_images_path}/#{remote_file}")
     end
 
     def copy_file_from_remote_server(server, remote_file)
-      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+      return unless (remote_path = self.class.image_server_data[server][:path])
 
       Rsync.run("#{remote_path}/#{remote_file}",
-                "#{LOCAL_IMAGES_PATH}/#{remote_file}")
+                "#{self.class.local_images_path}/#{remote_file}")
     end
 
     def copy_file_from_http_server(server, remote_file)
-      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+      return unless (remote_path = self.class.image_server_data[server][:path])
 
       case io = URI.parse("#{remote_path}/#{remote_file}").open
       when StringIO
-        File.write("#{LOCAL_IMAGES_PATH}/#{remote_file}", io.read)
+        File.write("#{self.class.local_images_path}/#{remote_file}", io.read)
       when Tempfile
         io.close
-        FileUtils.mv(io.path, "#{LOCAL_IMAGES_PATH}/#{remote_file}")
+        FileUtils.mv(io.path, "#{self.class.local_images_path}/#{remote_file}")
       end
     end
   end

--- a/app/models/image/processor.rb
+++ b/app/models/image/processor.rb
@@ -1,0 +1,330 @@
+# frozen_string_literal: true
+
+class Image
+  # Resizes, reorients, and transfers an uploaded image's files, and keeps
+  # the image server(s) in sync with what's stored locally. Runs the steps
+  # that used to live in script/process_image, script/rotate_image, and
+  # script/retransfer_images, but through ActiveRecord (`image.update`)
+  # instead of a raw SQL `UPDATE`, so `after_update_commit` callbacks fire.
+  #
+  # 1. convert original to jpeg if necessary
+  # 2. strip GPS data from the original if requested
+  # 3. reorient it correctly if necessary
+  # 4. set width/height of the original image in the database
+  # 5. create the five smaller-sized copies
+  # 6. copy all files to the configured image server(s)
+  # 7. email webmaster if there were any errors
+  class Processor
+    require "image_processing/mini_magick"
+    require "mini_exiftool_vendored"
+    require "fastimage"
+    require "rsync"
+    require "open-uri"
+
+    IMAGE_SUBDIRS = Image::URL::SUBDIRECTORIES.values.freeze
+    LOCAL_IMAGES_PATH = MO.local_image_files
+
+    # Store Exiftool's database in a temporary directory.
+    MiniExiftool.pstore_dir = Rails.root.join("tmp").to_s
+
+    # Source, destination sizes and quality settings for each conversion.
+    SIZE_CONVERSIONS = [
+      ["full_size", "huge", 1280, 93],
+      ["huge", "large", 960, 94],
+      ["huge", "medium", 640, 95], # medium = half of huge
+      ["medium", "small", 320, 95],
+      ["small", "thumbnail", 160, 95]
+    ].freeze
+
+    # Data (type/path/subdirs) for every configured image server, keyed by
+    # server name. Includes :local (the filesystem MO itself runs on).
+    IMAGE_SERVER_DATA = ServerData.build(LOCAL_IMAGES_PATH, IMAGE_SUBDIRS)
+    # Servers we transfer files *to* -- excludes :local, which is where the
+    # files already live, not a transfer destination.
+    IMAGE_SERVERS = (IMAGE_SERVER_DATA.keys - [:local]).freeze
+
+    attr_reader :transferred_any
+
+    def initialize(image:, user: nil, ext: nil, set_size: false,
+                   strip_gps: false)
+      @image = image
+      raise("Image::Processor needs an image.") unless @image
+
+      @user = user || @image.user
+      raise("Image::Processor needs a user.") unless @user
+
+      @ext = ext || @image.original_extension
+      @id = @image.id
+      @set_size = set_size
+      @strip_gps = strip_gps
+      @transferred_any = false
+      @errors = []
+    end
+
+    def process
+      convert_raw_to_jpg if @ext != "jpg"
+      strip_gps_from_file(full_size_filepath) if @strip_gps
+      auto_orient_if_needed(full_size_filepath)
+      update_image_record_width_height_and_transferred if @set_size
+      make_file_sizes
+      transfer_files_to_image_servers
+      mark_image_record_transferred_and_touch_obs if @transferred_any
+      email_webmaster if @errors.any?
+    end
+
+    def rotate(orientation)
+      make_sure_we_have_full_size_locally
+      reset_file_orientation
+      transform_full_size_file(orientation)
+      update_image_record_width_height_and_transferred
+      process
+    end
+
+    def transfer_files_to_image_servers
+      return if Rails.env.development?
+
+      IMAGE_SERVERS.each do |server|
+        transfer_all_sizes_to_server_subdirectories(server)
+      end
+    end
+
+    # Mark image as transferred and touch related obs (for caches) if all
+    # good. Public (not private) because `self.retransfer_images` below
+    # calls this on a `processor` instance it created for another image.
+    def mark_image_record_transferred_and_touch_obs
+      @image.update(transferred: @transferred_any)
+      Observation.joins(:observation_images).
+        where(observation_images: { image_id: @id }).touch_all
+    end
+
+    def self.retransfer_images
+      Image.where(transferred: false).find_each do |image|
+        processor = new(image: image)
+        processor.transfer_files_to_image_servers
+        if processor.transferred_any
+          processor.mark_image_record_transferred_and_touch_obs
+        end
+      end
+    end
+
+    private
+
+    # Strip GPS data
+    # "GPS:all"/"XMP:Geotag" are group-wildcard deletions, not tags
+    # MiniExiftool's typed `[]=`/`save` recognizes (it silently no-ops on
+    # any tag name outside ExifTool's known-tag map). Shell out directly,
+    # matching what script/process_image already did.
+    def strip_gps_from_file(file)
+      return if system("exiftool", "-gps:all=", "-xmp:geotag=",
+                       "-overwrite_original", "-q", file)
+
+      @errors << "Failed to strip GPS data from #{file}"
+    end
+
+    def make_sure_we_have_full_size_locally
+      return if File.exist?(full_size_filepath)
+
+      IMAGE_SERVERS.each do |server|
+        next unless image_server_has_subdir?(server, "orig")
+
+        copy_file_from_server(server, "orig/#{@id}.jpg")
+        break
+      end
+    end
+
+    def reset_file_orientation
+      working = MiniExiftool.new(full_size_filepath, numerical: true)
+      return unless working.orientation.to_i != 1
+
+      # This should reset the orientation to 1 from the original data.
+      working.copy_tags_from(full_size_filepath, "all")
+      return unless working.orientation.to_i != 1
+
+      working.orientation = 1
+      working.save
+    end
+
+    def transform_full_size_file(orientation)
+      operations = %w[-90 +90 180 -h -v]
+      return unless operations.include?(orientation)
+
+      pipeline = ImageProcessing::MiniMagick.source(full_size_filepath)
+      pipeline = case orientation
+                 when "-90", "+90", "180" then pipeline.rotate(orientation)
+                 when "-h" then pipeline.flop
+                 when "-v" then pipeline.flip
+                 end
+      pipeline.call(destination: full_size_filepath)
+    end
+
+    # Note this also calls strip_gps_from_file(original_filepath).
+    def convert_raw_to_jpg
+      pipeline = ImageProcessing::MiniMagick.source(original_filepath).
+                 append("-quality", 90).
+                 append("-auto-orient").
+                 saver(allow_splitting: true).
+                 convert("jpg")
+
+      pipeline.call(destination: full_size_filepath)
+      salvage_first_layer_if_multilayer
+
+      # Strip GPS out of header of original_file if hiding coordinates.
+      strip_gps_from_file(original_filepath) if @strip_gps
+    end
+
+    # If there were multiple layers, ImageMagick saves them as 1234-N.jpg.
+    # Take the first one, and delete the rest.
+    def salvage_first_layer_if_multilayer
+      return if File.exist?(full_size_filepath)
+
+      layers = Dir.glob("#{LOCAL_IMAGES_PATH}/orig/#{@id}-*.jpg")
+      biggest_layer = layers.first
+      return unless biggest_layer && File.exist?(biggest_layer)
+
+      FileUtils.cp(biggest_layer, full_size_filepath)
+      layers.each { |layer| File.delete(layer) }
+    end
+
+    def auto_orient_if_needed(filepath)
+      file_to_orient = MiniMagick::Image.open(filepath)
+      original_orientation = file_to_orient["%[orientation]"]
+      file_to_orient.auto_orient
+      new_orientation = file_to_orient["%[orientation]"]
+
+      file_to_orient.write(filepath) if original_orientation != new_orientation
+    end
+
+    # This also sets transferred to false to save db writes.
+    # Needed in rotate, and later overwritten in process.
+    def update_image_record_width_height_and_transferred
+      width, height = FastImage.size(full_size_filepath)
+      @image.update(width: width, height: height, transferred: false)
+    end
+
+    def make_file_sizes
+      SIZE_CONVERSIONS.each do |source, destination, size, quality|
+        convert_source_to_destination(source, destination, size, quality)
+      end
+    end
+
+    def convert_source_to_destination(source, destination, size, quality = 95)
+      source_filepath = send(:"#{source}_filepath")
+      destination_filepath = send(:"#{destination}_filepath")
+      pipeline = ImageProcessing::MiniMagick.source(source_filepath).
+                 append("-thumbnail", "#{size}x#{size}>").
+                 append("-quality", quality).
+                 convert("jpg")
+
+      pipeline.call(destination: destination_filepath)
+    end
+
+    def transfer_all_sizes_to_server_subdirectories(server)
+      subdirs = IMAGE_SERVER_DATA[server][:subdirs]
+      IMAGE_SUBDIRS.each do |subdir|
+        next unless subdirs.include?(subdir)
+
+        copy_file_to_server(server, "#{subdir}/#{@id}.jpg")
+      end
+      if @ext != "jpg" && subdirs.include?("orig")
+        copy_file_to_server(server, "orig/#{@id}.#{@ext}")
+      end
+      @transferred_any = true
+    end
+
+    # Email webmaster if there were any errors
+    def email_webmaster
+      QueuedEmail::Webmaster.create_email(
+        sender_email: @user.email,
+        subject: "[MO] process_image",
+        content: @errors.join("\n")
+      )
+    end
+
+    def image_server_has_subdir?(server, subdir)
+      IMAGE_SERVER_DATA[server][:subdirs].include?(subdir)
+    end
+
+    # Original file location
+    def original_filepath
+      "#{LOCAL_IMAGES_PATH}/orig/#{@id}.#{@ext}"
+    end
+
+    # full_size, huge, large, medium, small, thumbnail
+    Image::URL::SUBDIRECTORIES.each do |size, subdir|
+      define_method(:"#{size}_filepath") do
+        "#{LOCAL_IMAGES_PATH}/#{subdir}/#{@id}.jpg"
+      end
+    end
+
+    ############################################################
+
+    def copy_file_to_server(server, local_file, remote_file = local_file)
+      case IMAGE_SERVER_DATA[server][:type]
+      when "file"
+        copy_file_to_local_server(server, local_file, remote_file)
+      when "ssh"
+        copy_file_to_remote_server(server, local_file, remote_file)
+      else
+        raise("Unknown image server type: #{IMAGE_SERVER_DATA[server][:type]}")
+      end
+    end
+
+    def copy_file_to_local_server(server, local_file, remote_file)
+      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+
+      FileUtils.mkpath(File.dirname("#{remote_path}/#{remote_file}"))
+      FileUtils.cp("#{LOCAL_IMAGES_PATH}/#{local_file}",
+                   "#{remote_path}/#{remote_file}")
+    end
+
+    # Rsync is used to copy files to the image server(s).
+    def copy_file_to_remote_server(server, local_file, remote_file)
+      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+
+      Rsync.run("#{LOCAL_IMAGES_PATH}/#{local_file}",
+                "#{remote_path}/#{remote_file}") do |result|
+        @errors << result.error unless result.success?
+      end
+    end
+
+    def copy_file_from_server(server, remote_file)
+      case IMAGE_SERVER_DATA[server][:type]
+      when "file"
+        copy_file_from_local_server(server, remote_file)
+      when "ssh"
+        copy_file_from_remote_server(server, remote_file)
+      when "http", "https"
+        copy_file_from_http_server(server, remote_file)
+      else
+        raise("Don't know how to get #{remote_file} from #{server} via: " \
+              "#{IMAGE_SERVER_DATA[server][:type]}")
+      end
+    end
+
+    def copy_file_from_local_server(server, remote_file)
+      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+
+      FileUtils.cp("#{remote_path}/#{remote_file}",
+                   "#{LOCAL_IMAGES_PATH}/#{remote_file}")
+    end
+
+    def copy_file_from_remote_server(server, remote_file)
+      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+
+      Rsync.run("#{remote_path}/#{remote_file}",
+                "#{LOCAL_IMAGES_PATH}/#{remote_file}")
+    end
+
+    def copy_file_from_http_server(server, remote_file)
+      return unless (remote_path = IMAGE_SERVER_DATA[server][:path])
+
+      case io = URI.parse("#{remote_path}/#{remote_file}").open
+      when StringIO
+        File.write("#{LOCAL_IMAGES_PATH}/#{remote_file}", io.read)
+      when Tempfile
+        io.close
+        FileUtils.mv(io.path, "#{LOCAL_IMAGES_PATH}/#{remote_file}")
+      end
+    end
+  end
+end

--- a/app/models/image/processor/server_data.rb
+++ b/app/models/image/processor/server_data.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class Image
+  class Processor
+    # Builds the {type:, path:, subdirs:} table for every image server
+    # `config/image_config.yml` configures with a `:write` target, plus
+    # :local (the filesystem MO itself runs on).
+    module ServerData
+      def self.build(local_images_path, image_subdirs)
+        data = {
+          local: { type: "file", path: local_images_path,
+                   subdirs: image_subdirs }
+        }
+        MO.image_sources.each do |server, specs|
+          next unless specs[:write]
+
+          # NOTE: must use Addressable::URI to get "user@host:port"
+          # `authority`.
+          parsed = Addressable::URI.parse(format(specs[:write], root: MO.root))
+          data[server] = {
+            type: parsed.scheme,
+            path: write_target_path(parsed),
+            subdirs: write_target_subdirs(specs[:sizes], image_subdirs)
+          }
+        end
+        data.freeze
+      end
+
+      # rsync/scp need "user@host:/path"; a bare filesystem path needs no
+      # host prefix at all.
+      def self.write_target_path(parsed)
+        return parsed.path if parsed.authority.blank?
+
+        "#{parsed.authority}:#{parsed.path}"
+      end
+
+      # `image_config.yml`'s `:sizes:` lists image *sizes* (:thumbnail,
+      # :small, ...); IMAGE_SUBDIRS/transfer code deals in subdirectory
+      # strings ("thumb", "320", ...). Translate one to the other here so
+      # callers only ever compare subdir strings.
+      def self.write_target_subdirs(sizes, image_subdirs)
+        return image_subdirs unless sizes
+
+        sizes.map { |size| Image::URL::SUBDIRECTORIES[size] || size }
+      end
+    end
+  end
+end

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -267,11 +267,6 @@ MushroomObserver::Application.configure do
   # Cloud storage bucket name.
   config.image_bucket_name = "mo-image-archive-bucket"
 
-  # Location of script used to process and transfer images.
-  # (Set to nil to have it do nothing.)
-  config.process_image_command =
-    "#{config.root}/script/process_image <id> <ext> <set> <strip> &"
-
   # Limit size of image uploads (ImageMagick bogs down on large images).
   config.image_upload_max_size = 20_971_520 # 20*1024*1024 = 20 Mb
 

--- a/test/models/image/processor_test.rb
+++ b/test/models/image/processor_test.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Exercises Image::Processor directly (no shelling out) -- the Ruby
+# replacement for script/process_image, script/rotate_image, and
+# script/retransfer_images. See test/classes/image_script_test.rb for the
+# equivalent coverage of the still-live shell scripts.
+class Image::ProcessorTest < UnitTestCase
+  TIFF_FIXTURE = Rails.root.join("test/images/pleopsidium.tiff").to_s
+  JPG_FIXTURE = Rails.root.join("test/images/sticky.jpg").to_s
+  GEOTAGGED_FIXTURE = Rails.root.join("test/images/geotagged.jpg").to_s
+
+  def local_root
+    if (worker_num = database_worker_number)
+      Rails.public_path.join("test_images-#{worker_num}").to_s
+    else
+      Rails.public_path.join("test_images").to_s
+    end
+  end
+
+  def remote_server_path(num)
+    if (worker_num = database_worker_number)
+      Rails.public_path.join("test_server#{num}-#{worker_num}").to_s
+    else
+      Rails.public_path.join("test_server#{num}").to_s
+    end
+  end
+
+  SUBDIRS = %w[thumb 320 640 960 1280 orig].freeze
+
+  def setup
+    [local_root, remote_server_path(1), remote_server_path(2)].each do |root|
+      FileUtils.rm_rf(root)
+      SUBDIRS.each { |dir| FileUtils.mkpath("#{root}/#{dir}") }
+    end
+    super
+  end
+
+  def teardown
+    [local_root, remote_server_path(1), remote_server_path(2)].each do |root|
+      FileUtils.rm_rf(root)
+    end
+    super
+  end
+
+  def test_image_server_data_matches_config
+    assert_equal(local_root, Image::Processor::LOCAL_IMAGES_PATH)
+    assert_equal(remote_server_path(1),
+                 Image::Processor::IMAGE_SERVER_DATA[:remote1][:path])
+    assert_equal(remote_server_path(2),
+                 Image::Processor::IMAGE_SERVER_DATA[:remote2][:path])
+    assert_equal([:remote1, :remote2], Image::Processor::IMAGE_SERVERS,
+                 ":local must never be a transfer target")
+  end
+
+  def test_write_target_path
+    file_uri = Addressable::URI.parse("file://#{local_root}")
+    assert_equal(local_root,
+                 Image::Processor::ServerData.write_target_path(file_uri))
+
+    ssh_uri = Addressable::URI.parse("ssh://mo@images.example.org:/data/mo")
+    assert_equal(
+      "mo@images.example.org:/data/mo",
+      Image::Processor::ServerData.write_target_path(ssh_uri)
+    )
+  end
+
+  def test_write_target_subdirs_translates_sizes_to_subdirs
+    assert_equal(
+      %w[thumb 320 640],
+      Image::Processor::ServerData.write_target_subdirs(
+        [:thumbnail, :small, :medium], Image::Processor::IMAGE_SUBDIRS
+      )
+    )
+    assert_equal(
+      Image::Processor::IMAGE_SUBDIRS,
+      Image::Processor::ServerData.write_target_subdirs(
+        nil, Image::Processor::IMAGE_SUBDIRS
+      )
+    )
+  end
+
+  def test_process_jpg_resizes_and_transfers
+    image = images(:in_situ_image)
+    image.update_columns(transferred: false, width: nil, height: nil)
+    FileUtils.cp(JPG_FIXTURE, "#{local_root}/orig/#{image.id}.jpg")
+    obs = observations(:detailed_unknown_obs)
+    obs.update_columns(updated_at: 1.day.ago)
+
+    Image::Processor.new(image: image, ext: "jpg", set_size: true,
+                         strip_gps: false).process
+
+    image.reload
+    assert_equal(407, image.width)
+    assert_equal(500, image.height)
+    assert(image.transferred)
+
+    %w[thumb 320 640 960 1280 orig].each do |subdir|
+      assert_path_exists("#{local_root}/#{subdir}/#{image.id}.jpg")
+      assert_path_exists(
+        "#{remote_server_path(1)}/#{subdir}/#{image.id}.jpg",
+        "#{subdir} should have gone to remote1"
+      )
+    end
+    %w[thumb 320 640].each do |subdir|
+      assert_path_exists(
+        "#{remote_server_path(2)}/#{subdir}/#{image.id}.jpg",
+        "#{subdir} should have gone to remote2"
+      )
+    end
+    %w[960 1280 orig].each do |subdir|
+      assert_not(
+        File.exist?("#{remote_server_path(2)}/#{subdir}/#{image.id}.jpg"),
+        "#{subdir} should NOT have gone to remote2"
+      )
+    end
+
+    assert_operator(obs.reload.updated_at, :>, 1.hour.ago,
+                    "processing should touch observations for cache busting")
+  end
+
+  def test_process_converts_non_jpg_original
+    image = images(:turned_over_image)
+    image.update_columns(transferred: false, width: nil, height: nil)
+    FileUtils.cp(TIFF_FIXTURE, "#{local_root}/orig/#{image.id}.tiff")
+
+    Image::Processor.new(image: image, ext: "tiff", set_size: true,
+                         strip_gps: false).process
+
+    image.reload
+    assert_equal(2560, image.width)
+    assert_equal(1920, image.height)
+    assert(image.transferred)
+    assert_path_exists("#{local_root}/orig/#{image.id}.jpg")
+    assert_path_exists("#{remote_server_path(1)}/orig/#{image.id}.tiff")
+    assert_path_exists("#{remote_server_path(1)}/orig/#{image.id}.jpg")
+  end
+
+  def test_process_strips_gps_before_transfer
+    image = images(:in_situ_image)
+    image.update_columns(transferred: false)
+    FileUtils.cp(GEOTAGGED_FIXTURE, "#{local_root}/orig/#{image.id}.jpg")
+    assert(MiniExiftool.new("#{local_root}/orig/#{image.id}.jpg").gps_latitude,
+           "fixture should start with GPS data")
+
+    Image::Processor.new(image: image, ext: "jpg", set_size: false,
+                         strip_gps: true).process
+
+    stripped = MiniExiftool.new("#{local_root}/orig/#{image.id}.jpg")
+    assert_nil(stripped.gps_latitude)
+  end
+
+  def test_rotate_reorients_and_reprocesses
+    image = images(:in_situ_image)
+    image.update_columns(transferred: false, width: 1000, height: 1000)
+    FileUtils.cp(JPG_FIXTURE, "#{local_root}/orig/#{image.id}.jpg")
+
+    Image::Processor.new(image: image, ext: "jpg").rotate("+90")
+
+    image.reload
+    assert_equal(500, image.width)
+    assert_equal(407, image.height)
+    assert(image.transferred)
+    assert_path_exists("#{remote_server_path(1)}/thumb/#{image.id}.jpg")
+  end
+
+  def test_rotate_fetches_full_size_from_remote_if_missing_locally
+    image = images(:in_situ_image)
+    image.update_columns(transferred: false, width: 1000, height: 1000)
+    FileUtils.cp(JPG_FIXTURE, "#{remote_server_path(1)}/orig/#{image.id}.jpg")
+
+    Image::Processor.new(image: image, ext: "jpg").rotate("+90")
+
+    assert_path_exists("#{local_root}/orig/#{image.id}.jpg")
+    assert(image.reload.transferred)
+  end
+
+  def test_retransfer_images_only_touches_untransferred_images
+    in_situ = images(:in_situ_image)
+    turned_over = images(:turned_over_image)
+    assert_not(in_situ.transferred)
+    assert_not(turned_over.transferred)
+
+    File.write("#{local_root}/orig/#{in_situ.id}.jpg", "A")
+    File.write("#{local_root}/960/#{in_situ.id}.jpg", "B")
+    File.write("#{local_root}/640/#{in_situ.id}.jpg", "C")
+    File.write("#{local_root}/320/#{in_situ.id}.jpg", "D")
+    File.write("#{local_root}/thumb/#{in_situ.id}.jpg", "E")
+    File.write("#{local_root}/1280/#{in_situ.id}.jpg", "F")
+    File.write("#{local_root}/960/#{turned_over.id}.jpg", "G")
+    File.write("#{local_root}/640/#{turned_over.id}.jpg", "H")
+    File.write("#{local_root}/320/#{turned_over.id}.jpg", "I")
+    File.write("#{local_root}/thumb/#{turned_over.id}.jpg", "J")
+    File.write("#{local_root}/1280/#{turned_over.id}.jpg", "K")
+    File.write("#{local_root}/orig/#{turned_over.id}.jpg", "L")
+
+    Image::Processor.retransfer_images
+
+    assert(in_situ.reload.transferred)
+    assert(turned_over.reload.transferred)
+    assert_equal("A",
+                 File.read("#{remote_server_path(1)}/orig/#{in_situ.id}.jpg"))
+    assert_equal("E",
+                 File.read("#{remote_server_path(1)}/thumb/#{in_situ.id}.jpg"))
+    assert_equal("E",
+                 File.read("#{remote_server_path(2)}/thumb/#{in_situ.id}.jpg"))
+    assert_not(
+      File.exist?("#{remote_server_path(2)}/960/#{in_situ.id}.jpg"),
+      "large should NOT go to remote2 (not in its configured :sizes)"
+    )
+  end
+
+  def test_requires_image
+    assert_raises(RuntimeError) { Image::Processor.new(image: nil) }
+  end
+
+  def test_requires_user
+    image = images(:in_situ_image)
+    image.stub(:user, nil) do
+      assert_raises(RuntimeError) { Image::Processor.new(image: image) }
+    end
+  end
+end

--- a/test/models/image/processor_test.rb
+++ b/test/models/image/processor_test.rb
@@ -7,6 +7,8 @@ require("test_helper")
 # script/retransfer_images. See test/classes/image_script_test.rb for the
 # equivalent coverage of the still-live shell scripts.
 class Image::ProcessorTest < UnitTestCase
+  include ActiveJob::TestHelper
+
   TIFF_FIXTURE = Rails.root.join("test/images/pleopsidium.tiff").to_s
   JPG_FIXTURE = Rails.root.join("test/images/sticky.jpg").to_s
   GEOTAGGED_FIXTURE = Rails.root.join("test/images/geotagged.jpg").to_s
@@ -219,6 +221,157 @@ class Image::ProcessorTest < UnitTestCase
     image = images(:in_situ_image)
     image.stub(:user, nil) do
       assert_raises(RuntimeError) { Image::Processor.new(image: image) }
+    end
+  end
+
+  def test_process_strip_gps_failure_emails_webmaster
+    image = images(:in_situ_image)
+    image.update_columns(transferred: false)
+    FileUtils.cp(JPG_FIXTURE, "#{local_root}/orig/#{image.id}.jpg")
+    processor = Image::Processor.new(image: image, ext: "jpg",
+                                     strip_gps: true)
+
+    processor.stub(:system, false) do
+      assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+        processor.process
+      end
+    end
+  end
+
+  def test_rotate_mirror_horizontal
+    image = images(:in_situ_image)
+    image.update_columns(transferred: false, width: 1000, height: 1000)
+    FileUtils.cp(JPG_FIXTURE, "#{local_root}/orig/#{image.id}.jpg")
+
+    Image::Processor.new(image: image, ext: "jpg").rotate("-h")
+
+    image.reload
+    assert_equal(407, image.width)
+    assert_equal(500, image.height)
+    assert(image.transferred)
+  end
+
+  def test_rotate_mirror_vertical
+    image = images(:in_situ_image)
+    image.update_columns(transferred: false, width: 1000, height: 1000)
+    FileUtils.cp(JPG_FIXTURE, "#{local_root}/orig/#{image.id}.jpg")
+
+    Image::Processor.new(image: image, ext: "jpg").rotate("-v")
+
+    image.reload
+    assert_equal(407, image.width)
+    assert_equal(500, image.height)
+    assert(image.transferred)
+  end
+
+  def test_salvage_first_layer_if_multilayer_picks_one_and_cleans_up
+    image = images(:in_situ_image)
+    processor = Image::Processor.new(image: image, ext: "tiff")
+    File.write("#{local_root}/orig/#{image.id}-0.jpg", "first layer")
+    File.write("#{local_root}/orig/#{image.id}-1.jpg", "second layer")
+
+    processor.send(:salvage_first_layer_if_multilayer)
+
+    assert_path_exists("#{local_root}/orig/#{image.id}.jpg")
+    assert_includes(["first layer", "second layer"],
+                    File.read("#{local_root}/orig/#{image.id}.jpg"))
+    assert_not(File.exist?("#{local_root}/orig/#{image.id}-0.jpg"))
+    assert_not(File.exist?("#{local_root}/orig/#{image.id}-1.jpg"))
+  end
+
+  def test_copy_file_to_server_ssh_type_uses_rsync
+    image = images(:in_situ_image)
+    processor = Image::Processor.new(image: image, ext: "jpg")
+    File.write("#{local_root}/thumb/#{image.id}.jpg", "rsync me")
+    fake_data = { ssh_server: { type: "ssh", path: remote_server_path(1) } }
+
+    Image::Processor.stub(:image_server_data, fake_data) do
+      processor.send(:copy_file_to_server, :ssh_server,
+                     "thumb/#{image.id}.jpg")
+    end
+
+    assert_equal(
+      "rsync me",
+      File.read("#{remote_server_path(1)}/thumb/#{image.id}.jpg")
+    )
+  end
+
+  def test_copy_file_to_server_unknown_type_raises
+    image = images(:in_situ_image)
+    processor = Image::Processor.new(image: image, ext: "jpg")
+    fake_data = { weird: { type: "ftp", path: "/tmp" } }
+
+    Image::Processor.stub(:image_server_data, fake_data) do
+      assert_raises(RuntimeError) do
+        processor.send(:copy_file_to_server, :weird, "x.jpg")
+      end
+    end
+  end
+
+  def test_copy_file_from_server_ssh_type_uses_rsync
+    image = images(:in_situ_image)
+    processor = Image::Processor.new(image: image, ext: "jpg")
+    File.write("#{remote_server_path(1)}/thumb/#{image.id}.jpg",
+               "remote data")
+    fake_data = { ssh_server: { type: "ssh", path: remote_server_path(1) } }
+
+    Image::Processor.stub(:image_server_data, fake_data) do
+      processor.send(:copy_file_from_server, :ssh_server,
+                     "thumb/#{image.id}.jpg")
+    end
+
+    assert_equal("remote data",
+                 File.read("#{local_root}/thumb/#{image.id}.jpg"))
+  end
+
+  def test_copy_file_from_server_http_type_stringio_response
+    image = images(:in_situ_image)
+    processor = Image::Processor.new(image: image, ext: "jpg")
+    fake_data = { http_server: { type: "http", path: "http://example.test" } }
+    fake_uri = Object.new
+    fake_uri.define_singleton_method(:open) { StringIO.new("http body") }
+
+    Image::Processor.stub(:image_server_data, fake_data) do
+      URI.stub(:parse, fake_uri) do
+        processor.send(:copy_file_from_server, :http_server,
+                       "thumb/#{image.id}.jpg")
+      end
+    end
+
+    assert_equal("http body",
+                 File.read("#{local_root}/thumb/#{image.id}.jpg"))
+  end
+
+  def test_copy_file_from_server_http_type_tempfile_response
+    image = images(:in_situ_image)
+    processor = Image::Processor.new(image: image, ext: "jpg")
+    fake_data = { http_server: { type: "http", path: "http://example.test" } }
+    tempfile = Tempfile.new("http_test")
+    tempfile.write("tempfile body")
+    tempfile.rewind
+    fake_uri = Object.new
+    fake_uri.define_singleton_method(:open) { tempfile }
+
+    Image::Processor.stub(:image_server_data, fake_data) do
+      URI.stub(:parse, fake_uri) do
+        processor.send(:copy_file_from_server, :http_server,
+                       "thumb/#{image.id}.jpg")
+      end
+    end
+
+    assert_equal("tempfile body",
+                 File.read("#{local_root}/thumb/#{image.id}.jpg"))
+  end
+
+  def test_copy_file_from_server_unknown_type_raises
+    image = images(:in_situ_image)
+    processor = Image::Processor.new(image: image, ext: "jpg")
+    fake_data = { weird: { type: "ftp", path: "/tmp" } }
+
+    Image::Processor.stub(:image_server_data, fake_data) do
+      assert_raises(RuntimeError) do
+        processor.send(:copy_file_from_server, :weird, "x.jpg")
+      end
     end
   end
 end

--- a/test/models/image/processor_test.rb
+++ b/test/models/image/processor_test.rb
@@ -45,12 +45,12 @@ class Image::ProcessorTest < UnitTestCase
   end
 
   def test_image_server_data_matches_config
-    assert_equal(local_root, Image::Processor::LOCAL_IMAGES_PATH)
+    assert_equal(local_root, Image::Processor.local_images_path)
     assert_equal(remote_server_path(1),
-                 Image::Processor::IMAGE_SERVER_DATA[:remote1][:path])
+                 Image::Processor.image_server_data[:remote1][:path])
     assert_equal(remote_server_path(2),
-                 Image::Processor::IMAGE_SERVER_DATA[:remote2][:path])
-    assert_equal([:remote1, :remote2], Image::Processor::IMAGE_SERVERS,
+                 Image::Processor.image_server_data[:remote2][:path])
+    assert_equal([:remote1, :remote2], Image::Processor.image_servers,
                  ":local must never be a transfer target")
   end
 

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -314,8 +314,13 @@ class ImageTest < UnitTestCase
     img = images(:in_situ_image)
     img.upload_temp_file = "already-staged" # save_to_temp_file short-circuits
 
+    failing_processor = Object.new
+    def failing_processor.process
+      raise("boom")
+    end
+
     img.stub(:move_original, true) do
-      img.stub(:system, false) do
+      Image::Processor.stub(:new, failing_processor) do
         Rails.env.stub(:test?, false) do
           assert_not(img.process_image)
         end


### PR DESCRIPTION
## Summary

First PR in the job-ify-image-uploads plan for #4735 (full 4-PR breakdown posted as a comment on that issue). Ports the resize/reorient/transfer logic from `script/process_image` into a real Ruby class, `Image::Processor`, based on the draft in #2135.

The real motivation isn't just "no more shelling out" -- `script/process_image` flips `width`/`height`/`transferred` via a raw `mysql` `UPDATE`, so `after_update_commit` never fires today even if we added a callback. Writing through ActiveRecord (`image.update`) is what makes that possible, and it's a precondition for the Turbo Stream broadcast work planned later in this series, not a separate concern.

`Image#process_image` now calls `Image::Processor#process` directly instead of building and shelling out to `MO.process_image_command` (removed, now dead). Still skipped in test env exactly as before -- `Image::Processor` gets its own fast, direct unit tests instead of going through that guard.

`rotate` and `self.retransfer_images` are ported too (mirroring script/rotate_image and script/retransfer_images) but aren't wired to any call site or job yet -- that's the next PR, along with a from-scratch `verify_images` port.

### #2135 had never actually run

I used #2135's draft as the starting point, but close reading + writing real tests turned up quite a bit more than the two bugs I'd originally scoped in from a first read. None of this is a knock on that draft -- it was exploratory and never merged -- but worth being upfront that "port with the known bugs fixed" undersold the gap once I actually ran it against real files:

- A dead guard line in the rotate path (`nil unless operations.include?(orientation)` doesn't return/guard anything).
- `self.retransfer_images` read `@transferred_any` on `self` (the class) instead of on the `processor` instance that actually sets it -- the transferred flag was never marked.
- `mark_image_record_transferred_and_touch_obs` was `private` but called on a different instance's object from `self.retransfer_images` -- would raise `NoMethodError` the moment that path ran.
- `IMAGE_SERVER_DATA` was assigned in the class body by calling `image_server_data` (an *instance* method, defined *after* the assignment) -- the class couldn't even load.
- `IMAGE_SERVERS` included `:local`, so the transfer loop tried to copy local files onto themselves.
- The `ssh://` write-target path dropped the required `:` between `user@host` and the remote path, which rsync needs to know it's a remote target at all.
- `*_file` vs `*_filepath` -- `convert_source_to_destination` and `transform_full_size_file` called undefined `*_file` methods; only `*_filepath` was ever defined.
- `image_config.yml`'s `:sizes:` lists size names (`:thumbnail`) but the transfer code compares against subdirectory strings (`"thumb"`) -- direct comparison never matched, so `remote2`'s narrower size list silently transferred nothing.
- GPS stripping used `MiniExiftool#[]=`/`#save` with pseudo-tags like `"GPS:all"` -- these aren't real tags MiniExiftool recognizes, so `save` returns `false` and (since the return value was never checked) the file is left untouched. Fixed by shelling out to `exiftool` directly for this one operation, matching what `script/process_image` already did.

Extracted the server-config building (`IMAGE_SERVER_DATA`, the size↔subdir translation, the ssh path-joining) into `Image::Processor::ServerData` to keep `Image::Processor` itself under the class-length cop and separate "what servers exist" from "process this one image."

New gems: `image_processing`, `mini_magick`, `mini_exiftool_vendored`, `rsync`.

### Update: fixed a parallel-test-worker race in the path constants

`LOCAL_IMAGES_PATH`/`IMAGE_SERVER_DATA`/`IMAGE_SERVERS` were originally frozen constants computed once at class-load time from `MO.local_image_files`/`MO.image_sources`. Those two are deliberately lazy methods (see their comments in `config/consts.rb`) specifically so each parallel test worker gets its own suffixed directory (`test_images-3` vs `test_images-7`, etc.) -- caching their result in a frozen constant meant whichever forked worker happened to autoload `Image::Processor` before its own `TEST_ENV_NUMBER` was set would permanently lock in the wrong (unsuffixed) path for that worker's process lifetime, colliding with every other worker writing to the same shared directory.

I found this while working on the follow-up PR, which adds a second test file also referencing these constants -- with only this PR's own test file in the mix it doesn't reproduce in practice (stress-tested: 4 runs of 946 tests, 0 failures), but the design is unsafe under a different test distribution (CI's own parallelization included), and it's this class's own flaw regardless of which PR happened to expose it. Converted to plain class methods (`local_images_path`, `image_server_data`, `image_servers`) that recompute on every call.

## Test plan

- [x] `bin/rails test test/models/image/processor_test.rb` -- new, direct coverage of `process` (jpg + non-jpg/tiff conversion), GPS stripping (verified against a real geotagged fixture), `rotate` (including fetching the original back from a remote when missing locally), `self.retransfer_images`, and the `ServerData` helpers
- [x] `bin/rails test test/models/image_test.rb` -- existing `process_image` coverage, updated the one test that stubbed the old shell command
- [x] `bin/rails test test/classes/image_script_test.rb` -- shell-script integration tests unaffected (scripts still exist, untouched)
- [x] `bin/rails test test/controllers/observations_controller_create_test.rb test/controllers/observations_controller_update_test.rb` -- upload/update paths that call `process_image`
- [x] Stress-tested the parallel-worker-race fix: `bin/rails test test/models/image/processor_test.rb test/models/` (946 tests, full 12-way parallelization) x4, 0 failures
- [x] `bundle exec rubocop` clean on all new/changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
