### PR TITLE
Recognize webp/heic uploads instead of mislabeling them "raw"

### DIFF
--- a/app/javascript/controllers/file-input_controller.js
+++ b/app/javascript/controllers/file-input_controller.js
@@ -23,7 +23,7 @@ export default class extends Controller {
 
     // Check file type - folders have empty type, reject non-images
     if (!file.type || !file.type.startsWith('image/')) {
-      alert("Please select an image file (JPG, PNG, GIF, etc.)");
+      alert("Please select an image file.");
       this.inputTarget.value = "";
       return;
     }

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -462,6 +462,8 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     when "image/png" then "png"
     when "image/tiff" then "tiff"
     when "image/bmp", "image/x-ms-bmp" then "bmp"
+    when "image/webp" then "webp"
+    when "image/heif" then "heic"
     else; "raw"
     end
   end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -221,7 +221,8 @@ class ImageTest < UnitTestCase
     {
       "image/jpeg" => "jpg", "image/gif" => "gif", "image/png" => "png",
       "image/tiff" => "tiff", "image/bmp" => "bmp",
-      "image/x-ms-bmp" => "bmp", "application/octet-stream" => "raw"
+      "image/x-ms-bmp" => "bmp", "image/webp" => "webp",
+      "image/heif" => "heic", "application/octet-stream" => "raw"
     }.each do |content_type, ext|
       assert_equal(ext, Image.new(content_type: content_type).
                         original_extension)

--- a/test/system/image_upload_system_test.rb
+++ b/test/system/image_upload_system_test.rb
@@ -71,8 +71,7 @@ class ImageUploadSystemTest < ApplicationSystemTestCase
                     visible: false)
       end
 
-      assert_equal("Please select an image file (JPG, PNG, GIF, etc.)",
-                   alert_text)
+      assert_equal("Please select an image file.", alert_text)
     ensure
       text_file.unlink
     end


### PR DESCRIPTION
## Summary

`Image#original_extension` mapped any upload content-type outside jpeg/gif/png/tiff/bmp to the literal extension `"raw"`. This affected real WebP and HEIC uploads: `validate_image_type` already accepts them (it only checks the sniffed MIME type starts with `"image"`), and `MimeMagic.by_magic` already correctly detects them via real magic bytes (confirmed against actual generated files: `image/webp`, `image/heif`) — but `original_extension` then stored them as `orig/{id}.raw` and handed that wrong extension to ImageMagick for conversion.

- Adds `image/webp` -> `"webp"` and `image/heif` -> `"heic"` branches to `original_extension`.
- Fixes the client-side file-type rejection alert, which named only "JPG, PNG, GIF" despite the actual check (`file.type.startsWith('image/')`) already accepting any image MIME type — genericized to "Please select an image file." instead of maintaining a list that goes stale every time a new format is supported (this is literally how this bug was found: it didn't even mention TIFF, which has always been supported).

Note: AVIF and true camera RAW formats (CR2, NEF, ARW, DNG, etc.) are intentionally **not** included here. Locally, ImageMagick 7.1.2 has delegates for HEIC/WebP but not AVIF or any RAW/dcraw decoder — adding those extensions without confirming the production image server has the matching libraries (libheif w/ AV1, libraw) would just move the failure from "silently mislabeled" to "silently fails to convert." Worth a follow-up once that's confirmed.

Also out of scope here: `Image::ALL_EXTENSIONS`/`ALL_CONTENT_TYPES` (the search/filter-by-content-type feature) were deliberately left untouched. They're a parallel-indexed pair of arrays with a pre-existing quirk (bmp has two content-type spellings but one extension, so the arrays aren't cleanly 1:1), and extending them for webp/heic isn't part of what was asked (fixing the upload/conversion mislabeling) — flagging as a possible separate follow-up.

## Test plan

- [x] `bin/rails test test/models/image_test.rb test/system/image_upload_system_test.rb` — 38 tests, 0 failures
- [x] `bundle exec rubocop app/models/image.rb test/models/image_test.rb test/system/image_upload_system_test.rb` — no offenses
- [x] Confirmed via real generated WebP/HEIC files (`convert -size 300x200 xc:blue test.webp` etc.) that `MimeMagic.by_magic` correctly detects `image/webp`/`image/heif` today, independent of this change
