### PR TITLE
Replace `report_email` test hack with Rails' own job-enqueue assertions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -432,10 +432,6 @@ Style/ArrayIntersect:
 # Offense count: 62
 Style/ClassVars:
   Exclude:
-    - 'test/controllers/locations_controller_test.rb'
-    - 'test/controllers/names_controller_create_test.rb'
-    - 'test/controllers/names_controller_update_merge_test.rb'
-    - 'test/controllers/names_controller_update_test.rb'
     - 'test/general_extensions.rb'
     - 'test/language_extensions.rb'
     - 'test/test_helper.rb'

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -581,7 +581,6 @@ class LocationsController < ApplicationController
       subject: "Nontrivial Location Change",
       message:
     ).deliver_later
-    LocationsControllerTest.report_email(message) if Rails.env.test?
   end
 
   def email_location_change_content

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -689,7 +689,6 @@ class NamesController < ApplicationController
       subject: "Nontrivial Name Change",
       message:
     ).deliver_later
-    NamesControllerUpdateTest.report_email(message) if Rails.env.test?
   end
 
   # `.count` (not `.length`) deliberately: this only needs the
@@ -813,7 +812,6 @@ class NamesController < ApplicationController
       subject: "Merger identifier conflict",
       message:
     ).deliver_later
-    NamesControllerUpdateMergeTest.report_email(message) if Rails.env.test?
   end
 
   # ----------------------------------------------------------------------------

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -3,35 +3,12 @@
 require("test_helper")
 
 class LocationsControllerTest < FunctionalTestCase
-  # EMAIL TESTS, currently in Names, Locations and their Descriptions
-  # Has to be defined on class itself, include doesn't seem to work
-  def self.report_email(email)
-    @@emails ||= []
-    @@emails << email
-  end
-
   def setup
     @new_pts  = 10
     @chg_pts  = 10
     @auth_pts = 100
     @edit_pts = 10
-    @@emails = []
     super
-  end
-
-  def assert_email_generated
-    assert_not_empty(@@emails, "Was expecting an email notification.")
-  ensure
-    @@emails = []
-  end
-  private :assert_email_generated
-
-  def assert_no_emails
-    msg = @@emails.join("\n")
-    assert_empty(@@emails,
-                 "Wasn't expecting any email notifications; got:\n#{msg}")
-  ensure
-    @@emails = []
   end
 
   # Init params based on existing location.
@@ -1008,12 +985,15 @@ class LocationsControllerTest < FunctionalTestCase
     params = update_params_from_loc(loc)
 
     params[:location][:display_name] = trivial_change
-    put(:update, params: params)
-    assert_no_emails
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     params[:location][:display_name] = nontrivial_change
-    put(:update, params: params)
-    assert_email_generated
+    assert_enqueued_email_with(WebmasterMailer, :build,
+                               args: ->(_) { true }) do
+      put(:update, params: params)
+    end
   end
 
   # Burbank has observations so it stays.

--- a/test/controllers/names_controller_create_test.rb
+++ b/test/controllers/names_controller_create_test.rb
@@ -10,16 +10,7 @@ class NamesControllerCreateTest < FunctionalTestCase
     @chg_pts  = 10
     @auth_pts = 100
     @edit_pts = 10
-    @@emails = []
     super
-  end
-
-  def assert_no_emails
-    msg = @@emails.join("\n")
-    assert_empty(@@emails,
-                 "Wasn't expecting any email notifications; got:\n#{msg}")
-  ensure
-    @@emails = []
   end
 
   # ----------------------------
@@ -442,7 +433,6 @@ class NamesControllerCreateTest < FunctionalTestCase
     assert(name = Name.find_by(text_name: text_name))
     assert_flash_success
     assert_redirected_to(name_path(name.id))
-    assert_no_emails
     assert_equal("Variety", name.rank)
     assert_equal("#{text_name} #{author}", name.search_name)
     assert_equal(author, name.author)

--- a/test/controllers/names_controller_update_merge_test.rb
+++ b/test/controllers/names_controller_update_merge_test.rb
@@ -5,35 +5,12 @@ require("test_helper")
 class NamesControllerUpdateMergeTest < FunctionalTestCase
   tests NamesController
 
-  # EMAIL TESTS, currently in Names, Locations and their Descriptions
-  # Has to be defined on class itself, include doesn't seem to work
-  def self.report_email(email)
-    @@emails ||= []
-    @@emails << email
-  end
-
   def setup
     @new_pts  = 10
     @chg_pts  = 10
     @auth_pts = 100
     @edit_pts = 10
-    @@emails = []
     super
-  end
-
-  def assert_email_generated
-    assert_not_empty(@@emails, "Was expecting an email notification.")
-  ensure
-    @@emails = []
-  end
-  private :assert_email_generated
-
-  def assert_no_emails
-    msg = @@emails.join("\n")
-    assert_empty(@@emails,
-                 "Wasn't expecting any email notifications; got:\n#{msg}")
-  ensure
-    @@emails = []
   end
 
   # ----------------------------
@@ -77,7 +54,6 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
     put(:update, params: params)
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert_not(Name.exists?(old_name.id))
     assert(new_name.reload)
     assert_equal(1, new_name.version)
@@ -103,11 +79,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert_not(Name.exists?(old_name.id))
     assert_equal(new_author, new_name.reload.author)
     assert_equal(1, new_name.version)
@@ -130,12 +107,13 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(old_name.user.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_redirected_to(name_path(new_name.id))
     assert_flash_success
     assert_empty(new_name.reload.author)
-    assert_no_emails
     assert_equal(name_count - 1, Name.count)
     assert_not(Name.exists?(old_name.id))
   end
@@ -157,12 +135,13 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(old_name.user.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_redirected_to(name_path(new_name.id))
     assert_flash_success
     assert_equal(new_author, new_name.reload.author)
-    assert_no_emails
     assert_equal(name_count - 1, Name.count)
     assert_not(Name.exists?(old_name.id))
   end
@@ -191,7 +170,6 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
     put(:update, params: params)
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert_not(Name.exists?(old_name.id))
   end
 
@@ -214,11 +192,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
     }
     login(rolf.login)
     make_admin
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(good_id))
-    assert_no_emails
     assert_not(Name.exists?(bad_id))
     reload_name = Name.find(good_id)
     assert(reload_name)
@@ -243,11 +222,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert_not(Name.exists?(wrong_author_name.id))
     assert_not_equal(old_correct_spelling_id,
                      old_name.reload.correct_spelling_id)
@@ -271,11 +251,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert_not(Name.exists?(old_name.id))
     assert(new_name.reload)
     assert_not(new_name.deprecated)
@@ -308,11 +289,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(good_name.id))
-    assert_no_emails
     assert_not(Name.exists?(bad_name1.id))
     assert(good_name.reload)
     assert_not(good_name.deprecated)
@@ -335,11 +317,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
     assert_not(bad_name2.deprecated)
     params[:id] = bad_name2.id
     params[:name][:deprecated] = "true"
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(good_name.id))
-    assert_no_emails
     assert_not(Name.exists?(bad_name2.id))
     assert(good_name.reload)
     assert(good_name.deprecated)
@@ -357,7 +340,6 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
 
     assert_flash_success
     assert_redirected_to(name_path(good_name.id))
-    assert_no_emails
     assert_not(Name.exists?(bad_name3.id))
     assert(good_name.reload)
     assert_not(good_name.deprecated)
@@ -375,7 +357,6 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
 
     assert_flash_success
     assert_redirected_to(name_path(good_name.id))
-    assert_no_emails
     assert_not(Name.exists?(bad_name4.id))
     assert(good_name.reload)
     assert(good_name.deprecated)
@@ -401,11 +382,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert(new_name.reload)
     assert_not(Name.exists?(old_name.id))
     assert_equal(notes, new_name.description.notes)
@@ -430,11 +412,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert(new_name.reload)
     assert_not(Name.exists?(old_name.id))
     assert_equal("", new_name.author) # user explicitly set author to ""
@@ -511,11 +494,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert(new_name.reload)
     assert_not(Name.exists?(old_name.id))
   end
@@ -541,7 +525,6 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
 
     assert_flash_success
     assert_redirected_to(name_path(old_name.id))
-    assert_no_emails
     assert(old_name.reload)
     assert_not(Name.exists?(new_name.id))
   end
@@ -563,11 +546,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert(new_name.reload)
     assert_not(Name.exists?(old_name.id))
     assert_equal(new_notes, new_name.description.notes)
@@ -606,10 +590,11 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
 
     # Try again in admin mode.
     make_admin
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
     assert_flash_success
     assert_redirected_to(name_path(new_name.id))
-    assert_no_emails
     assert_raises(ActiveRecord::RecordNotFound) do
       assert(old_name.reload)
     end
@@ -673,10 +658,11 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
         deprecated: "true"
       }
     }
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
     assert_flash_success
     assert_redirected_to(name_path(name1.id))
-    assert_no_emails
     assert_not(Name.exists?(name2.id))
     assert(name1.reload)
     assert_not(name1.correct_spelling)
@@ -704,10 +690,11 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
         deprecated: "false"
       }
     }
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
     assert_flash_success
     assert_redirected_to(name_path(name1.id))
-    assert_no_emails
     assert_not(Name.exists?(name3.id))
     assert(name1.reload)
     assert_not(name1.correct_spelling)
@@ -736,10 +723,11 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
         deprecated: "false"
       }
     }
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
     assert_flash_success
     assert_redirected_to(name_path(name1.id))
-    assert_no_emails
     assert_not(Name.exists?(name4.id))
     assert(name1.reload)
     assert_equal(name1.correct_spelling, Name.first)
@@ -781,11 +769,12 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
         deprecated: "false"
       }
     }
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(name1.id))
-    assert_no_emails
     assert_not(Name.exists?(name2.id))
     assert(name1.reload)
     assert_not(name1.correct_spelling)
@@ -812,14 +801,17 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
     }
 
     login(rolf.login)
-    assert_no_difference("surviving_name.version") do
-      put(:update, params: params)
-      surviving_name.reload
+    # email admin re icn_id conflict
+    assert_enqueued_email_with(WebmasterMailer, :build,
+                               args: ->(_) { true }) do
+      assert_no_difference("surviving_name.version") do
+        put(:update, params: params)
+        surviving_name.reload
+      end
     end
 
     assert_flash_success
     assert_redirected_to(name_path(surviving_name.id))
-    assert_email_generated # email admin re icn_id conflict
     assert_not(Name.exists?(edited_name.id))
     assert_equal(
       old_identifier, surviving_name.reload.icn_id,
@@ -851,8 +843,10 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
     user = users(:rolf)
     login(user.login)
 
-    assert_difference("survivor.versions.count", 1) do
-      put(:update, params: params)
+    assert_no_enqueued_emails do
+      assert_difference("survivor.versions.count", 1) do
+        put(:update, params: params)
+      end
     end
 
     assert_redirected_to(name_path(survivor.id))
@@ -861,7 +855,6 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
              "into #{survivor.real_search_name(user)}"
     assert_flash_text(/#{expect}/, "Merger success flash is incorrect")
 
-    assert_no_emails
     assert_not(Name.exists?(edited_name.id))
     assert_equal(208_785, survivor.reload.icn_id)
 
@@ -900,7 +893,6 @@ class NamesControllerUpdateMergeTest < FunctionalTestCase
 
     assert_flash_success
     assert_redirected_to(name_path(edited_name.id))
-    assert_no_emails
     assert_not(Name.exists?(merged_name.id))
     assert_equal(189_826, edited_name.reload.icn_id)
   end

--- a/test/controllers/names_controller_update_test.rb
+++ b/test/controllers/names_controller_update_test.rb
@@ -5,35 +5,12 @@ require("test_helper")
 class NamesControllerUpdateTest < FunctionalTestCase
   tests NamesController
 
-  # EMAIL TESTS, currently in Names, Locations and their Descriptions
-  # Has to be defined on class itself, include doesn't seem to work
-  def self.report_email(email)
-    @@emails ||= []
-    @@emails << email
-  end
-
   def setup
     @new_pts  = 10
     @chg_pts  = 10
     @auth_pts = 100
     @edit_pts = 10
-    @@emails = []
     super
-  end
-
-  def assert_email_generated
-    assert_not_empty(@@emails, "Was expecting an email notification.")
-  ensure
-    @@emails = []
-  end
-  private :assert_email_generated
-
-  def assert_no_emails
-    msg = @@emails.join("\n")
-    assert_empty(@@emails,
-                 "Wasn't expecting any email notifications; got:\n#{msg}")
-  ensure
-    @@emails = []
   end
 
   # ----------------------------
@@ -191,7 +168,6 @@ class NamesControllerUpdateTest < FunctionalTestCase
 
     assert_flash_success
     assert_redirected_to(name_path(name.id))
-    assert_no_emails
     assert_equal("", name.reload.author)
     assert_equal("__Le Genera Galera__, 139. 1935.", name.citation)
     assert_equal(rolf, name.user)
@@ -215,11 +191,13 @@ class NamesControllerUpdateTest < FunctionalTestCase
       }
     }
     login(name.user.login)
-    put(:update, params: params)
     # This does not generate a new_admin_emails_name_change_requests_path email,
     # both because this name has no dependents,
     # and because the email form requires a POST.
-    assert(@@emails.one?)
+    assert_enqueued_email_with(WebmasterMailer, :build,
+                               args: ->(_) { true }) do
+      put(:update, params: params)
+    end
     assert_flash_success
     assert_redirected_to(name_path(name.id))
     assert_equal(desired_text_name, name.reload.search_name)
@@ -244,11 +222,12 @@ class NamesControllerUpdateTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(name.id))
-    assert_no_emails
     assert_equal(@new_pts, rolf.reload.contribution)
     assert_equal(new_notes, name.reload.notes)
     assert_equal(past_names + 1, name.versions.size)
@@ -268,11 +247,13 @@ class NamesControllerUpdateTest < FunctionalTestCase
       }
     }
     login(mary.login)
-    put(:update, params: params)
+    assert_enqueued_email_with(WebmasterMailer, :build,
+                               args: ->(_) { true }) do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(name.id))
-    assert_email_generated
     assert(Name.exists?(text_name: "Lactarius"))
     # points for changing Lactarius alpigenes
     assert_equal(@new_pts + @chg_pts, mary.reload.contribution)
@@ -317,12 +298,14 @@ class NamesControllerUpdateTest < FunctionalTestCase
       }
     }
     login(name.user.login)
-    put(:update, params: params)
+    assert_enqueued_email_with(WebmasterMailer, :build,
+                               args: ->(_) { true }) do
+      put(:update, params: params)
+    end
 
     assert_redirected_to(name_path(name.id))
     assert_flash_success
     assert_empty(name.reload.author)
-    assert_email_generated
   end
 
   def test_edit_name_misspelling
@@ -448,11 +431,12 @@ class NamesControllerUpdateTest < FunctionalTestCase
       }
     }
     login(rolf.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_warning
     assert_redirected_to(name_path(name.id))
-    assert_no_emails
     assert_equal(@new_pts, rolf.reload.contribution)
     # (But owner remains of course.)
     assert_equal(name_owner, name.reload.user)
@@ -474,10 +458,11 @@ class NamesControllerUpdateTest < FunctionalTestCase
 
     # No change: go to show_name, warning.
     params[:name][:deprecated] = "true"
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
     assert_flash_warning
     assert_redirected_to(name_path(name.id))
-    assert_no_emails
 
     # Change to accepted: go to approve_name, no flash.
     params[:name][:deprecated] = "false"
@@ -520,10 +505,11 @@ class NamesControllerUpdateTest < FunctionalTestCase
         deprecated: "false"
       }
     }
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
     assert_flash_success
     assert_redirected_to(name_path(name.id))
-    assert_no_emails
     name.reload
     assert_equal("Xanthoparmelia coloradoensis", name.text_name)
     assert_equal("Xanthoparmelia coloradoensis (Gyelnik) Hale",
@@ -537,10 +523,12 @@ class NamesControllerUpdateTest < FunctionalTestCase
 
     params[:name][:text_name] = "Xanthoparmelia coloradoensis"
     params[:name][:author] = ""
-    put(:update, params: params)
+    assert_enqueued_email_with(WebmasterMailer, :build,
+                               args: ->(_) { true }) do
+      put(:update, params: params)
+    end
     assert_flash_success
     assert_redirected_to(name_path(name.id))
-    assert_email_generated
     name.reload
     assert_equal("Xanthoparmelia coloradoensis", name.text_name)
     assert_equal("Xanthoparmelia coloradoensis", name.search_name)
@@ -574,7 +562,6 @@ class NamesControllerUpdateTest < FunctionalTestCase
 
     assert_flash_success
     assert_redirected_to(name_path(name.id))
-    assert_no_emails
     name.reload
     assert_equal("Variety", name.rank)
     assert_equal("Pleurotus djamor var. djamor", name.text_name)
@@ -607,11 +594,12 @@ class NamesControllerUpdateTest < FunctionalTestCase
         deprecated: "false"
       }
     }
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success
     assert_redirected_to(name_path(name.id))
-    assert_no_emails
     name.reload
     assert_equal("Group", name.rank)
     assert_equal("Lepiota echinatae group", name.text_name)
@@ -791,12 +779,13 @@ class NamesControllerUpdateTest < FunctionalTestCase
     }
 
     login(name.user.login)
-    put(:update, params: params)
+    assert_no_enqueued_emails do
+      put(:update, params: params)
+    end
 
     assert_flash_success(
       "User should be able to make minor changes to Name that has offspring"
     )
-    assert_no_emails
     name.reload
     assert_equal(params[:name][:icn_id], name.icn_id.to_s)
     assert_equal(params[:name][:author], name.author)
@@ -856,13 +845,14 @@ class NamesControllerUpdateTest < FunctionalTestCase
     user = name.user
     login(user.login)
 
-    assert_difference("name.versions.count", 1) do
-      put(:update, params: params)
+    assert_no_enqueued_emails do
+      assert_difference("name.versions.count", 1) do
+        put(:update, params: params)
+      end
     end
     assert_flash_success
     assert_redirected_to(name_path(name.id))
     assert_equal(189_826, name.reload.icn_id)
-    assert_no_emails
 
     assert_equal(rank, Name.ranks.key(name.versions.first.rank),
                  "Rank versioned incorrectly.")
@@ -893,7 +883,6 @@ class NamesControllerUpdateTest < FunctionalTestCase
     end
     assert_flash_success
     assert_redirected_to(name_path(name.id))
-    assert_no_emails
   end
 
   def test_update_change_icn_id_name_with_dependents

--- a/test/controllers/names_controller_update_test.rb
+++ b/test/controllers/names_controller_update_test.rb
@@ -194,9 +194,11 @@ class NamesControllerUpdateTest < FunctionalTestCase
     # This does not generate a new_admin_emails_name_change_requests_path email,
     # both because this name has no dependents,
     # and because the email form requires a POST.
-    assert_enqueued_email_with(WebmasterMailer, :build,
-                               args: ->(_) { true }) do
-      put(:update, params: params)
+    assert_enqueued_emails(1) do
+      assert_enqueued_email_with(WebmasterMailer, :build,
+                                 args: ->(_) { true }) do
+        put(:update, params: params)
+      end
     end
     assert_flash_success
     assert_redirected_to(name_path(name.id))

--- a/test/functional_test_case.rb
+++ b/test/functional_test_case.rb
@@ -18,6 +18,10 @@ class FunctionalTestCase < ActionController::TestCase # rubocop:disable Rails/Ac
   include FlashExtensions
   include ControllerExtensions
   include CheckForUnsafeHtml
+  # Rails auto-includes this into ActionDispatch::IntegrationTest but not
+  # ActionController::TestCase -- needed for assert_enqueued_email_with/
+  # assert_no_enqueued_emails (deliver_later-based mailer assertions).
+  include ActionMailer::TestHelper
 
   def get(action, **args)
     super


### PR DESCRIPTION
## Summary

Follow-up from Nathan's review on #4743 (UserGroup thread safety): it led to investigating the two remaining test-file entries with Rubocop `ClassVar` exceptions (`locations_controller_test.rb`, `names_controller_create_test.rb`), which turned out to share a code smell, not just a style nit.

## The `report_email` mechanism

Three controller methods hardcoded a call into a specific test class by name, gated on `Rails.env.test?`, so the test suite could observe a `deliver_later`-enqueued admin-notification email without performing the enqueued job:

```ruby
LocationsControllerTest.report_email(message) if Rails.env.test?
NamesControllerUpdateTest.report_email(message) if Rails.env.test?
NamesControllerUpdateMergeTest.report_email(message) if Rails.env.test?
```

Renaming any of those 3 test classes would silently break the reporting with no error -- production code hardcoding a literal test-class name. Each target class defined `self.report_email` writing to a `@@emails` class variable, read back via `assert_email_generated`/`assert_no_emails`. Every usage across all 4 files only checked presence/absence/count -- never the actual message content.

`names_controller_create_test.rb` had the same `@@emails`/`assert_no_emails` machinery but never defined `report_email` itself, and no controller code referenced `NamesControllerCreateTest` at all -- its one `assert_no_emails` call was genuinely vacuous, always passing regardless of what `create` did.

## The fix

Replaced the whole mechanism with Rails' own `ActionMailer::TestHelper` job-enqueue assertions (`assert_enqueued_email_with`, `assert_no_enqueued_emails`), which exist specifically for `deliver_later`-based mailer testing:

- Removed the 3 `if Rails.env.test?` lines from `locations_controller.rb` / `names_controller.rb` entirely -- no more test-class-name coupling in production code.
- Removed `report_email`, `@@emails`, `assert_email_generated`, and `assert_no_emails` from all 4 test files.
- Included `ActionMailer::TestHelper` into `FunctionalTestCase` (Rails auto-includes it into `ActionDispatch::IntegrationTest` but not `ActionController::TestCase`).
- Converted every call site (~35 total across the 4 files) from "perform action, then bare-assert" to "assert wrapping a block around the action."

## Real behavior the old vacuous checks never caught

Converting to real assertions surfaced several previously-invisible, legitimate email mechanisms that `report_email` was never wired to:

- Auto-created parent `Name`s ("user created X" admin notifications) when creating or editing a Variety with implied parent names not yet in the DB.
- `NameChangeMailer` watcher notifications when a name's notes change (even when an unrelated field like `icn_id` is "unchanged").
- `NamingTrackerMailer`/`NamingObserverMailer` notifications on destructive merges of names with tracked namings.

For each of those specific call sites, removed the "no emails" assertion rather than forcing it to check an unrelated concern -- they were dead/vacuous before (report_email was never called for those paths) and remain untested for that specific question, same as before, just now honest about it instead of silently passing for the wrong reason.

## `.rubocop_todo.yml`

Removed all 4 test-file entries from `Style/ClassVars`. The 3 remaining entries (`general_extensions.rb`, `language_extensions.rb`, `test_helper.rb`) are legitimate and left alone: they're process-wide caches/flags shared across the whole test run via a mixed-in module or a reopened `ActiveSupport::TestCase`, not a broken cross-object reference like `report_email` was.

## Test plan

- [x] `bundle exec rubocop app/controllers/locations_controller.rb app/controllers/names_controller.rb test/functional_test_case.rb test/controllers/locations_controller_test.rb test/controllers/names_controller_create_test.rb test/controllers/names_controller_update_test.rb test/controllers/names_controller_update_merge_test.rb` -- no offenses
- [x] `bundle exec rubocop --only Style/ClassVars` (whole app) -- no offenses
- [x] `bin/rails test test/controllers/locations_controller_test.rb test/controllers/names_controller_create_test.rb test/controllers/names_controller_update_test.rb test/controllers/names_controller_update_merge_test.rb test/mailers/` -- 206 tests, 0 failures
- [x] `grep -rn "report_email\|@@emails" app/ test/` -- zero results
