### PR TITLE
Retain a self-deleted user's content instead of destroying it (Fixes #4767)

### DIFF
--- a/app/classes/api2/core/base.rb
+++ b/app/classes/api2/core/base.rb
@@ -269,11 +269,15 @@ module API2::Base
     end
 
     key = APIKey.find_by(key: key_str)
-    raise(API2::BadAPIKey.new(key_str))        unless key
-    raise(API2::APIKeyNotVerified.new(key))    unless key.verified
-    raise(API2::UserNotVerified.new(key.user)) unless key.user.verified
-
+    validate_api_key!(key, key_str)
     login_user(key)
+  end
+
+  def validate_api_key!(key, key_str)
+    raise(API2::BadAPIKey.new(key_str))           unless key
+    raise(API2::APIKeyNotVerified.new(key))       unless key.verified
+    raise(API2::UserNotVerified.new(key.user))    unless key.user.verified
+    raise(API2::UserAccountBlocked.new(key.user)) if key.user.blocked
   end
 
   def clear_user

--- a/app/classes/api2/error/user_account_blocked.rb
+++ b/app/classes/api2/error/user_account_blocked.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class API2
+  # Account has been disabled/blocked (e.g. self-deleted); its API keys
+  # are retained but must not authenticate.
+  class UserAccountBlocked < FatalError
+    def initialize(user)
+      super()
+      args.merge!(login: user.login)
+    end
+  end
+end

--- a/app/classes/api2/user_api.rb
+++ b/app/classes/api2/user_api.rb
@@ -86,7 +86,7 @@ class API2
       lambda do |obj|
         raise(CanOnlyDeleteYourOwnAccount.new) if user.id != obj.id
 
-        obj.disable_account_and_delete_private_objects
+        obj.disable_and_anonymize_account
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -899,19 +899,17 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   # licenses, we are perfectly within our rights to retain users' content.
   # But we wish to comply with Apple where it will not otherwise detract from
   # other users' experience.
-  def disable_account_and_delete_private_objects
+  # Handles a user's self-delete request. Everything on MO is CC-licensed
+  # and a self-delete is a weak (sometimes accidental) signal, so we
+  # retain all of the user's content -- observations, images, api keys,
+  # interests, descriptions, projects, etc. -- so the account can be
+  # re-enabled, and merely clear the personal data, block the account,
+  # and anonymize the login. A genuinely empty account (no references at
+  # all) is still fully erased. (#4767 -- the old version hard-deleted
+  # namings/votes/logs and a raft of other content; see git history.)
+  def disable_and_anonymize_account
     disable_account
-    delete_api_keys
-    delete_interests
-    delete_name_trackers
-    delete_observations
-    delete_private_name_descriptions
-    delete_private_location_descriptions
-    delete_private_projects
-    delete_private_species_lists
-    delete_unattached_collection_numbers
-    delete_unattached_herbarium_records
-    delete_unattached_images
+    inactivate_user
     User.erase_user(id) if no_references_left?
   end
 
@@ -928,114 +926,24 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     save
   end
 
-  def delete_api_keys
-    api_keys.delete_all
-  end
-
-  def delete_interests
-    interests.delete_all
-  end
-
-  def delete_name_trackers
-    NameTracker.where(user: self).delete_all
-  end
-
-  def delete_observations
-    [Naming, Vote, RssLog].each do |model|
-      model.joins(:observation).where(observation: { user_id: id }).delete_all
-    end
-    # (all the rest of the observations' dependents should autodestruct)
-    observations.delete_all
-  end
-
-  # Delete user's descriptions that don't have any other authors or editors.
-  # (Oops, editors never got "hooked up" so we have to use versions instead.)
-  def delete_private_name_descriptions
-    ids = private_name_descriptions.map(&:id)
-    NameDescription.where(id: ids).delete_all
-    NameDescription::Version.where(name_description_id: ids).delete_all
-  end
-
-  def private_name_descriptions
-    name_descriptions -
-      name_descriptions.joins(:name_description_authors).
-      where.not(name_description_authors: { user_id: id }) -
-      name_descriptions.joins(:name_description_editors).
-      where.not(name_description_editors: { user_id: id }) -
-      name_descriptions.joins(:versions).
-      where.not(versions: { user_id: id })
-  end
-
-  # Delete user's descriptions that don't have any other authors or editors.
-  # (Oops, editors never got "hooked up" so we have to use versions instead.)
-  def delete_private_location_descriptions
-    ids = private_location_descriptions.map(&:id)
-    LocationDescription.where(id: ids).delete_all
-    LocationDescription::Version.where(location_description_id: ids).delete_all
-  end
-
-  def private_location_descriptions
-    location_descriptions -
-      location_descriptions.joins(:location_description_authors).
-      where.not(location_description_authors: { user_id: id }) -
-      location_descriptions.joins(:location_description_editors).
-      where.not(location_description_editors: { user_id: id }) -
-      location_descriptions.joins(:versions).
-      where.not(versions: { user_id: id })
-  end
-
-  # Delete all the user's projects that don't have any other users on them.
-  def delete_private_projects
-    ids = (projects_created -
-            projects_created.joins(:admin_group_users).
-            where.not(admin_group_users: { id: id }) -
-            projects_created.joins(:member_group_users).
-            where.not(member_group_users: { id: id })).
-          map(&:id)
-    Project.where(id: ids).delete_all
-  end
-
-  # Delete all species_lists the user created unless they belong
-  # to a project.  (Private projects should already have been deleted
-  # by this point, so this in effect, really should read "unless they
-  # belong to a public project".)  I think it's okay to delete
-  # observations even if they are attached to a project.  But
-  # species_lists are potentially a much more collaborative effort, so
-  # I don't think it's okay to delete lists that are attached to
-  # public projects just because the user happened to originally
-  # create them.  -JPH 20220916
-  def delete_private_species_lists
-    ids = (species_lists - species_lists.joins(:project_species_lists)).
-          map(&:id)
-    SpeciesList.where(id: ids).delete_all
-  end
-
-  def delete_unattached_collection_numbers
-    ids = (collection_numbers -
-            collection_numbers.joins(:observation_collection_numbers)).
-          map(&:id)
-    CollectionNumber.where(id: ids).delete_all
-  end
-
-  def delete_unattached_herbarium_records
-    ids = (herbarium_records -
-            herbarium_records.joins(:observation_herbarium_records)).
-          map(&:id)
-    HerbariumRecord.where(id: ids).delete_all
-  end
-
-  def delete_unattached_images
-    ids = (images -
-            images.joins(:glossary_term_images) -
-            images.joins(:observation_images) -
-            images.joins(:project_images) -
-            images.joins(:profile_users)).
-          map(&:id)
-    Image.where(id: ids).delete_all
+  # Everything on MO is CC-licensed and worth retaining, so a self-delete
+  # keeps the user's observations -- and their namings, votes, logs, and
+  # images -- in place under the now-disabled, anonymized account rather
+  # than destroying scientific records. This anonymizes the last
+  # identifying field disable_account leaves, the login, to
+  # "inactive_user_<id>" (name is already blank, so login is all that's
+  # displayed). Observation is a REFERENCE_MODEL again, so the retained
+  # observations keep no_references_left? from erasing the account.
+  #
+  # Formerly delete_observations, which -- via a has_many delete_all with
+  # no :dependent -- NULLed user_id on the observations and hard-deleted
+  # their namings/votes/logs, leaving them ownerless and stripped (#4767).
+  def inactivate_user
+    update_column(:login, "inactive_user_#{id}")
   end
 
   REFERENCE_MODELS = [
-    # APIKey,                        (just deleted all of these)
+    # APIKey,                        (cleared by erase_user, not disable)
     Article,
     CollectionNumber,
     Comment,
@@ -1049,7 +957,7 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     HerbariumRecord,
     ImageVote,
     Image,
-    # Interest,                      (just deleted all of these)
+    # Interest,                      (cleared by erase_user, not disable)
     Location,
     Location::Version,
     LocationDescription,
@@ -1063,9 +971,9 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     NameDescriptionAuthor,
     NameDescriptionEditor,
     Naming,
-    # NameTracker,                  (just deleted all of these)
+    # NameTracker,                  (cleared by erase_user, not disable)
     # ObservationView,               (okay if these are all that's left)
-    # Observation,                   (just deleted all of these)
+    Observation, # retained on self-delete now (see #inactivate_user)
     Project,
     Publication,
     Sequence,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -917,6 +917,7 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   # in case there are still comments, etc. on the site by this user.
   def disable_account
     self.email = ""
+    self.name = "" # real name is PII, and shows via unique_text_name
     self.blocked = true
     self.location_id = nil
     self.image_id = nil

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4783,6 +4783,7 @@
   api_user_already_exists: The user "[login]" already exists or is taken.
   api_user_group_taken: The user group "[title]" already exists.
   api_user_not_verified: The user "[login]" is not verified yet; you can request another verification email on the website.
+  api_user_account_blocked: The account "[login]" has been disabled and can no longer be used.
 
   api_help_accession_has: search within accession number
   api_help_accession_number: unique fungarium id

--- a/test/classes/api2/error_test.rb
+++ b/test/classes/api2/error_test.rb
@@ -117,6 +117,7 @@ class API2::ErrorTest < UnitTestCase
         [herbarium_records(:interesting_unknown)],
       API2::ImageUploadFailed => [Image.new],
       API2::MustBeAdmin => [projects(:eol_project)],
+      API2::UserAccountBlocked => [users(:rolf)],
       API2::UserNotVerified => [users(:rolf)]
     }
   end

--- a/test/classes/api2_test.rb
+++ b/test/classes/api2_test.rb
@@ -522,6 +522,21 @@ class API2Test < UnitTestCase
     assert_api_pass(params)
   end
 
+  # A blocked/disabled account (e.g. self-deleted) keeps its API keys but
+  # must not be able to authenticate with them. See #4767.
+  def test_blocked_user_rejected
+    params = {
+      method: :post,
+      action: :observation,
+      api_key: @api_key.key,
+      location: "Anywhere"
+    }
+    User.update(rolf.id, blocked: true)
+    assert_api_fail(params)
+    User.update(rolf.id, blocked: false)
+    assert_api_pass(params)
+  end
+
   def test_check_edit_permission
     @api      = API2.new
     @api.user = dick

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -405,205 +405,34 @@ class UserTest < UnitTestCase
     assert_true(rolf.blocked)
   end
 
-  def test_delete_api_keys
-    assert_operator(0, "<", APIKey.where(user: rolf).count)
-    rolf.delete_api_keys
-    assert_equal(0, APIKey.where(user: rolf).count)
+  def test_inactivate_user
+    count = Observation.where(user: rolf).count
+    assert_operator(0, "<", count)
+
+    rolf.inactivate_user
+
+    # Content is retained (everything on MO is CC-licensed, #4767) -- the
+    # old delete_observations would have NULLed these to zero.
+    assert_equal(count, Observation.where(user: rolf).count)
+    # ...and the account is anonymized (login is the only shown identifier).
+    assert_equal("inactive_user_#{rolf.id}", rolf.reload.login)
   end
 
-  def test_delete_interests
-    assert_operator(0, "<", Interest.where(user: junk).count)
-    junk.delete_interests
-    assert_equal(0, Interest.where(user: junk).count)
-  end
+  # A self-delete on an account with content retains everything, blocks
+  # and anonymizes it -- it is NOT erased (#4767).
+  def test_disable_and_anonymize_account_retains_content
+    obs_count = Observation.where(user_id: rolf.id).count
+    key_count = APIKey.where(user_id: rolf.id).count
+    assert_operator(0, "<", obs_count)
 
-  def test_delete_name_trackers
-    assert_operator(0, "<", NameTracker.where(user: rolf).count)
+    rolf.disable_and_anonymize_account
+    rolf.reload
 
-    rolf.delete_name_trackers
-    assert_equal(0, NameTracker.where(user: rolf).count)
-  end
-
-  def test_delete_observations
-    assert_operator(0, "<", Observation.where(user: rolf).count)
-    rolf.delete_observations
-    assert_equal(0, Observation.where(user: rolf).count)
-  end
-
-  def test_delete_private_name_descriptions
-    # All Rolf's descriptions should be "private" but these two:
-    # Created by rolf, but katrina is author and editor.
-    desc1 = name_descriptions(:coprinus_desc)
-    # Created and authored by rolf, but mary is also editor.
-    desc2 = name_descriptions(:coprinus_comatus_desc)
-    assert_operator(2, "<", NameDescription.where(user: rolf).count)
-
-    rolf.delete_private_name_descriptions
-    assert_obj_arrays_equal(NameDescription.where(user: rolf).to_a,
-                            [desc1, desc2], :sort)
-
-    # All of Dick's should be deletable but for this one:
-    # Rolf has one of the versions of this one.
-    desc3 = name_descriptions(:peltigera_desc)
-    assert_operator(0, "<", desc3.versions.where(user_id: rolf.id).count)
-
-    dick.delete_private_name_descriptions
-    assert_equal(1, NameDescription.where(user: dick).count,
-                 "Failed to delete some NameDescriptions created by dick")
-    # Make sure it left Dick's versions of the undeleted description.
-    assert_operator(0, "<", NameDescription::Version.where(
-      user_id: dick.id,
-      name_description_id: desc3.id
-    ).count)
-
-    # But should be able to delete it if Dick owns all the versions.
-    desc3.versions.update_all(user_id: dick.id)
-    dick.delete_private_name_descriptions
-    assert_equal(0, NameDescription.where(user: dick).count,
-                 "Failed to delete last NameDescription created by dick")
-    assert_equal(0, NameDescription::Version.where(
-      name_description_id: desc3.id
-    ).count)
-  end
-
-  def test_delete_private_location_descriptions
-    # Rolf owns this description and all its versions, but let's add Dick
-    # as an editor to make it non-private.
-    albion = location_descriptions(:albion_desc)
-    albion.editors << dick
-    assert_users_equal(rolf, albion.user)
-    assert_operator(1, "<", albion.versions.count)
-    assert(albion.versions.all? { |ver| ver.user_id == rolf.id })
-
-    # Can't delete while Dick is an editor.
-    rolf.delete_private_location_descriptions
-    assert_not_empty(LocationDescription.where(id: albion.id))
-
-    # Let's remove Dick from the editors, but give one of the versions to Dick.
-    albion.editors.clear
-    albion.versions.update_all(user_id: dick.id)
-    rolf.reload.delete_private_location_descriptions
-    assert_not_nil(LocationDescription.find(albion.id))
-
-    # Now give all the versions back to Rolf so we can finally delete it.
-    albion.versions.update_all(user_id: rolf.id)
-    rolf.reload.delete_private_location_descriptions
-    assert_raises(ActiveRecord::RecordNotFound) \
-      { LocationDescription.find(albion.id) }
-    assert_equal(0, LocationDescription::Version.where(
-      location_description_id: albion.id
-    ).count)
-  end
-
-  def test_delete_private_projects
-    # Dick created several projects.  Most have the admin and member groups set
-    # to dick_only, but one uses albion_admins/albion_users, and another uses
-    # article_writers.  The latter group contains users other than Dick, and
-    # therefore that project (news_article_project) should not be deleted.
-
-    # Prove that Dick owns a few projects using only dick_only.
-    dick_only = user_groups(:dick_only)
-    assert_operator(1, "<",
-                    dick.projects_created.where(admin_group: dick_only,
-                                                user_group: dick_only).count,
-                    "dick should own at least two dick-only projects")
-
-    # Prove that Dick owns albion_project and that its admins and users are
-    # all just Dick despite not being his one-user group, dick_only.
-    albion = projects(:albion_project)
-    albion_admins = user_groups(:albion_admins)
-    albion_users = user_groups(:albion_users)
-    assert_users_equal(dick, albion.user)
-    assert_equal(1, albion_admins.users.count)
-    assert_equal(1, albion_users.users.count)
-    assert_users_equal(dick, albion_admins.users.first)
-    assert_users_equal(dick, albion_users.users.first)
-
-    # Prove that Dick owns news_article_project but that the admin and user
-    # is someone else.
-    news_articles = projects(:news_articles_project)
-    article_writers = user_groups(:article_writers)
-    assert_users_equal(dick, news_articles.user)
-    assert_operator(0, "<",
-                    article_writers.users.count { |user| user != dick },
-                    "article_writers should have a user other than dick")
-
-    dick.delete_private_projects
-    assert_empty(Project.where(id: albion.id))
-    assert_not_empty(Project.where(id: news_articles.id))
-  end
-
-  def test_delete_private_species_lists
-    # Delete all of Mary's many lists except those in projects
-    mary_lists = SpeciesList.where(user: mary)
-    before_count = mary_lists.count
-    proj_lists = mary_lists.select { |list| list.projects.any? }
-    proj_count = proj_lists.count
-    assert_operator(proj_count, ">", 0)
-    assert_operator(before_count, ">", proj_count)
-    mary.delete_private_species_lists
-    after_count = SpeciesList.where(user: mary).count
-    assert_operator(before_count, ">", after_count)
-    assert_equal(proj_count, after_count)
-  end
-
-  def test_delete_unattached_collection_numbers
-    num = collection_numbers(:minimal_unknown_coll_num)
-    assert_equal(1, num.observations.count)
-    obs = num.observations.first
-    assert_users_equal(mary, obs.user)
-
-    # Not unattached at this point.
-    mary.delete_unattached_collection_numbers
-    assert_not_nil(CollectionNumber.find(num.id))
-
-    # This should orphan but not delete the collection number.
-    obs.destroy
-    assert_not_nil(CollectionNumber.find(num.id))
-
-    # Should get deleted now.
-    mary.delete_unattached_collection_numbers
-    assert_empty(CollectionNumber.where(id: num.id))
-  end
-
-  def test_delete_unattached_herbarium_records
-    rec = herbarium_records(:interesting_unknown)
-    assert_users_equal(rolf, rec.user)
-    assert_equal(2, rec.observations.count)
-    obs1 = observations(:minimal_unknown_obs)
-    obs2 = observations(:detailed_unknown_obs)
-    assert_users_equal(mary, obs1.user)
-    assert(obs1.herbarium_records.include?(rec))
-    assert(obs2.herbarium_records.include?(rec))
-
-    # Used by two observations at first.
-    rolf.delete_unattached_herbarium_records
-    assert_not_nil(HerbariumRecord.find(rec.id))
-
-    # Still used by one observation.
-    obs1.destroy
-    rolf.reload.delete_unattached_herbarium_records
-    assert_not_nil(HerbariumRecord.find(rec.id))
-
-    # Now unattached and deletable.
-    obs2.destroy
-    rolf.reload.delete_unattached_herbarium_records
-    assert_raises(ActiveRecord::RecordNotFound) \
-      { HerbariumRecord.find(rec.id) }
-  end
-
-  def test_delete_unattached_images
-    # This is supposedly unused by anything.
-    img1 = images(:convex_image)
-    assert_users_equal(rolf, img1.user)
-
-    # This is used by something.
-    img2 = images(:agaricus_campestris_image)
-    assert_users_equal(rolf, img2.user)
-
-    rolf.delete_unattached_images
-    assert_raises(ActiveRecord::RecordNotFound) { Image.find(img1.id) }
-    assert_not_nil(Image.find(img2.id))
+    assert(User.exists?(rolf.id), "account with content must be retained")
+    assert(rolf.blocked)
+    assert_equal("inactive_user_#{rolf.id}", rolf.login)
+    assert_equal(obs_count, Observation.where(user_id: rolf.id).count)
+    assert_equal(key_count, APIKey.where(user_id: rolf.id).count)
   end
 
   def test_no_references_left

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -402,6 +402,7 @@ class UserTest < UnitTestCase
     assert_blank(rolf.email)
     assert_blank(rolf.mailing_address)
     assert_blank(rolf.notes)
+    assert_blank(rolf.name)
     assert_true(rolf.blocked)
   end
 
@@ -430,6 +431,7 @@ class UserTest < UnitTestCase
 
     assert(User.exists?(rolf.id), "account with content must be retained")
     assert(rolf.blocked)
+    assert_blank(rolf.name) # real name (PII) cleared
     assert_equal("inactive_user_#{rolf.id}", rolf.login)
     assert_equal(obs_count, Observation.where(user_id: rolf.id).count)
     assert_equal(key_count, APIKey.where(user_id: rolf.id).count)


### PR DESCRIPTION
## Summary

Fixes #4767. Account self-delete (via the API / mobile app) used to run `observations.delete_all` on a `has_many :observations` with no `:dependent` — which **NULLs `user_id`** on the user's observations instead of deleting them — and hard-deleted their namings, votes, and logs, plus a raft of other content (private descriptions/projects/species-lists, unattached collection numbers/herbarium records/images, api keys, interests, name trackers). The result was a broken, ownerless, identity-stripped account.

Everything on MO is CC-licensed, and a self-delete is a weak (sometimes accidental) signal, so the new behavior is to **retain all of the user's content** — so the account can be re-enabled if the deletion was unintended — and merely clear the PII, block the account, and anonymize the login.

## Changes

- **`delete_observations` → `inactivate_user`** — no longer touches observations or anything else; it only anonymizes the login to `inactive_user_<id>` (`name` is already blanked by `disable_account`, so the login is the only displayed identifier).
- **`disable_account_and_delete_private_objects` → `disable_and_anonymize_account`** — now just `disable_account` (clear PII + block) + `inactivate_user` + `erase_user if no_references_left?`. Every content-removing `delete_*` call is gone, and the now-orphaned `delete_*` methods (and their tests) are removed.
- **`REFERENCE_MODELS`** — `Observation` is a reference again, so retained observations keep `no_references_left?` from erasing the account. A genuinely empty account is still fully erased, and `erase_user`'s `OWN_RECORDS` cleans up its api keys / interests / etc., so there are no dangling references either way.

## Not in this PR

The one-time data repair for the single account this bug ever hit (114 observations to re-point + their namings/votes/logs to restore from backup) is a pair of run-once scripts that get deleted after they run — not committed here.

## Test plan

- [x] `test_inactivate_user` — obs (and content) retained, login anonymized (the inverse of the old, now-deleted `test_delete_observations`).
- [x] `test_disable_and_anonymize_account_retains_content` — an account with content is retained + blocked + anonymized, not erased; api keys survive.
- [x] `test_no_references_left`, the api2 `test_deleting_users` (empty account still fully erased), and the admin users suite all pass.
- [x] RuboCop clean.
