### PR TITLE
Fix Textile cache leak across sequential matrix-box renders and background jobs

### DIFF
--- a/app/components/image/lightbox/caption.rb
+++ b/app/components/image/lightbox/caption.rb
@@ -217,9 +217,14 @@ class Components::Image::Lightbox::Caption < Components::Base
     end
   end
 
-  # ApplicationController resets the per-request Textile cache before
-  # every action; this only needs to prime it, not clear it first.
+  # ApplicationController's per-request reset only covers the FIRST
+  # render on a request. This component renders once per observation
+  # on a matrix/index page (Matrix::Box -> Image::Interactive ->
+  # lightbox_caption_html -> this), so without an explicit clear here,
+  # one observation's genus abbreviation leaks into the next
+  # observation's textile rendering within the same page load.
   def prepare_textile_cache
+    Textile.clear_textile_cache
     Textile.register_name(@obs.name)
   end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,6 +7,16 @@ class ApplicationJob < ActiveJob::Base
   # Most jobs are safe to ignore if the underlying records are no
   # longer available discard_on ActiveJob::DeserializationError
 
+  # Textile::THREAD_KEYS's name-lookup cache is thread-local -- isolated
+  # across concurrent job executions, but not auto-reset between
+  # sequential jobs pooled onto the same Solid Queue worker thread.
+  # Jobs never run through ApplicationController's before_action (its
+  # own reset_textile_cache), so mailer jobs that call `.tp`/`.tl` on
+  # translated text (e.g. NamingTrackerMailer, VerifyAccountMailer) can
+  # otherwise pick up a leftover genus abbreviation left by a prior,
+  # unrelated job on the same worker thread. See #3589, #4741.
+  before_perform { Textile.clear_textile_cache }
+
   # Report background-job failures to the same place web errors go (Slack via
   # exception_notification), then re-raise so SolidQueue still records the
   # failed execution. The notifiers check keeps this in lockstep with the

--- a/test/components/image/lightbox/caption_test.rb
+++ b/test/components/image/lightbox/caption_test.rb
@@ -207,6 +207,40 @@ class LightboxCaptionTest < ComponentTestCase
     assert_no_html(html, ".vote-meter")
   end
 
+  # Regression test for the #4741/#4772 matrix-box cache-leak bug:
+  # this component renders once per observation on a matrix/index
+  # page (Matrix::Box -> Image::Interactive -> lightbox_caption_html),
+  # not once per request, so ApplicationController's per-request
+  # Textile-cache reset alone doesn't isolate sequential renders in
+  # the same page load. `prepare_textile_cache` must explicitly clear
+  # before registering the current observation's name.
+  #
+  # agaricus_campestris_obs (genus "Agaricus", letter "A") renders
+  # first and registers "A" => "Agaricus" in Textile's cache.
+  # boletus_edulis_obs (genus "Boletus") renders second, with notes
+  # containing a bare "_A. campestris_" abbreviation it never
+  # registered itself. Textile keeps the abbreviated form as the link
+  # *text* either way, so the tell is the link's *href*: leaked state
+  # resolves it to lookup_name/Agaricus+campestris (wrong genus);
+  # correctly isolated, "A. campestris" can't resolve as a name at
+  # all and falls through to a lookup_glossary_term href instead.
+  def test_does_not_leak_name_lookup_across_sequential_renders
+    agaricus_obs = observations(:agaricus_campestris_obs)
+    boletus_obs = observations(:boletus_edulis_obs)
+    boletus_obs.notes = { Other: "_A. campestris_ was not seen here" }
+
+    render_caption(obs: agaricus_obs, image: nil)
+    html = render_caption(obs: boletus_obs, image: nil)
+
+    assert_no_html(
+      html,
+      "#observation_#{boletus_obs.id}_notes a[href*='lookup_name/Agaricus']",
+      "Boletus caption's bare abbreviation resolved against the prior " \
+      "render's leftover Agaricus registration -- Textile's " \
+      "name-lookup cache leaked across sequential renders"
+    )
+  end
+
   private
 
   def render_caption(user: @user, image: @image, obs: @obs, **)

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -10,6 +10,35 @@ class ApplicationJobTest < ActiveJob::TestCase
     end
   end
 
+  # Minimal job that just reports what it saw in Textile's cache when it
+  # started, to exercise ApplicationJob's before_perform reset. A plain
+  # class-instance-variable (not `@@`) is fine here -- this class has no
+  # subclasses.
+  class ReportsTextileCacheJob < ApplicationJob
+    class << self
+      attr_accessor :seen_name_lookup
+    end
+
+    def perform
+      self.class.seen_name_lookup = Textile.name_lookup.dup
+    end
+  end
+
+  # Regression test for #4741/#4772: mailer jobs never run through
+  # ApplicationController's before_action, so without ApplicationJob's
+  # own reset, a job dispatched to a Solid Queue worker thread right
+  # after another job registered a name on that same thread would see
+  # the leftover Textile cache instead of starting clean.
+  def test_resets_textile_cache_before_each_job
+    Textile.register_name(names(:agaricus))
+
+    ReportsTextileCacheJob.perform_now
+
+    assert_equal({}, ReportsTextileCacheJob.seen_name_lookup,
+                 "Job should start with a clean Textile name-lookup " \
+                 "cache, not one leaked from prior work on this thread")
+  end
+
   # When a notifier is registered (e.g. production), a failing job reports to
   # ExceptionNotifier and still re-raises so SolidQueue records the failure.
   def test_failure_is_reported_and_reraised_when_alerting_active


### PR DESCRIPTION
## Summary

Nathan asked for an independent, adversarial re-review of the already-merged thread-safety PRs (#4741, #4743, #4744, #4745) since none of them got a formal Copilot-style pass. Four independent reviewers each took one PR with fresh eyes. This PR fixes the one confirmed blocking bug that review turned up, in `#4741` (Textile thread safety).

## The bug

`ApplicationController`'s per-request Textile-cache reset (`before_action :reset_textile_cache`) only guards the *first* render on a request — it isn't a barrier between multiple renders within the same request.

**1. `Components::Image::Lightbox::Caption` on matrix/index pages.** This component renders once per observation on an index/matrix page (`Matrix::Box` → `Image::Interactive` → `lightbox_caption_html` → `Lightbox::Caption`), not once per request. `prepare_textile_cache` only called `Textile.register_name`, never `clear_textile_cache`, so one observation's genus abbreviation could leak into the next observation's notes rendering within the same page load — e.g. observation A (genus *Agaricus*) renders first; observation B (genus *Boletus*), rendered later on the same page, has notes containing a bare `_A. sp_` abbreviation that incorrectly resolves against A's leftover *Agaricus* registration instead of staying unexpanded.

Fixed by explicitly clearing before registering at this specific call site. `ObservationDetailsPanel`'s equivalent call site is unaffected — confirmed it only ever renders once per request, on single-observation show/edit/new pages, so the request-level reset is sufficient there.

**2. ActiveJob jobs never run through `ApplicationController`'s `before_action` at all.** Several mailer views (`naming_tracker_mailer.rb`, `verify_account_mailer.rb`, `verify_api_key_mailer.rb`, `inat_import_digest_mailer.rb`) call `.tp` on translated text, which routes through Textile's `expand_genus_abbreviation` (reads `Textile.name_lookup`). Since production runs Solid Queue as a fully separate service from Puma (confirmed in `config/puma.rb`'s comment), the relevant risk is job-to-job leakage on a reused Solid Queue worker thread: a mailer job dispatched right after an unrelated job that registered a name could pick up that leftover abbreviation.

Fixed with an equivalent `before_perform { Textile.clear_textile_cache }` in `ApplicationJob`.

## Test plan

- [x] `test/components/image/lightbox/caption_test.rb` — new regression test renders two observations of different genera in sequence and asserts the second's bare abbreviation doesn't resolve against the first's leftover registration. Verified it fails without the fix (temporarily reverted `caption.rb`, confirmed failure, restored).
- [x] `test/jobs/application_job_test.rb` — new regression test runs a job after registering a name directly, asserts the job starts with a clean cache. Verified it fails without the fix the same way.
- [x] `bundle exec rubocop` on all 4 changed files — clean.
- [x] `bin/rails test test/components/image/ test/jobs/ test/classes/textile_test.rb test/controllers/application_controller_test.rb test/style/` — 189 tests, 0 failures.
