### PR TITLE
Route raw navbar-*/btn classes through `Components::Navbar` constants and `Link` `button:`/`size:` kwargs

### DIFF
--- a/app/components/button/get.rb
+++ b/app/components/button/get.rb
@@ -11,7 +11,7 @@
 #
 # @example btn-link variant (no btn frame, underlined)
 #   Button(type: :get,
-#     name: user.login, target: user, variant: :btn_link
+#     name: user.login, target: user, variant: :link
 #   )
 class Components::Button::Get < Components::Link::Get
   def initialize(name:, target:, variant: nil, **)

--- a/app/components/button/styling.rb
+++ b/app/components/button/styling.rb
@@ -17,7 +17,12 @@
 # `"btn"` class is added separately by each component's `merged_class`, so
 # `variant: :strip` renders no Bootstrap button framing at all. Omit
 # `variant:` (or pass `nil`) for the standard grey button (`btn btn-default`).
-# `:default` is NOT a valid variant symbol — omit the kwarg instead.
+# `:default` is also accepted as an explicit synonym for nil/omitted —
+# `Components::Link`/`Link::Icon` need to distinguish "no button framing
+# at all" (nil, a plain link) from "framed as the default button"
+# (`:default`, a different state at that layer), so `btn_class` treats
+# both the same rather than making every such caller translate `:default`
+# to `nil` itself.
 module Components::Button::Styling
   extend ActiveSupport::Concern
 
@@ -46,6 +51,7 @@ module Components::Button::Styling
   module_function
 
   def btn_class(variant)
+    variant = nil if variant == :default
     return "btn-default" if variant.nil?
     return nil if variant == :strip
 

--- a/app/components/button/styling.rb
+++ b/app/components/button/styling.rb
@@ -32,7 +32,7 @@ module Components::Button::Styling
     warning: "btn-warning",
     success: "btn-success",
     info: "btn-info",
-    btn_link: "btn-link",
+    link: "btn-link",
     outline: "btn-outline-default",
     outline_primary: "btn-outline-primary",
     outline_danger: "btn-outline-danger",
@@ -51,8 +51,7 @@ module Components::Button::Styling
   module_function
 
   def btn_class(variant)
-    variant = nil if variant == :default
-    return "btn-default" if variant.nil?
+    return "btn-default" if variant.nil? || variant == :default
     return nil if variant == :strip
 
     css = BTN_VARIANTS[variant]

--- a/app/components/form/pattern_search.rb
+++ b/app/components/form/pattern_search.rb
@@ -31,7 +31,8 @@ class Components::Form::PatternSearch < Components::ApplicationForm
     [:app_search_google, :google]
   ].freeze
 
-  FORM_CLASS = "flex-bar flex-grow-1 navbar-form px-0 gap-2"
+  FORM_CLASS = "flex-bar flex-grow-1 #{Components::Navbar::FORM_CLASS} " \
+               "px-0 gap-2".freeze
 
   def initialize(model, **options)
     options[:id] ||= "pattern_search_form"

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -111,7 +111,7 @@ class Components::Form::Search < Components::ApplicationForm
          collapsed: false,
          icon: :minus,
          icon_title: :search_bar_fewer_options.l,
-         button: :btn_link,
+         button: :link,
          class: class_names(Components::Navbar::LINK_CLASS, "px-2"),
          data: { search_type_target: "barToggle" })
   end

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -112,7 +112,7 @@ class Components::Form::Search < Components::ApplicationForm
          icon: :minus,
          icon_title: :search_bar_fewer_options.l,
          button: :btn_link,
-         class: "navbar-link px-2",
+         class: class_names(Components::Navbar::LINK_CLASS, "px-2"),
          data: { search_type_target: "barToggle" })
   end
 

--- a/app/components/link.rb
+++ b/app/components/link.rb
@@ -71,11 +71,12 @@ class Components::Link < Components::Base
   # Returns the btn class string when `button:` is set, or nil for a
   # plain link. Intentionally different from `Button#btn_styling`:
   # nil means "plain link". Pass `:default` for the grey btn-default
-  # frame (same as omitting `variant:` on Components::Button).
+  # frame (same as omitting `variant:` on Components::Button) --
+  # `btn_class` itself treats `:default` as a synonym for nil, so no
+  # separate branch is needed here for that case.
   def btn_styling
     return nil unless @button
     return nil if @button == :strip
-    return class_names("btn", "btn-default") if @button == :default
 
     class_names("btn", btn_class(@button))
   end

--- a/app/components/link/collapse_toggle.rb
+++ b/app/components/link/collapse_toggle.rb
@@ -18,14 +18,14 @@
 # explicitly so Bootstrap still finds the collapse pane (Bootstrap
 # reads `data-target` before `href`).
 #
-# Pass `button:` for Bootstrap button styling (e.g. `:btn_link`,
+# Pass `button:` for Bootstrap button styling (e.g. `:link`,
 # `:outline`) and `size:` for size modifiers (e.g. `:xs`, `:sm`).
 #
 # @example icon kwarg toggle (starts closed)
 #   render(Components::Link::CollapseToggle.new(
 #     target_id: "contribution_legend",
 #     icon: :info_circle,
-#     button: :btn_link,
+#     button: :link,
 #     size: :xs
 #   ))
 #

--- a/app/components/link/get.rb
+++ b/app/components/link/get.rb
@@ -18,7 +18,7 @@
 #
 # @example btn-link variant (underlined, no btn frame)
 #   render(Components::Link::Get.new(
-#     name: user.login, target: user_path(user.id), button: :btn_link
+#     name: user.login, target: user_path(user.id), button: :link
 #   ))
 class Components::Link::Get < Components::Link
   include Components::CRUDPathBuilding

--- a/app/components/link/icon.rb
+++ b/app/components/link/icon.rb
@@ -32,7 +32,7 @@
 #
 # @example Framed as a Bootstrap button (e.g. a navbar icon-button)
 #   render(Components::Link::Icon.new(content: "Prev", path: prev_path,
-#                                     icon: :prev, button: :btn_link,
+#                                     icon: :prev, button: :link,
 #                                     size: :lg))
 class Components::Link::Icon < Components::Base
   include Components::IconLabel

--- a/app/components/link/icon.rb
+++ b/app/components/link/icon.rb
@@ -55,6 +55,7 @@ class Components::Link::Icon < Components::Base
       @path = path
       @opts = opts
     end
+    validate_no_btn_classes!(@opts[:class])
   end
 
   def view_template

--- a/app/components/link/icon.rb
+++ b/app/components/link/icon.rb
@@ -32,7 +32,7 @@
 #
 # @example Framed as a Bootstrap button (e.g. a navbar icon-button)
 #   render(Components::Link::Icon.new(content: "Prev", path: prev_path,
-#                                     icon: :prev, button: :default,
+#                                     icon: :prev, button: :btn_link,
 #                                     size: :lg))
 class Components::Link::Icon < Components::Base
   include Components::IconLabel

--- a/app/components/link/icon.rb
+++ b/app/components/link/icon.rb
@@ -29,11 +29,18 @@
 #
 # @example From a Tab PORO (shortcut)
 #   render(Components::Link::Icon.new(tab: Tab::Name::Edit.new(name: @name)))
+#
+# @example Framed as a Bootstrap button (e.g. a navbar icon-button)
+#   render(Components::Link::Icon.new(content: "Prev", path: prev_path,
+#                                     icon: :prev, button: :default,
+#                                     size: :lg))
 class Components::Link::Icon < Components::Base
   include Components::IconLabel
+  include Components::Button::Styling
 
   CONSUMED_OPTS = [:class, :icon, :icon_class, :show_text,
-                   :active_icon, :active_content, :button_to, :confirm].freeze
+                   :active_icon, :active_content, :button_to, :confirm,
+                   :button, :size].freeze
 
   attr_reader :content, :path, :opts
 
@@ -105,13 +112,26 @@ class Components::Link::Icon < Components::Base
     # Clone/Merge/Move). Turbo shows the dialog before following the link.
     base = {
       title: @content,
-      class: class_names("icon-link", @opts[:class]),
+      class: class_names("icon-link", btn_styling, size_class(@opts[:size]),
+                         @opts[:class]),
       data: { toggle: "tooltip", title: @content,
               active_title: @opts[:active_content] }
     }
     base[:data][:turbo_confirm] = @opts[:confirm] if @opts[:confirm]
     base[:role] = "button" if @opts[:button_to]
     base.deep_merge(@opts.except(*CONSUMED_OPTS))
+  end
+
+  # `nil` (button: omitted) means "plain link" — no btn framing at all,
+  # matching Components::Link#btn_styling's semantics so callers can't
+  # tell the two Link subclasses apart by behavior.
+  def btn_styling
+    button = @opts[:button]
+    return nil unless button
+    return nil if button == :strip
+    return class_names("btn", "btn-default") if button == :default
+
+    class_names("btn", btn_class(button))
   end
 
   def render_link_or_button(&block)

--- a/app/components/link/icon.rb
+++ b/app/components/link/icon.rb
@@ -113,14 +113,24 @@ class Components::Link::Icon < Components::Base
     # Clone/Merge/Move). Turbo shows the dialog before following the link.
     base = {
       title: @content,
-      class: class_names("icon-link", btn_styling, size_class(@opts[:size]),
-                         @opts[:class]),
+      class: class_names("icon-link", button_classes, @opts[:class]),
       data: { toggle: "tooltip", title: @content,
               active_title: @opts[:active_content] }
     }
     base[:data][:turbo_confirm] = @opts[:confirm] if @opts[:confirm]
     base[:role] = "button" if @opts[:button_to]
     base.deep_merge(@opts.except(*CONSUMED_OPTS))
+  end
+
+  # `size:` only ever makes sense alongside real btn framing — a
+  # dangling `btn-lg` with no `.btn` base class isn't valid Bootstrap
+  # markup — so it's computed here, gated on `btn_styling` being
+  # present, rather than appended unconditionally in `link_attrs`.
+  def button_classes
+    styling = btn_styling
+    return nil unless styling
+
+    class_names(styling, size_class(@opts[:size]))
   end
 
   # `nil` (button: omitted) means "plain link" — no btn framing at all,

--- a/app/components/link/icon.rb
+++ b/app/components/link/icon.rb
@@ -135,12 +135,13 @@ class Components::Link::Icon < Components::Base
 
   # `nil` (button: omitted) means "plain link" — no btn framing at all,
   # matching Components::Link#btn_styling's semantics so callers can't
-  # tell the two Link subclasses apart by behavior.
+  # tell the two Link subclasses apart by behavior. `btn_class` itself
+  # treats `:default` as a synonym for nil ("btn-default"), so no
+  # separate branch is needed here for that case.
   def btn_styling
     button = @opts[:button]
     return nil unless button
     return nil if button == :strip
-    return class_names("btn", "btn-default") if button == :default
 
     class_names("btn", btn_class(button))
   end

--- a/app/components/link/object.rb
+++ b/app/components/link/object.rb
@@ -5,7 +5,7 @@
 # tests / JS hooks.
 #
 # Pass `button:` to add Bootstrap button styling alongside the
-# identifier class (e.g. `button: :btn_link` emits `btn btn-link`).
+# identifier class (e.g. `button: :link` emits `btn btn-link`).
 # Omit `button:` for a plain unstyled link (the default).
 class Components::Link::Object < Components::Link
   prop :object, _Nilable(::AbstractModel), default: nil

--- a/app/components/link/user.rb
+++ b/app/components/link/user.rb
@@ -7,7 +7,7 @@
 # "Unknown User" string when `user` is nil.
 #
 # Pass `button:` to add Bootstrap button styling (e.g.
-# `button: :btn_link` renders `btn btn-link` alongside the identifier
+# `button: :link` renders `btn btn-link` alongside the identifier
 # class).
 class Components::Link::User < Components::Link::Object
   prop :user, _Nilable(_Union(::User, Integer)), default: nil

--- a/app/components/navbar.rb
+++ b/app/components/navbar.rb
@@ -33,27 +33,36 @@ module Components
   # real landmarks stay visually identical today while already being
   # expressed in BS4-forward terms.
   #
-  # Also holds `LINK_CLASSES` and `FORM_CLASS` — plain string/array
-  # constants (not renderable shapes) for two other `navbar-*`
-  # patterns that recur across the same files but don't share one
-  # fixed DOM shape: `.navbar-link` icon-buttons (sometimes a raw
-  # `<a>`, sometimes routed through `Link(type: :icon, ...)`) and
-  # `.navbar-form` (sometimes a real `<form>` tag, sometimes a plain
-  # `<div>` wrapper, sometimes just a `wrapper_class:` string handed
-  # to another component like `Dropdown`). A single Phlex tag-emitting
-  # component can't cover all three shapes, so callers compose these
-  # constants with `class_names` instead.
+  # Also holds several plain string/array constants (not renderable
+  # shapes) for other `navbar-*` patterns that recur across the same
+  # files but don't share one fixed DOM shape: `.navbar-link`
+  # icon-buttons (sometimes a raw `<a>`, sometimes routed through
+  # `Link(type: :icon, ...)`), `.navbar-form` (sometimes a real
+  # `<form>` tag, sometimes a plain `<div>` wrapper, sometimes just a
+  # `wrapper_class:` string handed to another component like
+  # `Dropdown`), and the `.navbar-nav`/`.navbar-right`/`.navbar-left`
+  # trio that shapes the nav-item list inside a `.navbar` landmark. A
+  # single Phlex tag-emitting component can't cover all these shapes,
+  # so callers compose the constants with `class_names` instead.
   #
-  # `LINK_CLASSES` intentionally does NOT include `btn`/`btn-lg` —
-  # `Components::Link::Icon` (the shape every current caller renders
-  # through) accepts `button:`/`size:` kwargs directly, so callers pass
-  # `button: :default, size: :lg` instead of baking Bootstrap button
-  # classes into a raw string constant.
+  # `LINK_CLASS`/`LINK_CLASSES` intentionally do NOT include
+  # `btn`/`btn-lg` — `Components::Link::Icon` (the shape every current
+  # caller renders through) accepts `button:`/`size:` kwargs directly,
+  # so callers pass `button: :default, size: :lg` instead of baking
+  # Bootstrap button classes into a raw string constant. `LINK_CLASS`
+  # is the bare `"navbar-link"` token for callers that need a
+  # different spacing utility than `LINK_CLASSES`'s bundled `px-0`
+  # (e.g. `search_bar.rb`, which wants `px-2`).
   #
   # BS4 drops `.navbar-form` entirely and renames `.navbar-right` /
   # `.navbar-left` to margin-auto utilities — every caller that
   # references these constants (instead of retyping the raw strings)
-  # gets that swap in one place.
+  # gets that swap in one place. `.navbar-nav`'s own migration risk is
+  # different in kind: BS4 keeps the class name but changes its CSS
+  # behavior (float-based in BS3, flex-based in BS4), so `NAV_CLASS`
+  # centralizes the token for consistency, but the actual fix for that
+  # risk is a CSS bridge rule (like `.navbar.navbar-flex` above), not a
+  # future string swap.
   #
   # @example The outer <nav class="navbar navbar-default"> landmark
   #   Navbar(variant: :default, id: "top_nav") { ... }
@@ -65,11 +74,17 @@ module Components
   #
   # @example The class-string constants
   #   a(href: url, class: class_names(Components::Navbar::LINK_CLASSES,
-  #                                   "navbar-left"))
+  #                                   Components::Navbar::LEFT_CLASS))
   #   form(class: class_names(Components::Navbar::FORM_CLASS, "px-0"))
+  #   ul(class: class_names(Components::Navbar::NAV_CLASS,
+  #                         Components::Navbar::RIGHT_CLASS))
   class Navbar < Base
-    LINK_CLASSES = %w[navbar-link px-0].freeze
+    LINK_CLASS = "navbar-link"
+    LINK_CLASSES = [LINK_CLASS, "px-0"].freeze
     FORM_CLASS = "navbar-form"
+    NAV_CLASS = "navbar-nav"
+    RIGHT_CLASS = "navbar-right"
+    LEFT_CLASS = "navbar-left"
 
     prop :element, _Nilable(Symbol), default: nil
     prop :variant, _Union(:default, :inverse)

--- a/app/components/navbar.rb
+++ b/app/components/navbar.rb
@@ -86,12 +86,12 @@ module Components
     RIGHT_CLASS = "navbar-right"
     LEFT_CLASS = "navbar-left"
 
-    prop :element, _Nilable(Symbol), default: nil
+    prop :element, Symbol, default: :nav
     prop :variant, _Union(:default, :inverse)
     prop :attributes, _Hash(Symbol, _Any), :**
 
     def view_template(&block)
-      send(@element || :nav, **computed_attributes, &block)
+      send(@element, **computed_attributes, &block)
     end
 
     private

--- a/app/components/navbar.rb
+++ b/app/components/navbar.rb
@@ -48,7 +48,7 @@ module Components
   # `LINK_CLASS`/`LINK_CLASSES` intentionally do NOT include
   # `btn`/`btn-lg` — `Components::Link::Icon` (the shape every current
   # caller renders through) accepts `button:`/`size:` kwargs directly,
-  # so callers pass `button: :btn_link, size: :lg` instead of baking
+  # so callers pass `button: :link, size: :lg` instead of baking
   # Bootstrap button classes into a raw string constant. `LINK_CLASS`
   # is the bare `"navbar-link"` token for callers that need a
   # different spacing utility than `LINK_CLASSES`'s bundled `px-0`

--- a/app/components/navbar.rb
+++ b/app/components/navbar.rb
@@ -44,6 +44,12 @@ module Components
   # component can't cover all three shapes, so callers compose these
   # constants with `class_names` instead.
   #
+  # `LINK_CLASSES` intentionally does NOT include `btn`/`btn-lg` —
+  # `Components::Link::Icon` (the shape every current caller renders
+  # through) accepts `button:`/`size:` kwargs directly, so callers pass
+  # `button: :default, size: :lg` instead of baking Bootstrap button
+  # classes into a raw string constant.
+  #
   # BS4 drops `.navbar-form` entirely and renames `.navbar-right` /
   # `.navbar-left` to margin-auto utilities — every caller that
   # references these constants (instead of retyping the raw strings)
@@ -62,7 +68,7 @@ module Components
   #                                   "navbar-left"))
   #   form(class: class_names(Components::Navbar::FORM_CLASS, "px-0"))
   class Navbar < Base
-    LINK_CLASSES = %w[navbar-link btn btn-lg px-0].freeze
+    LINK_CLASSES = %w[navbar-link px-0].freeze
     FORM_CLASS = "navbar-form"
 
     prop :element, _Nilable(Symbol), default: nil

--- a/app/components/navbar.rb
+++ b/app/components/navbar.rb
@@ -48,7 +48,7 @@ module Components
   # `LINK_CLASS`/`LINK_CLASSES` intentionally do NOT include
   # `btn`/`btn-lg` — `Components::Link::Icon` (the shape every current
   # caller renders through) accepts `button:`/`size:` kwargs directly,
-  # so callers pass `button: :default, size: :lg` instead of baking
+  # so callers pass `button: :btn_link, size: :lg` instead of baking
   # Bootstrap button classes into a raw string constant. `LINK_CLASS`
   # is the bare `"navbar-link"` token for callers that need a
   # different spacing utility than `LINK_CLASSES`'s bundled `px-0`

--- a/app/views/controllers/admin/blocked_ips/manager.rb
+++ b/app/views/controllers/admin/blocked_ips/manager.rb
@@ -164,7 +164,7 @@ module Views::Controllers::Admin::BlockedIps
       submit(:REMOVE.l, as: :button,
                         name: remove_param, value: ip,
                         id: "remove_#{@type}_ip_#{ip}",
-                        variant: :btn_link, size: :sm,
+                        variant: :link, size: :sm,
                         class: "font-weight-bold")
     end
 

--- a/app/views/controllers/checklists/panel.rb
+++ b/app/views/controllers/checklists/panel.rb
@@ -92,7 +92,7 @@ module Views::Controllers::Checklists
           name: Name.safe_find(name_id)&.text_name
         ),
         icon: :x,
-        variant: :btn_link,
+        variant: :link,
         class: "p-0 ml-1"
       )
     end

--- a/app/views/controllers/contributors/index/legend.rb
+++ b/app/views/controllers/contributors/index/legend.rb
@@ -46,7 +46,7 @@ module Views::Controllers::Contributors
         Link(type: :collapse_toggle,
              target_id: "contribution_legend",
              icon: :info_circle,
-             button: :btn_link,
+             button: :link,
              size: :xs)
       end
 

--- a/app/views/controllers/names/index/row.rb
+++ b/app/views/controllers/names/index/row.rb
@@ -56,7 +56,7 @@ class Views::Controllers::Names::Index::Row < Views::Base
 
   def render_copy_button
     Button(
-      variant: :btn_link,
+      variant: :link,
       class: "py-0 link-normal opacity-75",
       role: "button",
       data: { toggle: "tooltip", placement: "bottom",

--- a/app/views/controllers/observations/show/namings/row.rb
+++ b/app/views/controllers/observations/show/namings/row.rb
@@ -151,7 +151,7 @@ class Views::Controllers::Observations::Show::Namings::Row < Views::Base
       type: :get,
       target: url_for(occurrence_path(@naming.observation.occurrence)),
       name: :show_observation_matching_observations.l,
-      variant: :btn_link,
+      variant: :link,
       class: "text-wrap text-left px-0"
     )
   end
@@ -161,7 +161,7 @@ class Views::Controllers::Observations::Show::Namings::Row < Views::Base
     Link(type: :user,
          user: proposer,
          name: proposer.login,
-         button: :btn_link,
+         button: :link,
          attributes: { class: "text-wrap text-left px-0" })
   end
 
@@ -200,7 +200,7 @@ class Views::Controllers::Observations::Show::Namings::Row < Views::Base
       name: "#{@naming.vote_percent.round}%",
       target: vote_percent_modal_path,
       modal_id: "naming_votes_#{primary.id}",
-      variant: :btn_link, class: "vote-percent px-0"
+      variant: :link, class: "vote-percent px-0"
     )
   end
 

--- a/app/views/controllers/projects/locations/tables.rb
+++ b/app/views/controllers/projects/locations/tables.rb
@@ -203,7 +203,7 @@ module Views::Controllers::Projects::Locations
           name: loc.display_name
         ),
         icon: :x,
-        variant: :btn_link,
+        variant: :link,
         class: "p-0"
       )
     end

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -79,7 +79,7 @@ module Views::Layouts
       action = truncate ? "showFull" : "showTruncated"
       direction = truncate ? "down" : "up"
       Button(
-        variant: :btn_link,
+        variant: :link,
         class: "top-right toggle",
         title: if truncate
                  :filter_caption_expand.l

--- a/app/views/layouts/header/index_pagination_nav.rb
+++ b/app/views/layouts/header/index_pagination_nav.rb
@@ -109,7 +109,7 @@ module Views::Layouts
       url = pagination_link_url(page)
 
       Link(type: :icon, content: direction.to_s.upcase.to_sym.t, path: url,
-           icon: direction, button: :default, size: :lg, class: classes)
+           icon: direction, button: :btn_link, size: :lg, class: classes)
     end
 
     # Build URL for pagination links (prev/next page, max page link).

--- a/app/views/layouts/header/index_pagination_nav.rb
+++ b/app/views/layouts/header/index_pagination_nav.rb
@@ -109,7 +109,7 @@ module Views::Layouts
       url = pagination_link_url(page)
 
       Link(type: :icon, content: direction.to_s.upcase.to_sym.t, path: url,
-           icon: direction, button: :btn_link, size: :lg, class: classes)
+           icon: direction, button: :link, size: :lg, class: classes)
     end
 
     # Build URL for pagination links (prev/next page, max page link).

--- a/app/views/layouts/header/index_pagination_nav.rb
+++ b/app/views/layouts/header/index_pagination_nav.rb
@@ -107,13 +107,9 @@ module Views::Layouts
         ("disabled opacity-0" if disabled)
       )
       url = pagination_link_url(page)
-      a(href: url, class: classes) do
-        Icon(
-          type: direction,
-          title: direction.to_s.upcase.to_sym.t,
-          html_class: "px-2"
-        )
-      end
+
+      Link(type: :icon, content: direction.to_s.upcase.to_sym.t, path: url,
+           icon: direction, button: :default, size: :lg, class: classes)
     end
 
     # Build URL for pagination links (prev/next page, max page link).

--- a/app/views/layouts/header/show_prev_next_nav.rb
+++ b/app/views/layouts/header/show_prev_next_nav.rb
@@ -31,14 +31,14 @@ module Views::Layouts
       href = adjacent_id ? adjacent_path(adjacent_id) : "#"
 
       Link(type: :icon, content: adjacent_title(dir), path: href,
-           icon: dir, button: :default, size: :lg, class: classes)
+           icon: dir, button: :btn_link, size: :lg, class: classes)
     end
 
     def render_index_link
       classes = class_names(BTN_CLASSES, %w[mx-1 index_object_link])
 
       Link(type: :icon, content: index_title, path: index_path,
-           icon: index_icon, button: :default, size: :lg, class: classes)
+           icon: index_icon, button: :btn_link, size: :lg, class: classes)
     end
 
     def no_more?(dir)

--- a/app/views/layouts/header/show_prev_next_nav.rb
+++ b/app/views/layouts/header/show_prev_next_nav.rb
@@ -30,14 +30,14 @@ module Views::Layouts
       href = adjacent_id ? adjacent_path(adjacent_id) : "#"
 
       Link(type: :icon, content: adjacent_title(dir), path: href,
-           icon: dir, class: classes)
+           icon: dir, button: :default, size: :lg, class: classes)
     end
 
     def render_index_link
       classes = class_names(BTN_CLASSES, %w[mx-1 index_object_link])
 
       Link(type: :icon, content: index_title, path: index_path,
-           icon: index_icon, class: classes)
+           icon: index_icon, button: :default, size: :lg, class: classes)
     end
 
     def no_more?(dir)

--- a/app/views/layouts/header/show_prev_next_nav.rb
+++ b/app/views/layouts/header/show_prev_next_nav.rb
@@ -31,14 +31,14 @@ module Views::Layouts
       href = adjacent_id ? adjacent_path(adjacent_id) : "#"
 
       Link(type: :icon, content: adjacent_title(dir), path: href,
-           icon: dir, button: :btn_link, size: :lg, class: classes)
+           icon: dir, button: :link, size: :lg, class: classes)
     end
 
     def render_index_link
       classes = class_names(BTN_CLASSES, %w[mx-1 index_object_link])
 
       Link(type: :icon, content: index_title, path: index_path,
-           icon: index_icon, button: :btn_link, size: :lg, class: classes)
+           icon: index_icon, button: :link, size: :lg, class: classes)
     end
 
     def no_more?(dir)

--- a/app/views/layouts/header/show_prev_next_nav.rb
+++ b/app/views/layouts/header/show_prev_next_nav.rb
@@ -6,7 +6,8 @@
 # either prop is nil — the helper already gates on the same.
 module Views::Layouts
   class Header::ShowPrevNextNav < Views::Base
-    BTN_CLASSES = (Components::Navbar::LINK_CLASSES + %w[navbar-left]).freeze
+    BTN_CLASSES = (Components::Navbar::LINK_CLASSES +
+                   [Components::Navbar::LEFT_CLASS]).freeze
 
     prop :object, _Nilable(::AbstractModel), default: nil
     prop :query, _Nilable(::Query), default: nil

--- a/app/views/layouts/sidebar/admin.rb
+++ b/app/views/layouts/sidebar/admin.rb
@@ -40,7 +40,7 @@ class Views::Layouts::Sidebar
           type: :post,
           name: tab.title,
           target: tab.path,
-          variant: :btn_link,
+          variant: :link,
           class: class_names(css_class, tab.html_options[:class]),
           data: tab.html_options[:data]
         )

--- a/app/views/layouts/sidebar/user.rb
+++ b/app/views/layouts/sidebar/user.rb
@@ -46,7 +46,7 @@ class Views::Layouts::Sidebar
           type: :post,
           name: tab.title,
           target: tab.path,
-          variant: :btn_link,
+          variant: :link,
           class: class_names(css_class, tab.html_options[:class]),
           data: tab.html_options[:data]
         )
@@ -88,7 +88,7 @@ class Views::Layouts::Sidebar
           type: :post,
           name: tab.title,
           target: tab.path,
-          variant: :btn_link,
+          variant: :link,
           class: class_names(css_class, tab.html_options[:class]),
           data: tab.html_options[:data]
         )

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -89,7 +89,9 @@ class Views::Layouts::TopNav < Views::Base
   def render_right
     render_search_nav_toggle
     render_nav_scan_qr_code
-    ul(class: "nav navbar-nav navbar-right hidden-xs mr-0") do
+    ul(class: class_names("nav", Components::Navbar::NAV_CLASS,
+                          Components::Navbar::RIGHT_CLASS,
+                          "hidden-xs mr-0")) do
       # `content_for(:context_nav)` (no-block) returns the previously
       # stashed SafeBuffer; `trusted_html` emits it into Phlex's
       # buffer (a no-op `content_for` call would only read it).

--- a/app/views/layouts/top_nav/search_bar.rb
+++ b/app/views/layouts/top_nav/search_bar.rb
@@ -6,7 +6,7 @@
 # the advanced-search expander beneath the bar. When the viewer is
 # anonymous, renders a `<strong>` "Login required" reminder.
 class Views::Layouts::TopNav::SearchBar < Views::Base
-  BAR_TOGGLE_CLASSES = %w[navbar-link px-2].freeze
+  BAR_TOGGLE_CLASSES = [Components::Navbar::LINK_CLASS, "px-2"].freeze
 
   # Search types that have a per-type help expander. Mirrors
   # `Views::Layouts::TopNav::SEARCH_HELP_TYPES`; passed through

--- a/app/views/layouts/top_nav/search_bar.rb
+++ b/app/views/layouts/top_nav/search_bar.rb
@@ -6,7 +6,7 @@
 # the advanced-search expander beneath the bar. When the viewer is
 # anonymous, renders a `<strong>` "Login required" reminder.
 class Views::Layouts::TopNav::SearchBar < Views::Base
-  BAR_TOGGLE_CLASSES = %w[btn btn-link navbar-link px-2].freeze
+  BAR_TOGGLE_CLASSES = %w[navbar-link px-2].freeze
 
   # Search types that have a per-type help expander. Mirrors
   # `Views::Layouts::TopNav::SEARCH_HELP_TYPES`; passed through
@@ -70,6 +70,7 @@ class Views::Layouts::TopNav::SearchBar < Views::Base
          target_id: "search_bar_help",
          icon: :info,
          icon_title: :search_bar_help.l,
+         button: :btn_link,
          class: bar_toggle_class(visible: help_visible?),
          data: { search_type_target: "helpToggle" })
   end
@@ -82,6 +83,7 @@ class Views::Layouts::TopNav::SearchBar < Views::Base
          target_id: "search_nav_form",
          icon: :plus,
          icon_title: :search_bar_more_options.l,
+         button: :btn_link,
          class: bar_toggle_class(visible: form_visible?),
          data: { search_type_target: "formToggle" })
   end

--- a/app/views/layouts/top_nav/search_bar.rb
+++ b/app/views/layouts/top_nav/search_bar.rb
@@ -70,7 +70,7 @@ class Views::Layouts::TopNav::SearchBar < Views::Base
          target_id: "search_bar_help",
          icon: :info,
          icon_title: :search_bar_help.l,
-         button: :btn_link,
+         button: :link,
          class: bar_toggle_class(visible: help_visible?),
          data: { search_type_target: "helpToggle" })
   end
@@ -83,7 +83,7 @@ class Views::Layouts::TopNav::SearchBar < Views::Base
          target_id: "search_nav_form",
          icon: :plus,
          icon_title: :search_bar_more_options.l,
-         button: :btn_link,
+         button: :link,
          class: bar_toggle_class(visible: form_visible?),
          data: { search_type_target: "formToggle" })
   end

--- a/test/components/button/crud_base_test.rb
+++ b/test/components/button/crud_base_test.rb
@@ -292,7 +292,7 @@ class ButtonSubclassesTest < ComponentTestCase
   def test_edit_with_string_target_and_class
     html = render(Components::Button::Edit.new(
                     target: "/items/42/edit", name: "Edit it",
-                    variant: :btn_link
+                    variant: :link
                   ))
 
     assert_html(html, "a.btn.btn-link[href='/items/42/edit']")

--- a/test/components/button/external_test.rb
+++ b/test/components/button/external_test.rb
@@ -19,7 +19,7 @@ class Components::Button::ExternalTest < ComponentTestCase
     html = render(Components::Button::External.new(
                     name: "Go",
                     url: "https://example.com",
-                    variant: :btn_link
+                    variant: :link
                   ))
 
     assert_html(html, "a[target='_blank'][rel='noopener noreferrer']")

--- a/test/components/button_test.rb
+++ b/test/components/button_test.rb
@@ -88,6 +88,15 @@ end
 
 # Tests for the Components::Button::Styling concern's raise paths.
 class Components::Button::StylingTest < ComponentTestCase
+  def test_default_variant_matches_nil
+    # :default is an explicit synonym for nil/omitted -- Link/Link::Icon
+    # need to distinguish "no button framing" (nil) from "framed as the
+    # default button" (:default) at their own layer, so btn_class treats
+    # both the same rather than making every such caller translate.
+    assert_equal(Components::Button::Styling.btn_class(nil),
+                 Components::Button::Styling.btn_class(:default))
+  end
+
   def test_unknown_variant_raises_argument_error
     assert_raises(ArgumentError) do
       Components::Button::Styling.btn_class(:nonexistent)

--- a/test/components/form/search_test.rb
+++ b/test/components/form/search_test.rb
@@ -93,6 +93,10 @@ class SearchFormTest < ComponentTestCase
     assert_html(html,
                 "a[data-search-type-target='barToggle'] span.sr-only",
                 text: :search_bar_fewer_options.l.as_displayed)
+    # navbar-link comes from Components::Navbar::LINK_CLASS, not a raw
+    # literal.
+    assert_html(html,
+                "a[data-search-type-target='barToggle'].navbar-link")
   end
 
   def test_does_not_render_header_when_local

--- a/test/components/link/collapse_toggle_test.rb
+++ b/test/components/link/collapse_toggle_test.rb
@@ -96,7 +96,7 @@ class CollapseToggleLinkTest < ComponentTestCase
   end
 
   def test_button_variant_adds_btn_classes
-    html = render_it(button: :btn_link)
+    html = render_it(button: :link)
 
     assert_html(html, "a[data-toggle='collapse']")
   end
@@ -108,7 +108,7 @@ class CollapseToggleLinkTest < ComponentTestCase
   end
 
   def test_size_adds_btn_size_class_alongside_button
-    html = render_it(button: :btn_link, size: :xs)
+    html = render_it(button: :link, size: :xs)
 
     assert_html(html, "a[data-toggle='collapse']")
   end

--- a/test/components/link/icon_test.rb
+++ b/test/components/link/icon_test.rb
@@ -161,6 +161,29 @@ class IconLinkTest < ComponentTestCase
     assert_no_html(html, "a.btn")
   end
 
+  def test_size_kwarg_without_button_does_not_dangle
+    html = render(Components::Link::Icon.new(
+                    content: "Next", path: "/x",
+                    icon: :next, size: :lg
+                  ))
+
+    # No `.btn` base class, so `.btn-lg` alone must not appear either --
+    # a dangling size modifier with no button framing isn't valid
+    # Bootstrap markup.
+    assert_no_html(html, "a.btn")
+    assert_no_html(html, "a.btn-lg")
+  end
+
+  def test_size_kwarg_with_button_strip_does_not_dangle
+    html = render(Components::Link::Icon.new(
+                    content: "Next", path: "/x",
+                    icon: :next, button: :strip, size: :lg
+                  ))
+
+    assert_no_html(html, "a.btn")
+    assert_no_html(html, "a.btn-lg")
+  end
+
   def test_raw_btn_class_raises_argument_error
     # Matches Link::Get/Modal/User: btn classes must go through
     # button:/size:, not a raw class: string.

--- a/test/components/link/icon_test.rb
+++ b/test/components/link/icon_test.rb
@@ -160,4 +160,13 @@ class IconLinkTest < ComponentTestCase
 
     assert_no_html(html, "a.btn")
   end
+
+  def test_raw_btn_class_raises_argument_error
+    # Matches Link::Get/Modal/User: btn classes must go through
+    # button:/size:, not a raw class: string.
+    assert_raises(ArgumentError) do
+      Components::Link::Icon.new(content: "Next", path: "/x",
+                                 icon: :next, class: "btn btn-primary")
+    end
+  end
 end

--- a/test/components/link/icon_test.rb
+++ b/test/components/link/icon_test.rb
@@ -117,4 +117,47 @@ class IconLinkTest < ComponentTestCase
 
     assert_html(html, "a[data-turbo-confirm]")
   end
+
+  def test_no_button_kwarg_renders_plain_link
+    html = render(Components::Link::Icon.new(content: "Edit", path: "/x",
+                                             icon: :edit))
+
+    assert_no_html(html, "a.btn")
+  end
+
+  def test_button_default_kwarg_adds_btn_framing
+    html = render(Components::Link::Icon.new(
+                    content: "Next", path: "/x",
+                    icon: :next, button: :default
+                  ))
+
+    assert_html(html, "a.icon-link.btn.btn-default")
+  end
+
+  def test_button_variant_kwarg_adds_matching_btn_class
+    html = render(Components::Link::Icon.new(
+                    content: "Next", path: "/x",
+                    icon: :next, button: :outline
+                  ))
+
+    assert_html(html, "a.btn.btn-outline-default")
+  end
+
+  def test_size_kwarg_adds_size_class_alongside_button
+    html = render(Components::Link::Icon.new(
+                    content: "Next", path: "/x",
+                    icon: :next, button: :default, size: :lg
+                  ))
+
+    assert_html(html, "a.btn.btn-default.btn-lg")
+  end
+
+  def test_button_strip_kwarg_adds_no_btn_framing
+    html = render(Components::Link::Icon.new(
+                    content: "Next", path: "/x",
+                    icon: :next, button: :strip
+                  ))
+
+    assert_no_html(html, "a.btn")
+  end
 end

--- a/test/components/navbar_test.rb
+++ b/test/components/navbar_test.rb
@@ -26,7 +26,7 @@ class NavbarTest < ComponentTestCase
   end
 
   def test_link_classes_constant
-    assert_equal(%w[navbar-link btn btn-lg px-0],
+    assert_equal(%w[navbar-link px-0],
                  Components::Navbar::LINK_CLASSES)
   end
 

--- a/test/components/navbar_test.rb
+++ b/test/components/navbar_test.rb
@@ -25,6 +25,10 @@ class NavbarTest < ComponentTestCase
                 text: "Content")
   end
 
+  def test_link_class_constant
+    assert_equal("navbar-link", Components::Navbar::LINK_CLASS)
+  end
+
   def test_link_classes_constant
     assert_equal(%w[navbar-link px-0],
                  Components::Navbar::LINK_CLASSES)
@@ -32,5 +36,11 @@ class NavbarTest < ComponentTestCase
 
   def test_form_class_constant
     assert_equal("navbar-form", Components::Navbar::FORM_CLASS)
+  end
+
+  def test_nav_right_left_class_constants
+    assert_equal("navbar-nav", Components::Navbar::NAV_CLASS)
+    assert_equal("navbar-right", Components::Navbar::RIGHT_CLASS)
+    assert_equal("navbar-left", Components::Navbar::LEFT_CLASS)
   end
 end

--- a/test/views/controllers/observations/show/namings/row_test.rb
+++ b/test/views/controllers/observations/show/namings/row_test.rb
@@ -263,7 +263,7 @@ class Views::Controllers::Observations::Show::Namings::RowTest <
     new_html = render(Components::Button::Get.new(
                         target: url,
                         name: name,
-                        variant: :btn_link,
+                        variant: :link,
                         class: "text-wrap text-left px-0"
                       ))
 

--- a/test/views/layouts/header/index_pagination_nav_test.rb
+++ b/test/views/layouts/header/index_pagination_nav_test.rb
@@ -46,13 +46,15 @@ module Views::Layouts
       assert_not_includes(html, "pagination_numbers")
     end
 
-    def test_page_links_are_styled_as_large_default_buttons
+    def test_page_links_are_styled_as_large_link_buttons
       html = render_nav(pagination_data: paginated(50, 1))
 
       # Rendered via Link::Icon's button:/size: kwargs, not via raw
       # btn/btn-lg strings — see Components::Navbar::LINK_CLASSES.
-      assert_html(html, "a.prev_page_link.btn.btn-default.btn-lg")
-      assert_html(html, "a.next_page_link.btn.btn-default.btn-lg")
+      # btn_link (not default) strips the background — these are
+      # plain icon-only nav buttons, not filled buttons.
+      assert_html(html, "a.prev_page_link.btn.btn-link.btn-lg")
+      assert_html(html, "a.next_page_link.btn.btn-link.btn-lg")
     end
 
     def test_prev_link_disabled_on_first_page

--- a/test/views/layouts/header/index_pagination_nav_test.rb
+++ b/test/views/layouts/header/index_pagination_nav_test.rb
@@ -51,8 +51,9 @@ module Views::Layouts
 
       # Rendered via Link::Icon's button:/size: kwargs, not via raw
       # btn/btn-lg strings — see Components::Navbar::LINK_CLASSES.
-      # btn_link (not default) strips the background — these are
-      # plain icon-only nav buttons, not filled buttons.
+      # :link (not :default) removes the background/border while
+      # keeping button padding — plain icon-only nav buttons, not
+      # filled buttons. (:strip would remove padding too.)
       assert_html(html, "a.prev_page_link.btn.btn-link.btn-lg")
       assert_html(html, "a.next_page_link.btn.btn-link.btn-lg")
     end

--- a/test/views/layouts/header/index_pagination_nav_test.rb
+++ b/test/views/layouts/header/index_pagination_nav_test.rb
@@ -46,6 +46,15 @@ module Views::Layouts
       assert_not_includes(html, "pagination_numbers")
     end
 
+    def test_page_links_are_styled_as_large_default_buttons
+      html = render_nav(pagination_data: paginated(50, 1))
+
+      # Rendered via Link::Icon's button:/size: kwargs, not via raw
+      # btn/btn-lg strings — see Components::Navbar::LINK_CLASSES.
+      assert_html(html, "a.prev_page_link.btn.btn-default.btn-lg")
+      assert_html(html, "a.next_page_link.btn.btn-default.btn-lg")
+    end
+
     def test_prev_link_disabled_on_first_page
       html = render_nav(pagination_data: paginated(50, 1))
 

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -171,9 +171,10 @@ module Views::Layouts
                     ))
 
       # Framed as buttons via Link::Icon's button:/size: kwargs, not
-      # via raw btn/btn-lg strings in Navbar::LINK_CLASSES. btn_link
-      # (not default) strips the background — these are plain
-      # icon-only nav buttons, not filled buttons.
+      # via raw btn/btn-lg strings in Navbar::LINK_CLASSES. :link
+      # (not :default) removes the background/border while keeping
+      # button padding — plain icon-only nav buttons, not filled
+      # buttons. (:strip would remove padding too.)
       assert_html(html, "a.prev_object_link.btn.btn-link.btn-lg")
       assert_html(html, "a.index_object_link.btn.btn-link.btn-lg")
       assert_html(html, "a.next_object_link.btn.btn-link.btn-lg")

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -175,6 +175,9 @@ module Views::Layouts
       assert_html(html, "a.prev_object_link.btn.btn-default.btn-lg")
       assert_html(html, "a.index_object_link.btn.btn-default.btn-lg")
       assert_html(html, "a.next_object_link.btn.btn-default.btn-lg")
+      # navbar-left comes from Components::Navbar::LEFT_CLASS, not a
+      # raw literal.
+      assert_html(html, "a.prev_object_link.navbar-left")
     end
 
     def test_links_have_tooltips

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -162,7 +162,7 @@ module Views::Layouts
       )
     end
 
-    def test_links_are_styled_as_large_default_buttons
+    def test_links_are_styled_as_large_link_buttons
       @query.current_id = @middle_obs.id
 
       html = render(Views::Layouts::Header::ShowPrevNextNav.new(
@@ -171,10 +171,12 @@ module Views::Layouts
                     ))
 
       # Framed as buttons via Link::Icon's button:/size: kwargs, not
-      # via raw btn/btn-lg strings in Navbar::LINK_CLASSES.
-      assert_html(html, "a.prev_object_link.btn.btn-default.btn-lg")
-      assert_html(html, "a.index_object_link.btn.btn-default.btn-lg")
-      assert_html(html, "a.next_object_link.btn.btn-default.btn-lg")
+      # via raw btn/btn-lg strings in Navbar::LINK_CLASSES. btn_link
+      # (not default) strips the background — these are plain
+      # icon-only nav buttons, not filled buttons.
+      assert_html(html, "a.prev_object_link.btn.btn-link.btn-lg")
+      assert_html(html, "a.index_object_link.btn.btn-link.btn-lg")
+      assert_html(html, "a.next_object_link.btn.btn-link.btn-lg")
       # navbar-left comes from Components::Navbar::LEFT_CLASS, not a
       # raw literal.
       assert_html(html, "a.prev_object_link.navbar-left")

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -162,6 +162,21 @@ module Views::Layouts
       )
     end
 
+    def test_links_are_styled_as_large_default_buttons
+      @query.current_id = @middle_obs.id
+
+      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
+                      object: @middle_obs,
+                      query: @query
+                    ))
+
+      # Framed as buttons via Link::Icon's button:/size: kwargs, not
+      # via raw btn/btn-lg strings in Navbar::LINK_CLASSES.
+      assert_html(html, "a.prev_object_link.btn.btn-default.btn-lg")
+      assert_html(html, "a.index_object_link.btn.btn-default.btn-lg")
+      assert_html(html, "a.next_object_link.btn.btn-default.btn-lg")
+    end
+
     def test_links_have_tooltips
       @query.current_id = @middle_obs.id
 

--- a/test/views/layouts/top_nav/search_bar_test.rb
+++ b/test/views/layouts/top_nav/search_bar_test.rb
@@ -31,6 +31,10 @@ class Views::Layouts::TopNav
                   text: :search_bar_help.t.as_displayed)
       assert_no_html(html,
                      "a[data-search-type-target='helpToggle'].d-none")
+      # Rendered via CollapseToggle's button:/size: kwarg, not via raw
+      # btn/btn-link strings — see BAR_TOGGLE_CLASSES.
+      assert_html(html,
+                  "a[data-search-type-target='helpToggle'].btn.btn-link")
     end
 
     def test_help_toggle_hidden_when_type_has_no_help
@@ -57,6 +61,8 @@ class Views::Layouts::TopNav
                   text: :search_bar_more_options.l.as_displayed)
       assert_no_html(html,
                      "a[data-search-type-target='formToggle'].d-none")
+      assert_html(html,
+                  "a[data-search-type-target='formToggle'].btn.btn-link")
     end
 
     def test_form_toggle_hidden_when_type_has_no_form

--- a/test/views/layouts/top_nav_test.rb
+++ b/test/views/layouts/top_nav_test.rb
@@ -161,6 +161,14 @@ class Views::Layouts::TopNavTest < ComponentTestCase
     assert_html(html, "a.dropdown-toggle", text: @user.login)
   end
 
+  def test_right_nav_list_uses_navbar_constants
+    html = render(top_nav(user: @user))
+
+    # Built from Components::Navbar::NAV_CLASS/RIGHT_CLASS, not raw
+    # navbar-nav/navbar-right literals.
+    assert_html(html, "ul.nav.navbar-nav.navbar-right.hidden-xs.mr-0")
+  end
+
   private
 
   def top_nav(user:, query: nil)


### PR DESCRIPTION
## Summary

Part of the BS3→4 runway-clearing audit on issue #3797. Cleans up every raw `navbar-*`/`btn`/`btn-lg`/`btn-link` string still hardcoded across the top-nav/pagination files instead of routed through `Components::Navbar`'s constants or `Components::Link`'s `button:`/`size:` kwargs.

### `button:`/`size:` support on `Link::Icon`

`Components::Link::Icon` didn't support the `button:`/`size:` kwarg mechanism that `Link::CollapseToggle` already has, so two call sites hardcoded raw `btn`/`btn-lg`/`btn-link` strings into `Components::Navbar::LINK_CLASSES` and `search_bar.rb`'s `BAR_TOGGLE_CLASSES` instead.

- `Components::Link::Icon` now accepts `button:`/`size:`, generating `btn`/`btn-{variant}`/`btn-{size}` the same way `CollapseToggle` does (`include Components::Button::Styling`, same `nil`-means-plain-link semantics).
- `index_pagination_nav.rb`'s `render_page_link` was a hand-rolled `a(href:, class:) { Icon(...) }` that bypassed `Link`/`Link::Icon` entirely. Converted to `Link(type: :icon, ...)`, since `Link::Icon` now covers this exact case directly.

### Navbar constants for the remaining raw `navbar-*` sites

`Components::Navbar::LINK_CLASSES`/`FORM_CLASS` only ever covered the `navbar-link`/`navbar-form` half of the story — `navbar-nav`, `navbar-right`, and `navbar-left` had no constant at all, so `top_nav.rb` and `show_prev_next_nav.rb` still carried raw literals. Added `LINK_CLASS` (bare `"navbar-link"` token, for callers wanting different spacing than `LINK_CLASSES`'s bundled `px-0`), `NAV_CLASS`, `RIGHT_CLASS`, and `LEFT_CLASS`, mirroring the existing `FORM_CLASS` pattern.

- `Components::Navbar::LINK_CLASSES` drops `btn btn-lg`, now just `[LINK_CLASS, "px-0"]`. Its two consumers (`show_prev_next_nav.rb`, `index_pagination_nav.rb`) pass `button: :link, size: :lg` explicitly instead, and `show_prev_next_nav.rb`'s `navbar-left` literal now references `Navbar::LEFT_CLASS`.
- `top_nav.rb`'s right-nav `<ul class="nav navbar-nav navbar-right ...">` now builds its classes from `Navbar::NAV_CLASS`/`RIGHT_CLASS`.
- `search_bar.rb`'s `BAR_TOGGLE_CLASSES` drops `btn btn-link`, now `[Navbar::LINK_CLASS, "px-2"]`. Both `Link(type: :collapse_toggle, ...)` calls pass `button: :link` instead.
- `form/pattern_search.rb`'s `FORM_CLASS` and `form/search.rb`'s toggle now reference `Navbar::FORM_CLASS`/`LINK_CLASS` instead of independent raw copies.

Note: `navbar-nav`'s own migration risk is different in kind from the others — BS4 keeps the class name but changes its CSS behavior (float-based in BS3, flex-based in BS4), so `NAV_CLASS` centralizes the token for consistency, but the actual fix for that risk is a future CSS bridge rule (like the existing `.navbar.navbar-flex` bridge), not a string swap. Documented in `navbar.rb`'s class comment.

### `:btn_link` renamed to `:link` (sweep, all callers)

Renamed the `BTN_VARIANTS` key and every `button:`/`variant:` call site across the app and tests from `:btn_link` to `:link` — the shorter name reads just as clearly in context (`button: :link`) without the redundant `btn_` prefix.

### `btn_class` now treats `:default` as a synonym for `nil`

`Components::Link`/`Link::Icon` each had their own `return class_names("btn", "btn-default") if button == :default` branch, duplicating logic that's really `Button::Styling#btn_class`'s job. `btn_class` now returns `"btn-default"` for `variant.nil? || variant == :default` directly (single line), so both callers simplify to one `class_names("btn", btn_class(button))` call with no special-casing.

Checked for a broader `:default` sweep too: `Components::Button`'s `variant: :default` would be genuinely redundant (nil/omitted means the same thing there), but there are zero such explicit call sites in the app. `Components::Link`'s `button: :default` is *not* redundant — `nil`/omitted means "plain link, no button framing at all" while `:default` means "framed as a real grey button" — so the 3 real `Link::CollapseToggle` triggers in `account/api_keys/*` that pass it are left as-is.

### `size:` no longer dangles without real button framing (Copilot review)

`size_class(@opts[:size])` was applied unconditionally in `Link::Icon#link_attrs`, so a caller passing `size:` without `button:` (or with `button: :strip`) got a dangling `btn-lg` class with no `.btn` base class — not valid Bootstrap markup. Extracted `button_classes`, gated on `btn_styling` being present, so `size:` only ever renders alongside real btn framing. No existing caller is affected. `Link::Icon` also now calls `validate_no_btn_classes!` on its `class:` kwarg, matching `Link::Get`/`Modal`/`User` (same Copilot review).

## Note on a markup change

Converting `index_pagination_nav.rb`'s prev/next page links to `Link::Icon` moves the tooltip (`data-toggle="tooltip"`) and screen-reader label (`span.sr-only`) from the inner glyph `<span>` (where the old hand-rolled `Icon(title:, ...)` put them) to the outer `<a>` (where `Link::Icon` puts them) — matching the same shape already used by the sibling `show_prev_next_nav.rb` component. Still equally accessible, just moved.

**Update after browser check:** the prev/next/index buttons (both `index_pagination_nav.rb` and `show_prev_next_nav.rb`) initially shipped with `button: :default`, which added a solid grey background these plain icon-only nav buttons never had. Caught in browser testing — fixed to `button: :link` (renamed from `:btn_link` per the sweep above), which removes the background/border while keeping button padding, matching how these plain icon-only nav buttons actually behave (`variant: :strip` would remove padding too, which isn't what's wanted here). Test assertions updated to match (`.btn-link` instead of `.btn-default`).

## Test plan
- [x] `bin/rails test test/components/navbar_test.rb test/components/form/search_test.rb test/views/layouts/top_nav/search_bar_test.rb test/views/layouts/top_nav_test.rb test/views/layouts/header/show_prev_next_nav_test.rb test/components/link/icon_test.rb test/views/layouts/header/index_pagination_nav_test.rb` — all green (pre-sweep)
- [x] `bundle exec rubocop` on all touched files — no offenses
- [x] Visual/browser check of the index pagination row and show-page prev/next/index links confirmed the `btn-link` fix
- [ ] Full test run after the `:btn_link`→`:link` sweep + `btn_class`/`size_class` follow-ups (in progress)
- [ ] Visual check of the top-nav right-nav list and search bar's help/advanced-search toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

