### PR TITLE
Restore bloodworm's zombie + deleted observation logs (#4763 Option A)

### DIFF
--- a/script/restore_deleted_observation_logs.rb
+++ b/script/restore_deleted_observation_logs.rb
@@ -1,29 +1,19 @@
 # frozen_string_literal: true
 
-# Restore the deleted RssLogs of "detonated" observations, from notes
-# recovered out of older database backups (GitHub issue #4763).
+# Restore the deleted RssLogs of observations that lost their history when a
+# pre-#4764 touch turned their orphaned log into a "ghost" that
+# script/check_rss_logs then deleted (GitHub issue #4763).
 #
-# When one of bloodworm's zombie observations (see
-# restore_orphaned_observation_logs.rb) was touched before PR #4764 landed,
-# its orphaned log turned into a "ghost" and script/check_rss_logs deleted
-# it, leaving the live observation with a dangling (or NULL) rss_log_id and
-# no history. This script recreates those logs where the pre-deletion notes
-# could still be recovered from a backup, re-links the observation, and sets
-# updated_at to the newest surviving entry so the log reads as it did before.
+# All notes below are the REAL original logs, recovered from database backups
+# (2024-01-01 for the first three; 2019-01-27 for the rest, which predates
+# every detonation) and cleaned the same way a zombie is cleaned: the false
+# title line and the log_observation_destroyed entry are dropped, leaving the
+# genuine pre-2016 history. Each log is reinserted with its original id,
+# observation_id, and an updated_at matching its newest surviving entry.
 #
-# The recovered notes below were extracted from the 2024-01-01 backup (which
-# still held these three logs in their orphaned state) and cleaned the same
-# way restore_orphaned_observation_logs.rb cleans a zombie: the false title
-# line and the log_observation_destroyed entry were dropped, leaving the real
-# pre-2016 history.
-#
-# NOT recovered (their logs were already gone from the oldest backup we have,
-# 2024-01-01, so their history is lost unless an earlier dump turns up):
-#   obs 205554 (log 233520, detonated 2022-04-23)
-#   obs 140593 (log 159708, detonated 2022-09-19; obs since got a fresh log)
-#   obs 131983 (log 149611, detonated 2022-10-02)
-#   obs  96712 (log 105921, detonated 2023-07-22)
-# A single backup from before 2022-04-23 would hold all four.
+# obs 140593 is special: it already has a fresh log (682221) from post-2024
+# activity, whose entries are authentic and kept verbatim. Its recovered
+# pre-detonation history is appended BELOW them, so nothing is duplicated.
 #
 # Usage (dry run by default; --apply to write):
 #   bin/rails runner script/restore_deleted_observation_logs.rb
@@ -31,7 +21,7 @@
 
 # Recreates deleted observation logs from backup-recovered notes.
 class DeletedObservationLogRestorer
-  RECORDS = [
+  INSERTS = [
     # obs 159258 -- Phellinus gilvus
     {
       log_id: 182_192, obs_id: 159_258,
@@ -62,6 +52,141 @@ class DeletedObservationLogRestorer
         20151115071623 log_image_created_at name Image%20#575862 user inspiteofourselves
         20151115071621 log_consensus_changed new **__Hericium%20erinaceus__**%20(Bull.)%20Pers. old **__Fungi__**%20Bartl. user inspiteofourselves
       NOTES
+    },
+    # obs 96712 -- Callistosporium
+    {
+      log_id: 105_921, obs_id: 96_712,
+      created_at: "2012-06-08 22:37:23", updated_at: "2014-10-29 09:05:32",
+      notes: <<~NOTES.chomp
+        20141029090532 log_comment_added summary thanks%20Jacob user myxomop
+        20141029002739 log_comment_updated summary myxomop user Pulk
+        20141029002726 log_comment_added summary myxomop user Pulk
+        20120911105259 log_comment_updated summary forgive%20me user myxomop
+        20120911034756 log_comment_added summary forgive%20me user myxomop
+        20120911031200 log_comment_updated summary Danny... user bloodworm
+        20120911031114 log_comment_added summary Danny... user bloodworm
+        20120910220942 log_comment_added summary too%20immature user myxomop
+        20120910220923 log_consensus_changed new **__Agaricales__**%20sensu%20lato old **__Callistosporium__**%20Singer user myxomop
+        20120909134524 log_consensus_changed new **__Callistosporium__**%20Singer old **__Agaricales__**%20sensu%20lato user bloodworm
+        20120831190454 log_consensus_changed new **__Agaricales__**%20sensu%20lato old **__Callistosporium__**%20Singer user myxomop
+        20120831130517 log_naming_created name **__Callistosporium__**%20Singer user bloodworm
+        20120831130517 log_consensus_changed new **__Callistosporium__**%20Singer old **__Agaricales__**%20sensu%20lato user bloodworm
+        20120831083038 log_naming_created name **__Agaricales__**%20sensu%20lato user myxomop
+        20120831083038 log_consensus_changed new **__Agaricales__**%20sensu%20lato old **__Fungi__**%20Bartling user myxomop
+        20120831082121 log_naming_created name **__Collybia%20aurea__**%20(Beeli)%20Pegler user myxomop
+        20120608223725 log_observation_created user bloodworm
+        20120608223725 log_image_created name Image%20#225942 user bloodworm
+        20120608223725 log_image_created name Image%20#225941 user bloodworm
+      NOTES
+    },
+    # obs 131983 -- Panaeolus cinctulus
+    {
+      log_id: 149_611, obs_id: 131_983,
+      created_at: "2013-04-16 15:24:10", updated_at: "2014-02-06 17:02:39",
+      notes: <<~NOTES.chomp
+        20140206170239 log_comment_added summary Light%20stem user Byrain
+        20140206165208 log_naming_created_at name **__Panaeolus__**%20(Fr.)%20Quél. user Byrain
+        20140206165208 log_consensus_changed new **__Panaeolus__**%20(Fr.)%20Quél. old **__Panaeolus%20subbalteatus__**%20(Berk.%20&%20Broome)%20Sacc. user Byrain
+        20140206164139 log_comment_updated summary thanks%20Alan... user bloodworm
+        20140206164034 log_comment_added summary thanks%20Alan... user bloodworm
+        20131214214422 log_naming_created_at name **__Panaeolus%20subbalteatus__**%20(Berk.%20&%20Broome)%20Sacc. user Alan%20Rockefeller
+        20131214214422 log_consensus_changed new **__Panaeolus%20subbalteatus__**%20(Berk.%20&%20Broome)%20Sacc. old __Panaeolus%20cinctulus__%20(Bolton)%20Britzelm. user Alan%20Rockefeller
+        20130416152414 log_observation_created user bloodworm
+        20130416152414 log_image_created name Image%20#322869 user bloodworm
+        20130416152414 log_image_created name Image%20#322868 user bloodworm
+        20130416152413 log_consensus_changed new **__Panaeolus%20cinctulus__**%20(Bolton)%20Britzelm. old **__Fungi__**%20Bartl. user bloodworm
+      NOTES
+    },
+    # obs 205554 -- Psathyrella carbonicola
+    {
+      log_id: 233_520, obs_id: 205_554,
+      created_at: "2015-06-03 05:13:35", updated_at: "2015-06-03 05:40:35",
+      notes: <<~NOTES.chomp
+        20150603054035 log_naming_created_at name **__Psathyrella%20carbonicola__**%20A.H.%20Sm. user Pulk
+        20150603054035 log_consensus_changed new **__Psathyrella%20carbonicola__**%20A.H.%20Sm. old **__Psathyrella__**%20(Fr.)%20Quél. user Pulk
+        20150603051337 log_observation_created_at user RJK
+        20150603051337 log_image_created_at name Image%20#524468 user RJK
+        20150603051336 log_image_created_at name Image%20#524467 user RJK
+        20150603051336 log_consensus_changed new **__Psathyrella__**%20(Fr.)%20Quél. old **__Fungi__**%20Bartl. user RJK
+      NOTES
+    }
+  ].freeze
+
+  APPENDS = [
+    # obs 140593 -- recovered pre-detonation history spliced below the
+    # authentic 2024-2025 entries of its existing fresh log 682221.
+    {
+      existing_log_id: 682_221, obs_id: 140_593,
+      notes: <<~NOTES.chomp
+        20140704155136 log_consensus_changed new **__Copelandia__**%20Bres. old **__Copelandia%20cambodginiensis__**%20(Ola'h%20&%20R.%20Heim)%20Singer%20&%20R.A.%20Weeks user bloodworm
+        20140704155058 log_consensus_changed new **__Copelandia%20cambodginiensis__**%20(Ola'h%20&%20R.%20Heim)%20Singer%20&%20R.A.%20Weeks old **__Copelandia__**%20Bres. user bloodworm
+        20140629061933 log_consensus_changed new **__Copelandia__**%20Bres. old **__Panaeolus%20cyanescens__**%20(Berk.%20&%20Broome)%20Sacc. user bloodworm
+        20140629061734 log_consensus_changed new **__Panaeolus%20cyanescens__**%20(Berk.%20&%20Broome)%20Sacc. old **__Copelandia__**%20Bres. user Alan%20Rockefeller
+        20140223170314 log_comment_updated summary Time%20to%20figure%20out%20 user Byrain
+        20140223170114 log_consensus_changed new **__Copelandia__**%20Bres. old **__Copelandia%20cambodginiensis__** user Byrain
+        20140223164659 log_comment_updated summary Time%20to%20figure%20out%20 user Byrain
+        20140223164610 log_comment_added summary Time%20to%20figure%20out%20 user Byrain
+        20140223133236 log_comment_added summary Time%20to%20figure%20out user Rocky%20Houghtby
+        20140223085609 log_naming_created_at name **__Copelandia%20cambodginiensis__** user bloodworm
+        20140223085609 log_consensus_changed new **__Copelandia%20cambodginiensis__** old **__Copelandia__**%20Bres. user bloodworm
+        20140202165257 log_consensus_changed new **__Copelandia__**%20Bres. old **__Panaeolus%20cambodginiensis__**%20Ola'h%20and%20Heim user Byrain
+        20140202161222 log_naming_created_at name **__Panaeolus%20cambodginiensis__**%20Ola'h%20and%20Heim user bloodworm
+        20140202161222 log_consensus_changed new **__Panaeolus%20cambodginiensis__**%20Ola'h%20and%20Heim old **__Copelandia__**%20Bres. user bloodworm
+        20140104125741 log_consensus_changed new **__Copelandia__**%20Bres. old **__Panaeolus__**%20subgenus%20**__Copelandia__** user bloodworm
+        20131230190338 log_comment_added summary Well user Byrain
+        20131230081128 log_naming_created_at name __Copelandia__%20Bres. user Alan%20Rockefeller
+        20131230061628 log_consensus_changed new **__Panaeolus__**%20subgenus%20**__Copelandia__** old **__Panaeolus%20bisporus__**%20(Malençon%20&%20Bertault)%20Ew.%20Gerhardt user Joust
+        20131230050307 log_consensus_changed new **__Panaeolus%20bisporus__**%20(Malençon%20&%20Bertault)%20Ew.%20Gerhardt old **__Panaeolus%20cyanescens__**%20(Berk.%20&%20Broome)%20Sacc. user bloodworm
+        20131230045705 log_comment_added summary thanks%20Christine!! user bloodworm
+        20130808181111 log_observation_updated user wintersbefore
+        20130802172049 log_comment_added summary Spore%20measurements user wintersbefore
+        20130802170504 log_comment_added summary bloodworm user Byrain
+        20130802170417 log_consensus_changed new **__Panaeolus%20cyanescens__**%20(Berk.%20&%20Broome)%20Sacc. old **__Panaeolus__**%20(Fr.)%20Quél. user Byrain
+        20130802151243 log_image_created name Image%20#354418 user wintersbefore
+        20130802151146 log_image_created name Image%20#354417 user wintersbefore
+        20130802151145 log_image_created name Image%20#354416 user wintersbefore
+        20130802145910 log_image_created name Image%20#354415 user wintersbefore
+        20130802145909 log_image_created name Image%20#354414 user wintersbefore
+        20130802145908 log_image_created name Image%20#354413 user wintersbefore
+        20130802145907 log_image_created name Image%20#354412 user wintersbefore
+        20130802145634 log_image_created name Image%20#354407 user wintersbefore
+        20130802145634 log_image_created name Image%20#354406 user wintersbefore
+        20130802145633 log_image_created name Image%20#354405 user wintersbefore
+        20130802145426 log_image_created name Image%20#354401 user wintersbefore
+        20130802145426 log_image_created name Image%20#354400 user wintersbefore
+        20130802145425 log_image_created name Image%20#354399 user wintersbefore
+        20130802145424 log_image_created name Image%20#354398 user wintersbefore
+        20130802145047 log_image_created name Image%20#354397 user wintersbefore
+        20130802144747 log_image_created name Image%20#354396 user wintersbefore
+        20130802144013 log_image_created name Image%20#354395 user wintersbefore
+        20130802144011 log_image_created name Image%20#354394 user wintersbefore
+        20130802144009 log_image_created name Image%20#354393 user wintersbefore
+        20130802144008 log_image_created name Image%20#354392 user wintersbefore
+        20130802143840 log_image_created name Image%20#354391 user wintersbefore
+        20130802143839 log_image_created name Image%20#354390 user wintersbefore
+        20130802143737 log_image_created name Image%20#354389 user wintersbefore
+        20130802143736 log_image_created name Image%20#354388 user wintersbefore
+        20130802143735 log_image_created name Image%20#354387 user wintersbefore
+        20130802143734 log_image_created name Image%20#354386 user wintersbefore
+        20130723065327 log_comment_added summary Byrain... user bloodworm
+        20130723064737 log_comment_added summary Micro? user Byrain
+        20130723064552 log_consensus_changed new **__Panaeolus__**%20(Fr.)%20Quél. old **__Panaeolus%20bisporus__**%20(Malençon%20&%20Bertault)%20Ew.%20Gerhardt user Byrain
+        20130723050524 log_consensus_changed new **__Panaeolus%20bisporus__**%20(Malençon%20&%20Bertault)%20Ew.%20Gerhardt old **__Panaeolus__**%20(Fr.)%20Quél. user bloodworm
+        20130722144024 log_naming_created name **__Panaeolus%20bisporus__**%20(Malençon%20&%20Bertault)%20Ew.%20Gerhardt user bloodworm
+        20130722130617 log_image_created name Image%20#351215 user bloodworm
+        20130722130501 log_image_removed name Image%20#351214 user bloodworm
+        20130722130113 log_image_created name Image%20#351214 user bloodworm
+        20130722124428 log_naming_created name **__Panaeolus%20cyanescens__**%20(Berk.%20&%20Broome)%20Sacc. user bloodworm
+        20130722123932 log_naming_created name **__Panaeolus__**%20subgenus%20**__Copelandia__** user bloodworm
+        20130722122825 log_observation_created user bloodworm
+        20130722122825 log_specimen_added name Panaeolus%20:%20140593 user bloodworm
+        20130722122825 log_image_created name Image%20#351211 user bloodworm
+        20130722122824 log_image_created name Image%20#351210 user bloodworm
+        20130722122824 log_image_created name Image%20#351209 user bloodworm
+        20130722122824 log_image_created name Image%20#351208 user bloodworm
+        20130722122824 log_image_created name Image%20#351207 user bloodworm
+        20130722122824 log_consensus_changed new **__Panaeolus__**%20(Fr.)%20Quél. old **__Fungi__**%20Bartl. user bloodworm
+      NOTES
     }
   ].freeze
 
@@ -72,41 +197,58 @@ class DeletedObservationLogRestorer
   end
 
   def run
-    warn("#{"[DRY RUN] " if @dry_run}Restoring #{RECORDS.size} deleted " \
-         "observation log(s).\n\n")
-    RECORDS.each { |rec| process(rec) }
+    warn("#{"[DRY RUN] " if @dry_run}Restoring #{INSERTS.size} log(s) + " \
+         "#{APPENDS.size} splice(s).\n\n")
+    INSERTS.each { |rec| insert_record(rec) }
+    APPENDS.each { |rec| append_record(rec) }
     report
   end
 
   private
 
-  def process(rec)
-    obs = Observation.find_by(id: rec[:obs_id])
-    return skip(rec, "observation not found") unless obs
-    return skip(rec, "log already exists") if RssLog.exists?(rec[:log_id])
+  def insert_record(rec)
+    return skip(rec, "log exists") if RssLog.exists?(rec[:log_id])
 
-    restore(obs, rec) unless @dry_run
-    @done += 1
-    warn("#{@dry_run ? "WOULD RESTORE" : "RESTORED"} log #{rec[:log_id]} " \
-         "-> obs #{rec[:obs_id]} (updated_at #{rec[:updated_at]})")
+    obs = Observation.find_by(id: rec[:obs_id])
+    return skip(rec, "obs not found") unless obs
+
+    write_insert(rec, obs) unless @dry_run
+    done("insert log #{rec[:log_id]} -> obs #{rec[:obs_id]}")
   end
 
-  # insert! writes the row directly -- no callbacks, no timestamp override --
-  # so the recovered created_at / updated_at are preserved verbatim.
-  def restore(obs, rec)
+  def write_insert(rec, obs)
     RssLog.insert!(rec.slice(:created_at, :updated_at, :notes).
                    merge(id: rec[:log_id], observation_id: rec[:obs_id]))
     obs.update_column(:rss_log_id, rec[:log_id])
   end
 
+  def append_record(rec)
+    log = RssLog.find_by(id: rec[:existing_log_id])
+    return skip(rec, "log missing") unless log
+    return skip(rec, "already spliced") if log.notes.to_s.include?(rec[:notes])
+
+    log.update_columns(notes: spliced(log, rec)) unless @dry_run
+    done("splice history -> obs #{rec[:obs_id]} (log #{rec[:existing_log_id]})")
+  end
+
+  def spliced(log, rec)
+    "#{log.notes.to_s.chomp}\n#{rec[:notes]}"
+  end
+
+  def done(msg)
+    @done += 1
+    warn("#{@dry_run ? "WOULD" : "DID"} #{msg}")
+  end
+
   def skip(rec, reason)
-    @skipped << [rec[:obs_id], rec[:log_id], reason]
-    warn("SKIP obs #{rec[:obs_id]} log #{rec[:log_id]}: #{reason}")
+    log_id = rec[:log_id] || rec[:existing_log_id]
+    @skipped << [rec[:obs_id], log_id, reason]
+    warn("SKIP obs #{rec[:obs_id]} log #{log_id}: #{reason}")
   end
 
   def report
-    warn("\n#{@dry_run ? "[DRY RUN] would restore" : "Restored"} #{@done}, " \
-         "skipped #{@skipped.size}, of #{RECORDS.size}.")
+    warn("\n#{@dry_run ? "[DRY RUN] would apply" : "Applied"} #{@done}, " \
+         "skipped #{@skipped.size}.")
     return unless @dry_run && @done.positive?
 
     warn("Re-run with --apply to write the changes.")

--- a/script/restore_deleted_observation_logs.rb
+++ b/script/restore_deleted_observation_logs.rb
@@ -211,24 +211,44 @@ class DeletedObservationLogRestorer
 
     obs = Observation.find_by(id: rec[:obs_id])
     return skip(rec, "obs not found") unless obs
+    return skip(rec, "obs already points at another log") unless linkable?(obs,
+                                                                           rec)
 
     write_insert(rec, obs) unless @dry_run
     done("insert log #{rec[:log_id]} -> obs #{rec[:obs_id]}")
   end
 
+  # Only overwrite rss_log_id when it's blank or already this log, so a log
+  # created since this script was authored (as 140593 got) is never clobbered.
+  def linkable?(obs, rec)
+    obs.rss_log_id.nil? || obs.rss_log_id == rec[:log_id]
+  end
+
   def write_insert(rec, obs)
-    RssLog.insert!(rec.slice(:created_at, :updated_at, :notes).
-                   merge(id: rec[:log_id], observation_id: rec[:obs_id]))
+    RssLog.insert!({ id: rec[:log_id], observation_id: rec[:obs_id],
+                     notes: rec[:notes], created_at: utc(rec[:created_at]),
+                     updated_at: utc(rec[:updated_at]) })
     obs.update_column(:rss_log_id, rec[:log_id])
+  end
+
+  # Recovered timestamps are UTC wall-clock; parse them as UTC so they aren't
+  # shifted through the app time zone.
+  def utc(str)
+    Time.find_zone("UTC").parse(str)
   end
 
   def append_record(rec)
     log = RssLog.find_by(id: rec[:existing_log_id])
     return skip(rec, "log missing") unless log
+    return skip(rec, "obs missing or points elsewhere") unless spliceable?(rec)
     return skip(rec, "already spliced") if log.notes.to_s.include?(rec[:notes])
 
     log.update_columns(notes: spliced(log, rec)) unless @dry_run
     done("splice history -> obs #{rec[:obs_id]} (log #{rec[:existing_log_id]})")
+  end
+
+  def spliceable?(rec)
+    Observation.find_by(id: rec[:obs_id])&.rss_log_id == rec[:existing_log_id]
   end
 
   def spliced(log, rec)

--- a/script/restore_deleted_observation_logs.rb
+++ b/script/restore_deleted_observation_logs.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# Restore the deleted RssLogs of "detonated" observations, from notes
+# recovered out of older database backups (GitHub issue #4763).
+#
+# When one of bloodworm's zombie observations (see
+# restore_orphaned_observation_logs.rb) was touched before PR #4764 landed,
+# its orphaned log turned into a "ghost" and script/check_rss_logs deleted
+# it, leaving the live observation with a dangling (or NULL) rss_log_id and
+# no history. This script recreates those logs where the pre-deletion notes
+# could still be recovered from a backup, re-links the observation, and sets
+# updated_at to the newest surviving entry so the log reads as it did before.
+#
+# The recovered notes below were extracted from the 2024-01-01 backup (which
+# still held these three logs in their orphaned state) and cleaned the same
+# way restore_orphaned_observation_logs.rb cleans a zombie: the false title
+# line and the log_observation_destroyed entry were dropped, leaving the real
+# pre-2016 history.
+#
+# NOT recovered (their logs were already gone from the oldest backup we have,
+# 2024-01-01, so their history is lost unless an earlier dump turns up):
+#   obs 205554 (log 233520, detonated 2022-04-23)
+#   obs 140593 (log 159708, detonated 2022-09-19; obs since got a fresh log)
+#   obs 131983 (log 149611, detonated 2022-10-02)
+#   obs  96712 (log 105921, detonated 2023-07-22)
+# A single backup from before 2022-04-23 would hold all four.
+#
+# Usage (dry run by default; --apply to write):
+#   bin/rails runner script/restore_deleted_observation_logs.rb
+#   bin/rails runner script/restore_deleted_observation_logs.rb --apply
+
+# Recreates deleted observation logs from backup-recovered notes.
+class DeletedObservationLogRestorer
+  RECORDS = [
+    # obs 159258 -- Phellinus gilvus
+    {
+      log_id: 182_192, obs_id: 159_258,
+      created_at: "2014-02-06 21:50:32", updated_at: "2014-02-06 21:50:41",
+      notes: <<~NOTES.chomp
+        20140206215041 log_observation_created_at user bloodworm
+        20140206215041 log_image_created_at name Image%20#402504 user bloodworm
+        20140206215040 log_consensus_changed new **__Phellinus%20gilvus__**%20(Schwein.)%20Pat. old **__Fungi__** user bloodworm
+      NOTES
+    },
+    # obs 218032 -- Chromosera cyanophylla
+    {
+      log_id: 247_617, obs_id: 218_032,
+      created_at: "2015-10-07 21:59:02", updated_at: "2015-10-07 21:59:11",
+      notes: <<~NOTES.chomp
+        20151007215911 log_observation_created_at user inspiteofourselves
+        20151007215911 log_image_created_at name Image%20#562015 user inspiteofourselves
+        20151007215909 log_image_created_at name Image%20#562014 user inspiteofourselves
+        20151007215908 log_consensus_changed new **__Chromosera%20cyanophylla__**%20(Fr.)%20Redhead,%20Ammirati%20&%20Norvell old **__Fungi__**%20Bartl. user inspiteofourselves
+      NOTES
+    },
+    # obs 223025 -- Hericium erinaceus
+    {
+      log_id: 253_226, obs_id: 223_025,
+      created_at: "2015-11-15 07:16:18", updated_at: "2015-11-15 07:16:23",
+      notes: <<~NOTES.chomp
+        20151115071623 log_observation_created_at user inspiteofourselves
+        20151115071623 log_image_created_at name Image%20#575862 user inspiteofourselves
+        20151115071621 log_consensus_changed new **__Hericium%20erinaceus__**%20(Bull.)%20Pers. old **__Fungi__**%20Bartl. user inspiteofourselves
+      NOTES
+    }
+  ].freeze
+
+  def initialize(apply:)
+    @dry_run = !apply
+    @done = 0
+    @skipped = []
+  end
+
+  def run
+    warn("#{"[DRY RUN] " if @dry_run}Restoring #{RECORDS.size} deleted " \
+         "observation log(s).\n\n")
+    RECORDS.each { |rec| process(rec) }
+    report
+  end
+
+  private
+
+  def process(rec)
+    obs = Observation.find_by(id: rec[:obs_id])
+    return skip(rec, "observation not found") unless obs
+    return skip(rec, "log already exists") if RssLog.exists?(rec[:log_id])
+
+    restore(obs, rec) unless @dry_run
+    @done += 1
+    warn("#{@dry_run ? "WOULD RESTORE" : "RESTORED"} log #{rec[:log_id]} " \
+         "-> obs #{rec[:obs_id]} (updated_at #{rec[:updated_at]})")
+  end
+
+  # insert! writes the row directly -- no callbacks, no timestamp override --
+  # so the recovered created_at / updated_at are preserved verbatim.
+  def restore(obs, rec)
+    RssLog.insert!(rec.slice(:created_at, :updated_at, :notes).
+                   merge(id: rec[:log_id], observation_id: rec[:obs_id]))
+    obs.update_column(:rss_log_id, rec[:log_id])
+  end
+
+  def skip(rec, reason)
+    @skipped << [rec[:obs_id], rec[:log_id], reason]
+    warn("SKIP obs #{rec[:obs_id]} log #{rec[:log_id]}: #{reason}")
+  end
+
+  def report
+    warn("\n#{@dry_run ? "[DRY RUN] would restore" : "Restored"} #{@done}, " \
+         "skipped #{@skipped.size}, of #{RECORDS.size}.")
+    return unless @dry_run && @done.positive?
+
+    warn("Re-run with --apply to write the changes.")
+  end
+end
+
+DeletedObservationLogRestorer.new(apply: ARGV.include?("--apply")).run

--- a/script/restore_orphaned_observation_logs.rb
+++ b/script/restore_orphaned_observation_logs.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# Repair "zombie" observations: live Observations whose RssLog was wrongly
+# left in an orphaned state.
+#
+# Background (GitHub issue #4763): in 2016 a user manually deleted ~850 of
+# their observations; the destroys ran normally, orphaning each log (a title
+# line prepended above the timestamped history, a `log_observation_destroyed`
+# entry added, and every target id nulled). Around 2018 the observations were
+# restored from a pre-incident backup -- but the restore never reconciled the
+# already-orphaned logs. The result is a live Observation pointing at an
+# orphaned log: a landmine that turns into a deletable "ghost" the moment the
+# observation is touched. PR #4764 stopped new detonations; this script
+# repairs the existing pairs (Option A).
+#
+# For each zombie it strips the false title line and the bogus
+# `log_observation_destroyed` entry from the log's notes, restores
+# `rss_logs.observation_id`, and resets `updated_at` to the timestamp of the
+# newest surviving (real) entry -- reconstructing the log exactly as it stood
+# just before the 2016 destroy. Notes and the foreign key MUST be fixed
+# together: re-pointing the FK alone would be re-nulled by
+# script/check_rss_logs the next night, because the notes would still lead
+# with the title line.
+#
+# Idempotent: a repaired log has observation_id set, so it drops out of the
+# selection on any later run.
+#
+# Usage (default is a dry run that writes nothing):
+#   bin/rails runner script/restore_orphaned_observation_logs.rb
+#   bin/rails runner script/restore_orphaned_observation_logs.rb --apply
+#   bin/rails runner script/restore_orphaned_observation_logs.rb --apply -v
+
+# Restores live observations whose logs were wrongly left orphaned.
+class OrphanedObservationLogRestorer
+  DESTROYED = /\A\d{14} log_observation_destroyed(?:\s|\z)/
+  TIMESTAMPED = /\A\d{14}/
+
+  def initialize(apply:, verbose:)
+    @dry_run = !apply
+    @verbose = verbose
+    @fixed = 0
+    @skipped = []
+  end
+
+  def run
+    zombies = select_zombies
+    @total = zombies.count
+    warn("#{"[DRY RUN] " if @dry_run}Found #{@total} zombie observation(s) " \
+         "(live observation pointing at an orphaned log).\n\n")
+    started = Time.zone.now
+    zombies.find_each.with_index do |obs, i|
+      process(obs)
+      report_progress(i + 1, started)
+    end
+    report_summary
+  end
+
+  private
+
+  def select_zombies
+    Observation.
+      joins("INNER JOIN rss_logs ON rss_logs.id = observations.rss_log_id").
+      where(rss_logs: { observation_id: nil }).
+      order(:id)
+  end
+
+  def process(obs)
+    log = obs.rss_log
+    parts = log.notes.to_s.split("\n", 3)
+    reason = rejection_reason(parts)
+    return skip(obs, log, reason) if reason
+
+    new_time = parse_time(parts[2])
+    return skip(obs, log, "bad leading timestamp") if new_time.nil?
+
+    fix(obs, log, parts, new_time)
+  end
+
+  # Split gives [title, destroyed_entry, rest]; rest keeps its internal
+  # newlines and trailing content byte-for-byte.
+  def rejection_reason(parts)
+    if parts.size < 3
+      "notes have fewer than 3 lines"
+    elsif parts[0].match?(TIMESTAMPED)
+      "line 1 is timestamped (expected a title line)"
+    elsif !parts[1].match?(DESTROYED)
+      "line 2 is not a log_observation_destroyed entry"
+    elsif !parts[2].match?(TIMESTAMPED)
+      "surviving history does not lead with a timestamp"
+    end
+  end
+
+  def parse_time(rest)
+    Time.parse("#{rest[/\A\d{14}/]}+0000")
+  rescue ArgumentError
+    nil
+  end
+
+  def fix(obs, log, parts, new_time)
+    unless @dry_run
+      log.update_columns(observation_id: obs.id, notes: parts[2],
+                         updated_at: new_time)
+    end
+    @fixed += 1
+    return unless @verbose || @dry_run
+
+    warn("FIX  obs #{obs.id} (log #{log.id}) owner=#{obs.user_id} " \
+         "updated_at #{log.updated_at.utc.iso8601} -> " \
+         "#{new_time.utc.iso8601} | title: #{truncate(parts[0])}")
+  end
+
+  def skip(obs, log, reason)
+    @skipped << [obs.id, log.id, reason]
+    warn("SKIP obs #{obs.id} (log #{log.id}): #{reason}")
+  end
+
+  def truncate(str)
+    str.length > 60 ? "#{str[0, 57]}..." : str
+  end
+
+  def report_progress(done, started)
+    return unless (done % 100).zero?
+
+    elapsed = Time.zone.now - started
+    warn("  ...#{done}/#{@total} processed " \
+         "(#{elapsed.round}s, #{(done / elapsed).round(1)}/s)")
+  end
+
+  def report_summary
+    warn("\n#{@dry_run ? "[DRY RUN] would fix" : "Fixed"} #{@fixed}, " \
+         "skipped #{@skipped.size}, of #{@total} found.")
+    if @skipped.any?
+      warn("Skipped (need manual review):")
+      @skipped.each { |oid, lid, why| warn("  obs #{oid} log #{lid}: #{why}") }
+    end
+    return unless @dry_run && @fixed.positive?
+
+    warn("Re-run with --apply to write the changes.")
+  end
+end
+
+OrphanedObservationLogRestorer.new(
+  apply: ARGV.include?("--apply"),
+  verbose: ARGV.include?("--verbose") || ARGV.include?("-v")
+).run

--- a/script/restore_orphaned_observation_logs.rb
+++ b/script/restore_orphaned_observation_logs.rb
@@ -58,10 +58,10 @@ class OrphanedObservationLogRestorer
   private
 
   def select_zombies
+    # find_each batches by primary key ascending, so no explicit order.
     Observation.
       joins("INNER JOIN rss_logs ON rss_logs.id = observations.rss_log_id").
-      where(rss_logs: { observation_id: nil }).
-      order(:id)
+      where(rss_logs: { observation_id: nil })
   end
 
   def process(obs)
@@ -97,6 +97,7 @@ class OrphanedObservationLogRestorer
   end
 
   def fix(obs, log, parts, new_time)
+    old_time = log.updated_at
     unless @dry_run
       log.update_columns(observation_id: obs.id, notes: parts[2],
                          updated_at: new_time)
@@ -105,7 +106,7 @@ class OrphanedObservationLogRestorer
     return unless @verbose || @dry_run
 
     warn("FIX  obs #{obs.id} (log #{log.id}) owner=#{obs.user_id} " \
-         "updated_at #{log.updated_at.utc.iso8601} -> " \
+         "updated_at #{old_time.utc.iso8601} -> " \
          "#{new_time.utc.iso8601} | title: #{truncate(parts[0])}")
   end
 
@@ -122,8 +123,8 @@ class OrphanedObservationLogRestorer
     return unless (done % 100).zero?
 
     elapsed = Time.zone.now - started
-    warn("  ...#{done}/#{@total} processed " \
-         "(#{elapsed.round}s, #{(done / elapsed).round(1)}/s)")
+    rate = elapsed.positive? ? (done / elapsed).round(1) : done
+    warn("  ...#{done}/#{@total} processed (#{elapsed.round}s, #{rate}/s)")
   end
 
   def report_summary


### PR DESCRIPTION
## Summary

The Option A data-repair scripts from #4763. Both default to a dry run and take `--apply` to write.

### 1. `script/restore_orphaned_observation_logs.rb` — the ~851 zombies

Live observations whose `RssLog` was left orphaned by the 2016-delete / ~2018-restore mismatch. For each (`Observation` whose log has `observation_id IS NULL`): strips the false title line and the `log_observation_destroyed` entry from the notes, restores `rss_logs.observation_id`, and resets `updated_at` to the newest surviving real entry. Notes and the FK are fixed together (FK-alone gets re-nulled by `check_rss_logs`). Idempotent; anything not matching the expected orphan shape is skipped for manual review. Verified against a current-production checkpoint: 851 found, all bloodworm, 0 skipped; a rolled-back apply confirms each fixed log is non-orphan, non-ghost, reattached.

### 2. `script/restore_deleted_observation_logs.rb` — all 7 detonated observations

Observations whose orphaned log was already *deleted* (a pre-#4764 touch turned it into a ghost that `check_rss_logs` removed), leaving a dangling/NULL `rss_log_id` and no history. All seven were recovered as **real original logs** from backups — three from 2024-01-01, and the remaining four from a **2019-01-27 checkpoint** that predates every detonation. Each recovered log is cleaned the same way (drop the title + `log_observation_destroyed` lines) and reinserted with its original id, `observation_id`, and a faithful `updated_at`.

- **6 inserts**: 159258, 218032, 223025, 96712, 131983, 205554.
- **1 splice**: obs 140593 already has a fresh log (682221) from 2024 activity; its recovered pre-detonation history is appended *below* those authentic entries, so nothing is duplicated (the 2024 naming stays only in the authentic portion).

Recovered logs are byte-identical across overlapping backups (2019 vs 2024 cross-check passed), and every old-era log tag still renders. Verified via a rolled-back apply: all seven come back non-orphan, non-ghost, reattached, `detail` rendering. Idempotent (inserts skip an existing log id; the splice skips if already applied).

Nothing is left unrecovered — the earlier "4 logs lost" gap is closed by the 2019 checkpoint, so no reconstruction-from-surviving-records is needed.

## Run order

Land the #4764 guard first (done — merged and deployed). Then:

```
bin/rails runner script/restore_orphaned_observation_logs.rb            # dry run
bin/rails runner script/restore_orphaned_observation_logs.rb --apply
bin/rails runner script/restore_deleted_observation_logs.rb            # dry run
bin/rails runner script/restore_deleted_observation_logs.rb --apply
```

Refs #4763.
