### PR TITLE
Refuse to write to an orphaned RssLog (defuse ghost landmines)

### DIFF
--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -313,6 +313,10 @@ class RssLog < AbstractModel
 
     RssLog.record_timestamps = false if args.key?(:touch) && !args[:touch]
     save_without_our_callbacks
+  ensure
+    # record_timestamps is a class-level flag; reset it in an ensure so a
+    # raise in save_without_our_callbacks can't leave it false and silently
+    # suppress updated_at on every later RssLog save in the process.
     RssLog.record_timestamps = true
   end
 

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -297,12 +297,38 @@ class RssLog < AbstractModel
   #   :save  => true            # Save changes?
   #
   def add_with_date(tag, user: nil, **args)
+    return if already_orphaned?
+
     entry = encode(tag, relevant_args(args, user: user),
                    args[:time] || Time.zone.now)
-    RssLog.record_timestamps = false if args.key?(:touch) && !args[:touch]
     add_entry(entry)
-    save_without_our_callbacks unless args.key?(:save) && !args[:save]
+    save_dated_entry(args)
+  end
+
+  # Persist a freshly-added entry, honouring the +save+ and +touch+ args:
+  # +save: false+ skips the save entirely; +touch: false+ saves without
+  # bumping +updated_at+ (so the entry doesn't jump to the top of the feed).
+  def save_dated_entry(args)
+    return if args.key?(:save) && !args[:save]
+
+    RssLog.record_timestamps = false if args.key?(:touch) && !args[:touch]
+    save_without_our_callbacks
     RssLog.record_timestamps = true
+  end
+
+  # An orphaned log leads with the destroyed object's title instead of a
+  # timestamped entry (see #orphan), and is meant never to change again.
+  # Prepending a fresh timestamped entry would bury that title and turn the
+  # log back into a "ghost" (all target ids nil, notes newly timestamped)
+  # that script/check_rss_logs then deletes -- destroying the history of a
+  # live object that still points at this log. Refuse the write. See
+  # GitHub issue #4763.
+  #
+  # This is nil-safe (a brand-new log has blank notes) and does not block
+  # #orphan itself: orphan calls add_with_date *before* prepending the
+  # title, so the log still leads with a timestamp at that point.
+  def already_orphaned?
+    notes.present? && !notes.match?(/\A\d{14}/)
   end
 
   # `user:` is a User instance, a bare login string (some callers already

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -38,10 +38,12 @@ class RssLogTest < UnitTestCase
 
   def test_add_with_date_refuses_to_write_to_orphaned_log
     log = rss_logs(:location_rss_log)
-    # Orphan it: prepend a title line so notes no longer lead with a
-    # timestamp, exactly as #orphan leaves things.
+    # Orphan it the way #orphan does: clear the target ids and prepend a
+    # title line so notes no longer lead with a timestamp.
+    log.clear_target_id
     log.update(notes: "Target Title\n#{log.notes}")
     assert(log.already_orphaned?)
+    assert_nil(log.target_id)
     before = log.notes
 
     log.add_with_date(:log_location_updated, user: "mary")
@@ -51,6 +53,7 @@ class RssLogTest < UnitTestCase
     # orphan instead of turning back into a deletable "ghost". See #4763.
     assert_equal(before, log.notes)
     assert(log.already_orphaned?)
+    assert_nil(log.target_id)
   end
 
   def test_orphaning_still_works_through_the_guard

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -36,6 +36,49 @@ class RssLogTest < UnitTestCase
     assert_equal(:rss_created_at.t(type: :observation), detail)
   end
 
+  def test_add_with_date_refuses_to_write_to_orphaned_log
+    log = rss_logs(:location_rss_log)
+    # Orphan it: prepend a title line so notes no longer lead with a
+    # timestamp, exactly as #orphan leaves things.
+    log.update(notes: "Target Title\n#{log.notes}")
+    assert(log.already_orphaned?)
+    before = log.notes
+
+    log.add_with_date(:log_location_updated, user: "mary")
+    log.reload
+
+    # The write is refused: notes are unchanged, so the log stays a proper
+    # orphan instead of turning back into a deletable "ghost". See #4763.
+    assert_equal(before, log.notes)
+    assert(log.already_orphaned?)
+  end
+
+  def test_orphaning_still_works_through_the_guard
+    obs = observations(:detailed_unknown_obs)
+    obs.current_user = users(:dick)
+    log = obs.rss_log
+    assert_not(log.already_orphaned?)
+
+    # Destroying the object orphans its log via #orphan, which calls
+    # add_with_date *before* prepending the title. The guard must not block
+    # that path.
+    obs.destroy!
+    log.reload
+
+    assert(log.orphan?)
+    assert(log.already_orphaned?)
+    assert_equal(:log_observation_destroyed.t(user: "dick"), log.detail)
+  end
+
+  def test_a_fresh_log_is_not_treated_as_orphaned
+    log = RssLog.new
+    assert_not(log.already_orphaned?)
+
+    log.add_with_date(:log_observation_created, user: "mary")
+
+    assert_match(/log_observation_created/, log.notes)
+  end
+
   def test_detail_for_destroyed_object
     obs = observations(:detailed_unknown_obs)
     obs.current_user = users(:dick)


### PR DESCRIPTION
## Summary

Refuses to write new entries to an already-orphaned `RssLog`, defusing the "ghost landmines" investigated in #4763. This is the immediate, data-decision-independent fix from that issue — it stops any further loss of live objects' activity-log history.

## Background

An orphaned `RssLog` leads with the destroyed object's title instead of a timestamped entry, and the class documents that it "will never change again." Nothing enforced that. `RssLog#add_with_date` would happily prepend a fresh timestamped line above the orphan title, which turns the log back into a *ghost* — all target ids nil, notes newly leading with a timestamp — exactly the state `script/check_rss_logs` deletes on its nightly run. When the object that still points at that log is alive, deleting the log destroys its history and leaves a dangling `rss_log_id`.

Two triggers hit this in practice, both documented on #4763:

1. **Landmines** — roughly 845 still-live observations whose logs were falsely orphaned during a 2016 mass-deletion malfunction. Any comment, naming, or edit on one reactivates its orphaned log → ghost → deleted. Seven of these have already fired (once a year since 2022), each destroying an observation's history.
2. **Destroy-time sequence cascade** — destroying an observation that has a sequence orphans its log in `before_destroy`, then the `dependent: :destroy` sequence cascade re-logs to the now-orphaned log, minting a ghost that gets swept the same night.

## Change

`RssLog#add_with_date` returns early when the log is already orphaned:

```ruby
def already_orphaned?
  notes.present? && !notes.match?(/\A\d{14}/)
end
```

This is nil-safe (a brand-new log has blank notes) and deliberately does **not** block `#orphan` itself: `orphan` calls `add_with_date` *before* prepending the title, so the log still leads with a timestamp at that moment and the guard passes. The extraction of `save_dated_entry` from `add_with_date` is only to keep `AbcSize` within the cop limit after adding the guard clause — no behavior change.

With the guard in place, touching a landmine observation is a no-op on its log instead of a conversion-to-ghost: nothing is deleted, and the observation keeps pointing at its (still-inaccurate) orphan log. Correcting those ~845 logs is the separate Option A/B data decision still open on #4763; this PR only stops the bleeding.

## Test plan

- [x] `bin/rails test test/models/rss_log_test.rb` — added three tests: guard refuses a write to an orphaned log; orphaning still works through the guard (object destroy path); a fresh log is not treated as orphaned.
- [x] `bin/rails test test/models/observation_test.rb test/models/comment_test.rb test/models/naming_test.rb` — logging on create/update/destroy unaffected.
- [x] `bin/rails test test/models/name_test.rb test/models/location_test.rb` — merge/orphan paths unaffected.
- [x] `bundle exec rubocop app/models/rss_log.rb test/models/rss_log_test.rb` — no offenses.

Refs #4763.
