### PR TITLE
Alert on nil box_area in UpdateBoxAreaAndCenterColumnsJob (#4780)

### DIFF
--- a/app/jobs/update_box_area_and_center_columns_job.rb
+++ b/app/jobs/update_box_area_and_center_columns_job.rb
@@ -9,7 +9,6 @@ class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
     # This should be zero, but count just in case.
     loc_count = Location.where(box_area: nil).count
     log("Found #{loc_count} locations without a box_area.")
-    alert_on_missing_box_area(loc_count)
     # Count the observations associated with locations that are under the
     # max area, but haven't got a center lat/lng, and log what we're updating.
     obs_count = Observation.in_box_of_max_area.where(location_lat: nil).count
@@ -24,6 +23,7 @@ class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
     log("Updated #{loc_updated} locations' box_area and center_lat/lng.")
     log("Updated #{obs_centered} observations' location_lat/lng.")
     log("Nulled #{obs_center_nulled} observations' location_lat/lng.")
+    alert_on_missing_box_area(loc_count)
     # Return the values for debugging
     [loc_updated, obs_centered, obs_center_nulled]
   end
@@ -32,8 +32,8 @@ class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
 
   # box_area is computed when a Location is saved, so a nil is a data
   # anomaly - a location persisted through a path that bypassed it - not
-  # routine backlog. Surface it (the job repairs them regardless). A
-  # clean run stays silent.
+  # routine backlog. Surface it after the repair (so this only fires on a
+  # real run, not a dry-run inspection). A clean run stays silent.
   def alert_on_missing_box_area(loc_count)
     return unless loc_count.positive?
 

--- a/app/jobs/update_box_area_and_center_columns_job.rb
+++ b/app/jobs/update_box_area_and_center_columns_job.rb
@@ -9,6 +9,7 @@ class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
     # This should be zero, but count just in case.
     loc_count = Location.where(box_area: nil).count
     log("Found #{loc_count} locations without a box_area.")
+    alert_on_missing_box_area(loc_count)
     # Count the observations associated with locations that are under the
     # max area, but haven't got a center lat/lng, and log what we're updating.
     obs_count = Observation.in_box_of_max_area.where(location_lat: nil).count
@@ -25,5 +26,19 @@ class UpdateBoxAreaAndCenterColumnsJob < ApplicationJob
     log("Nulled #{obs_center_nulled} observations' location_lat/lng.")
     # Return the values for debugging
     [loc_updated, obs_centered, obs_center_nulled]
+  end
+
+  private
+
+  # box_area is computed when a Location is saved, so a nil is a data
+  # anomaly - a location persisted through a path that bypassed it - not
+  # routine backlog. Surface it (the job repairs them regardless). A
+  # clean run stays silent.
+  def alert_on_missing_box_area(loc_count)
+    return unless loc_count.positive?
+
+    alert("#{loc_count} location(s) have a nil box_area (expected 0) - a " \
+          "location was saved without computing box_area. Repaired this " \
+          "run; investigate the source if it recurs.")
   end
 end

--- a/test/jobs/update_box_area_and_center_columns_job_test.rb
+++ b/test/jobs/update_box_area_and_center_columns_job_test.rb
@@ -27,4 +27,42 @@ class UpdateBoxAreaAndCenterColumnsJobTest < ActiveJob::TestCase
     assert_not_empty(needs_update)
     assert_equal(obs_count, needs_update.count)
   end
+
+  # A nil box_area is a data anomaly (box_area is computed on save), so it
+  # gets a single #alerts summary.
+  def test_alerts_when_a_location_is_missing_box_area
+    locations(:albion).update_column(:box_area, nil)
+
+    alerts = capture_alerts do
+      UpdateBoxAreaAndCenterColumnsJob.new.perform(dry_run: true)
+    end
+
+    assert_equal(1, alerts.size)
+    assert_instance_of(JobAlert, alerts.first)
+    assert_includes(alerts.first.message, "box_area")
+  end
+
+  def test_no_alert_when_all_locations_have_box_area
+    assert_empty(Location.where(box_area: nil),
+                 "precondition: fixtures have no nil box_area")
+
+    alerts = capture_alerts do
+      UpdateBoxAreaAndCenterColumnsJob.new.perform(dry_run: true)
+    end
+
+    assert_empty(alerts)
+  end
+
+  private
+
+  def capture_alerts(&block)
+    alerts = []
+    ExceptionNotifier.stub(:notifiers, [:slack]) do
+      ExceptionNotifier.stub(:notify_exception,
+                             lambda { |exception, **_o|
+                               alerts << exception
+                             }, &block)
+    end
+    alerts
+  end
 end

--- a/test/jobs/update_box_area_and_center_columns_job_test.rb
+++ b/test/jobs/update_box_area_and_center_columns_job_test.rb
@@ -28,27 +28,35 @@ class UpdateBoxAreaAndCenterColumnsJobTest < ActiveJob::TestCase
     assert_equal(obs_count, needs_update.count)
   end
 
-  # A nil box_area is a data anomaly (box_area is computed on save), so it
-  # gets a single #alerts summary.
+  # A nil box_area is a data anomaly (box_area is computed on save), so a
+  # real run gets a single #alerts summary once it has repaired the rows.
   def test_alerts_when_a_location_is_missing_box_area
     locations(:albion).update_column(:box_area, nil)
 
-    alerts = capture_alerts do
-      UpdateBoxAreaAndCenterColumnsJob.new.perform(dry_run: true)
-    end
+    alerts = capture_alerts { UpdateBoxAreaAndCenterColumnsJob.new.perform }
 
     assert_equal(1, alerts.size)
     assert_instance_of(JobAlert, alerts.first)
     assert_includes(alerts.first.message, "box_area")
   end
 
-  def test_no_alert_when_all_locations_have_box_area
-    assert_empty(Location.where(box_area: nil),
-                 "precondition: fixtures have no nil box_area")
+  # A dry-run inspection must not post to #alerts even when the anomaly
+  # exists - it hasn't repaired anything.
+  def test_dry_run_does_not_alert
+    locations(:albion).update_column(:box_area, nil)
 
     alerts = capture_alerts do
       UpdateBoxAreaAndCenterColumnsJob.new.perform(dry_run: true)
     end
+
+    assert_empty(alerts)
+  end
+
+  def test_no_alert_when_all_locations_have_box_area
+    assert_empty(Location.where(box_area: nil),
+                 "precondition: fixtures have no nil box_area")
+
+    alerts = capture_alerts { UpdateBoxAreaAndCenterColumnsJob.new.perform }
 
     assert_empty(alerts)
   end


### PR DESCRIPTION
## Summary

Part of #4780. Instruments `UpdateBoxAreaAndCenterColumnsJob` with a single, targeted `#alerts` case.

The job's own comment says the count of locations with a nil `box_area` *"should be zero"* — `box_area` is computed when a `Location` is saved, so a nil means a location was persisted through a path that bypassed that computation. That's a data anomaly worth acting on, not routine backlog. This routes exactly that case to `#alerts`: one summary per run, only when the count is nonzero. The job still repairs the rows regardless, and everything else it logs (the routine Found/Updated/Nulled counts) stays in `job.log`.

This is the one anomaly-detector among the remaining recurring jobs. Per the discussion on #4780, the `refresh_caches`-derived jobs, `RefreshNameListerCacheJob`, and `DiscardStaleJobsJob` stay log-only (their output is informative but not act-on-able), and actual errors in any job already route to `#alerts` via `ApplicationJob`'s `rescue_from`. `InatImportRecoveryJob` is deferred pending a decision.

## Test plan

- [x] `bin/rails test test/jobs/update_box_area_and_center_columns_job_test.rb` — a nil `box_area` produces one `JobAlert`; a clean run produces none.
- [x] RuboCop clean.
