### PR TITLE
Add RetransferImagesJob, VerifyImagesJob, RotateImageJob (#4735 PR 2/4)

### DIFF
--- a/app/jobs/retransfer_images_job.rb
+++ b/app/jobs/retransfer_images_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Recurring safety net: re-transfer any image still marked untransferred
+# (e.g. a process that died mid-upload before reaching the image server).
+class RetransferImagesJob < ApplicationJob
+  queue_as(:maintenance)
+
+  def perform
+    Image::Processor.retransfer_images
+  end
+end

--- a/app/jobs/rotate_image_job.rb
+++ b/app/jobs/rotate_image_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Rotates/mirrors an image outside the request cycle. Replaces the old
+# bare `system("script/rotate_image ... &")` fire-and-forget: since this
+# runs as a real, awaited job, ImageDhashJob can be enqueued right after
+# rotate finishes instead of guessing at a fixed delay.
+class RotateImageJob < ApplicationJob
+  queue_as(:default)
+
+  def perform(image_id, ext, orientation)
+    image = Image.find_by(id: image_id)
+    return unless image
+
+    Image::Processor.new(image: image, ext: ext).rotate(orientation)
+    ImageDhashJob.perform_later(image_id)
+  end
+end

--- a/app/jobs/verify_images_job.rb
+++ b/app/jobs/verify_images_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Recurring local/remote image sync check: uploads anything missing or
+# mismatched on a server, deletes local copies once they're confirmed
+# transferred everywhere relevant.
+class VerifyImagesJob < ApplicationJob
+  queue_as(:maintenance)
+
+  def perform
+    result = Image::Processor.verify_images { |msg| log(msg) }
+    log("Uploaded #{result[:uploaded].size}, deleted #{result[:deleted].size}")
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -835,18 +835,11 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     else
       raise("Invalid transform operator: #{operator.inspect}")
     end
-    # Rotation invalidates the perceptual hash; rotate_image runs in the
-    # background (fire-and-forget), so schedule the rehash with a delay
-    # rather than chaining it to a completion signal we never receive.
-    ImageDhashJob.set(wait: 5.minutes).perform_later(id) if persisted?
-    return if Rails.env.test?
+    return unless persisted?
 
-    # `operator` is one of the three literals set above (never raw input)
-    # and `id` is this record's integer primary key, so neither can carry
-    # shell syntax. The trailing "&" backgrounds the rotate; the shell form
-    # is what enables it. (Brakeman command-injection warning ignored on
-    # this basis in config/brakeman.ignore.)
-    system("script/rotate_image #{id} #{operator}&")
+    # RotateImageJob enqueues ImageDhashJob itself once rotation actually
+    # finishes -- a real completion signal, not a guessed delay.
+    RotateImageJob.perform_later(id, original_extension, operator)
   end
 
   # Compute and store the perceptual hash (Image::Dhash) for this image

--- a/app/models/image/processor.rb
+++ b/app/models/image/processor.rb
@@ -124,6 +124,13 @@ class Image
       end
     end
 
+    # Ruby port of script/verify_images: lists local vs remote file sizes
+    # per subdir/server, uploads mismatches, and deletes local copies once
+    # confirmed transferred everywhere relevant. See Verifier for details.
+    def self.verify_images(&log)
+      Verifier.new(&log).run
+    end
+
     private
 
     # Strip GPS data
@@ -277,73 +284,13 @@ class Image
     ############################################################
 
     def copy_file_to_server(server, local_file, remote_file = local_file)
-      case self.class.image_server_data[server][:type]
-      when "file"
-        copy_file_to_local_server(server, local_file, remote_file)
-      when "ssh"
-        copy_file_to_remote_server(server, local_file, remote_file)
-      else
-        raise("Unknown image server type: " \
-              "#{self.class.image_server_data[server][:type]}")
-      end
-    end
-
-    def copy_file_to_local_server(server, local_file, remote_file)
-      return unless (remote_path = self.class.image_server_data[server][:path])
-
-      FileUtils.mkpath(File.dirname("#{remote_path}/#{remote_file}"))
-      FileUtils.cp("#{self.class.local_images_path}/#{local_file}",
-                   "#{remote_path}/#{remote_file}")
-    end
-
-    # Rsync is used to copy files to the image server(s).
-    def copy_file_to_remote_server(server, local_file, remote_file)
-      return unless (remote_path = self.class.image_server_data[server][:path])
-
-      Rsync.run("#{self.class.local_images_path}/#{local_file}",
-                "#{remote_path}/#{remote_file}") do |result|
-        @errors << result.error unless result.success?
-      end
+      success = FileTransfer.copy_file_to_server(server, local_file,
+                                                 remote_file)
+      @errors << "Failed to transfer #{local_file} to #{server}" unless success
     end
 
     def copy_file_from_server(server, remote_file)
-      case self.class.image_server_data[server][:type]
-      when "file"
-        copy_file_from_local_server(server, remote_file)
-      when "ssh"
-        copy_file_from_remote_server(server, remote_file)
-      when "http", "https"
-        copy_file_from_http_server(server, remote_file)
-      else
-        raise("Don't know how to get #{remote_file} from #{server} via: " \
-              "#{self.class.image_server_data[server][:type]}")
-      end
-    end
-
-    def copy_file_from_local_server(server, remote_file)
-      return unless (remote_path = self.class.image_server_data[server][:path])
-
-      FileUtils.cp("#{remote_path}/#{remote_file}",
-                   "#{self.class.local_images_path}/#{remote_file}")
-    end
-
-    def copy_file_from_remote_server(server, remote_file)
-      return unless (remote_path = self.class.image_server_data[server][:path])
-
-      Rsync.run("#{remote_path}/#{remote_file}",
-                "#{self.class.local_images_path}/#{remote_file}")
-    end
-
-    def copy_file_from_http_server(server, remote_file)
-      return unless (remote_path = self.class.image_server_data[server][:path])
-
-      case io = URI.parse("#{remote_path}/#{remote_file}").open
-      when StringIO
-        File.write("#{self.class.local_images_path}/#{remote_file}", io.read)
-      when Tempfile
-        io.close
-        FileUtils.mv(io.path, "#{self.class.local_images_path}/#{remote_file}")
-      end
+      FileTransfer.copy_file_from_server(server, remote_file)
     end
   end
 end

--- a/app/models/image/processor/file_transfer.rb
+++ b/app/models/image/processor/file_transfer.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class Image
+  class Processor
+    # Copies one file between the local filesystem and a configured image
+    # server. No per-image state -- shared by Image::Processor (per-upload
+    # transfers) and Image::Processor::Verifier (bulk local/remote sync).
+    module FileTransfer
+      def self.copy_file_to_server(server, local_file, remote_file = local_file)
+        case Processor.image_server_data[server][:type]
+        when "file"
+          copy_file_to_local_server(server, local_file, remote_file)
+        when "ssh"
+          copy_file_to_remote_server(server, local_file, remote_file)
+        else
+          raise("Unknown image server type: " \
+                "#{Processor.image_server_data[server][:type]}")
+        end
+      end
+
+      def self.copy_file_from_server(server, remote_file,
+                                     local_file = remote_file)
+        case Processor.image_server_data[server][:type]
+        when "file"
+          copy_file_from_local_server(server, remote_file, local_file)
+        when "ssh"
+          copy_file_from_remote_server(server, remote_file, local_file)
+        when "http", "https"
+          copy_file_from_http_server(server, remote_file, local_file)
+        else
+          raise("Don't know how to get #{remote_file} from #{server} via: " \
+                "#{Processor.image_server_data[server][:type]}")
+        end
+      end
+
+      def self.copy_file_to_local_server(server, local_file, remote_file)
+        return unless (remote_path = Processor.image_server_data[server][:path])
+
+        FileUtils.mkpath(File.dirname("#{remote_path}/#{remote_file}"))
+        FileUtils.cp("#{Processor.local_images_path}/#{local_file}",
+                     "#{remote_path}/#{remote_file}")
+        true
+      end
+
+      # Rsync is used to copy files to remote image server(s).
+      def self.copy_file_to_remote_server(server, local_file, remote_file)
+        return unless (remote_path = Processor.image_server_data[server][:path])
+
+        result = nil
+        Rsync.run("#{Processor.local_images_path}/#{local_file}",
+                  "#{remote_path}/#{remote_file}") { |r| result = r }
+        result.success?
+      end
+
+      def self.copy_file_from_local_server(server, remote_file, local_file)
+        return unless (remote_path = Processor.image_server_data[server][:path])
+
+        local_path = "#{Processor.local_images_path}/#{local_file}"
+        FileUtils.mkpath(File.dirname(local_path))
+        FileUtils.cp("#{remote_path}/#{remote_file}", local_path)
+        true
+      end
+
+      def self.copy_file_from_remote_server(server, remote_file, local_file)
+        return unless (remote_path = Processor.image_server_data[server][:path])
+
+        result = nil
+        Rsync.run("#{remote_path}/#{remote_file}",
+                  "#{Processor.local_images_path}/#{local_file}") do |r|
+          result = r
+        end
+        result.success?
+      end
+
+      def self.copy_file_from_http_server(server, remote_file, local_file)
+        return unless (remote_path = Processor.image_server_data[server][:path])
+
+        local_path = "#{Processor.local_images_path}/#{local_file}"
+        case io = URI.parse("#{remote_path}/#{remote_file}").open
+        when StringIO
+          File.write(local_path, io.read)
+        when Tempfile
+          io.close
+          FileUtils.mv(io.path, local_path)
+        end
+        true
+      end
+    end
+  end
+end

--- a/app/models/image/processor/verifier.rb
+++ b/app/models/image/processor/verifier.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class Image
+  class Processor
+    # Ruby port of script/verify_images. Lists every local and remote image
+    # file (by subdir/filename => byte size), uploads any local file that's
+    # missing or mismatched on a server that's supposed to have it, then
+    # deletes local copies once they're confirmed to match on every server
+    # that carries that subdirectory -- skipping any size configured in
+    # MO.keep_these_image_sizes_local, which never gets deleted locally.
+    class Verifier
+      def initialize(&log)
+        @log = log
+        @uploaded = []
+        @deleted = []
+        # Fetched once per run (not cached at the class level -- see the
+        # comment on Image::Processor.local_images_path).
+        @image_server_data = Processor.image_server_data
+        @image_servers = @image_server_data.keys - [:local]
+      end
+
+      def run
+        listings = build_listings
+        upload_mismatches(listings)
+        delete_files_no_longer_needed(listings)
+        { uploaded: @uploaded, deleted: @deleted }
+      end
+
+      private
+
+      def build_listings
+        [:local, *@image_servers].index_with { |server| list_server(server) }
+      end
+
+      def list_server(server)
+        data = @image_server_data[server]
+        data[:subdirs].each_with_object({}) do |subdir, files|
+          log("Listing #{server} #{subdir}")
+          Dir.glob("#{data[:path]}/#{subdir}/*").each do |path|
+            next unless File.file?(path)
+
+            files["#{subdir}/#{File.basename(path)}"] = File.size(path)
+          end
+        end
+      end
+
+      def upload_mismatches(listings)
+        local = listings[:local]
+        @image_servers.each do |server|
+          subdirs = @image_server_data[server][:subdirs]
+          local.each_key do |path|
+            next unless subdirs.include?(subdir_of(path))
+            next if listings[server][path] == local[path]
+
+            log("Uploading #{path} to #{server}")
+            FileTransfer.copy_file_to_server(server, path)
+            @uploaded << [server, path]
+          end
+        end
+      end
+
+      def delete_files_no_longer_needed(listings)
+        local = listings[:local]
+        local.each_key do |path|
+          next if keep_local?(subdir_of(path))
+          next unless fully_synced?(path, listings)
+
+          log("Deleting #{path}")
+          File.delete("#{Processor.local_images_path}/#{path}")
+          @deleted << path
+        end
+      end
+
+      def fully_synced?(path, listings)
+        local_size = listings[:local][path]
+        @image_servers.all? do |server|
+          subdirs = @image_server_data[server][:subdirs]
+          subdirs.exclude?(subdir_of(path)) ||
+            listings[server][path] == local_size
+        end
+      end
+
+      def keep_local?(subdir)
+        MO.keep_these_image_sizes_local.any? do |size|
+          Image::URL::SUBDIRECTORIES[size] == subdir
+        end
+      end
+
+      def subdir_of(path)
+        path.split("/", 2).first
+      end
+
+      def log(msg)
+        @log&.call(msg)
+      end
+    end
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -115,29 +115,6 @@
       "note": "False positive: Open3.capture3 is called in argv (list) form, so no shell is spawned and each interpolated argument reaches ImageMagick verbatim and cannot be parsed as shell syntax. `path` is not user input: it is an internally constructed absolute path (Image#full_filepath or a Tempfile), so it also cannot begin with '-' and be misread as a convert option."
     },
     {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "590d3cd50f65173eac040a0c06e53a81af605cd1c821ad07ae8e88ccf49d467b",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "app/models/image.rb",
-      "line": 850,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "system(\"script/rotate_image #{id} #{((\"-90\" or \"+90\") or \"-h\")}&\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Image",
-        "method": "transform"
-      },
-      "user_input": "id",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
-      ],
-      "note": "False positive: `id` is this Image record's integer primary key (never a user-supplied string) and the operator is one of three string literals set by the case statement immediately above (unknown operators raise before this line). Neither interpolated value can carry shell metacharacters. The shell-string form is kept because the trailing '&' backgrounds the rotate script."
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "a6e091d1b880b1bf981ac1fe1b928105a62e8f0f3b71bea926142ccd08d1cc97",

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -22,3 +22,9 @@ production:
   discard_stale_jobs:
     class: DiscardStaleJobsJob
     schedule: every day at midnight
+  retransfer_images:
+    class: RetransferImagesJob
+    schedule: every day at 12:10am
+  verify_images:
+    class: VerifyImagesJob
+    schedule: every day at 1:01am

--- a/test/jobs/retransfer_images_job_test.rb
+++ b/test/jobs/retransfer_images_job_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class RetransferImagesJobTest < ActiveJob::TestCase
+  def test_calls_processor_retransfer_images
+    called = false
+    Image::Processor.stub(:retransfer_images, -> { called = true }) do
+      RetransferImagesJob.perform_now
+    end
+    assert(called)
+  end
+end

--- a/test/jobs/rotate_image_job_test.rb
+++ b/test/jobs/rotate_image_job_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class RotateImageJobTest < ActiveJob::TestCase
+  include ActiveJob::TestHelper
+
+  def test_rotates_and_enqueues_dhash_job
+    image = images(:in_situ_image)
+    rotated_with = nil
+    fake_processor = Object.new
+    fake_processor.define_singleton_method(:rotate) { |o| rotated_with = o }
+
+    Image::Processor.stub(:new, fake_processor) do
+      assert_enqueued_with(job: ImageDhashJob, args: [image.id]) do
+        RotateImageJob.perform_now(image.id, "jpg", "+90")
+      end
+    end
+    assert_equal("+90", rotated_with)
+  end
+
+  def test_missing_image_is_a_noop
+    assert_nothing_raised { RotateImageJob.perform_now(-1, "jpg", "+90") }
+  end
+end

--- a/test/jobs/verify_images_job_test.rb
+++ b/test/jobs/verify_images_job_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class VerifyImagesJobTest < ActiveJob::TestCase
+  def test_calls_processor_verify_images_and_logs_summary
+    result = { uploaded: ["320/1.jpg"], deleted: ["960/1.jpg", "640/2.jpg"] }
+    Image::Processor.stub(:verify_images, result) do
+      assert_nothing_raised { VerifyImagesJob.perform_now }
+    end
+  end
+end

--- a/test/models/image/processor/verifier_test.rb
+++ b/test/models/image/processor/verifier_test.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Ruby port of script/verify_images -- see test/classes/image_script_test.rb
+# for the equivalent shell-script coverage this fixture data is drawn from.
+class Image::Processor::VerifierTest < UnitTestCase
+  SUBDIRS = %w[thumb 320 640 960 1280 orig].freeze
+
+  def local_root
+    if (worker_num = database_worker_number)
+      Rails.public_path.join("test_images-#{worker_num}").to_s
+    else
+      Rails.public_path.join("test_images").to_s
+    end
+  end
+
+  def remote_server_path(num)
+    if (worker_num = database_worker_number)
+      Rails.public_path.join("test_server#{num}-#{worker_num}").to_s
+    else
+      Rails.public_path.join("test_server#{num}").to_s
+    end
+  end
+
+  def setup
+    [local_root, remote_server_path(1), remote_server_path(2)].each do |root|
+      FileUtils.rm_rf(root)
+      SUBDIRS.each { |dir| FileUtils.mkpath("#{root}/#{dir}") }
+    end
+    super
+  end
+
+  def teardown
+    [local_root, remote_server_path(1), remote_server_path(2)].each do |root|
+      FileUtils.rm_rf(root)
+    end
+    super
+  end
+
+  def test_verify_uploads_mismatches_and_deletes_fully_synced_files
+    in_situ = images(:in_situ_image).id
+    turned_over = images(:turned_over_image).id
+    commercial = images(:commercial_inquiry_image).id
+    disconnected = images(:disconnected_coprinus_comatus_image).id
+    seed_local_files(turned_over, commercial, disconnected)
+    seed_remote1_files(in_situ, turned_over, commercial, disconnected)
+    seed_remote2_files(in_situ, turned_over, commercial)
+
+    result = Image::Processor.verify_images
+
+    assert_uploads(result, turned_over, commercial, disconnected)
+    assert_deletes(result, turned_over, commercial)
+  end
+
+  def test_verify_yields_log_lines_to_the_given_block
+    lines = []
+    Image::Processor.verify_images { |msg| lines << msg }
+    assert_includes(lines, "Listing local thumb")
+  end
+
+  private
+
+  def seed_local_files(turned_over, commercial, disconnected)
+    File.write("#{local_root}/orig/#{turned_over}.tiff", "A")
+    File.write("#{local_root}/orig/#{turned_over}.jpg", "AB")
+    File.write("#{local_root}/960/#{turned_over}.jpg", "ABC")
+    File.write("#{local_root}/640/#{turned_over}.jpg", "ABCD")
+    File.write("#{local_root}/320/#{turned_over}.jpg", "ABCDE")
+    File.write("#{local_root}/960/#{commercial}.jpg", "ABCDEF")
+    File.write("#{local_root}/640/#{commercial}.jpg", "ABCDEFG")
+    File.write("#{local_root}/320/#{commercial}.jpg", "ABCDEFGH")
+    File.write("#{local_root}/960/#{disconnected}.jpg", "ABCDEFGHI")
+    File.write("#{local_root}/640/#{disconnected}.jpg", "ABCDEFGHIJ")
+    File.write("#{local_root}/320/#{disconnected}.jpg", "ABCDEFGHIJK")
+  end
+
+  def seed_remote1_files(in_situ, turned_over, commercial, disconnected)
+    root = remote_server_path(1)
+    File.write("#{root}/960/#{in_situ}.jpg", "correct")
+    File.write("#{root}/640/#{in_situ}.jpg", "correct")
+    File.write("#{root}/320/#{in_situ}.jpg", "correct")
+    File.write("#{root}/960/#{turned_over}.jpg", "ABC")
+    File.write("#{root}/640/#{turned_over}.jpg", "ABCD")
+    File.write("#{root}/320/#{turned_over}.jpg", "ABCDE")
+    File.write("#{root}/960/#{commercial}.jpg", "ABCDEF")
+    File.write("#{root}/640/#{commercial}.jpg", "ABCDEFG")
+    File.write("#{root}/320/#{commercial}.jpg", "ABCDEFGH")
+    File.write("#{root}/960/#{disconnected}.jpg", "allcorrupted!")
+    File.write("#{root}/640/#{disconnected}.jpg", "allcorrupted!")
+    File.write("#{root}/320/#{disconnected}.jpg", "allcorrupted!")
+  end
+
+  def seed_remote2_files(in_situ, turned_over, commercial)
+    root = remote_server_path(2)
+    File.write("#{root}/640/#{in_situ}.jpg", "correct")
+    File.write("#{root}/320/#{in_situ}.jpg", "correct")
+    File.write("#{root}/640/#{turned_over}.jpg", "ABCD")
+    File.write("#{root}/320/#{turned_over}.jpg", "ABCDE")
+    File.write("#{root}/640/#{commercial}.jpg", "allcorrupted!")
+    File.write("#{root}/320/#{commercial}.jpg", "allcorrupted!")
+  end
+
+  def assert_uploads(result, turned_over, commercial, disconnected)
+    expected = [
+      [:remote1, "320/#{disconnected}.jpg"],
+      [:remote2, "320/#{commercial}.jpg"],
+      [:remote2, "320/#{disconnected}.jpg"],
+      [:remote1, "640/#{disconnected}.jpg"],
+      [:remote2, "640/#{commercial}.jpg"],
+      [:remote2, "640/#{disconnected}.jpg"],
+      [:remote1, "960/#{disconnected}.jpg"],
+      [:remote1, "orig/#{turned_over}.jpg"],
+      [:remote1, "orig/#{turned_over}.tiff"]
+    ]
+    expected.each { |entry| assert_includes(result[:uploaded], entry) }
+    assert_equal(expected.size, result[:uploaded].size)
+
+    assert_equal("ABCDEFGHIJK",
+                 File.read("#{remote_server_path(1)}/320/#{disconnected}.jpg"))
+    assert_equal("ABCDEFGH",
+                 File.read("#{remote_server_path(2)}/320/#{commercial}.jpg"))
+    assert_equal("AB",
+                 File.read("#{remote_server_path(1)}/orig/#{turned_over}.jpg"))
+    assert_equal(
+      "A", File.read("#{remote_server_path(1)}/orig/#{turned_over}.tiff")
+    )
+  end
+
+  def assert_deletes(result, turned_over, commercial)
+    expected = ["640/#{turned_over}.jpg", "960/#{turned_over}.jpg",
+                "960/#{commercial}.jpg"]
+    expected.each { |path| assert_includes(result[:deleted], path) }
+    assert_equal(expected.size, result[:deleted].size)
+    expected.each do |path|
+      assert_not(File.exist?("#{local_root}/#{path}"), "#{path} should be gone")
+    end
+
+    # "small" (320) is in MO.keep_these_image_sizes_local -- never deleted,
+    # even though it's fully synced everywhere relevant.
+    assert_path_exists("#{local_root}/320/#{turned_over}.jpg")
+    # 640/commercial mismatches on remote2 -- not eligible for deletion.
+    assert_path_exists("#{local_root}/640/#{commercial}.jpg")
+  end
+end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -3,6 +3,8 @@
 require("test_helper")
 
 class ImageTest < UnitTestCase
+  include ActiveJob::TestHelper
+
   # log_update/log_destroy/log_create_for/log_reuse_for/log_remove_from
   # attribute to `current_user` (the acting/editing user), not `user`
   # (the image's owner) - an admin editing/removing someone else's image
@@ -166,21 +168,16 @@ class ImageTest < UnitTestCase
 
   def test_transform
     img = Image.new
-    assert_nil(img.transform(:mirror))
+    assert_no_enqueued_jobs { assert_nil(img.transform(:mirror)) }
     assert_raises(RuntimeError) { img.transform(:edible) }
   end
 
-  # Outside the test env the guard clause is skipped and transform shells
-  # out to script/rotate_image with the mapped operator.
-  def test_transform_shells_out_when_not_in_test_env
+  def test_transform_enqueues_rotate_image_job
     img = images(:in_situ_image)
-    commands = []
-    img.stub(:system, ->(cmd) { commands << cmd }) do
-      Rails.env.stub(:test?, false) do
-        img.transform(:rotate_left)
-      end
+    assert_enqueued_with(job: RotateImageJob,
+                         args: [img.id, img.original_extension, "-90"]) do
+      img.transform(:rotate_left)
     end
-    assert_equal(["script/rotate_image #{img.id} -90&"], commands)
   end
 
   # With no local rendition on disk, compute_dhash! fetches the remote


### PR DESCRIPTION
## Summary

Second PR in the job-ify-image-uploads plan for #4735 (stacked on #4747 -- `Image::Processor`, still open). Converts the three remaining shell scripts to real, scheduled Solid Queue jobs, using `Image::Processor` from the first PR.

- `RetransferImagesJob` wraps `Image::Processor.retransfer_images` (already ported in #4747) -- a thin recurring wrapper, no new logic.
- `VerifyImagesJob` wraps a fresh Ruby port of `script/verify_images`: `Image::Processor::Verifier` lists every local and remote image file (by subdir/filename => byte size), uploads anything missing or mismatched on a server that's meant to have it, then deletes local copies once they're confirmed to match on every server that carries that subdirectory -- skipping any size in `MO.keep_these_image_sizes_local`, which never gets deleted locally. Tested against the exact same fixture data `test/classes/image_script_test.rb`'s shell-script test uses, but asserting on resulting file state and the returned `{uploaded:, deleted:}` rather than replicating the shell script's exact log-line output.
- `RotateImageJob` replaces `Image#transform`'s bare `system("script/rotate_image ... &")` fire-and-forget. That also let me drop the hardcoded 5-minute delay before re-hashing (a guess at how long the untracked background script would take) -- since the job is awaited, it enqueues `ImageDhashJob` immediately after `Image::Processor#rotate` actually finishes, a real completion signal instead of a guess.

Extracted the low-level per-file copy logic (`copy_file_to_server` et al) out of `Image::Processor` into `Image::Processor::FileTransfer`, a stateless module, so `Verifier`'s bulk sync and `Processor`'s per-image transfers share one implementation instead of risking two copies of the same rsync/scp logic drifting apart.

*(A parallel-test-worker race I originally found and fixed while building this PR turned out to be a defect in `Image::Processor` itself, not specific to anything added here -- moved to #4747, see that PR's description. This PR is based on top of that fix.)*

### Schedule

Registered both new recurring jobs in `config/recurring.yml`:

```
retransfer_images:  every day at 12:10am
verify_images:      every day at 1:01am
```

Staggered off the existing midnight maintenance jobs and off the every-3-minutes inat-import recovery job's `:00`/`:03`/`:06`... marks (same reasoning as #4746 earlier this week). Verified both parse to the intended cron expressions via `Fugit.parse(...).to_cron_s`.

## Test plan

- [x] `bin/rails test test/models/image/processor/verifier_test.rb test/jobs/retransfer_images_job_test.rb test/jobs/verify_images_job_test.rb test/jobs/rotate_image_job_test.rb` -- new coverage
- [x] `bin/rails test test/models/image_test.rb test/models/image/` -- updated `transform` tests, rest unaffected
- [x] `bin/rails test test/classes/image_script_test.rb test/controllers/observations_controller_create_test.rb test/controllers/observations_controller_update_test.rb test/controllers/images/` -- unaffected
- [x] `ruby -ryaml -e "YAML.load_file('config/recurring.yml')"` -- valid YAML
- [x] `bundle exec rubocop` clean on all new/changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
