### PR TITLE
Add `Components::Modal::CloseButton`; route 5 Cancel-button sites through it

### DIFF
--- a/app/components/button.rb
+++ b/app/components/button.rb
@@ -77,6 +77,8 @@ class Components::Button < Components::Base
   #                          open_text: "Close", closed_text: "Open",
   #                          collapsed: true, icon: :globe)
   #   Components::Button.new(name: "Cancel", data: { dismiss: "modal" })
+  #     # for a Modal's footer Cancel button, prefer
+  #     # Components::Modal::CloseButton instead of hand-rolling this
   def self.new(**kwargs, &block)
     type_sym = kwargs[:type]&.to_sym
     if (klass_name = DISPATCH[type_sym])

--- a/app/components/modal/close_button.rb
+++ b/app/components/modal/close_button.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Footer "Cancel" button for a `Components::Modal` — the DRY
+# counterpart to `Modal#close_button` (the header's `×` icon).
+# Different role: `close_button` is header-icon-only chrome;
+# `CloseButton` is the labeled Cancel button that sits in
+# `.modal-footer` alongside Submit.
+#
+# Not a BS4-migration-safety fix on its own — `data-dismiss="modal"`
+# is unchanged in BS4 (only BS5 renames it to `data-bs-dismiss`).
+# Worth doing anyway for DRY (5 identical call sites) and to derisk
+# that eventual BS5 rename to one place.
+#
+# @example Plain dismiss-only Cancel (the common case)
+#   render(Components::Modal::CloseButton.new)
+#
+# @example Navigational Cancel — dismisses the modal AND follows a
+#   real link (e.g. the caller wants Cancel to redirect back to a
+#   listing page, not just close the modal in place)
+#   render(Components::Modal::CloseButton.new(target: cancel_path))
+class Components::Modal::CloseButton < Components::Base
+  prop :target, _Nilable(String), default: nil
+  prop :name, String, default: -> { :CANCEL.l }
+  prop :attributes, _Hash(Symbol, _Any), :**
+
+  def view_template
+    Button(**button_attrs)
+  end
+
+  private
+
+  def button_attrs
+    attrs = @attributes.dup
+    attrs[:data] = { dismiss: "modal" }.merge(attrs[:data] || {})
+    attrs[:name] = @name
+    if @target
+      attrs[:type] = :get
+      attrs[:target] = @target
+    end
+    attrs
+  end
+end

--- a/app/components/modal/close_button.rb
+++ b/app/components/modal/close_button.rb
@@ -19,9 +19,12 @@
 #   listing page, not just close the modal in place)
 #   render(Components::Modal::CloseButton.new(target: cancel_path))
 class Components::Modal::CloseButton < Components::Base
-  prop :target, _Nilable(String), default: nil
+  prop :target, _Nilable(_Union(String, Hash, ::AbstractModel)), default: nil
   prop :name, String, default: -> { :CANCEL.l }
-  prop :attributes, _Hash(Symbol, _Any), :**
+  # `_Any?`, not bare `_Any` -- Literal's `_Any` excludes `NilClass`,
+  # so a caller passing an explicit `key: nil` (not just omitting the
+  # key) would otherwise raise a Literal::TypeError.
+  prop :attributes, _Hash(Symbol, _Any?), :**
 
   def view_template
     Button(**button_attrs)
@@ -31,7 +34,7 @@ class Components::Modal::CloseButton < Components::Base
 
   def button_attrs
     attrs = @attributes.dup
-    attrs[:data] = { dismiss: "modal" }.merge(attrs[:data] || {})
+    attrs[:data] = (attrs[:data] || {}).merge(dismiss: "modal")
     attrs[:name] = @name
     if @target
       attrs[:type] = :get

--- a/app/views/controllers/occurrences/projects/form.rb
+++ b/app/views/controllers/occurrences/projects/form.rb
@@ -130,12 +130,7 @@ module Views::Controllers::Occurrences::Projects
     end
 
     def render_buttons
-      Button(
-        type: :get,
-        target: cancel_path,
-        name: :CANCEL.l,
-        data: { dismiss: "modal" }
-      )
+      render(Components::Modal::CloseButton.new(target: cancel_path))
       whitespace
       # Skip = proceed without backfilling projects. Both controllers
       # (`OccurrencesController#create` and

--- a/app/views/controllers/projects/members/add_obs_modal.rb
+++ b/app/views/controllers/projects/members/add_obs_modal.rb
@@ -37,10 +37,7 @@ module Views::Controllers::Projects::Members
     end
 
     def render_footer_buttons
-      Button(
-        name: :CANCEL.l,
-        data: { dismiss: "modal" }
-      )
+      render(Components::Modal::CloseButton.new)
       whitespace
       render_submit_button if @count.positive?
     end

--- a/app/views/controllers/projects/members/trust_settings.rb
+++ b/app/views/controllers/projects/members/trust_settings.rb
@@ -106,10 +106,7 @@ module Views::Controllers::Projects::Members
     end
 
     def render_footer_buttons
-      Button(
-        name: :CANCEL.l,
-        data: { dismiss: "modal" }
-      )
+      render(Components::Modal::CloseButton.new)
       whitespace
       # `name: "save"` overrides Superform's default `name: "commit"`
       # to avoid colliding with the radio group's own `commit` name —

--- a/app/views/controllers/projects/violations/target_location_form.rb
+++ b/app/views/controllers/projects/violations/target_location_form.rb
@@ -128,10 +128,7 @@ module Views::Controllers::Projects::Violations
       submit(:form_violations_modal_target_location_submit.l,
              as: :button, variant: :primary)
       whitespace
-      Button(
-        name: :CANCEL.l,
-        data: { dismiss: "modal" }
-      )
+      render(Components::Modal::CloseButton.new)
     end
 
     def render_suffix_radios

--- a/app/views/controllers/projects/violations/target_location_modal.rb
+++ b/app/views/controllers/projects/violations/target_location_modal.rb
@@ -50,10 +50,7 @@ module Views::Controllers::Projects::Violations
         p { :form_violations_modal_target_location_no_suffixes.l }
       end
       modal.with_footer do
-        Button(
-          name: :CANCEL.l,
-          data: { dismiss: "modal" }
-        )
+        render(Components::Modal::CloseButton.new)
       end
     end
   end

--- a/test/components/modal/close_button_test.rb
+++ b/test/components/modal/close_button_test.rb
@@ -18,6 +18,17 @@ class ModalCloseButtonTest < ComponentTestCase
                 text: :CANCEL.l)
   end
 
+  def test_target_kwarg_accepts_an_abstract_model
+    # Matches Components::Button::Project's target: type -- not every
+    # caller has a plain String path handy; some want to pass a model
+    # and let CRUDPathBuilding derive the path.
+    herbarium = herbaria(:nybg_herbarium)
+    html = render(Components::Modal::CloseButton.new(target: herbarium))
+
+    assert_html(html, "a[href='#{routes.herbarium_path(id: herbarium.id)}']" \
+                       "[data-dismiss='modal']")
+  end
+
   def test_name_kwarg_overrides_default_label
     html = render(Components::Modal::CloseButton.new(name: "Nevermind"))
 
@@ -31,5 +42,23 @@ class ModalCloseButtonTest < ComponentTestCase
 
     assert_html(html, "button[data-dismiss='modal']" \
                        "[data-action='confirm-modal#cancel']")
+  end
+
+  def test_caller_data_cannot_override_dismiss
+    # A caller-supplied data: { dismiss: ... } must never win -- that
+    # would silently break the component's whole point (closing the
+    # modal).
+    html = render(Components::Modal::CloseButton.new(
+                    data: { dismiss: "something-else" }
+                  ))
+
+    assert_html(html, "button[data-dismiss='modal']")
+    assert_no_html(html, "button[data-dismiss='something-else']")
+  end
+
+  private
+
+  def routes
+    Rails.application.routes.url_helpers
   end
 end

--- a/test/components/modal/close_button_test.rb
+++ b/test/components/modal/close_button_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class ModalCloseButtonTest < ComponentTestCase
+  def test_default_renders_dismiss_only_cancel_button
+    html = render(Components::Modal::CloseButton.new)
+
+    assert_html(html, "button[data-dismiss='modal']", text: :CANCEL.l)
+    assert_no_html(html, "a")
+  end
+
+  def test_target_kwarg_renders_navigational_get_button
+    html = render(Components::Modal::CloseButton.new(target: "/foo/cancel"))
+
+    # Still dismisses the modal via JS AND navigates to the real path.
+    assert_html(html, "a[href='/foo/cancel'][data-dismiss='modal']",
+                text: :CANCEL.l)
+  end
+
+  def test_name_kwarg_overrides_default_label
+    html = render(Components::Modal::CloseButton.new(name: "Nevermind"))
+
+    assert_html(html, "button[data-dismiss='modal']", text: "Nevermind")
+  end
+
+  def test_extra_data_attrs_merge_with_dismiss
+    html = render(Components::Modal::CloseButton.new(
+                    data: { action: "confirm-modal#cancel" }
+                  ))
+
+    assert_html(html, "button[data-dismiss='modal']" \
+                       "[data-action='confirm-modal#cancel']")
+  end
+end


### PR DESCRIPTION
## Summary

Part of the BS3→4 runway-clearing audit on issue #3797. 5 modal footer Cancel buttons across the codebase were identical copies of `Components::Button.new(name: :CANCEL.l, data: { dismiss: "modal" })` — a DRY gap, not a BS4-migration-safety issue on its own (`data-dismiss="modal"` is unchanged in BS4). Worth fixing now for DRY, and it also derisks the eventual BS5 rename to `data-bs-dismiss` down to one place.

- Added `Components::Modal::CloseButton` — the footer counterpart to `Modal#close_button` (the header `×` icon, a different role). Supports the plain dismiss-only shape (4 of 5 call sites) and a navigational variant (`target:`, dispatches to `Button(type: :get, ...)` so Cancel both dismisses the modal and follows a real link — `occurrences/projects/form.rb` needs this to redirect back to a listing page rather than just closing in place).
- Routed all 5 sites through it: `occurrences/projects/form.rb`, `projects/members/trust_settings.rb`, `projects/members/add_obs_modal.rb`, `projects/violations/target_location_modal.rb`, `projects/violations/target_location_form.rb`.
- Updated `Components::Button`'s own doc comment (the `Cancel` example) to point at `Modal::CloseButton` instead of the raw hand-rolled shape.

## Test plan
- [x] `bin/rails test test/components/modal/ test/components/button_test.rb test/views/controllers/occurrences/projects/form_test.rb test/views/controllers/projects/members/add_obs_modal_test.rb test/views/controllers/projects/members/trust_settings_test.rb test/views/controllers/projects/violations/target_location_form_test.rb` — 85 tests, all green
- [x] `bin/rails test test/system/project_violations_target_location_modal_system_test.rb` — real-browser system test covering `target_location_modal.rb` (the one site with no dedicated view test), green
- [x] `bundle exec rubocop` on all touched files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
