### PR TITLE
Guard against Solid Queue thread-pool-vs-DB-pool crash (prod incident)

### DIFF
--- a/db/vagrant/database.yml
+++ b/db/vagrant/database.yml
@@ -48,6 +48,11 @@ test:
   database: "<%= ENV['MO_TEST_DATABASE'] || (ENV['TEST_ENV_NUMBER'].to_s.empty? && 'mo_test') || 'mo_test-' + ENV['TEST_ENV_NUMBER'] %>"
   username: mo
   password: mo
+  # Must exceed Solid Queue's own estimated thread need -- see
+  # test/jobs/queue_config_test.rb and the comment on the equivalent
+  # setting in config/database.yml (not checked in; this file is what CI
+  # copies to config/database.yml for test runs).
+  pool: 10
 
 production:
   database: mo_development

--- a/test/jobs/queue_config_test.rb
+++ b/test/jobs/queue_config_test.rb
@@ -40,7 +40,7 @@ class QueueConfigTest < UnitTestCase
   def test_database_pool_is_large_enough_for_configured_worker_threads
     config = SolidQueue::Configuration.new
     valid = config.valid?
-    assert_equal(valid, config.error_messages.join("\n"))
+    assert_equal(valid, config.error_messages)
   end
 
   private

--- a/test/jobs/queue_config_test.rb
+++ b/test/jobs/queue_config_test.rb
@@ -28,6 +28,20 @@ class QueueConfigTest < UnitTestCase
                     "deliver_later would never send in production")
   end
 
+  # Regression guard for the incident on 2026-07-09: config/queue.yml's
+  # busiest worker pool needed more threads than config/database.yml's
+  # connection pool had, so Solid Queue's own startup validation
+  # (SolidQueue::Configuration#ensure_correctly_sized_thread_pool) failed
+  # every single time the supervisor (re)started, crash-looping forever --
+  # no queue, including "mailers", was ever claimed again after that.
+  # Nothing in the app raises on this at boot; it only surfaces if
+  # something actually asks Solid Queue to validate its own configuration,
+  # which is exactly what this test does.
+  def test_database_pool_is_large_enough_for_configured_worker_threads
+    config = SolidQueue::Configuration.new
+    assert_predicate(config, :valid?, config.error_messages)
+  end
+
   private
 
   def all_queues_covered?

--- a/test/jobs/queue_config_test.rb
+++ b/test/jobs/queue_config_test.rb
@@ -39,7 +39,8 @@ class QueueConfigTest < UnitTestCase
   # which is exactly what this test does.
   def test_database_pool_is_large_enough_for_configured_worker_threads
     config = SolidQueue::Configuration.new
-    assert_predicate(config, :valid?, config.error_messages)
+    valid = config.valid?
+    assert(valid, config.error_messages.join("\n"))
   end
 
   private

--- a/test/jobs/queue_config_test.rb
+++ b/test/jobs/queue_config_test.rb
@@ -40,7 +40,15 @@ class QueueConfigTest < UnitTestCase
   def test_database_pool_is_large_enough_for_configured_worker_threads
     config = SolidQueue::Configuration.new
     valid = config.valid?
-    assert_equal(valid, config.error_messages)
+
+    # config.error_messages is a failure MESSAGE (already a String), not
+    # an expected value -- assert_equal(valid, config.error_messages)
+    # (what the cop suggests, and what a prior Copilot-suggested edit
+    # actually shipped) compares a boolean against a String and can
+    # never pass.
+    # rubocop:disable Minitest/AssertWithExpectedArgument
+    assert(valid, config.error_messages)
+    # rubocop:enable Minitest/AssertWithExpectedArgument
   end
 
   private

--- a/test/jobs/queue_config_test.rb
+++ b/test/jobs/queue_config_test.rb
@@ -40,7 +40,7 @@ class QueueConfigTest < UnitTestCase
   def test_database_pool_is_large_enough_for_configured_worker_threads
     config = SolidQueue::Configuration.new
     valid = config.valid?
-    assert(valid, config.error_messages.join("\n"))
+    assert_equal(valid, config.error_messages.join("\n"))
   end
 
   private


### PR DESCRIPTION
## Summary

Production incident: after #4727 landed, Solid Queue stopped processing jobs entirely (most visibly noticed via the `mailers` queue backing up, but it affected every queue once the supervisor restarted onto the new config).

Root cause: `config/database.yml` is gitignored and not checked in, so production's file never had an explicit `pool:` for its `production:` environment -- it silently used ActiveRecord's default of 5. That was adequate while Solid Queue's busiest worker pool needed `3 threads + 2 (worker + heartbeat) = 5`, but #4727 bumped that worker's `threads:` to 4, needing 6 -- one more than the connection pool had.

`SolidQueue::Configuration#ensure_correctly_sized_thread_pool` validates this at supervisor startup and refuses to run if the pool is too small. Combined with `Restart=always` in the systemd unit, every single (re)start of the supervisor after that point failed instantly and got respawned a few seconds later, forever -- no queue was ever claimed again after whatever first restart picked up the new thread count. Confirmed directly on the server: `systemctl status solidqueue` showed the process endlessly "just started Ns ago," and `SolidQueue::Process.count` was 0 despite the service reporting active.

Since `config/database.yml` isn't tracked, there's no code change to make for production's own file -- that's already been corrected directly on the server (added `pool: 10`). What *is* fixable here: `db/vagrant/database.yml`, which CI copies to `config/database.yml` for test runs, had the exact same latent gap (test env's effective pool was also 5, confirmed via `SolidQueue::Record.connection_pool.size`). Bumped it to 10.

Added a regression test (`test/jobs/queue_config_test.rb`) that instantiates a real `SolidQueue::Configuration` for the current environment and asserts it's valid. Verified it actually catches the regression -- temporarily reverting the pool bump reproduces the exact same error message seen in production (`"Solid Queue is configured to use 6 threads but the database connection pool is 5"`).

## Test plan

- [x] `bin/rails test test/jobs/queue_config_test.rb` -- new test passes with the fix; confirmed it fails with the exact production error message when the pool bump is reverted
- [x] `bin/rails test test/jobs/` -- unaffected
- [x] `bundle exec rubocop` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
