### PR TITLE
Route review-worthy job output to #alerts via ApplicationJob#alert (#4780)

### DIFF
--- a/app/jobs/alert_test_job.rb
+++ b/app/jobs/alert_test_job.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# On-demand end-to-end check of the job -> #alerts pipeline. Enqueue it
+# with perform_later so a real Solid Queue worker runs it, then confirm
+# the message lands in #alerts. Unlike the `alerts:test` rake task (which
+# notifies inline in the rake process), this verifies the whole chain
+# from a *worker* process: that the worker has an ExceptionNotifier
+# notifier registered, that #alert routes through it, and that Slack
+# delivery works. Only reachable via console/rake (no route); never add
+# it to recurring.yml.
+#
+# Modes:
+#   "alert"  (default) - unique message via #alert; always delivers.
+#   "raise"            - unique message via a raise, to exercise the crash
+#                        path (rescue_from -> ExceptionNotifier). Leaves a
+#                        solid_queue_failed_executions row.
+#   "repeat"           - a *constant* message, so repeated runs share one
+#                        error_grouping signature; enqueue it several times
+#                        to watch de-dup collapse a burst (delivers at
+#                        counts 1, 2, 4, 8, ...; suppresses the rest within
+#                        the 5-minute window).
+class AlertTestJob < ApplicationJob
+  queue_as :maintenance
+
+  REPEAT_MESSAGE = "AlertTestJob de-dup probe (constant message)"
+
+  def perform(mode: "alert")
+    raise_probe if mode == "raise"
+
+    alert(mode == "repeat" ? REPEAT_MESSAGE : unique_message(mode))
+  end
+
+  private
+
+  def raise_probe
+    raise("AlertTestJob raise-path at #{Time.zone.now} (#{job_id})")
+  end
+
+  def unique_message(mode)
+    "AlertTestJob #{mode}-path at #{Time.zone.now} (#{job_id})"
+  end
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -40,6 +40,22 @@ class ApplicationJob < ActiveJob::Base
     end
   end
 
+  # Route review-worthy job output to the #alerts Slack channel (in
+  # addition to the durable job.log record). Reuses the exception_
+  # notification pipeline via a synthetic JobAlert, so it inherits the
+  # same production gating and de-duplication as crash notifications
+  # without conflating with them. A no-op for Slack outside production
+  # (no notifiers registered) - the job.log line still lands.
+  def alert(message, **context)
+    log(message)
+    return unless ExceptionNotifier.notifiers.any?
+
+    ExceptionNotifier.notify_exception(
+      JobAlert.new(message),
+      data: { job: self.class.name, job_id: job_id, **context }
+    )
+  end
+
   private
 
   def job_log_path

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -43,16 +43,20 @@ class ApplicationJob < ActiveJob::Base
   # Route review-worthy job output to the #alerts Slack channel (in
   # addition to the durable job.log record). Reuses the exception_
   # notification pipeline via a synthetic JobAlert, so it inherits the
-  # same production gating and de-duplication as crash notifications
-  # without conflating with them. A no-op for Slack outside production
-  # (no notifiers registered) - the job.log line still lands.
+  # same gating and de-duplication as crash notifications without
+  # conflating with them. Notification happens only when ExceptionNotifier
+  # has a registered notifier (production, or wherever NOTIFY_EXCEPTIONS
+  # opts in - see config/initializers/exception_notification.rb);
+  # otherwise it is log-only, and the job.log line still lands.
+  # `job`/`job_id` are set last so caller context can't clobber the
+  # alert's own identity.
   def alert(message, **context)
     log(message)
     return unless ExceptionNotifier.notifiers.any?
 
     ExceptionNotifier.notify_exception(
       JobAlert.new(message),
-      data: { job: self.class.name, job_id: job_id, **context }
+      data: { **context, job: self.class.name, job_id: job_id }
     )
   end
 

--- a/app/jobs/check_for_broken_references_job.rb
+++ b/app/jobs/check_for_broken_references_job.rb
@@ -22,14 +22,34 @@ class CheckForBrokenReferencesJob < ApplicationJob
   def perform(dry_run: false, verbose: false)
     @dry_run = dry_run
     @verbose = verbose
+    @review_findings = []
     @reflections = discover_belongs_to_reflections
 
     Checks::MONOMORPHIC.each { |args| check_monomorphic(*args) }
     Checks::POLYMORPHIC.each { |args| check_polymorphic(*args) }
     report_missing_reflections
+    emit_review_summary
   end
 
   private
+
+  # Everything routed here (dangling :alert references, stale checks,
+  # missing reflections) is "a human should look at this" - collected
+  # across the run and delivered as a single #alerts summary. Routine
+  # :delete/:nil/:zero cleanups stay in job.log only.
+  def note_for_review(line)
+    (@review_findings ||= []) << line
+  end
+
+  # At most one alert per run, and none when the run is clean - so a
+  # quiet week is silent rather than a stream of "found 0 problems".
+  def emit_review_summary
+    return if @review_findings.empty?
+
+    count = @review_findings.size
+    alert("found #{count} reference issue(s) needing review:\n- " \
+          "#{@review_findings.join("\n- ")}")
+  end
 
   def discover_belongs_to_reflections
     reflections = {}
@@ -95,6 +115,7 @@ class CheckForBrokenReferencesJob < ApplicationJob
     log("STALE CHECK: #{key} is declared in CheckForBrokenReferencesJob::" \
         "Checks, but no such belongs_to association exists anymore. " \
         "Update or remove that entry.")
+    note_for_review("STALE CHECK: #{key} (declared, but no such belongs_to)")
   end
 
   # `model` may be a `::Version` class (e.g. `Name::Version`), which
@@ -135,6 +156,8 @@ class CheckForBrokenReferencesJob < ApplicationJob
     sample = query.limit(10).pluck(:id, column)
     log("ALERT!! #{ids.size} #{model.table_name} row(s) with a dangling " \
         "#{column} - [id, #{column}]: #{sample.inspect}")
+    note_for_review("#{ids.size} #{model.table_name}.#{column} dangling " \
+                    "(e.g. #{sample.first(3).inspect})")
   end
 
   def delete_broken(model, column, query, ids)
@@ -198,7 +221,10 @@ class CheckForBrokenReferencesJob < ApplicationJob
 
   def report_missing_reflections
     @reflections.each do |key, val|
-      log("MISSING REFLECTION #{key}") if val != :done
+      next if val == :done
+
+      log("MISSING REFLECTION #{key}")
+      note_for_review("MISSING REFLECTION: #{key}")
     end
   end
 end

--- a/app/jobs/job_alert.rb
+++ b/app/jobs/job_alert.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Marker exception for review-worthy background-job output routed to the
+# #alerts Slack channel via ApplicationJob#alert. It is never raised -
+# it is handed to ExceptionNotifier.notify_exception so a job's "a human
+# should look at this" summary reuses the same Slack pipeline (and
+# de-duplication) as real crashes, while staying visibly distinct from
+# them in the channel ("A JobAlert occurred ...").
+class JobAlert < StandardError; end

--- a/app/jobs/job_alert.rb
+++ b/app/jobs/job_alert.rb
@@ -6,4 +6,5 @@
 # should look at this" summary reuses the same Slack pipeline (and
 # de-duplication) as real crashes, while staying visibly distinct from
 # them in the channel ("A JobAlert occurred ...").
-class JobAlert < StandardError; end
+class JobAlert < StandardError
+end

--- a/lib/tasks/alerts.rake
+++ b/lib/tasks/alerts.rake
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+def alerts_active?
+  webhook = ENV["SLACK_ALERTS_WEBHOOK_URL"].presence ||
+            Rails.application.credentials.slack_alerts_webhook_url
+  webhook.present? && !Rails.env.test? &&
+    (Rails.env.production? || ENV["NOTIFY_EXCEPTIONS"] == "1")
+end
+
 namespace :alerts do
   desc "Send a test exception alert to verify exception_notification -> Slack"
   task test: :environment do
@@ -16,10 +23,14 @@ namespace :alerts do
     puts("Sent test alert via ExceptionNotifier — check the #alerts channel.")
   end
 
-  def alerts_active?
-    webhook = ENV["SLACK_ALERTS_WEBHOOK_URL"].presence ||
-              Rails.application.credentials.slack_alerts_webhook_url
-    webhook.present? && !Rails.env.test? &&
-      (Rails.env.production? || ENV["NOTIFY_EXCEPTIONS"] == "1")
+  desc "Enqueue AlertTestJob so a Solid Queue worker exercises the " \
+       "job -> #alerts path end to end (modes: alert, raise, repeat)"
+  task :test_job, [:mode] => :environment do |_t, args|
+    mode = args[:mode] || "alert"
+    AlertTestJob.perform_later(mode: mode)
+    puts("Enqueued AlertTestJob (mode=#{mode}). A worker on the " \
+         ":maintenance queue should run it shortly — check #alerts. For " \
+         "de-dup testing, run `alerts:test_job[repeat]` several times in " \
+         "quick succession.")
   end
 end

--- a/lib/tasks/alerts.rake
+++ b/lib/tasks/alerts.rake
@@ -7,15 +7,17 @@ def alerts_active?
     (Rails.env.production? || ENV["NOTIFY_EXCEPTIONS"] == "1")
 end
 
+def warn_alerts_gated_off
+  puts("Alerting is gated off here — nothing to do (a worker couldn't " \
+       "notify, and the silence would look like a missing notifier). Run " \
+       "in production, or locally with `NOTIFY_EXCEPTIONS=1 " \
+       "SLACK_ALERTS_WEBHOOK_URL=<url>`.")
+end
+
 namespace :alerts do
   desc "Send a test exception alert to verify exception_notification -> Slack"
   task test: :environment do
-    unless alerts_active?
-      puts("Alerting is gated off here — nothing sent. Locally use " \
-           "`NOTIFY_EXCEPTIONS=1 SLACK_ALERTS_WEBHOOK_URL=<url> bin/rails " \
-           "alerts:test`, or run in production.")
-      next
-    end
+    next warn_alerts_gated_off unless alerts_active?
 
     ExceptionNotifier.notify_exception(
       RuntimeError.new("MO Alerts test (#{Rails.env}) at #{Time.zone.now}")
@@ -26,11 +28,12 @@ namespace :alerts do
   desc "Enqueue AlertTestJob so a Solid Queue worker exercises the " \
        "job -> #alerts path end to end (modes: alert, raise, repeat)"
   task :test_job, [:mode] => :environment do |_t, args|
+    next warn_alerts_gated_off unless alerts_active?
+
     mode = args[:mode] || "alert"
     AlertTestJob.perform_later(mode: mode)
-    puts("Enqueued AlertTestJob (mode=#{mode}). A worker on the " \
-         ":maintenance queue should run it shortly — check #alerts. For " \
-         "de-dup testing, run `alerts:test_job[repeat]` several times in " \
-         "quick succession.")
+    puts("Enqueued AlertTestJob (mode=#{mode}). A worker on :maintenance " \
+         "should run it shortly — check #alerts. For de-dup testing, run " \
+         "`alerts:test_job[repeat]` several times in quick succession.")
   end
 end

--- a/test/jobs/alert_test_job_test.rb
+++ b/test/jobs/alert_test_job_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class AlertTestJobTest < ActiveJob::TestCase
+  def test_alert_mode_sends_a_unique_message
+    alerts = capture_alerts { AlertTestJob.perform_now(mode: "alert") }
+
+    assert_equal(1, alerts.size)
+    assert_instance_of(JobAlert, alerts.first)
+    assert_includes(alerts.first.message, "alert-path")
+  end
+
+  # repeat mode must produce the SAME message every run, so error_grouping
+  # can collapse a burst - that is the whole point of the mode.
+  def test_repeat_mode_sends_a_constant_message
+    first = capture_alerts { AlertTestJob.perform_now(mode: "repeat") }
+    second = capture_alerts { AlertTestJob.perform_now(mode: "repeat") }
+
+    assert_equal(AlertTestJob::REPEAT_MESSAGE, first.first.message)
+    assert_equal(first.first.message, second.first.message)
+  end
+
+  def test_raise_mode_raises
+    assert_raises(RuntimeError) { AlertTestJob.perform_now(mode: "raise") }
+  end
+
+  private
+
+  def capture_alerts(&block)
+    alerts = []
+    ExceptionNotifier.stub(:notifiers, [:slack]) do
+      ExceptionNotifier.stub(:notify_exception,
+                             lambda { |exception, **_o|
+                               alerts << exception
+                             }, &block)
+    end
+    alerts
+  end
+end

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -24,6 +24,14 @@ class ApplicationJobTest < ActiveJob::TestCase
     end
   end
 
+  # Minimal job that emits a review-worthy alert, to exercise
+  # ApplicationJob#alert.
+  class AlertingJob < ApplicationJob
+    def perform
+      alert("review this", extra: "ctx")
+    end
+  end
+
   # Regression test for #4741/#4772: mailer jobs never run through
   # ApplicationController's before_action, so without ApplicationJob's
   # own reset, a job dispatched to a Solid Queue worker thread right
@@ -64,5 +72,37 @@ class ApplicationJobTest < ActiveJob::TestCase
       end
     end
     assert_not(notified, "Should not notify when no notifier is registered")
+  end
+
+  # #alert routes review-worthy output to the notifier (Slack in prod) as a
+  # JobAlert carrying the job's identity, when alerting is active.
+  def test_alert_notifies_with_job_alert_when_alerting_active
+    reported = nil
+    opts_seen = nil
+    ExceptionNotifier.stub(:notifiers, [:slack]) do
+      ExceptionNotifier.stub(:notify_exception,
+                             lambda { |exception, **opts|
+                               reported = exception
+                               opts_seen = opts
+                             }) do
+        AlertingJob.perform_now
+      end
+    end
+    assert_instance_of(JobAlert, reported)
+    assert_equal("review this", reported.message)
+    assert_equal("ApplicationJobTest::AlertingJob", opts_seen[:data][:job])
+    assert_equal("ctx", opts_seen[:data][:extra])
+    assert(opts_seen[:data].key?(:job_id), "alert should carry the job_id")
+  end
+
+  # With no notifier registered, #alert stays log-only and does not notify.
+  def test_alert_is_log_only_when_alerting_off
+    notified = false
+    ExceptionNotifier.stub(:notifiers, []) do
+      ExceptionNotifier.stub(:notify_exception, ->(*) { notified = true }) do
+        AlertingJob.perform_now
+      end
+    end
+    assert_not(notified, "alert must not notify when no notifier registered")
   end
 end

--- a/test/jobs/check_for_broken_references_job_test.rb
+++ b/test/jobs/check_for_broken_references_job_test.rb
@@ -99,6 +99,44 @@ class CheckForBrokenReferencesJobTest < ActiveJob::TestCase
     CheckForBrokenReferencesJob.perform_now(verbose: true)
   end
 
+  # A dangling :alert reference produces exactly one summary alert for the
+  # whole run, naming the offending table.column.
+  def test_emits_one_review_alert_for_dangling_alert_reference
+    coll_num = collection_numbers(:minimal_unknown_coll_num)
+    coll_num.update_column(:user_id, DANGLING_ID)
+
+    alerts = capture_alerts { CheckForBrokenReferencesJob.perform_now }
+
+    assert_equal(1, alerts.size, "expected exactly one summary alert per run")
+    assert_instance_of(JobAlert, alerts.first)
+    assert_includes(alerts.first.message, "collection_numbers.user_id")
+  end
+
+  # emit_review_summary is the "at most one alert per run" choke point:
+  # nothing to review => no alert, so a quiet week stays silent.
+  def test_no_alert_when_run_finds_nothing_to_review
+    job = CheckForBrokenReferencesJob.new
+    job.instance_variable_set(:@review_findings, [])
+
+    alerts = capture_alerts { job.send(:emit_review_summary) }
+
+    assert_empty(alerts, "a run with no findings should emit no alert")
+  end
+
+  # Multiple findings in one run collapse into a single summary alert.
+  def test_multiple_findings_collapse_into_one_summary_alert
+    job = CheckForBrokenReferencesJob.new
+    job.instance_variable_set(:@review_findings,
+                              ["dangling foo.bar", "STALE CHECK: Baz.qux"])
+
+    alerts = capture_alerts { job.send(:emit_review_summary) }
+
+    assert_equal(1, alerts.size)
+    assert_includes(alerts.first.message, "2 reference issue")
+    assert_includes(alerts.first.message, "dangling foo.bar")
+    assert_includes(alerts.first.message, "STALE CHECK: Baz.qux")
+  end
+
   # Guards against model drift: every belongs_to must be covered by
   # Checks::MONOMORPHIC/POLYMORPHIC (or be a typed view of a polymorphic
   # target, which discovery skips). A new/renamed/removed association that
@@ -118,5 +156,20 @@ class CheckForBrokenReferencesJobTest < ActiveJob::TestCase
     assert_empty(logged.grep(/STALE CHECK/),
                  "Check list names associations that no longer exist:\n" \
                  "#{logged.grep(/STALE CHECK/).join("\n")}")
+  end
+
+  private
+
+  # Records the exceptions handed to the #alerts pipeline while alerting is
+  # forced active, so tests can assert on what a run would post to Slack.
+  def capture_alerts(&block)
+    alerts = []
+    ExceptionNotifier.stub(:notifiers, [:slack]) do
+      ExceptionNotifier.stub(:notify_exception,
+                             lambda { |exception, **_o|
+                               alerts << exception
+                             }, &block)
+    end
+    alerts
   end
 end

--- a/test/jobs/check_for_broken_references_job_test.rb
+++ b/test/jobs/check_for_broken_references_job_test.rb
@@ -137,6 +137,22 @@ class CheckForBrokenReferencesJobTest < ActiveJob::TestCase
     assert_includes(alerts.first.message, "STALE CHECK: Baz.qux")
   end
 
+  # A reflection left uncovered by the Checks lists (val stays :need) is
+  # logged AND flagged for the #alerts summary.
+  def test_missing_reflection_is_logged_and_flagged_for_review
+    job = CheckForBrokenReferencesJob.new
+    logged = []
+    job.define_singleton_method(:log) { |msg| logged << msg }
+    job.instance_variable_set(:@reflections, { "Foo.bar" => :need })
+    job.instance_variable_set(:@review_findings, [])
+
+    job.send(:report_missing_reflections)
+
+    assert_includes(logged, "MISSING REFLECTION Foo.bar")
+    assert_includes(job.instance_variable_get(:@review_findings),
+                    "MISSING REFLECTION: Foo.bar")
+  end
+
   # Guards against model drift: every belongs_to must be covered by
   # Checks::MONOMORPHIC/POLYMORPHIC (or be a typed view of a polymorphic
   # target, which discovery skips). A new/renamed/removed association that


### PR DESCRIPTION
## Summary

First implementation step for #4780. As maintenance tasks move from cron to Solid Queue (#4726), the cron `MAILTO` behavior is lost: a job's normal output goes to `log/job.log` (which nobody watches), and only uncaught exceptions reach `#alerts`. So a job that runs *successfully* but emits review-worthy output — `check_for_broken_references`'s `ALERT!!` lines literally mean "tell a human something's wrong upstream" — notifies no one.

## What this adds

`ApplicationJob#alert(message, **context)`: writes to `job.log` **and**, when a notifier is registered (production), routes the message to `#alerts` as a synthetic `JobAlert` through the existing `exception_notification` pipeline. Reusing that pipeline means job alerts inherit the same production gating and de-duplication as crash notifications, without a bespoke webhook or a grouping bypass — and because distinct job runs are always far more than the 5-minute de-dup window apart, each run's alert always delivers (see the de-dup analysis in #4780). Outside production (no notifiers registered) it is log-only, so dev/test/CI never post to Slack.

`JobAlert < StandardError` is a marker so review-worthy output shows in the channel as `A JobAlert occurred …`, visibly distinct from real crashes.

## First consumer

`CheckForBrokenReferencesJob` collects its review-worthy findings (dangling `:alert` references, `STALE CHECK`, `MISSING REFLECTION`) across the run and emits **at most one summary alert per run** — and **none when the run is clean**, so a quiet week stays silent rather than posting "found 0 problems". Routine `:delete`/`:nil`/`:zero` cleanups remain `job.log`-only. Other jobs (`check_rss_logs`, etc.) are follow-ups.

## Manual end-to-end verification (`AlertTestJob`)

The unit tests stub `ExceptionNotifier`, and the existing `alerts:test` rake task notifies inline in the rake process — neither proves the pipeline works from a Solid Queue *worker*, which is where the real maintenance jobs run. That matters because the notifier is registered by the `ExceptionNotification::Rack` middleware, and a standalone worker process may never build that middleware — in which case `#alert` (and the existing `rescue_from` crash-notification) would silently no-op from jobs. We have no direct evidence in the #alerts history that a background-job alert has ever landed, so this is genuinely unverified.

`AlertTestJob` (+ `bin/rails alerts:test_job`) closes that gap: it's enqueued with `perform_later` so a real worker on the `:maintenance` queue runs it, then you confirm the message lands in #alerts. Modes:

- `alert` (default) — unique message via `#alert`; always delivers.
- `raise` — unique message via a raise, exercising the `rescue_from` crash path.
- `repeat` — a *constant* message, so repeated runs share one `error_grouping` signature; run `alerts:test_job[repeat]` several times to watch de-dup collapse a burst (delivers at counts 1, 2, 4, 8, …; suppresses the rest within the 5-minute window).

Reading the result: message in #alerts → the whole chain works from a worker. `job.log` line appears but #alerts stays silent → the worker has no registered notifier, and registration needs to move out of the Rack-middleware `use` (or Solid Queue must run under Puma). It's reachable only via console/rake and is never scheduled.

## Not included, by design

Problem 2 from #4780 (dedup/filtering) needs no code change — the audit found the ignore list correct and the de-dup mechanism sound (rare-but-recurring errors already alert every time; only sub-5-minute bursts get thinned).

## Test plan

- [x] `bin/rails test test/jobs/application_job_test.rb test/jobs/check_for_broken_references_job_test.rb` — 20 tests, 0 failures.
- [x] `#alert` routes a `JobAlert` (carrying `job`/`job_id`/context) when alerting is active; stays log-only when no notifier is registered.
- [x] One summary alert per run for a dangling `:alert` reference; no alert when there are no findings; multiple findings collapse into a single alert.
- [x] `AlertTestJob`: `alert` mode sends a unique message; `repeat` mode sends the constant `REPEAT_MESSAGE` identically across runs; `raise` mode raises.
- [x] RuboCop clean on all changed files.
- [ ] Manual, post-deploy: `bin/rails alerts:test_job` lands a message in #alerts from a worker; `alerts:test_job[repeat]` ×N shows de-dup collapse.
