### PR TITLE
Harden check_for_broken_references against stale check entries (Sunday crash hotfix)

### DIFF
--- a/script/check_for_broken_references
+++ b/script/check_for_broken_references
@@ -192,6 +192,15 @@ end
   reflection =
     model2.reflections[reflection_name.to_s] ||
     model.reflections[reflection_name.to_s]
+  # An entry naming an association that no longer exists (renamed, removed,
+  # or turned polymorphic - e.g. ExternalLink/FieldSlip losing observation_id)
+  # would crash the whole run at reflection.foreign_key. Warn and skip
+  # instead so the rest of the checks still run.
+  if reflection.nil?
+    puts("STALE CHECK: #{model.name}.#{reflection_name} - no such " \
+         "belongs_to association; skipping. Update or remove this entry.")
+    next
+  end
   column = reflection.foreign_key
   ref_model = reflection.class_name.constantize
   warn("#{model.name} #{reflection_name}...") if verbose


### PR DESCRIPTION
## Summary

Hotfix for the Sunday `check_for_broken_references` cron, which crashed this morning with:

```
script/check_for_broken_references:195:in 'block in <main>': undefined method 'foreign_key' for nil (NoMethodError)
  column = reflection.foreign_key
```

## Cause

Two entries in the monomorphic check list name a `belongs_to :observation` that no longer exists:

- **`[ExternalLink, :observation]`** — ExternalLink's observation link is polymorphic now (`target_id`/`target_type`, from the #4299 unified external-relationship model); there's no `observation_id` column/association.
- **`[FieldSlip, :observation]`** — FieldSlip has no `observation_id`; it reaches observations through `occurrence`.

So `Model.reflections["observation"]` is `nil`, `reflection.foreign_key` raises, and the whole run aborts **before doing any of its cleanup** — not just the two stale entries.

## Fix

Guard the reflection lookup: if it's `nil`, log a `STALE CHECK` line and `next` so the remaining checks still run. Minimal, safe, deployable today.

Verified via `--dry-run` against a current-production checkpoint: the two stale entries are skipped with a warning and the full run completes (all downstream checks execute).

## Relationship to #4732

This is a stopgap for the *running* script. `CheckForBrokenReferencesJob` (#4732) already has the equivalent guard in **both** its monomorphic (`reflection.nil?`) and polymorphic (`polymorphic_target?`) paths, and drops these two stale entries entirely (ExternalLink moved to the polymorphic checks). When #4732 lands and deploys, it supersedes this script.
