### PR TITLE
Fix job-alert de-dup: anchor JobAlert backtrace per message (#4780)

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -55,12 +55,27 @@ class ApplicationJob < ActiveJob::Base
     return unless ExceptionNotifier.notifiers.any?
 
     ExceptionNotifier.notify_exception(
-      JobAlert.new(message),
+      job_alert(message),
       data: { **context, job: self.class.name, job_id: job_id }
     )
   end
 
   private
+
+  # error_grouping falls back to a backtrace-based key whenever the
+  # message key misses (every first occurrence of a message). A synthetic
+  # JobAlert has no backtrace, so without this every job alert would
+  # collide on one nil-backtrace group and de-dup against unrelated
+  # alerts. Anchor a single synthetic frame to the message so each
+  # distinct alert is its own group; identical messages still group
+  # (that is the point of de-dup). The crc32 keeps the shown frame short
+  # rather than echoing the whole (possibly multi-line) message.
+  def job_alert(message)
+    anchor = "job-alert:#{self.class.name}:#{Zlib.crc32(message)}"
+    alert = JobAlert.new(message)
+    alert.set_backtrace([anchor])
+    alert
+  end
 
   def job_log_path
     # Use worker-specific log files in parallel testing to avoid conflicts

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require("zlib")
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
@@ -71,8 +73,9 @@ class ApplicationJob < ActiveJob::Base
   # (that is the point of de-dup). The crc32 keeps the shown frame short
   # rather than echoing the whole (possibly multi-line) message.
   def job_alert(message)
-    anchor = "job-alert:#{self.class.name}:#{Zlib.crc32(message)}"
-    alert = JobAlert.new(message)
+    text = message.to_s
+    anchor = "job-alert:#{self.class.name}:#{Zlib.crc32(text)}"
+    alert = JobAlert.new(text)
     alert.set_backtrace([anchor])
     alert
   end

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -95,6 +95,24 @@ class ApplicationJobTest < ActiveJob::TestCase
     assert(opts_seen[:data].key?(:job_id), "alert should carry the job_id")
   end
 
+  # A synthetic JobAlert has no real backtrace, so error_grouping would
+  # collide all job alerts on one nil-backtrace key. #alert anchors a
+  # backtrace frame to the message: distinct messages get distinct anchors
+  # (separate de-dup groups), identical messages share one (they de-dup).
+  def test_alert_anchors_backtrace_to_the_message_for_grouping
+    job = AlertingJob.new
+    one = job.send(:job_alert, "message one")
+    two = job.send(:job_alert, "message two")
+    one_again = job.send(:job_alert, "message one")
+
+    assert_equal(1, one.backtrace.size)
+    assert_includes(one.backtrace.first, "ApplicationJobTest::AlertingJob")
+    assert_not_equal(one.backtrace, two.backtrace,
+                     "different messages must get different anchors")
+    assert_equal(one.backtrace, one_again.backtrace,
+                 "identical messages must get the same anchor")
+  end
+
   # With no notifier registered, #alert stays log-only and does not notify.
   def test_alert_is_log_only_when_alerting_off
     notified = false

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -113,6 +113,15 @@ class ApplicationJobTest < ActiveJob::TestCase
                  "identical messages must get the same anchor")
   end
 
+  # message.to_s normalization keeps the String-only crc32 from raising on
+  # a non-String, and keeps the anchor and alert text consistent.
+  def test_alert_tolerates_non_string_message
+    alert = AlertingJob.new.send(:job_alert, :a_symbol_message)
+
+    assert_equal("a_symbol_message", alert.message)
+    assert_equal(1, alert.backtrace.size)
+  end
+
   # With no notifier registered, #alert stays log-only and does not notify.
   def test_alert_is_log_only_when_alerting_off
     notified = false


### PR DESCRIPTION
## Summary

Follow-up to #4783 (#4780). Manual testing on production with `alerts:test_job` surfaced a de-dup bug in the job-alert path.

`ApplicationJob#alert` hands a synthetic `JobAlert` to `ExceptionNotifier.notify_exception`. Because the `JobAlert` is *constructed, never raised*, `exception.backtrace` is `nil`. `error_grouping` keys primarily on `crc32(class + message)`, but falls back to `crc32(class + backtrace.first)` whenever the message key *misses* — which is every first occurrence of a message. With a `nil` backtrace that fallback key is a single constant for **all** job alerts, and the fallback branch bumps the shared key without ever saving the per-message key. So distinct alerts inside the 5-minute grouping window all landed in **one** counter and de-duped against each other.

Observed on production: one `alert`-mode run followed by three `repeat`-mode runs delivered at counts 1, 2, and 4 of a *single shared* counter (the `alert` job seeded it to 1, so the first `repeat` came through as "2"), instead of each message de-duping on its own counter. The real-world risk: a burst of *different* job alerts (e.g. staggered maintenance jobs firing close together) would suppress all but the powers-of-2.

## Fix

`#alert` now gives the `JobAlert` a synthetic single-frame backtrace anchored to the message — `job-alert:<JobClass>:<crc32(message)>`. So each distinct message is its own de-dup group (always delivers first occurrence), while identical messages still group (de-dup works as intended). The `crc32` keeps the frame short in the Slack "Backtrace" field rather than echoing the whole (possibly multi-line) message.

## Test plan

- [x] `bin/rails test test/jobs/application_job_test.rb` — distinct messages get distinct backtrace anchors (separate groups); identical messages share one anchor (de-dup).
- [x] RuboCop clean.
- [ ] Manual, post-deploy: `alerts:test_job` then `alerts:test_job[repeat]` ×N — the `alert` run and the `repeat` runs now de-dup on independent counters (repeat shows a clean 1, 2, 4, … on its own).
