### PR TITLE
Route remaining raw col-xs-* strings through Grid constants (#3797 prep)

### DIFF
--- a/app/components/nav_tabs.rb
+++ b/app/components/nav_tabs.rb
@@ -37,7 +37,7 @@
 #   ))
 #
 # @example With wrapper chrome at the call site
-#   div(class: "col-xs-12", id: "project_tabs") do
+#   div(class: Grid::FULL, id: "project_tabs") do
 #     render(Components::NavTabs.new(current: @current_tab,
 #                                    link_class: "mt-3")) do |tabs|
 #       # ...

--- a/app/views/controllers/comments/comment_item.rb
+++ b/app/views/controllers/comments/comment_item.rb
@@ -56,7 +56,7 @@ module Views::Controllers::Comments
     private
 
     def render_main_column
-      div(class: "col-xs-12 col-sm-9 col-lg-10") do
+      div(class: class_names(Grid::SM9, "col-lg-10")) do
         render_target_heading if @show_name
         render_summary
         render_comment_info

--- a/app/views/controllers/herbaria/show.rb
+++ b/app/views/controllers/herbaria/show.rb
@@ -40,7 +40,9 @@ module Views::Controllers::Herbaria
     # --- Left + right columns --------------------------------------
 
     def render_body_columns
-      div(class: "col-xs-12 col-sm-#{map ? 8 : 12}") { render_left_column }
+      div(class: class_names(Grid::FULL, "col-sm-#{map ? 8 : 12}")) do
+        render_left_column
+      end
       render_right_column if map
     end
 

--- a/app/views/controllers/observations/images/edit.rb
+++ b/app/views/controllers/observations/images/edit.rb
@@ -17,8 +17,8 @@ module Views::Controllers::Observations::Images
       container_class(:wide)
 
       div(class: "row") do
-        div(class: "col-xs-12 col-sm-8 col-md-6 col-lg-4") { render_form }
-        div(class: "col-xs-12 col-sm-4 col-md-6 col-lg-8") do
+        div(class: class_names(Grid::SM8, "col-md-6 col-lg-4")) { render_form }
+        div(class: class_names(Grid::SM4, "col-md-6 col-lg-8")) do
           render_image_preview
         end
       end

--- a/app/views/controllers/projects/admin_subtabs.rb
+++ b/app/views/controllers/projects/admin_subtabs.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Projects
 
     def view_template
       div(class: "row") do
-        div(class: "col-xs-12 pl-4 mt-2 mb-3",
+        div(class: class_names(Grid::FULL, "pl-4 mt-2 mb-3"),
             id: "project_admin_subtabs") do
           NavTabs(
             current: @current_subtab,

--- a/app/views/controllers/species_lists/observation.rb
+++ b/app/views/controllers/species_lists/observation.rb
@@ -26,7 +26,7 @@ module Views::Controllers::SpeciesLists
     private
 
     def details_column_classes
-      @image ? "col-sm-8 col-md-9" : "col-xs-12"
+      @image ? "col-sm-8 col-md-9" : Grid::FULL
     end
 
     def render_image_column

--- a/app/views/controllers/translations/index.rb
+++ b/app/views/controllers/translations/index.rb
@@ -20,8 +20,12 @@ module Views::Controllers::Translations
       add_page_title(:edit_translations_title.t)
       render_help_block
       div(class: "row") do
-        div(class: "col-xs-6 translation_container") { render_index_panel }
-        div(class: "col-xs-6 translation_container") { render_ui_panel }
+        div(class: class_names(Grid::HALF, "translation_container")) do
+          render_index_panel
+        end
+        div(class: class_names(Grid::HALF, "translation_container")) do
+          render_ui_panel
+        end
       end
     end
 

--- a/app/views/layouts/header.rb
+++ b/app/views/layouts/header.rb
@@ -66,7 +66,7 @@ module Views::Layouts
     end
 
     def render_type_filters
-      div(class: "hidden-print col-xs-12") do
+      div(class: class_names("hidden-print", Grid::FULL)) do
         trusted_html(content_for(:type_filters))
       end
     end
@@ -81,12 +81,12 @@ module Views::Layouts
     # `content_for?(:left_columns) || "col-sm-8 col-lg-7"` — the `||`
     # there is operating on a boolean, so when `:left_columns` IS set
     # the LHS is `true` and `cols` becomes the literal `true`. Then
-    # `class_names("col-xs-12", true)` evaluates to `"col-xs-12"`.
+    # `class_names(Grid::FULL, true)` evaluates to `"col-xs-12"`.
     # Keep the bug for visual parity; fix in a separate PR if needed.
     def title_cols
       cols = content_for?(:left_columns) || "col-sm-8 col-lg-7"
       cols = "" unless content_for?(:interest_icons)
-      class_names("col-xs-12", cols)
+      class_names(Grid::FULL, cols)
     end
   end
 end

--- a/app/views/layouts/header/index_bar.rb
+++ b/app/views/layouts/header/index_bar.rb
@@ -18,7 +18,7 @@ module Views::Layouts
       return unless content_for?(:filters) || content_for?(:filter_help)
 
       div(class: "row") do
-        div(class: "col-xs-12") do
+        div(class: Grid::FULL) do
           div(id: "index_bar", class: "mb-2") do
             div(class: "px-3 mt-2 mb-3") do
               render_filters


### PR DESCRIPTION
## Summary

Part of #3797's ongoing Bootstrap 3→4/5 prep. This is the **prep-only** version of the `col-xs-*` sweep flagged in the June/July status comments — not the BS4 rename.

**This makes zero visual change.** Every raw string swapped out is byte-identical to what it replaces: `Grid`'s constants are still Bootstrap 3 syntax (see `app/classes/grid.rb`'s own header comment), so `Grid::FULL` today is just `"col-xs-12"` under a name.

## Why not the actual `col-xs-N` → `col-N` rename

Confirmed before touching anything: `bootstrap-sass (3.4.1)` is still the only Bootstrap gem in the `Gemfile.lock`, and there isn't a single `.col-N`/`.offset-N` CSS rule anywhere in `app/assets/stylesheets` yet — those are Bootstrap 4-only class names. Renaming to them now would silently break every touched layout (the new classes would just have no matching CSS rule) until the separate BS4 SCSS swap also lands. That's a bigger, riskier change bundled with a gem swap, not a plain class-rename sweep, so it's out of scope here.

What this PR *does* set up: once the BS4 swap happens, `Grid`'s own constant values become the one place to update for everything routed through it here — no repeat multi-file hunt.

## What changed

10 sites across 8 files now route through an existing `Grid` constant — either an exact full-string match, or (after a second, more careful pass) a **prefix match**, where the raw string is a `Grid` constant plus an extra breakpoint tacked on via `class_names`:

- `header.rb` — `hidden-print col-xs-12` → `Grid::FULL`; the documented `title_cols` boolean quirk (`class_names("col-xs-12", true)`) is preserved byte-for-byte, just spelled with the constant.
- `header/index_bar.rb` — `col-xs-12` → `Grid::FULL`.
- `projects/admin_subtabs.rb` — `col-xs-12 pl-4 mt-2 mb-3` → `Grid::FULL` + `class_names`.
- `translations/index.rb` — `col-xs-6` (both panels) → `Grid::HALF` + `class_names`.
- `species_lists/observation.rb` — the no-image ternary branch → `Grid::FULL`.
- `nav_tabs.rb` — doc-comment `@example` updated to match the real-code convention.
- `herbaria/show.rb` — `"col-xs-12 col-sm-#{map ? 8 : 12}"` → `class_names(Grid::FULL, "col-sm-#{...}")`.
- `comment_item.rb` — `"col-xs-12 col-sm-9 col-lg-10"` → `class_names(Grid::SM9, "col-lg-10")`.
- `observations/images/edit.rb` (both columns) — `"col-xs-12 col-sm-8 col-md-6 col-lg-4"` → `class_names(Grid::SM8, "col-md-6 col-lg-4")`; `"col-xs-12 col-sm-4 col-md-6 col-lg-8"` → `class_names(Grid::SM4, "col-md-6 col-lg-8")`.

The prefix-match sites (`herbaria/show.rb`, `comment_item.rb`, `observations/images/edit.rb`) were missed in the first pass — verified `class_names`' tokenize/dedupe/rejoin behavior against Rails' `TagHelper#token_list` source and with a direct render-and-compare check before trusting the byte-identical claim.

**Left as raw strings** — re-checked each against every `Grid` constant (not just assumed): genuinely no full or prefix match exists, since `Grid` has no `col-xs-8`/`col-xs-10`/`col-xs-2` atomics and a couple of these don't even have a `col-xs-` prefix to match against. Forcing a single-use constant into the shared `Grid` module for something used in exactly one file doesn't reduce future migration surface either — it still needs individual attention whether it's inline or a same-file constant:

- `sidebar.rb` (`col-xs-8 col-sm-2`, offcanvas-specific)
- `observations/show/namings/header.rb` (`col-xs-10 col-sm-11` / `col-xs-2 col-sm-1`, asymmetric label/icon pair specific to this view)
- `species_lists/observation.rb`'s image-present branch (`col-sm-8 col-md-9`, paired with its own `col-sm-4 col-md-3` image column — neither has a `col-xs-` prefix at all)

## Test plan

- [x] No test changes needed — every swap preserves the exact rendered class string (same literal value), confirmed via a direct render-and-compare check for every `class_names(...)` combination used.
- [x] `bundle exec rubocop` on all 9 touched files — clean.
- [x] `bin/rails test test/classes/grid_test.rb test/components/nav_tabs_test.rb test/views/controllers/projects/admin_subtabs_test.rb test/views/controllers/comments/comment_item_test.rb` — clean.
- [x] `bin/rails test test/controllers/translations_controller_test.rb test/controllers/species_lists_controller_test.rb test/controllers/observations_controller_index_test.rb test/controllers/names_controller_index_test.rb test/controllers/herbaria_controller_test.rb test/controllers/observations/images_controller_test.rb` — clean (exercises the views with no direct unit test).
- [x] `bin/rails test test/style/` — clean.
