### PR TITLE
Block PII (emails) in GitHub publish commands via PreToolUse hook + rule

### DIFF
--- a/.claude/hooks/block_pii_in_gh.sh
+++ b/.claude/hooks/block_pii_in_gh.sh
@@ -12,7 +12,7 @@
 # .claude/rules/no_pii_in_public.md.
 #
 # Scope: scans the command string itself (inline `--body`/`-b`/`-f body=`)
-# AND the contents of any `--body-file` (the mandated form for PR/issue
+# AND the contents of any `--body-file` (the mandated form for PR
 # bodies -- see .claude/rules/gh_pr_bodies.md), which is where the real
 # leak hid in the incident that prompted this hook.
 #

--- a/.claude/hooks/block_pii_in_gh.sh
+++ b/.claude/hooks/block_pii_in_gh.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook.
+# Fires before `Bash` calls. Blocks `gh` commands that would PUBLISH
+# content to (public) GitHub -- issue/PR create|edit|comment|review and
+# `gh api` calls that set a `body=` field -- when the content contains a
+# real email address.
+#
+# Why: an email in a GitHub issue/PR/comment is PII posted publicly. On a
+# public repo it is broadcast verbatim to the events firehose (GH Archive,
+# bots) at creation time, and editing afterward does NOT remove it (edit
+# history is retained). So it has to be stopped BEFORE it is sent. See
+# .claude/rules/no_pii_in_public.md.
+#
+# Scope: scans the command string itself (inline `--body`/`-b`/`-f body=`)
+# AND the contents of any `--body-file` (the mandated form for PR/issue
+# bodies -- see .claude/rules/gh_pr_bodies.md), which is where the real
+# leak hid in the incident that prompted this hook.
+#
+# Blunt by design: for outbound-to-public commands, err toward blocking.
+# Known non-PII addresses (noreply, git@github.com) are allowlisted so
+# Co-Authored-By trailers and SSH-style refs don't trip it.
+set -euo pipefail
+
+INPUT="$(cat)"
+COMMAND="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')"
+
+# Gate: only inspect gh commands that publish content.
+if ! printf '%s' "$COMMAND" | grep -qE \
+  'gh[[:space:]]+(issue|pr)[[:space:]]+(create|edit|comment|review)|gh[[:space:]]+api[[:space:]].*body='; then
+  exit 0
+fi
+
+EMAIL_RE='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+
+# Gather candidate emails from the command string and any --body-file(s).
+CANDIDATES="$(printf '%s' "$COMMAND" | grep -oE "$EMAIL_RE" || true)"
+FILES="$(printf '%s' "$COMMAND" \
+  | grep -oE -- '--body-file[[:space:]=]+[^[:space:]]+' \
+  | sed -E 's/^--body-file[[:space:]=]+//' | tr -d "\"'" || true)"
+for f in $FILES; do
+  [ -f "$f" ] && CANDIDATES="$CANDIDATES
+$(grep -oE "$EMAIL_RE" "$f" || true)"
+done
+
+# Drop well-known non-PII addresses (noreply, github noreply, git@github.com).
+REAL="$(printf '%s' "$CANDIDATES" | grep -vE \
+  '(^|[^A-Za-z0-9._%+-])(no-?reply@|git@github\.com)|\.noreply\.github\.com' \
+  | grep -E "$EMAIL_RE" || true)"
+
+if [ -n "$REAL" ]; then
+  cat >&2 <<'EOF'
+🚫 BLOCKED: this GitHub publish command contains an email address.
+
+Email addresses are PII and must never be posted to GitHub issues,
+PRs, or comments. On a public repo the content is broadcast to the
+events firehose (GH Archive / bots) the moment it is created, and
+editing later does NOT remove it -- so it has to be stopped now.
+
+Fix: remove the email from the body. Refer to the person by their
+internal id or public handle, and write "contact details on file
+(not reproduced here)" instead of the address. Then retry.
+
+If this is a false positive (a non-PII address that must appear),
+ask the user to confirm before posting.
+
+See .claude/rules/no_pii_in_public.md.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/rules/no_pii_in_public.md
+++ b/.claude/rules/no_pii_in_public.md
@@ -9,7 +9,7 @@ Editing the issue/PR to remove the PII is **not enough**:
 - GitHub retains full **edit history** on issue and PR bodies. Anyone with read access (and crawlers) can view every prior revision via the "edited" dropdown. The PII stays recoverable.
 - On a **public** repo, creating an issue/PR/comment emits a public event to GitHub's events firehose the moment it is posted. That firehose is archived permanently (GH Archive) and consumed by bots and research crawlers in real time. Deleting the content later does **not** reach anything that already ingested it.
 
-So PII has to be stopped **before** it is posted. If it does leak, a plain edit is insufficient — delete the entire issue/PR (`gh issue delete <n> --yes` / `gh pr close` + delete), which purges the body and its edit history from GitHub, then recreate a sanitized version. (This still cannot retract anything the firehose already captured.)
+So PII has to be stopped **before** it is posted. If it does leak, a plain edit is insufficient — the edit history keeps every prior revision. For an **issue**, delete it entirely (`gh issue delete <n> --yes`); that removes the issue and its history from GitHub. Then recreate a sanitized version. A **PR cannot be deleted** this way — `gh pr close` only closes it, leaving the body and edit history intact — so scrubbing a leaked PR body needs a repo admin (or GitHub Support). Either route still **cannot** retract anything the firehose already captured.
 
 ## What to write instead
 
@@ -19,6 +19,6 @@ So PII has to be stopped **before** it is posted. If it does leak, a plain edit 
 
 ## Enforcement
 
-This is enforced by a `PreToolUse` hook, `.claude/hooks/block_pii_in_gh.sh`, wired into `.claude/settings.json`. It blocks any `gh issue`/`gh pr` create/edit/comment/review and any `gh api` body-post whose command **or `--body-file`** contains an email-shaped string (allowlisting `noreply@…` and `git@github.com`). If it fires, remove the address and retry; if it is a genuine false positive, confirm with the user before posting.
+This is enforced by a `PreToolUse` hook, `.claude/hooks/block_pii_in_gh.sh`, wired into `.claude/settings.json`. It blocks two things when an email-shaped string appears (allowlisting `noreply@…` and `git@github.com`): a `gh issue`/`gh pr` create/edit/comment/review whose inline body **or `--body-file`** contents contain one, and a `gh api` call that sets a `body=` field inline. If it fires, remove the address and retry; if it is a genuine false positive, confirm with the user before posting.
 
 The hook is a backstop, not a substitute for judgment — the primary rule is simply: don't write PII into anything that goes to GitHub.

--- a/.claude/rules/no_pii_in_public.md
+++ b/.claude/rules/no_pii_in_public.md
@@ -1,0 +1,24 @@
+# No PII in GitHub issues, PRs, or any public artifact
+
+**Never** put personally identifiable information — email addresses, phone numbers, physical/mailing addresses, or other private personal data — into a GitHub issue, pull request, comment, review, or any other publicly shared artifact. This is a hard rule.
+
+## Why this is not fixable after the fact
+
+Editing the issue/PR to remove the PII is **not enough**:
+
+- GitHub retains full **edit history** on issue and PR bodies. Anyone with read access (and crawlers) can view every prior revision via the "edited" dropdown. The PII stays recoverable.
+- On a **public** repo, creating an issue/PR/comment emits a public event to GitHub's events firehose the moment it is posted. That firehose is archived permanently (GH Archive) and consumed by bots and research crawlers in real time. Deleting the content later does **not** reach anything that already ingested it.
+
+So PII has to be stopped **before** it is posted. If it does leak, a plain edit is insufficient — delete the entire issue/PR (`gh issue delete <n> --yes` / `gh pr close` + delete), which purges the body and its edit history from GitHub, then recreate a sanitized version. (This still cannot retract anything the firehose already captured.)
+
+## What to write instead
+
+- Refer to a person only by their **internal id** (e.g. "user 8504") or their **public handle/login**.
+- Instead of pasting an email or other contact info, write **"contact details on file (recoverable from backups; not reproduced here)."**
+- Public MO data is fine — observation locations, a public login or display name. The **private account fields are not**: email, password, mailing address, phone.
+
+## Enforcement
+
+This is enforced by a `PreToolUse` hook, `.claude/hooks/block_pii_in_gh.sh`, wired into `.claude/settings.json`. It blocks any `gh issue`/`gh pr` create/edit/comment/review and any `gh api` body-post whose command **or `--body-file`** contains an email-shaped string (allowlisting `noreply@…` and `git@github.com`). If it fires, remove the address and retry; if it is a genuine false positive, confirm with the user before posting.
+
+The hook is a backstop, not a substitute for judgment — the primary rule is simply: don't write PII into anything that goes to GitHub.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "test -x .claude/hooks/block_pii_in_gh.sh && exec .claude/hooks/block_pii_in_gh.sh || exit 0",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "test -x .claude/hooks/check_branch_up_to_date.sh && exec .claude/hooks/check_branch_up_to_date.sh || exit 0",
             "timeout": 30
           },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,9 @@ See `.claude/rules/sweeps.md` for PR-scope guidance on broad sweeps
 scope below what the sweep already declared.
 See `.claude/rules/no_raw_sql.md` — no raw SQL strings anywhere in the
 app; use ActiveRecord/Arel instead.
+See `.claude/rules/no_pii_in_public.md` for the hard rule against
+putting PII (emails, etc.) in GitHub issues/PRs/comments — enforced
+by a `PreToolUse` hook.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

Adds a hard guardrail — a rule doc plus an enforcing `PreToolUse` hook — against posting PII (email addresses, etc.) into GitHub issues, PRs, or comments. Prompted by an email address being posted to a public issue during a Claude Code session; on a public repo that content is broadcast to the events firehose (GH Archive / bots) the moment it's created and retained in edit history, so a later edit can't retract it. The only reliable protection is to block it before it's sent.

## Changes

- **`.claude/hooks/block_pii_in_gh.sh`** — `PreToolUse` (Bash) hook. Blocks `gh issue`/`gh pr` `create`/`edit`/`comment`/`review` and `gh api` body-posts whose command **or `--body-file`** contents contain an email-shaped string. Allowlists `noreply@…` and `git@github.com` so `Co-Authored-By` trailers and SSH-style refs don't trip it. Wired first in the Bash `PreToolUse` chain in `.claude/settings.json`.
- **`.claude/rules/no_pii_in_public.md`** — the hard rule: never put PII in issues/PRs/comments; refer to people by internal id or public handle; if PII does leak, delete-and-recreate (a plain edit leaves it in history), and note that nothing retracts what the firehose already captured.
- **`CLAUDE.md`** — references the new rule.

Committed to the repo (not a per-user `settings.local.json`) so it applies to every Claude Code user on the team.

## Test plan

Verified the hook against 9 cases — blocks inline emails, `--body-file` emails, and `gh api` body-posts; allows clean bodies, `noreply`/`git@github.com`, non-`gh` commands, and read-only `gh` commands. `jq empty` confirms `settings.json` is valid.
