### PR TITLE
Add `Components::Container`, centralize width-class handling (1/3: Container, Row, Column)

### DIFF
--- a/app/assets/stylesheets/mo/_content.scss
+++ b/app/assets/stylesheets/mo/_content.scss
@@ -102,10 +102,6 @@ ul.tight-list {
   font-weight: bold;
 }
 
-.content-block {
-  @extend .p-3;
-}
-
 .h3.page-title {
   font-size: 22px;
 

--- a/app/components/container.rb
+++ b/app/components/container.rb
@@ -41,9 +41,11 @@ class Components::Container < Components::Base
 
   # Dual access, matching Components::Collapsible.collapse_classes --
   # callable directly for string-only callers, and used internally by
-  # #width_class below. Any width not in WIDTH_CLASSES (including
-  # explicit :full) falls back to "container-full", matching
-  # container_class's original case statement.
+  # #width_class below. Any width that isn't a WIDTH_CLASSES key (nil,
+  # or an unrecognized symbol) falls back to "container-full", matching
+  # container_class's original case statement -- :full itself is a
+  # defined key mapping to that same string, not something that relies
+  # on the fallback.
   def self.class_for(width)
     WIDTH_CLASSES.fetch(width, WIDTH_CLASSES[:full])
   end

--- a/app/components/container.rb
+++ b/app/components/container.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Renders a max-width-constrained wrapper element -- `<div>` by default,
+# or any other tag via `element:` (the shared layout uses this for its
+# one `<main>`). Centralizes the width-symbol -> CSS-class mapping that
+# used to live duplicated between `container_class` (`Views::
+# FullPageBase::LayoutClasses`, which signals page-level width across
+# the layout render boundary via `content_for`) and ~16 call sites that
+# hardcoded the same class strings directly for sub-section width limits.
+#
+# MO's `container-*` classes are custom, fixed pixel-width ceilings, not
+# Bootstrap's own `.container`/`.container-fluid` mechanism (Bootstrap's
+# is a multi-breakpoint staircase of exact widths, not a single cap) --
+# see `app/assets/stylesheets/mo/_layout.scss`. Centralizing the mapping
+# here means a future Bootstrap 3->4 container-class migration (#3797)
+# only touches WIDTH_CLASSES, not every call site.
+#
+# @example Basic (a <div>)
+#   Container(width: :text) { render_fields }
+#
+# @example With extra classes/attrs
+#   Container(width: :text, class: "ml-4", data: { controller: "foo" }) do
+#     render_fields
+#   end
+#
+# @example As the layout's <main>
+#   Container(element: :main, id: "content", class: content_classes,
+#             data: { controller: "lightgallery" }) { yield }
+#
+# @example Class-only, for callers that can't render the component
+#   directly (e.g. a Components::Table column, or merging into another
+#   component's class: arg)
+#   t.column(nil, class: Components::Container.class_for(:text)) { ... }
+class Components::Container < Components::Base
+  WIDTH_CLASSES = {
+    text: "container-text",
+    text_image: "container-text-image",
+    wide: "container-wide",
+    full: "container-full"
+  }.freeze
+
+  # Dual access, matching Components::Collapsible.collapse_classes --
+  # callable directly for string-only callers, and used internally by
+  # #width_class below. Any width not in WIDTH_CLASSES (including
+  # explicit :full) falls back to "container-full", matching
+  # container_class's original case statement.
+  def self.class_for(width)
+    WIDTH_CLASSES.fetch(width, WIDTH_CLASSES[:full])
+  end
+
+  prop :width, _Nilable(Symbol), default: nil
+  prop :element, Symbol, default: :div
+  # Catch-all for class:, id:, data:, and any other HTML attrs --
+  # matches Components::Collapsible/Navbar's pattern.
+  prop :attributes, _Hash(Symbol, _Any?), :**
+
+  def view_template(&block)
+    send(@element,
+         class: class_names(width_class, @attributes[:class]),
+         **@attributes.except(:class),
+         &block)
+  end
+
+  private
+
+  def width_class
+    self.class.class_for(@width) if @width
+  end
+end

--- a/app/components/image/reuse_form.rb
+++ b/app/components/image/reuse_form.rb
@@ -37,7 +37,7 @@ class Components::Image::ReuseForm < Components::ApplicationForm
   end
 
   def view_template
-    div(class: "container-text") do
+    Container(width: :text) do
       render_id_field_row
       Help(class: "form-group", content: :image_reuse_id_help.tp)
       render_toggle_link

--- a/app/views/controllers/account/api_keys/index.rb
+++ b/app/views/controllers/account/api_keys/index.rb
@@ -13,7 +13,7 @@ module Views::Controllers::Account::APIKeys
       add_context_nav(Tab::Account::APIActions.new)
       container_class(:full)
 
-      div(class: "container-text") do
+      Container(width: :text) do
         ContentPadded { trusted_html(:account_api_keys_help.tp) }
       end
 

--- a/app/views/controllers/collection_numbers/show.rb
+++ b/app/views/controllers/collection_numbers/show.rb
@@ -16,9 +16,9 @@ module Views::Controllers::CollectionNumbers
       # Top text details + bottom footer both kept at
       # `container-text` width; the obs-matrix between them runs
       # full-width inside the page's full-width `<main>`.
-      div(class: "container-text") { render_details }
+      Container(width: :text) { render_details }
       render_observation_matrix
-      div(class: "container-text") do
+      Container(width: :text) do
         render(::Views::Layouts::ObjectFooter.new(
                  obj: @collection_number, minimal: true
                ))

--- a/app/views/controllers/descriptions/form.rb
+++ b/app/views/controllers/descriptions/form.rb
@@ -22,7 +22,7 @@ module Views::Controllers::Descriptions
     end
 
     def view_template
-      div(class: "container-text") do
+      Container(width: :text) do
         submit(submit_button_text.l, center: true)
         render_source_fields
         render_permissions_fields

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -73,7 +73,7 @@ module Views::Controllers::FieldSlips
       # an empty value is fine and the form context
       # (`?species_list=...`) is what carries the actual id.
       hidden_field("species_list", value: @species_list)
-      div(class: "container-text") do
+      Container(width: :text) do
         render_left_column_fields
         render_submit_quick_create if new_record?
         render_notes_panel

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -24,7 +24,7 @@ module Views::Controllers::FieldSlips
       container_class(:wide)
 
       render_notice
-      div(class: "content-block") { render_project_or_filter_section }
+      ContentPadded { render_project_or_filter_section }
       render_list
     end
 

--- a/app/views/controllers/glossary_terms/show.rb
+++ b/app/views/controllers/glossary_terms/show.rb
@@ -33,7 +33,7 @@ module Views::Controllers::GlossaryTerms
     end
 
     def render_left_column
-      div(class: "content-block") do
+      ContentPadded do
         div(class: "description") do
           p { trusted_html(@glossary_term.description.tpl) }
         end
@@ -63,7 +63,7 @@ module Views::Controllers::GlossaryTerms
     end
 
     def render_image_action_links
-      div(class: "mb-3 content-block") do
+      ContentPadded(class: "mb-3") do
         link_to(:show_glossary_term_reuse_image.t,
                 reuse_images_for_glossary_term_path(@glossary_term.id))
         br
@@ -95,7 +95,7 @@ module Views::Controllers::GlossaryTerms
     end
 
     def render_versions_footer
-      div(class: "mt-3 content-block") do
+      ContentPadded(class: "mt-3") do
         render(::Components::Description::PreviousVersion.new(
                  obj: @glossary_term, versions: @versions.to_a
                ))

--- a/app/views/controllers/herbaria/index.rb
+++ b/app/views/controllers/herbaria/index.rb
@@ -30,13 +30,15 @@ module Views::Controllers::Herbaria
     end
 
     def render_merge_alert
-      Alert(level: :warning, class: "container-text mt-3") do
-        trusted_html(
-          :herbarium_index_merge_help.tp(
-            name: @merge.format_name,
-            url: reload_with_args(merge: nil)
+      Container(width: :text, class: "mt-3") do
+        Alert(level: :warning) do
+          trusted_html(
+            :herbarium_index_merge_help.tp(
+              name: @merge.format_name,
+              url: reload_with_args(merge: nil)
+            )
           )
-        )
+        end
       end
     end
 

--- a/app/views/controllers/herbarium_records/show.rb
+++ b/app/views/controllers/herbarium_records/show.rb
@@ -19,9 +19,9 @@ module Views::Controllers::HerbariumRecords
       # Top text details + bottom footer both kept at
       # `container-text` width; the obs-matrix between them runs
       # full-width inside the page's full-width `<main>`.
-      div(class: "container-text") { render_details }
+      Container(width: :text) { render_details }
       render_observation_matrix
-      div(class: "container-text") do
+      Container(width: :text) do
         render(::Views::Layouts::ObjectFooter.new(
                  obj: @herbarium_record, minimal: true
                ))

--- a/app/views/controllers/images/licenses/form.rb
+++ b/app/views/controllers/images/licenses/form.rb
@@ -19,7 +19,7 @@ module Views::Controllers::Images::Licenses
   class Form < ::Components::ApplicationForm
     def view_template
       super do
-        div(class: "container-text") do
+        Container(width: :text) do
           trusted_html(:image_updater_help.tp)
         end
         render_table if model.rows.any?

--- a/app/views/controllers/observations/identify/index.rb
+++ b/app/views/controllers/observations/identify/index.rb
@@ -24,8 +24,10 @@ module Views::Controllers::Observations::Identify
       add_index_title(@query)
       add_pagination(@pagination_data)
 
-      div(class: "container-text content-block") do
-        p { trusted_html(:obs_needing_id_intro.tp) }
+      Container(width: :text) do
+        ContentPadded do
+          p { trusted_html(:obs_needing_id_intro.tp) }
+        end
       end
 
       PaginatedResults { render_matrix }

--- a/app/views/controllers/projects/form.rb
+++ b/app/views/controllers/projects/form.rb
@@ -83,7 +83,7 @@ module Views::Controllers::Projects
         p { "*#{:form_projects_date_range.t}*".t }
         p { :form_projects_dates_explain.t }
       end
-      div(class: "container-text ml-4") do
+      Container(width: :text, class: "ml-4") do
         date_field(:start_date,
                    label: "#{:form_projects_start_date.t}: ",
                    wrap_class: "mb-2")

--- a/app/views/controllers/projects/members/form.rb
+++ b/app/views/controllers/projects/members/form.rb
@@ -23,7 +23,7 @@ module Views::Controllers::Projects::Members
     private
 
     def render_create_form
-      div(class: "container-text mt-5 ml-3") do
+      Container(width: :text, class: "mt-5 ml-3") do
         div(class: "d-flex align-items-start") do
           autocompleter_field(
             :candidate,

--- a/app/views/controllers/publications/index.rb
+++ b/app/views/controllers/publications/index.rb
@@ -31,7 +31,7 @@ module Views::Controllers::Publications
       add_context_nav(::Tab::Publication::IndexActions.new)
       container_class(:wide)
 
-      div(class: "container-text") { render_intro }
+      Container(width: :text) { render_intro }
       render_publications_table
       ContentPadded do
         trusted_html(:publication_legend.tp)

--- a/app/views/controllers/sequences/show.rb
+++ b/app/views/controllers/sequences/show.rb
@@ -9,8 +9,10 @@ module Views::Controllers::Sequences
 
     def view_template
       register_chrome
-      ContentPadded(class: "container-text") do
-        render_fields
+      Container(width: :text) do
+        ContentPadded do
+          render_fields
+        end
       end
       render(::Views::Layouts::ObjectFooter.new(
                user: current_user, obj: @sequence

--- a/app/views/controllers/species_lists/name_lists/new.rb
+++ b/app/views/controllers/species_lists/name_lists/new.rb
@@ -32,7 +32,7 @@ module Views::Controllers::SpeciesLists::NameLists
 
     def render_noscript
       noscript do
-        div(class: "container-text mt-3") do
+        Container(width: :text, class: "mt-3") do
           trusted_html(:name_lister_no_js.tp)
         end
       end

--- a/app/views/controllers/translations/index.rb
+++ b/app/views/controllers/translations/index.rb
@@ -32,7 +32,7 @@ module Views::Controllers::Translations
     private
 
     def render_help_block
-      div(class: "container-text") do
+      Container(width: :text) do
         Help(element: :p, content: :edit_translations_help.t)
       end
     end

--- a/app/views/controllers/visual_groups/edit.rb
+++ b/app/views/controllers/visual_groups/edit.rb
@@ -27,7 +27,7 @@ module Views::Controllers::VisualGroups
       add_edit_title(@visual_group)
       container_class(:full)
 
-      div(class: "container-text") do
+      Container(width: :text) do
         render_top_nav
         render(Form.new(@visual_group,
                         visual_model: @visual_group.visual_model))

--- a/app/views/full_page_base/layout_classes.rb
+++ b/app/views/full_page_base/layout_classes.rb
@@ -19,12 +19,7 @@ module Views::FullPageBase::LayoutClasses
   def container_class(container = :text)
     container ||= :text
     content_for(:container_class, flush: true) do
-      case container
-      when :text       then "container-text"
-      when :text_image then "container-text-image"
-      when :wide       then "container-wide"
-      else                  "container-full"
-      end
+      Components::Container.class_for(container)
     end
   end
 

--- a/app/views/layouts/app/page_flash.rb
+++ b/app/views/layouts/app/page_flash.rb
@@ -6,7 +6,7 @@ module Views::Layouts::App
   # so JS has a stable mount point.
   class PageFlash < Views::Base
     def view_template
-      div(class: "container-full hidden-print", id: "page_flash") do
+      div(class: "hidden-print", id: "page_flash") do
         render(FlashNotices.new)
       end
     end

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -117,8 +117,8 @@ module Views::Layouts
         render(Views::Layouts::Header.new(
                  any_content_filters_applied: @any_content_filters_applied
                ))
-        main(id: "content", class: content_classes,
-             data: { controller: "lightgallery" }) do
+        Container(element: :main, id: "content", class: content_classes,
+                  data: { controller: "lightgallery" }) do
           comment { "MAIN_PAGE_CONTENT" }
           yield
           comment { "/MAIN_PAGE_CONTENT" }

--- a/app/views/layouts/login_welcome.rb
+++ b/app/views/layouts/login_welcome.rb
@@ -16,7 +16,7 @@ module Views::Layouts
   class LoginWelcome < Views::Base
     def view_template
       comment { "LOGIN WELCOME" }
-      div(class: "container-text") do
+      Container(width: :text) do
         div(class: "text-center visible-xs-block") do
           img(class: "logo-trim", alt: "MO Logo", src: "/logo-trim.png")
         end

--- a/test/components/container_test.rb
+++ b/test/components/container_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class ContainerTest < ComponentTestCase
+  def test_class_for_known_widths
+    assert_equal("container-text", Components::Container.class_for(:text))
+    assert_equal("container-text-image",
+                 Components::Container.class_for(:text_image))
+    assert_equal("container-wide", Components::Container.class_for(:wide))
+    assert_equal("container-full", Components::Container.class_for(:full))
+  end
+
+  def test_class_for_unrecognized_width_falls_back_to_full
+    assert_equal("container-full", Components::Container.class_for(:double))
+    assert_equal("container-full", Components::Container.class_for(nil))
+  end
+
+  def test_default_is_a_plain_div_with_no_width_class
+    html = render(Components::Container.new)
+
+    assert_html(html, "div")
+    assert_no_html(html, "div[class*='container']")
+  end
+
+  def test_width_renders_matching_class
+    html = render(Components::Container.new(width: :wide))
+
+    assert_html(html, "div.container-wide")
+  end
+
+  def test_element_renders_alternate_tag
+    html = render(Components::Container.new(element: :main, width: :text))
+
+    assert_html(html, "main.container-text")
+    assert_no_html(html, "div.container-text")
+  end
+
+  def test_extra_class_merges_with_width_class
+    html = render(Components::Container.new(width: :text, class: "ml-4"))
+
+    assert_html(html, "div.container-text.ml-4")
+  end
+
+  def test_extra_class_alone_with_no_width
+    html = render(Components::Container.new(class: "hidden-print"))
+
+    assert_html(html, "div.hidden-print")
+    assert_no_html(html, "div.container-full")
+  end
+
+  def test_other_attrs_pass_through
+    html = render(Components::Container.new(
+                    id: "content", data: { controller: "lightgallery" }
+                  ))
+
+    assert_html(html, "div#content[data-controller='lightgallery']")
+  end
+
+  def test_yields_content
+    html = render(phlex_wrapper do
+      render(Components::Container.new(width: :text)) { plain("hello") }
+    end)
+
+    assert_html(html, "div.container-text", text: "hello")
+  end
+
+  private
+
+  # Returns an anonymous Components::Base instance whose view_template
+  # runs the given block in Phlex context (so `plain`, `div`, `render`
+  # etc. are all available).
+  def phlex_wrapper(&block)
+    Class.new(Components::Base) do
+      define_method(:view_template, &block)
+    end.new
+  end
+end


### PR DESCRIPTION
## Summary

First of 3 planned PRs building reusable Bootstrap grid/layout primitives — `Container` here, `Row` next, `Column` last (the last one will likely need a rethink of MO's Grid-classes API, e.g. `Column(xs: 12, sm: 9)`).

MO's page width was controlled by `container_class(width)` (`Views::FullPageBase::LayoutClasses`) — a setter every page view calls, writing a computed CSS class string into `content_for(:container_class)`, which the shared layout reads back onto its one hardcoded `<main id="content">`. Meanwhile ~21 other call sites across page views hardcoded the same `container-text`/`container-full` strings directly for sub-section width limits, duplicating the mapping logic a third time.

`Components::Container` (`app/components/container.rb`) follows the existing `Collapsible`/`Navbar` prop pattern (`prop :element, Symbol, default: :div`, `prop :attributes, _Hash(Symbol, _Any?), :**`, dispatch via `send(@element, ...)`) to centralize the width-symbol -> CSS-class mapping in one place (`WIDTH_CLASSES` / `.class_for`), usable both as a renderable component and as a class-string source for callers that can't render it directly.

### Changes

- `container_class`'s case statement now calls `Components::Container.class_for` internally — same signature/`content_for` side effect, all 114 existing callers unaffected.
- `Views::Layouts::Application`'s hardcoded `<main>` becomes `Container(element: :main, ...)`.
- 17 hardcoded `div(class: "container-*")` sites (plain wraps + ones with extra utility classes) converted to `Container(width: ...)`, including `herbaria/index.rb`'s merge-mode `Alert`, which now wraps the `Alert` instead of merging `container-text` into the `Alert`'s own `class:`.
- `page_flash.rb`: `container-full` was a no-op (no CSS rule was ever defined for it) — dropped entirely rather than routed through the mapping.
- `login_welcome.rb`: converted for consistency (dead code, call site commented out, kept for future re-enablement).
- `sequences/show.rb` and `observations/identify/index.rb` were merging the width class into `ContentPadded`'s/a raw class list instead of wrapping — both restructured to `Container(width: :text) { ContentPadded { ... } }`.
- Swept 4 remaining `content-block` usages (`field_slips/index.rb`, `glossary_terms/show.rb` x3) to `ContentPadded` — `content-block` was `@extend .p-3` in `_content.scss`, i.e. a duplicate of `ContentPadded`'s own default class under a different name. Deleted the now-dead SCSS rule.

Deliberately left alone (a different existing component/builder merging the class string, not a `Container` wrap): the 3 `Components::Table` column sites in `names/lifeforms/form.rb` and `propagate/form.rb`.

This also sets up MO's Bootstrap 3->4 migration ([#3797](https://github.com/MushroomObserver/mushroom-observer/issues/3797)): Bootstrap 4's container classes may eventually replace or need to coexist with MO's custom pixel-based `container-*` classes. Centralizing the mapping now means that migration only touches one table, not every call site.

## Test plan

- [x] `bin/rails test test/components/container_test.rb` — new: width mapping (all 4 named symbols + unrecognized-symbol fallback), `element:` dispatch, `class:` merge (both present / only one / neither), other attrs pass through, `self.class_for` callable directly
- [x] `bin/rails test test/views/full_page_base/layout_classes_test.rb test/views/layouts/application_test.rb test/views/layouts/login_welcome_test.rb` — confirm `container_class`/layout `<main>` swap unaffected
- [x] `bin/rails test test/views/controllers/sequences/show_test.rb test/views/controllers/field_slips/index_test.rb test/controllers/glossary_terms_controller_test.rb test/controllers/observations/identify_controller_test.rb test/views/controllers/images/licenses/form_test.rb test/views/controllers/herbaria/index_test.rb` — all converted call sites with dedicated tests
- [x] `bin/rails test test/controllers/publications_controller_test.rb test/views/controllers/descriptions/form_test.rb test/controllers/translations_controller_test.rb test/views/controllers/translations/index_test.rb test/controllers/account/api_keys_controller_test.rb test/components/image/reuse_form_test.rb test/views/controllers/projects/form_test.rb test/views/controllers/projects/members/form_test.rb test/controllers/species_lists/name_lists_controller_test.rb test/controllers/herbarium_records_controller_test.rb test/controllers/collection_numbers_controller_test.rb test/controllers/visual_groups_controller_test.rb test/views/controllers/field_slips/form_test.rb` — remaining converted call sites without a dedicated view test, via their controller tests
- [x] `bundle exec rubocop` clean on all touched/created files
- [x] No `db/schema.rb` drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
