### PR TITLE
Fix Errno::ENOENT race reading blocked_ips.txt during rewrite

### DIFF
--- a/app/classes/ip_stats.rb
+++ b/app/classes/ip_stats.rb
@@ -162,6 +162,11 @@ class IpStats
         File.exist?(MO.okay_ips_file) &&
         @blocked_ips_time >= File.mtime(MO.blocked_ips_file) &&
         @blocked_ips_time >= File.mtime(MO.okay_ips_file)
+    rescue Errno::ENOENT
+      # A file vanished between File.exist? and File.mtime (e.g. mid-rewrite).
+      # Treat as stale so the caller repopulates instead of raising on a
+      # per-request hot path.
+      false
     end
 
     def populate_blocked_ips
@@ -208,7 +213,10 @@ class IpStats
           end
         end
       end
-      File.delete(file1)
+      # File.rename atomically replaces file1 (rename(2) overwrites on the
+      # same filesystem), so file1 is never absent. Do NOT File.delete(file1)
+      # first -- that left a window where every request's blocked_ips_current?
+      # check raised Errno::ENOENT if it hit File.mtime mid-rewrite.
       File.rename(file2, file1)
     end
   end

--- a/test/classes/ip_stats_test.rb
+++ b/test/classes/ip_stats_test.rb
@@ -80,6 +80,17 @@ class IpStatsTest < UnitTestCase
     assert_true(new_ips.include?(old_ips[1]))
   end
 
+  # blocked_ips_current? checks File.exist? then File.mtime; a rewrite can
+  # remove the file in between. It must not raise on the per-request hot path.
+  def test_blocked_ips_current_survives_file_vanishing_mid_check
+    IpStats.blocked?("12.34.56.78") # prime cache: @blocked_ips_time + files
+    # File.exist? still passes, but File.mtime raises as if the file was
+    # removed by a concurrent rewrite between the two calls.
+    File.stub(:mtime, ->(*) { raise(Errno::ENOENT) }) do
+      assert_not(IpStats.send(:blocked_ips_current?))
+    end
+  end
+
   def test_clear_bad_ips
     assert_not_empty(IpStats.blocked_ips)
     IpStats.clear_blocked_ips


### PR DESCRIPTION
## Summary

Fixes a production `Errno::ENOENT ... No such file or directory @ rb_file_s_mtime - /var/web/mo/config/blocked_ips.txt` in `IpStats.blocked_ips_current?` (from the MO alerts channel). This runs on **every request** via `kick_out_excessive_traffic → is_cool? → blocked?`, so a transient failure there errors an otherwise-normal request.

## Root cause: a time-of-check/time-of-use race

`rewrite_file` (used when blocked/okay IPs are pruned — `remove_blocked_ips` / `clean_blocked_ips`) rewrote the list non-atomically:

```ruby
File.delete(file1)          # blocked_ips.txt is now GONE
File.rename(file2, file1)   # ...until this line lands
```

Between the `delete` and the `rename` the file does not exist. Meanwhile `blocked_ips_current?` does:

```ruby
File.exist?(f) && ... && @blocked_ips_time >= File.mtime(f)
```

A request that passed `File.exist?` just before the `delete`, then reached `File.mtime` during the gap, raised `Errno::ENOENT`. That's why it looked mysterious: the file exists now (the rename finished), it generally works (you need a request landing in a millisecond-wide window), and no deploy was involved — a routine IP-list rewrite collided with live traffic.

## Fix

- **`rewrite_file`**: drop the `File.delete(file1)`. `File.rename(file2, file1)` atomically replaces the destination (`rename(2)`, same filesystem), so the file is never absent. This closes the window at the source.
- **`blocked_ips_current?`**: `rescue Errno::ENOENT → false` (treat the cache as stale so the caller repopulates) as belt-and-suspenders on the per-request hot path.

## Test

Adds `test_blocked_ips_current_survives_file_vanishing_mid_check`, which stubs `File.mtime` to raise `ENOENT` (as during a mid-rewrite window) and asserts the check returns false rather than raising. Verified it reproduces the exact `Errno::ENOENT` without the rescue; full `ip_stats_test.rb` green; RuboCop clean.
