### PR TITLE
Hash the small rendition, never the full-size original (Fixes #4796)

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -851,18 +851,22 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
 
   # Compute and store the perceptual hash (Image::Dhash) for this image
   # (#4585/#4673). Derived data, hence update_column — recomputing a hash
-  # is not an edit. Prefers a local file (fresh uploads: the original; the
-  # web server after cleanup: the small rendition); falls back to fetching
-  # the transferred medium rendition. dHash is resolution-invariant, so
-  # any rendition serves.
+  # is not an edit. dHash is resolution-invariant, so any rendition
+  # serves: hash the small (then medium) local rendition and NEVER the
+  # full-size original — decoding a large original with ImageMagick can
+  # exhaust the host (a routine 25 MP upload froze the site for ~3.5 min,
+  # #4796). The small rendition is generated before ImageDhashJob is
+  # enqueued (Image#process_image), so it is present on fresh
+  # uploads. With no local rendition (e.g. after the originals are
+  # cleaned up), fall back to fetching the transferred small rendition.
   def compute_dhash!
-    source = [:original, :medium, :small].
+    source = [:small, :medium].
              map { |size| full_filepath(size) }.
              find { |path| File.exist?(path) }
     value = if source
               Image::Dhash.from_file(source)
             else
-              Image::Dhash.from_url(medium_url)
+              Image::Dhash.from_url(small_url)
             end
     update_column(:dhash, value)
     value

--- a/test/jobs/image_dhash_job_test.rb
+++ b/test/jobs/image_dhash_job_test.rb
@@ -9,11 +9,14 @@ class ImageDhashJobTest < ActiveJob::TestCase
     end
 
     image = images(:in_situ_image)
-    # Point the test-env original fallback at a real fixture file.
-    image.update_columns(original_name: "Coprinus_comatus.jpg")
+    fixture = Rails.root.join("test/images/Coprinus_comatus.jpg").to_s
 
     assert_nil(image.dhash)
-    ImageDhashJob.perform_now(image.id)
+    image.stub(:full_filepath, fixture) do
+      Image.stub(:find_by, image) do
+        ImageDhashJob.perform_now(image.id)
+      end
+    end
 
     assert_not_nil(image.reload.dhash)
   end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -183,15 +183,39 @@ class ImageTest < UnitTestCase
     assert_equal(["script/rotate_image #{img.id} -90&"], commands)
   end
 
-  # With no local rendition on disk, compute_dhash! fetches the remote
-  # medium image (the transferred-image path the backfill relies on).
-  def test_compute_dhash_fetches_remote_when_no_local_file
+  # dHash is computed from the small local rendition — never the full-size
+  # original, whose ImageMagick decode can exhaust the host (#4796).
+  def test_compute_dhash_uses_small_local_rendition
     img = images(:in_situ_image)
+    small = img.full_filepath(:small)
+    hashed = nil
+    File.stub(:exist?, ->(path) { path == small }) do
+      Image::Dhash.stub(:from_file, lambda { |path|
+        hashed = path
+        456
+      }) do
+        assert_equal(456, img.compute_dhash!)
+      end
+    end
+    assert_equal(small, hashed)
+    assert_equal(456, img.reload.dhash)
+  end
+
+  # With no local rendition (e.g. after originals are cleaned up),
+  # compute_dhash! fetches the remote small rendition — still never the
+  # full-size original (#4796).
+  def test_compute_dhash_fetches_remote_small_when_no_local_file
+    img = images(:in_situ_image)
+    fetched = nil
     img.stub(:full_filepath, "/no/such/file.jpg") do
-      Image::Dhash.stub(:from_url, 123) do
+      Image::Dhash.stub(:from_url, lambda { |url|
+        fetched = url
+        123
+      }) do
         assert_equal(123, img.compute_dhash!)
       end
     end
+    assert_equal(img.small_url, fetched)
     assert_equal(123, img.reload.dhash)
   end
 


### PR DESCRIPTION
## Summary

Fixes #4796. On 2026-07-14 the site was unresponsive for ~3.5 minutes because a routine two-image upload of 25 MP photos ran two `ImageDhashJob`s concurrently, each decoding the **full-size original** with ImageMagick, which exhausted the host until the jobs finished (full root-cause analysis on the issue).

`Image#compute_dhash!` sourced its hash from `[:original, :medium, :small]`, **preferring the full-size original** — exactly what's on local disk right after an upload. `Image::Dhash` decodes that source with ImageMagick before shrinking it to 9×8, so a 25 MP original meant a 25 MP decode; two at once (the `default` SolidQueue pool is 4 threads / 1 process) took the box down.

## Change

`compute_dhash!` now hashes the small (then medium) local rendition, and **never the original**. dHash is resolution-invariant by design, so a 320 px rendition produces the same hash at a fraction of the decode cost. The small rendition is generated before `ImageDhashJob` is enqueued (`process_and_enqueue_jobs`), so it's present on fresh uploads.

With no local rendition (e.g. after originals are cleaned up), it falls back to fetching the transferred **small** rendition (`small_url`) — bounded at 320 px, and still never the original. That fallback covers the batch/backfill callers too, so nothing else needed to change.

The one-line essence: `[:original, :medium, :small]` → `[:small, :medium]`, and the no-local fallback fetches `small_url` instead of `medium_url`.

## Test plan

- [x] `bin/rails test test/models/image_test.rb test/jobs/image_dhash_job_test.rb test/models/image/dhash_test.rb`
- New `image_test.rb` coverage: asserts the decode source is the small local path (not the original) when present; asserts the no-local-file path fetches `small_url`.
- Updated the `image_dhash_job_test.rb` happy-path test to hash a rendition rather than the (now-unused) `:original` fixture fallback.
- [x] `bundle exec rubocop` clean on all changed files.
