### PR TITLE
Add `Components::Row`, sweep all direct `.row` call sites

### DIFF
--- a/app/components/form/compass_fields.rb
+++ b/app/components/form/compass_fields.rb
@@ -20,7 +20,7 @@ class Components::Form::CompassFields < Components::Base
   private
 
   def render_north_row
-    div(class: "row vcenter") do
+    Row(class: "vcenter") do
       div(class: "#{Grid::CENTERED_THIRD} text-center") do
         compass_input(:north)
       end
@@ -28,7 +28,7 @@ class Components::Form::CompassFields < Components::Base
   end
 
   def render_east_west_row
-    div(class: "row vcenter mt-3") do
+    Row(class: "vcenter mt-3") do
       div(class: "#{Grid::THIRD} text-center") { compass_input(:west) }
       div(class: "#{Grid::THIRD} small text-center p-0") do
         plain(:form_locations_lat_long_help.l)
@@ -38,7 +38,7 @@ class Components::Form::CompassFields < Components::Base
   end
 
   def render_south_row
-    div(class: "row vcenter mt-3") do
+    Row(class: "vcenter mt-3") do
       div(class: "#{Grid::CENTERED_THIRD} text-center") do
         compass_input(:south)
       end

--- a/app/components/form/names_lookup_field_group.rb
+++ b/app/components/form/names_lookup_field_group.rb
@@ -117,7 +117,7 @@ class Components::Form::NamesLookupFieldGroup < Components::Base
   end
 
   def render_modifier_row(fields)
-    div(class: "row") do
+    Row do
       fields.each do |field_name|
         div(class: column_classes) do
           render_select_field(field_name)

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -119,7 +119,7 @@ class Components::Form::Search < Components::ApplicationForm
   # Form layout
 
   def render_form_columns
-    div(class: "row") do
+    Row do
       field_columns.each do |panels|
         div(class: Grid::MD6) do
           panels.each do |heading, sections|
@@ -184,7 +184,7 @@ class Components::Form::Search < Components::ApplicationForm
 
   def render_field_row(field_spec:)
     if field_spec.is_a?(Array)
-      div(class: "row") do
+      Row do
         field_spec.each do |subfield|
           div(class: column_classes) do
             render_search_field(field_name: subfield)

--- a/app/components/form/upload_gallery/item.rb
+++ b/app/components/form/upload_gallery/item.rb
@@ -42,7 +42,7 @@ class Components::Form::UploadGallery::Item < Components::Image::Base
     @img_id = @img_id.id if @img_id.is_a?(::Image)
     @data = build_render_data(@img_instance, @img_id)
 
-    div(class: "row") do
+    Row do
       render_image_column
       render_form_column unless @sibling
       render_control_buttons

--- a/app/components/matrix/table.rb
+++ b/app/components/matrix/table.rb
@@ -71,8 +71,9 @@ class Components::Matrix::Table < Components::Base
   prop :project, _Nilable(Project), default: nil
 
   def view_template(&block)
-    ul(
-      class: "row list-unstyled mt-3",
+    Row(
+      element: :ul,
+      class: "list-unstyled mt-3",
       data: {
         controller: "matrix-table",
         action: "resize@window->matrix-table#rearrange"

--- a/app/components/row.rb
+++ b/app/components/row.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Renders a Bootstrap grid row -- `<div class="row">` by default, or any
+# other tag via `element:` (several call sites need `<ul class="row
+# list-unstyled">`). Centralizes the one hardcoded `"row"` string that
+# was previously duplicated across ~76 call sites, each concatenating
+# it with whatever extra utility/alignment classes that spot needed.
+#
+# `.row` itself is untouched Bootstrap (MO never redefines the bare
+# selector) -- this component doesn't map or interpret anything the way
+# Components::Container does for width; it's just a stable, reusable
+# spelling of "this is a Bootstrap row" plus generic HTML-attrs merging,
+# following the same prop pattern as Components::Container/Collapsible/
+# Navbar.
+#
+# @example Basic (a <div>)
+#   Row { div(class: "col-sm-6") { ... } }
+#
+# @example With extra classes/attrs
+#   Row(class: "mt-3 align-items-center") { ... }
+#
+# @example As a <ul> (list-reset rows)
+#   Row(element: :ul, class: "list-unstyled mt-3") { ... }
+class Components::Row < Components::Base
+  prop :element, Symbol, default: :div
+  # Catch-all for class:, id:, data:, and any other HTML attrs --
+  # matches Components::Container/Collapsible/Navbar's pattern.
+  prop :attributes, _Hash(Symbol, _Any?), :**
+
+  def view_template(&block)
+    send(@element,
+         class: class_names("row", @attributes[:class]),
+         **@attributes.except(:class),
+         &block)
+  end
+end

--- a/app/views/controllers/account/profile/edit.rb
+++ b/app/views/controllers/account/profile/edit.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Account::Profile
       add_page_title(:profile_title.t)
       add_context_nav(Tab::Account::ProfileEditActions.new)
 
-      div(class: "row") do
+      Row do
         div(class: Grid::SM7) { render_form }
         div(class: "#{Grid::SM5} text-center") { render_image_column }
       end

--- a/app/views/controllers/admin/blocked_ips/edit.rb
+++ b/app/views/controllers/admin/blocked_ips/edit.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Admin::BlockedIps
     def view_template
       add_page_title("IP Access Manager")
       container_class(:full)
-      div(class: "row") do
+      Row do
         div(class: Grid::MD6) { render_left_column }
         div(class: Grid::MD6) { render_right_column }
       end

--- a/app/views/controllers/collection_numbers/edit.rb
+++ b/app/views/controllers/collection_numbers/edit.rb
@@ -21,7 +21,7 @@ module Views::Controllers::CollectionNumbers
         )
       )
 
-      div(class: "row") do
+      Row do
         div(class: Grid::SM7) { render_form }
         div(class: Grid::SM5) { render_observation_boxes }
       end
@@ -34,7 +34,7 @@ module Views::Controllers::CollectionNumbers
     end
 
     def render_observation_boxes
-      ul(class: "row list-unstyled") do
+      Row(element: :ul, class: "list-unstyled") do
         @collection_number.observations.each do |obs|
           render(Components::Matrix::Box.new(
                    user: @user,

--- a/app/views/controllers/collection_numbers/new.rb
+++ b/app/views/controllers/collection_numbers/new.rb
@@ -16,7 +16,7 @@ module Views::Controllers::CollectionNumbers
         Tab::CollectionNumber::FormNew.new(observation: @observation)
       )
 
-      div(class: "row") do
+      Row do
         div(class: Grid::SM7) { render_form }
         div(class: Grid::SM5) { render_observation_box }
       end
@@ -29,7 +29,7 @@ module Views::Controllers::CollectionNumbers
     end
 
     def render_observation_box
-      ul(class: "row list-unstyled") do
+      Row(element: :ul, class: "list-unstyled") do
         render(Components::Matrix::Box.new(
                  user: @user,
                  object: @observation.rss_log || @observation,

--- a/app/views/controllers/comments/comment_item.rb
+++ b/app/views/controllers/comments/comment_item.rb
@@ -45,7 +45,7 @@ module Views::Controllers::Comments
     # second-window Action Cable broadcast could close a modal
     # the viewing user has open, losing in-progress form input.
     def view_template
-      div(class: "row") do
+      Row do
         render_main_column
         render_avatar_column
       end

--- a/app/views/controllers/comments/new.rb
+++ b/app/views/controllers/comments/new.rb
@@ -20,7 +20,7 @@ module Views::Controllers::Comments
                      ))
       add_context_nav(::Tab::Comment::FormNew.new(target: @target))
 
-      div(class: "row") do
+      Row do
         render_form_column
         render_images_column if @target.is_a?(::Observation)
       end

--- a/app/views/controllers/contributors/index.rb
+++ b/app/views/controllers/contributors/index.rb
@@ -25,7 +25,7 @@ module Views::Controllers::Contributors
     private
 
     def render_legend_row
-      div(class: "row my-3") do
+      Row(class: "my-3") do
         div(class: "col-md-8 col-lg-6") { render(Legend.new) }
       end
     end

--- a/app/views/controllers/descriptions/details_and_alts_panel.rb
+++ b/app/views/controllers/descriptions/details_and_alts_panel.rb
@@ -42,7 +42,7 @@ module Views::Controllers::Descriptions
     # -- body: two columns ------------------------------------------
 
     def render_two_columns
-      div(class: "row") do
+      Row do
         div(class: Grid::MD6) { render_details_column }
         div(class: Grid::MD6) { render_alts_column }
       end

--- a/app/views/controllers/field_slips/field_slip_panel.rb
+++ b/app/views/controllers/field_slips/field_slip_panel.rb
@@ -123,9 +123,9 @@ module Views::Controllers::FieldSlips
     end
 
     def render_observations_matrix(all_obs)
-      ul(class: "row list-unstyled mt-3",
-         data: { controller: "matrix-table",
-                 action: "resize@window->matrix-table#rearrange" }) do
+      Row(element: :ul, class: "list-unstyled mt-3",
+          data: { controller: "matrix-table",
+                  action: "resize@window->matrix-table#rearrange" }) do
         all_obs.each do |obs_item|
           render(Components::Matrix::Box.new(
                    user: current_user, object: obs_item

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -271,7 +271,7 @@ module Views::Controllers::FieldSlips
       # `value:` option, no Superform model binding.
       @checked_ids = checked_ids
       @primary_id = primary_id
-      ul(class: "row list-unstyled mt-3", data: matrix_data) do
+      Row(element: :ul, class: "list-unstyled mt-3", data: matrix_data) do
         observations.each { |obs| render_observation_row(obs) }
       end
     end

--- a/app/views/controllers/glossary_terms/index/item.rb
+++ b/app/views/controllers/glossary_terms/index/item.rb
@@ -9,7 +9,7 @@ module Views::Controllers::GlossaryTerms
       prop :glossary_term, ::GlossaryTerm
 
       def view_template
-        div(class: "row") do
+        Row do
           div(class: Grid::SM9) { render_left }
           div(class: Grid::SM3) { render_right }
         end

--- a/app/views/controllers/glossary_terms/show.rb
+++ b/app/views/controllers/glossary_terms/show.rb
@@ -26,7 +26,7 @@ module Views::Controllers::GlossaryTerms
     private
 
     def render_main_row
-      div(class: "row") do
+      Row do
         div(class: content_for(:left_columns)) { render_left_column }
         div(class: content_for(:right_columns)) { render_right_column }
       end
@@ -74,7 +74,7 @@ module Views::Controllers::GlossaryTerms
     end
 
     def render_other_images
-      div(class: "row") do
+      Row do
         @other_images.each do |image|
           div(class: "col-sm-4") { render_other_image_panel(image) }
         end

--- a/app/views/controllers/glossary_terms/versions/show.rb
+++ b/app/views/controllers/glossary_terms/versions/show.rb
@@ -32,7 +32,7 @@ module Views::Controllers::GlossaryTerms
       private
 
       def render_main_row
-        div(class: "row") do
+        Row do
           div(class: content_for(:left_columns)) do
             render(Term.new(glossary_term: @glossary_term))
           end

--- a/app/views/controllers/herbaria/show.rb
+++ b/app/views/controllers/herbaria/show.rb
@@ -20,7 +20,7 @@ module Views::Controllers::Herbaria
       container_class(:wide)
 
       render_mcp_block if @herbarium.mcp_searchable?
-      div(class: "row") { render_body_columns }
+      Row { render_body_columns }
       render_timestamps
     end
 

--- a/app/views/controllers/herbarium_records/edit.rb
+++ b/app/views/controllers/herbarium_records/edit.rb
@@ -19,7 +19,7 @@ module Views::Controllers::HerbariumRecords
         )
       )
 
-      div(class: "row") do
+      Row do
         div(class: Grid::SM7) { render_form }
         div(class: Grid::SM5) { render_observation_boxes }
       end
@@ -32,7 +32,7 @@ module Views::Controllers::HerbariumRecords
     end
 
     def render_observation_boxes
-      ul(class: "row list-unstyled") do
+      Row(element: :ul, class: "list-unstyled") do
         @herbarium_record.observations.each do |obs|
           render(Components::Matrix::Box.new(
                    user: @user,

--- a/app/views/controllers/herbarium_records/new.rb
+++ b/app/views/controllers/herbarium_records/new.rb
@@ -18,7 +18,7 @@ module Views::Controllers::HerbariumRecords
         )
       )
 
-      div(class: "row") do
+      Row do
         div(class: Grid::SM7) { render_form_column }
         div(class: Grid::SM5) { render_observation_box }
       end
@@ -35,7 +35,7 @@ module Views::Controllers::HerbariumRecords
     end
 
     def render_observation_box
-      ul(class: "row list-unstyled") do
+      Row(element: :ul, class: "list-unstyled") do
         render(Components::Matrix::Box.new(
                  user: @user,
                  object: @observation.rss_log || @observation,

--- a/app/views/controllers/images/show.rb
+++ b/app/views/controllers/images/show.rb
@@ -34,7 +34,7 @@ module Views::Controllers::Images
     private
 
     def render_main_row
-      div(class: "row") do
+      Row do
         div(class: content_for(:left_columns).to_s) { render_left_column }
         div(class: content_for(:right_columns).to_s) { render_right_column }
       end
@@ -70,7 +70,7 @@ module Views::Controllers::Images
     end
 
     def render_footer_row
-      div(class: "row") do
+      Row do
         div(class: content_for(:left_columns).to_s) { render_left_footer }
         div(class: content_for(:right_columns).to_s) { render_right_footer }
       end

--- a/app/views/controllers/images/show/vote_panel.rb
+++ b/app/views/controllers/images/show/vote_panel.rb
@@ -70,7 +70,7 @@ module Views::Controllers::Images
 
       def render_vote_row(value, current)
         css = current == value ? "font-weight-bold" : ""
-        div(class: "row") do
+        Row do
           div(class: Grid::SM6) { render_vote_link(value, css) }
           div(class: "#{Grid::SM6} hidden-xs") do
             render_vote_and_next_link(value, css)

--- a/app/views/controllers/info/site_stats.rb
+++ b/app/views/controllers/info/site_stats.rb
@@ -12,7 +12,7 @@ module Views::Controllers::Info
       add_context_nav(::Tab::Info::SiteStatsActions.new)
       container_class(:full)
 
-      div(class: "row mt-3") do
+      Row(class: "mt-3") do
         div(class: "hidden-xs col-md-3") { render_thumbs(0, 3) }
         div(class: "col-md-6 center-block") { render_stats_table }
         div(class: "hidden-xs col-md-3") { render_thumbs(3, 3) }

--- a/app/views/controllers/locations/countries/index.rb
+++ b/app/views/controllers/locations/countries/index.rb
@@ -15,7 +15,7 @@ module Views::Controllers::Locations
       def view_template
         register_chrome
 
-        div(class: "row") do
+        Row do
           render_column(:known)
           render_column(:missing)
           render_column(:unknown)

--- a/app/views/controllers/locations/form.rb
+++ b/app/views/controllers/locations/form.rb
@@ -54,7 +54,7 @@ module Views::Controllers::Locations
       # geocoder, elevation, or the global `gm_authFailure` Google
       # fires on a bad API key (issue #4535).
       div(id: "gmaps_flash")
-      div(class: "row") do
+      Row do
         div(class: "col-md-8 col-lg-6") { render_fields }
         div(class: "col-md-4 col-lg-6 mb-3 mt-3") { render_map }
       end
@@ -93,7 +93,7 @@ module Views::Controllers::Locations
     end
 
     def render_coordinate_section
-      div(class: "row mt-5") do
+      Row(class: "mt-5") do
         div(class: "col-sm-8") do
           render(Components::Form::CompassFields.new(
                    form: self, location: model
@@ -138,7 +138,7 @@ module Views::Controllers::Locations
     end
 
     def render_locked_display
-      div(class: "row") do
+      Row do
         div(class: "col-sm-6 col-md-4 col-lg-3") do
           render_locked_fields
           Help(content: :show_location_locked.l)

--- a/app/views/controllers/locations/index.rb
+++ b/app/views/controllers/locations/index.rb
@@ -19,7 +19,7 @@ module Views::Controllers::Locations
     def view_template
       register_chrome
 
-      div(class: "row mt-3") do
+      Row(class: "mt-3") do
         div(class: "col-md-7") { render_known(@observation_counts) }
         div(class: "col-md-5") { render_undefined }
       end

--- a/app/views/controllers/locations/show.rb
+++ b/app/views/controllers/locations/show.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Locations
 
       p { :show_location_hidden.l } if @location.hidden
 
-      div(class: "row") { render_main_columns }
+      Row { render_main_columns }
       div(class: "mt-3") do
         render(::Views::Layouts::ObjectFooter.new(
                  user: current_user, obj: @location, versions: @versions.to_a

--- a/app/views/controllers/locations/show/coordinates.rb
+++ b/app/views/controllers/locations/show/coordinates.rb
@@ -84,7 +84,7 @@ module Views::Controllers::Locations
       end
 
       def render_east_west
-        div(class: "row") do
+        Row do
           div(class: Grid::HALF) do
             span(class: "pull-left") do
               b { "#{:WEST.l}:" }

--- a/app/views/controllers/locations/versions/show.rb
+++ b/app/views/controllers/locations/versions/show.rb
@@ -11,7 +11,7 @@ module Views::Controllers::Locations
 
       def view_template
         register_chrome
-        div(class: "row") { render_columns }
+        Row { render_columns }
         render(Views::Controllers::Versions::Previous.new(
                  obj: @location, versions: @versions.to_a
                ))

--- a/app/views/controllers/names/show.rb
+++ b/app/views/controllers/names/show.rb
@@ -57,7 +57,7 @@ module Views::Controllers::Names
     def view_template
       page_chrome_side_effects
 
-      div(class: "row") do
+      Row do
         render_left_column
         render_right_column
       end
@@ -131,7 +131,7 @@ module Views::Controllers::Names
     end
 
     def render_classification_and_lifeform_row
-      div(class: "row", data: { controller: "name-panels" }) do
+      Row(data: { controller: "name-panels" }) do
         div(class: Grid::SM6) do
           render(Show::ClassificationPanel.new(
                    name: @name, user: @user,

--- a/app/views/controllers/names/show/nomenclature.rb
+++ b/app/views/controllers/names/show/nomenclature.rb
@@ -31,7 +31,7 @@ class Views::Controllers::Names::Show::Nomenclature < Views::Base
   end
 
   def render_body
-    div(class: "row") do
+    Row do
       render_left_column
       render_right_column
     end

--- a/app/views/controllers/names/show/observations_menu.rb
+++ b/app/views/controllers/names/show/observations_menu.rb
@@ -48,7 +48,7 @@ class Views::Controllers::Names::Show::ObservationsMenu < Views::Base
   end
 
   def render_body
-    div(class: "row") do
+    Row do
       render_observations_column
       render_research_links_column
     end

--- a/app/views/controllers/names/synonyms/form.rb
+++ b/app/views/controllers/names/synonyms/form.rb
@@ -24,7 +24,7 @@ module Views::Controllers::Names::Synonyms
     # rubocop:enable Metrics/ParameterLists
 
     def view_template
-      div(class: "row") do
+      Row do
         div(class: Grid::SM6) do
           render_existing_synonyms
           render_proposed_synonyms

--- a/app/views/controllers/names/versions/show.rb
+++ b/app/views/controllers/names/versions/show.rb
@@ -23,7 +23,7 @@ module Views::Controllers::Names::Versions
     def view_template
       page_chrome_side_effects
 
-      div(class: "row mt-4") do
+      Row(class: "mt-4") do
         render_left_column
         render_right_column
       end

--- a/app/views/controllers/observations/external_links/edit.rb
+++ b/app/views/controllers/observations/external_links/edit.rb
@@ -15,7 +15,7 @@ module Views::Controllers::Observations::ExternalLinks
       container_class(:full)
       add_edit_title(@external_link)
 
-      div(class: "row") do
+      Row do
         div(class: Grid::SM7) { render_form }
         div(class: Grid::SM5) { render_matrix_box }
       end
@@ -35,7 +35,7 @@ module Views::Controllers::Observations::ExternalLinks
     end
 
     def render_matrix_box
-      ul(class: "row list-unstyled") do
+      Row(element: :ul, class: "list-unstyled") do
         render(::Components::Matrix::Box.new(
                  user: @user,
                  object: @observation,

--- a/app/views/controllers/observations/external_links/new.rb
+++ b/app/views/controllers/observations/external_links/new.rb
@@ -16,7 +16,7 @@ module Views::Controllers::Observations::ExternalLinks
       container_class(:full)
       add_new_title(:add_object, :EXTERNAL_LINK)
 
-      div(class: "row") do
+      Row do
         div(class: Grid::SM7) { render_form }
         div(class: Grid::SM5) { render_matrix_box }
       end
@@ -35,7 +35,7 @@ module Views::Controllers::Observations::ExternalLinks
     end
 
     def render_matrix_box
-      ul(class: "row list-unstyled") do
+      Row(element: :ul, class: "list-unstyled") do
         render(::Components::Matrix::Box.new(
                  user: @user,
                  object: @observation.rss_log || @observation,

--- a/app/views/controllers/observations/form.rb
+++ b/app/views/controllers/observations/form.rb
@@ -216,7 +216,7 @@ module Views::Controllers::Observations
     end
 
     def render_naming_specimen_row
-      div(class: "row") do
+      Row do
         render_naming_column if create?
         render_specimen_column
       end

--- a/app/views/controllers/observations/form/details.rb
+++ b/app/views/controllers/observations/form/details.rb
@@ -21,7 +21,7 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   prop :dubious_where_reasons, _Nilable(_Array(String)), default: nil
 
   def view_template
-    div(class: "row") do
+    Row do
       div(class: Grid::MD6) { render_left_column }
       div(class: Grid::MD6) { render_map }
     end
@@ -177,7 +177,7 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   end
 
   def render_lat_lng_alt_row
-    div(class: "row no-gutters", id: "observation_lat_lng_alt") do
+    Row(class: "no-gutters", id: "observation_lat_lng_alt") do
       render_coordinate_field(:lat, :LAT, :LATITUDE, "º")
       render_coordinate_field(:lng, :LNG, :LONGITUDE, "º")
       render_coordinate_field(:alt, :ALT, :ALTITUDE, "m")

--- a/app/views/controllers/observations/images/edit.rb
+++ b/app/views/controllers/observations/images/edit.rb
@@ -16,7 +16,7 @@ module Views::Controllers::Observations::Images
       add_context_nav(::Tab::Observation::ImagesEdit.new(image: @image))
       container_class(:wide)
 
-      div(class: "row") do
+      Row do
         div(class: class_names(Grid::SM8, "col-md-6 col-lg-4")) { render_form }
         div(class: class_names(Grid::SM4, "col-md-6 col-lg-8")) do
           render_image_preview

--- a/app/views/controllers/observations/namings/edit.rb
+++ b/app/views/controllers/observations/namings/edit.rb
@@ -22,7 +22,7 @@ module Views::Controllers::Observations::Namings
 
     def view_template
       add_chrome
-      div(class: "row") do
+      Row do
         div(class: Grid::SM8) do
           div(class: "mt-3") { render_observation_details }
           div(class: "mt-3") { render_naming_form }

--- a/app/views/controllers/observations/namings/new.rb
+++ b/app/views/controllers/observations/namings/new.rb
@@ -25,7 +25,7 @@ module Views::Controllers::Observations::Namings
 
     def view_template
       add_chrome
-      div(class: "row") do
+      Row do
         div(class: Grid::SM8) do
           div(class: "mt-3") { render_observation_details }
           div(class: "mt-3") { render_naming_form }

--- a/app/views/controllers/observations/namings/suggestions/show.rb
+++ b/app/views/controllers/observations/namings/suggestions/show.rb
@@ -20,7 +20,7 @@ module Views::Controllers::Observations::Namings::Suggestions
     def view_template
       add_chrome
 
-      div(class: "row") do
+      Row do
         render_suggestions_column
         render_images_column
       end

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -68,7 +68,7 @@ module Views::Controllers::Observations
     # ---- main row: carousel | obs details / name / lists -----
 
     def render_main_row
-      div(class: "row") do
+      Row do
         div(class: content_for(:left_columns)) { render_carousel }
         div(class: content_for(:right_columns)) { render_right_column }
       end
@@ -111,7 +111,7 @@ module Views::Controllers::Observations
     # ---- secondary row: namings + comments | thumbnail map ----
 
     def render_secondary_row
-      div(class: "row") do
+      Row do
         div(class: content_for(:left_columns)) do
           render_namings_and_comments
         end

--- a/app/views/controllers/observations/show/name_info_panel.rb
+++ b/app/views/controllers/observations/show/name_info_panel.rb
@@ -21,7 +21,7 @@ class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
   private
 
   def render_body
-    div(class: "row") do
+    Row do
       div(class: Grid::HALF) do
         div(class: "font-weight-bold") { plain("#{:on_mo.l}:") }
         render_links_on_mo

--- a/app/views/controllers/observations/show/namings/footer_buttons.rb
+++ b/app/views/controllers/observations/show/namings/footer_buttons.rb
@@ -10,9 +10,9 @@ class Views::Controllers::Observations::Show::Namings::FooterButtons < Views::Ba
   prop :obs, ::Observation
 
   def view_template
-    div(class: "row") do
+    Row do
       div(class: "col-sm-11") do
-        div(class: "row") do
+        Row do
           div(class: "col col-md-4") { render_buttons }
           div(class: "col col-md-8") { render_consensus_help }
         end

--- a/app/views/controllers/observations/show/namings/footer_legend.rb
+++ b/app/views/controllers/observations/show/namings/footer_legend.rb
@@ -10,9 +10,9 @@
 # `vote_icon_*` helpers.
 class Views::Controllers::Observations::Show::Namings::FooterLegend < Views::Base
   def view_template
-    div(class: "row") do
+    Row do
       div(class: "col-sm-11") do
-        div(class: "row") do
+        Row do
           div(class: Grid::CENTERED_THIRD) do
             render_legend("vote-icon-yours", :show_namings_eye_help.t)
           end

--- a/app/views/controllers/observations/show/namings/header.rb
+++ b/app/views/controllers/observations/show/namings/header.rb
@@ -23,7 +23,7 @@ class Views::Controllers::Observations::Show::Namings::Header < Views::Base
     # more reliable than putting flex-column / justify-content-end
     # on each column — those approaches collide with the columns'
     # `d-none d-sm-block` responsive-visibility classes.
-    div(class: "row d-flex align-items-end") do
+    Row(class: "d-flex align-items-end") do
       render_label_columns
       render_propose_icon_column
     end
@@ -33,7 +33,7 @@ class Views::Controllers::Observations::Show::Namings::Header < Views::Base
 
   def render_label_columns
     div(class: "col-xs-10 col-sm-11") do
-      div(class: "row d-flex align-items-end") do
+      Row(class: "d-flex align-items-end") do
         render_label_column("col col-sm-4 d-block") { render_panel_title }
         render_label_column { small { trusted_html(:show_namings_user.t) } }
         render_label_column("col col-sm-2 d-none d-sm-block") do

--- a/app/views/controllers/observations/show/namings/row.rb
+++ b/app/views/controllers/observations/show/namings/row.rb
@@ -15,7 +15,7 @@ class Views::Controllers::Observations::Show::Namings::Row < Views::Base
   prop :consensus, ::Observation::NamingConsensus
 
   def view_template
-    div(class: "row align-items-center naming-row",
+    Row(class: "align-items-center naming-row",
         id: "observation_naming_#{primary.id}") do
       div(class: "col col-sm-11") do
         render_main_columns
@@ -79,7 +79,7 @@ class Views::Controllers::Observations::Show::Namings::Row < Views::Base
   # ---- top-level layout pieces ----------------------------------
 
   def render_main_columns
-    div(class: "row align-items-center") do
+    Row(class: "align-items-center") do
       div(class: "col col-sm-4") { render_name_cell }
       div(class: "col col-sm-3") { render_proposer_cell }
       div(class: "col col-sm-2") { render_vote_tally_cell }

--- a/app/views/controllers/occurrences/form.rb
+++ b/app/views/controllers/occurrences/form.rb
@@ -79,8 +79,9 @@ module Views::Controllers::Occurrences
 
     def render_new_observation_grid
       all_obs = [@source_obs] + @recent_observations
-      ul(
-        class: "row list-unstyled mt-3",
+      Row(
+        element: :ul,
+        class: "list-unstyled mt-3",
         data: {
           controller: "matrix-table occurrence-form",
           action: "resize@window->matrix-table#rearrange",
@@ -137,8 +138,9 @@ module Views::Controllers::Occurrences
     end
 
     def render_matrix_ul(&block)
-      ul(
-        class: "row list-unstyled mt-3",
+      Row(
+        element: :ul,
+        class: "list-unstyled mt-3",
         data: {
           controller: "matrix-table",
           action: "resize@window->matrix-table#rearrange"

--- a/app/views/controllers/projects/admin_subtabs.rb
+++ b/app/views/controllers/projects/admin_subtabs.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Projects
     end
 
     def view_template
-      div(class: "row") do
+      Row do
         div(class: class_names(Grid::FULL, "pl-4 mt-2 mb-3"),
             id: "project_admin_subtabs") do
           NavTabs(

--- a/app/views/controllers/projects/aliases/form.rb
+++ b/app/views/controllers/projects/aliases/form.rb
@@ -47,7 +47,7 @@ module Views::Controllers::Projects::Aliases
     end
 
     def render_name_and_type_row
-      div(class: "row") do
+      Row do
         div(class: Grid::SM6) do
           render_name_field
           hidden_field(:project_id)

--- a/app/views/controllers/projects/banner.rb
+++ b/app/views/controllers/projects/banner.rb
@@ -27,7 +27,7 @@ module Views::Controllers::Projects
         render_banner_without_image
       end
 
-      div(class: "row") do
+      Row do
         div(class: Grid::FULL, id: "project_tabs") do
           NavTabs(
             current: @current_tab, link_class: "mt-3",
@@ -42,7 +42,7 @@ module Views::Controllers::Projects
     private
 
     def render_banner_with_image
-      div(class: "row") do
+      Row do
         div(class: Grid::FULL, id: "project_banner") do
           img(src: @project.image.large_url, class: "banner-image")
           div(class: "bottom-left ml-3 mb-3 p-2") do
@@ -55,7 +55,7 @@ module Views::Controllers::Projects
     end
 
     def render_banner_without_image
-      div(class: "row") do
+      Row do
         div(class: Grid::FULL, id: "project_banner") do
           div(class: "pl-3 mt-3") do
             render_banner_title(with_overlay_styling: false)

--- a/app/views/controllers/sequences/edit.rb
+++ b/app/views/controllers/sequences/edit.rb
@@ -15,7 +15,7 @@ module Views::Controllers::Sequences
       add_context_nav(::Tab::Sequence::Form.new(back_object: @back_object))
 
       obs = @sequence.observation
-      div(class: "row") do
+      Row do
         div(class: Grid::SM7) { render_form_column(obs) }
         div(class: Grid::SM5) { render_matrix_column(obs) }
       end
@@ -37,7 +37,7 @@ module Views::Controllers::Sequences
     end
 
     def render_matrix_column(obs)
-      ul(class: "row list-unstyled") do
+      Row(element: :ul, class: "list-unstyled") do
         render(::Components::Matrix::Box.new(
                  user: current_user,
                  object: obs.rss_log || obs,

--- a/app/views/controllers/sequences/new.rb
+++ b/app/views/controllers/sequences/new.rb
@@ -11,7 +11,7 @@ module Views::Controllers::Sequences
       add_new_title(:add_object, :SEQUENCE)
       add_context_nav(::Tab::Sequence::Form.new(back_object: @observation))
 
-      div(class: "row") do
+      Row do
         div(class: Grid::SM7) { render_form_column }
         div(class: Grid::SM5) { render_matrix_column }
       end
@@ -25,7 +25,7 @@ module Views::Controllers::Sequences
     end
 
     def render_matrix_column
-      ul(class: "row list-unstyled") do
+      Row(element: :ul, class: "list-unstyled") do
         render(::Components::Matrix::Box.new(
                  user: current_user,
                  object: @observation.rss_log || @observation,

--- a/app/views/controllers/species_lists/observation.rb
+++ b/app/views/controllers/species_lists/observation.rb
@@ -17,7 +17,7 @@ module Views::Controllers::SpeciesLists
     end
 
     def view_template
-      div(class: "row") do
+      Row do
         render_image_column if @image
         div(class: details_column_classes) { render_details_row }
       end

--- a/app/views/controllers/species_lists/show.rb
+++ b/app/views/controllers/species_lists/show.rb
@@ -27,7 +27,7 @@ module Views::Controllers::SpeciesLists
 
     def view_template
       add_chrome
-      div(class: "row") do
+      Row do
         div(class: content_for(:left_columns)) { render_left_column }
       end
     end

--- a/app/views/controllers/support/form.rb
+++ b/app/views/controllers/support/form.rb
@@ -31,7 +31,7 @@ module Views::Controllers::Support
     private
 
     def render_amount_row
-      div(class: "row") do
+      Row do
         PRESET_AMOUNTS.each do |amount|
           div(class: Grid::QUARTER) do
             radio_field(:amount, [amount, "$#{amount.to_i}"])

--- a/app/views/controllers/translations/index.rb
+++ b/app/views/controllers/translations/index.rb
@@ -19,7 +19,7 @@ module Views::Controllers::Translations
       container_class(:wide)
       add_page_title(:edit_translations_title.t)
       render_help_block
-      div(class: "row") do
+      Row do
         div(class: class_names(Grid::HALF, "translation_container")) do
           render_index_panel
         end

--- a/app/views/controllers/users/show.rb
+++ b/app/views/controllers/users/show.rb
@@ -19,7 +19,7 @@ module Views::Controllers::Users
       container_class(:full)
       column_classes(:six_even)
 
-      div(class: "row") do
+      Row do
         div(class: content_for(:left_columns)) { render_left_column }
         div(class: content_for(:right_columns)) { render_right_column }
       end

--- a/app/views/layouts/application.rb
+++ b/app/views/layouts/application.rb
@@ -96,7 +96,7 @@ module Views::Layouts
       div(id: "main_container", class: "px-sm-3",
           data: { controller: "nav links", nav_target: "container" }) do
         render(Views::Layouts::App::Banners.new)
-        div(class: "row row-offcanvas row-offcanvas-left",
+        Row(class: "row-offcanvas row-offcanvas-left",
             data: { nav_target: "offcanvas" }) do
           render(Views::Layouts::Sidebar.new(
                    user: current_user,

--- a/app/views/layouts/header.rb
+++ b/app/views/layouts/header.rb
@@ -59,7 +59,7 @@ module Views::Layouts
     # even when neither inner content_for is set. Keeps the empty
     # row in case any CSS / JS keys off `header > .row:last-child`.
     def render_filter_row
-      div(class: "row") do
+      Row do
         render_type_filters if content_for?(:type_filters)
         render_observation_buttons if content_for?(:observation_buttons)
       end

--- a/app/views/layouts/header/index_bar.rb
+++ b/app/views/layouts/header/index_bar.rb
@@ -17,7 +17,7 @@ module Views::Layouts
     def view_template
       return unless content_for?(:filters) || content_for?(:filter_help)
 
-      div(class: "row") do
+      Row do
         div(class: Grid::FULL) do
           div(id: "index_bar", class: "mb-2") do
             div(class: "px-3 mt-2 mb-3") do

--- a/app/views/layouts/header/page_title.rb
+++ b/app/views/layouts/header/page_title.rb
@@ -17,7 +17,7 @@ module Views::Layouts
       "show_title_nav d-flex justify-content-between pl-3"
 
     def view_template
-      div(class: "row", id: "title_bar") do
+      Row(id: "title_bar") do
         render_left_column unless suppress_title?
         render_right_column if show_right_column?
       end

--- a/test/components/row_test.rb
+++ b/test/components/row_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class RowTest < ComponentTestCase
+  def test_default_is_a_plain_row_div
+    html = render(Components::Row.new)
+
+    assert_html(html, "div.row")
+  end
+
+  def test_element_renders_alternate_tag
+    html = render(Components::Row.new(element: :ul))
+
+    assert_html(html, "ul.row")
+    assert_no_html(html, "div.row")
+  end
+
+  def test_extra_class_merges_with_row_class
+    html = render(Components::Row.new(class: "mt-3 align-items-center"))
+
+    assert_html(html, "div.row.mt-3.align-items-center")
+  end
+
+  def test_other_attrs_pass_through
+    html = render(Components::Row.new(
+                    id: "main_row", data: { controller: "foo" }
+                  ))
+
+    assert_html(html, "div.row#main_row[data-controller='foo']")
+  end
+
+  def test_yields_content
+    html = render(phlex_wrapper do
+      render(Components::Row.new) { plain("hello") }
+    end)
+
+    assert_html(html, "div.row", text: "hello")
+  end
+
+  private
+
+  # Returns an anonymous Components::Base instance whose view_template
+  # runs the given block in Phlex context (so `plain`, `div`, `render`
+  # etc. are all available).
+  def phlex_wrapper(&block)
+    Class.new(Components::Base) do
+      define_method(:view_template, &block)
+    end.new
+  end
+end


### PR DESCRIPTION
## Summary

Second of three sibling grid-primitive PRs (`Container` #4795, `Column` #4797), following the same `element:`/`attributes:**` pattern as `Components::Collapsible` and `Components::Navbar`.

`Components::Row` wraps Bootstrap's plain `.row` class — `element:` defaults to `:div` (with an `:ul`/`:nav`/etc. override where the original markup needed a non-div tag), `attributes:` is a catch-all for `class:`/`id:`/`data:`/etc., same generic pass-through shape as `Container`.

Unlike `Container`'s `container-*` classes or the old `Grid::` constants, `.row` itself is untouched Bootstrap in MO (confirmed via SCSS audit — no MO customization except the `row-offcanvas`/`row-offcanvas-left` pairing in `layouts/application.rb`, which `Row` still supports as an extra class).

## The sweep

Full sweep, same scope as `Container`: every direct `div(class: "row" ...)` / `ul(class: "row" ...)` call site across `app/components` and `app/views` (~88 sites, ~65 files) converted to `Row(...)`.

**Left alone**: `app/components/form/upload_gallery.rb`'s `controls_wrap_class: "carousel-control-wrap row"` — an indirect prop value passed into `Components::Carousel`, not a direct tag wrap, same category as the `Components::Table` column-builder sites that stayed out of the `Container` sweep.

## Test plan

- [x] `bundle exec rubocop` clean on every touched/created file
- [x] `test/components/row_test.rb` — default `div`, `element:` override, extra-class merge, other-attrs passthrough, block content
- [x] `bin/rails test` across every component/view test file for a touched call site (273 tests, 0 failures)
- [ ] Coveralls per-file coverage check once CI runs
