### PR TITLE
Close modal and flash the page on successful email send

### DIFF
--- a/app/controllers/application_controller/modal_updater.rb
+++ b/app/controllers/application_controller/modal_updater.rb
@@ -18,12 +18,28 @@
 #    re-running validations against a different model state).
 #    Updates the flash AND replaces the `#<id>_form` body with a
 #    freshly-rendered `Components::Modal::TurboForm`.
+#  - `render_modal_close_and_flash(identifier)` — for actions that
+#    SUCCEED and have nothing left to show in the modal: closes +
+#    removes the modal and pushes the accumulated flash into the
+#    page's own `#page_flash`, not the modal's. Use this instead of
+#    `render_modal_flash_update` once the modal's job is done --
+#    that one leaves the modal open, with the flash rendered inside
+#    it instead of on the page, so the modal never closes and just
+#    sits there looking stuck (see #3791).
 #
 module ApplicationController::ModalUpdater
   private
 
   def render_modal_flash_update(identifier)
     render(turbo_stream: turbo_stream_flash_update("modal_#{identifier}_flash"))
+  end
+
+  def render_modal_close_and_flash(identifier)
+    render(turbo_stream: [
+             turbo_stream.close_modal("modal_#{identifier}"),
+             turbo_stream.remove("modal_#{identifier}"),
+             turbo_stream_flash_update
+           ])
   end
 
   def render_modal_form_reload(identifier:, form_locals:)

--- a/app/controllers/images/emails_controller.rb
+++ b/app/controllers/images/emails_controller.rb
@@ -71,7 +71,7 @@ module Images
           redirect_to(image_path(image.id)) and return
         end
         format.turbo_stream do
-          render_modal_flash_update("commercial_inquiry_email") and return
+          render_modal_close_and_flash("commercial_inquiry_email") and return
         end
       end
     end

--- a/app/controllers/observations/emails_controller.rb
+++ b/app/controllers/observations/emails_controller.rb
@@ -66,7 +66,7 @@ module Observations
           redirect_to(observation_path(observation.id)) and return
         end
         format.turbo_stream do
-          render_modal_flash_update("observation_email") and return
+          render_modal_close_and_flash("observation_email") and return
         end
       end
     end

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -63,7 +63,7 @@ module Users
           redirect_to(user_path(receiver.id)) and return
         end
         format.turbo_stream do
-          render_modal_flash_update("user_question_email") and return
+          render_modal_close_and_flash("user_question_email") and return
         end
       end
     end

--- a/test/controllers/images/emails_controller_test.rb
+++ b/test/controllers/images/emails_controller_test.rb
@@ -53,6 +53,9 @@ module Images
       assert_response(:success)
     end
 
+    # Regression test for #3791: on success the modal must close (not
+    # stay open looking frozen) and the flash must land in the page's
+    # own #page_flash, not the modal's own in-body flash slot.
     def test_create_turbo_stream
       image = images(:commercial_inquiry_image)
       params = {
@@ -65,6 +68,13 @@ module Images
         post(:create, params: params, as: :turbo_stream)
       end
       assert_response(:success)
+      assert_select("turbo-stream[action='close_modal']",
+                    text: "modal_commercial_inquiry_email")
+      assert_select(
+        "turbo-stream[action='remove']" \
+        "[target='modal_commercial_inquiry_email']"
+      )
+      assert_select("turbo-stream[action='update'][target='page_flash']")
     end
   end
 end

--- a/test/controllers/observations/emails_controller_test.rb
+++ b/test/controllers/observations/emails_controller_test.rb
@@ -47,6 +47,9 @@ module Observations
       assert_flash_text(:runtime_ask_observation_question_success.t)
     end
 
+    # Regression test for #3791: on success the modal must close (not
+    # stay open looking frozen) and the flash must land in the page's
+    # own #page_flash, not the modal's own in-body flash slot.
     def test_send_observation_question_turbo_stream
       obs = observations(:minimal_unknown_obs)
       params = {
@@ -64,6 +67,12 @@ module Observations
       end
       assert_response(:success)
       assert_flash_text(:runtime_ask_observation_question_success.t)
+      assert_select("turbo-stream[action='close_modal']",
+                    text: "modal_observation_email")
+      assert_select(
+        "turbo-stream[action='remove'][target='modal_observation_email']"
+      )
+      assert_select("turbo-stream[action='update'][target='page_flash']")
     end
 
     def test_send_observation_question_requires_message

--- a/test/controllers/users/emails_controller_test.rb
+++ b/test/controllers/users/emails_controller_test.rb
@@ -82,6 +82,9 @@ module Users
       assert_response(:success)
     end
 
+    # Regression test for #3791: on success the modal must close (not
+    # stay open looking frozen) and the flash must land in the page's
+    # own #page_flash, not the modal's own in-body flash slot.
     def test_create_turbo_stream
       login("rolf")
       params = {
@@ -95,6 +98,12 @@ module Users
         post(:create, params: params, as: :turbo_stream)
       end
       assert_response(:success)
+      assert_select("turbo-stream[action='close_modal']",
+                    text: "modal_user_question_email")
+      assert_select(
+        "turbo-stream[action='remove'][target='modal_user_question_email']"
+      )
+      assert_select("turbo-stream[action='update'][target='page_flash']")
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #3791. The reported "frozen page" symptom is a stuck-open modal, not an actual freeze: `Users::EmailsController`, `Observations::EmailsController`, and `Images::EmailsController` all reuse `render_modal_flash_update` for their `create` action's success path, which pushes the flash into the modal's own `#modal_<id>_flash` slot and leaves the modal open. None of these three flows has a `data-controller="section-update"` page panel to trigger the existing auto-close listener, so the modal just sits there with the success message rendered inside it instead of on the page behind it.

Adds `render_modal_close_and_flash(identifier)` to `ApplicationController::ModalUpdater` -- `close_modal` + `remove` the modal, then `turbo_stream_flash_update` to the page's own `#page_flash` -- and switches all three controllers' success path to it. Modeled on the existing `herbaria_controller.rb#update_observation_after_herbarium_save_streams` pattern, the same "close modal, flash the page" convention already used by `comments_controller.rb`, `observations/namings/votes_controller.rb`, and `projects/aliases_controller.rb`.

`render_modal_flash_update` itself is untouched and still used correctly elsewhere for validation-failure flows that keep the modal open.

## Test plan

- [x] `bundle exec rubocop` clean on every touched file
- [x] Updated `test_create_turbo_stream` in all three `*_controller_test.rb` files to assert the fixed turbo-stream response: `close_modal` targeting the right `modal_<identifier>`, `remove` of that same element, and an `update` targeting `page_flash` (not the modal's own flash slot)
- [x] All 16 tests across the three controller test files pass
- [x] No new system test -- the `close_modal` custom Turbo action + `remove` mechanism already has real browser-level coverage in `test/system/project_violations_target_location_modal_system_test.rb`; what's specific to this fix is server-side turbo-stream content, fully covered by the `assert_select` additions above
