### PR TITLE
Use `Components::Localization` more widely, fix `image_vote_short` drift

### DIFF
--- a/app/components/form/names_lookup_field_group.rb
+++ b/app/components/form/names_lookup_field_group.rb
@@ -133,16 +133,12 @@ class Components::Form::NamesLookupFieldGroup < Components::Base
     field_component = @names_namespace.field(field_name).select(
       options,
       wrapper_options: {
-        label: field_label(field_name),
+        label: query_field_label(field_name),
         inline: true
       },
       selected: bool_to_string(field_selected_value(field_name))
     )
     render(field_component)
-  end
-
-  def field_label(field_name)
-    :"query_#{field_name}".l.humanize
   end
 
   def field_selected_value(field_name)

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -219,7 +219,7 @@ class Components::Form::Search < Components::ApplicationForm
               field_value(field_name)
             end
     text_field(field_name,
-               label: field_label(field_name),
+               label: query_field_label(field_name),
                value: value) do |f|
       f.with_help { field_help(field_name) }
     end
@@ -230,7 +230,7 @@ class Components::Form::Search < Components::ApplicationForm
     text_field(field_name,
                textarea: true,
                rows: 1,
-               label: field_label(field_name),
+               label: query_field_label(field_name),
                value: value) do |f|
       f.with_help { field_help(field_name) }
     end
@@ -246,7 +246,7 @@ class Components::Form::Search < Components::ApplicationForm
 
   def render_boolean_select(field_name:, style:)
     select_field(field_name, BOOL_OPTIONS[style],
-                 label: field_label(field_name),
+                 label: query_field_label(field_name),
                  inline: true,
                  selected: bool_to_string(field_value(field_name))) do |f|
       f.with_help { field_help(field_name) }
@@ -260,7 +260,7 @@ class Components::Form::Search < Components::ApplicationForm
     # Valid values from query_attr: [:no, :include, :only]
     options = [%w[no no], %w[include include], %w[only only]]
     select_field(field_name, options,
-                 label: field_label(field_name),
+                 label: query_field_label(field_name),
                  inline: true,
                  selected: field_value(field_name)&.to_s) do |f|
       f.with_help { field_help(field_name) }
@@ -274,7 +274,7 @@ class Components::Form::Search < Components::ApplicationForm
     render(ApplicationForm::SelectRangeField.new(
              form: self, field_name:, options:,
              value:, range_value:,
-             label: field_label(field_name)
+             label: query_field_label(field_name)
            )) do |f|
       f.with_help { field_help(field_name) }
     end
@@ -314,7 +314,7 @@ class Components::Form::Search < Components::ApplicationForm
     render(ApplicationForm::SelectRangeField.new(
              form: self, field_name:, options:,
              value:, range_value:,
-             label: field_label(field_name)
+             label: query_field_label(field_name)
            )) do |f|
       f.with_help { field_help(field_name) }
     end
@@ -370,7 +370,7 @@ class Components::Form::Search < Components::ApplicationForm
     autocompleter_field(field_name,
                         type: type,
                         textarea: true,
-                        label: field_label(field_name),
+                        label: query_field_label(field_name),
                         value: prefilled_autocompleter_value(ids, type),
                         hidden_value: ids) do |f|
       f.with_help { multiple_help(field_name) }
@@ -407,10 +407,6 @@ class Components::Form::Search < Components::ApplicationForm
   end
 
   # Field helpers
-
-  def field_label(field_name)
-    :"query_#{field_name}".l.humanize
-  end
 
   def field_help(field_name)
     :"#{model.type_tag}_term_#{field_name}".l

--- a/app/components/localization.rb
+++ b/app/components/localization.rb
@@ -42,7 +42,7 @@ module Components::Localization
     :"query_#{key}".l
   end
 
-  # `Name#lifeform`, one word, e.g. `"lichen"` → `:lichen_form`. Returns
+  # `Name#lifeform`, one word, e.g. `"lichen"` → `:lifeform_lichen`. Returns
   # the translation key itself (not resolved) -- callers need both
   # `.l` (checkbox labels) and `.t` (plain display text) depending on
   # context, and `AuthorsAndEditors#user_list_title` also needs the

--- a/app/components/localization.rb
+++ b/app/components/localization.rb
@@ -30,4 +30,42 @@ module Components::Localization
   def image_vote_as_short_string(val)
     :"image_vote_short_#{val || 0}".l
   end
+
+  # A search/query field's form label, e.g. `:date` → "Date".
+  def query_field_label(field_name)
+    :"query_#{field_name}".l.humanize
+  end
+
+  # A query param's display name in the index filter caption, e.g.
+  # `:by_user` → "By user".
+  def query_param_label(key)
+    :"query_#{key}".l
+  end
+
+  # `Name#lifeform`, one word, e.g. `"lichen"` → `:lichen_form`. Returns
+  # the translation key itself (not resolved) -- callers need both
+  # `.l` (checkbox labels) and `.t` (plain display text) depending on
+  # context, and `AuthorsAndEditors#user_list_title` also needs the
+  # bare symbol to conditionally `.pluralize` before resolving it.
+  def lifeform_key(word)
+    :"lifeform_#{word}"
+  end
+
+  # `Name#lifeform`, one word's help text, e.g. `"lichen"` → the
+  # textile-rendered explanation of what that lifeform means.
+  def lifeform_help_as_string(word)
+    :"lifeform_help_#{word}".t
+  end
+
+  # A user content-filter's form label, e.g. `:has_images` →
+  # the textile-rendered filter name.
+  def prefs_filter_label(sym)
+    :"prefs_filters_#{sym}".t
+  end
+
+  # `type_tag` (e.g. `"name"`, `"location"`) → the textile-rendered
+  # "no descriptions yet" empty-state text for that model type.
+  def show_no_descriptions_as_string(type)
+    :"show_#{type}_no_descriptions".t
+  end
 end

--- a/app/views/controllers/account/preferences/form.rb
+++ b/app/views/controllers/account/preferences/form.rb
@@ -283,7 +283,7 @@ class Views::Controllers::Account::Preferences::Form <
 
   def render_boolean_checkbox_filter(filter)
     checkbox_field(filter.sym,
-                   label: :"prefs_filters_#{filter.sym}".t,
+                   label: prefs_filter_label(filter.sym),
                    checked: model.content_filter[filter.sym] ==
                             filter.prefs_vals.first)
   end
@@ -294,14 +294,14 @@ class Views::Controllers::Account::Preferences::Form <
                 [:"prefs_filters_#{filter.sym}_#{val}".t, val]
               end
     select_field(filter.sym, options,
-                 label: "#{:"prefs_filters_#{filter.sym}".t}:",
+                 label: "#{prefs_filter_label(filter.sym)}:",
                  selected: model.content_filter[filter.sym],
                  inline: true)
   end
 
   def render_string_filter(filter)
     text_field(filter.sym,
-               label: "#{:"prefs_filters_#{filter.sym}".t}:",
+               label: "#{prefs_filter_label(filter.sym)}:",
                value: model.content_filter[filter.sym]) do |f|
       f.with_between { render_string_filter_help(filter) }
     end

--- a/app/views/controllers/descriptions/details_and_alts_panel.rb
+++ b/app/views/controllers/descriptions/details_and_alts_panel.rb
@@ -127,7 +127,7 @@ module Views::Controllers::Descriptions
     end
 
     def alts_empty_text(type)
-      :"show_#{type}_no_descriptions".t
+      show_no_descriptions_as_string(type)
     end
 
     # "Create New Draft For: <project1> <project2> ..."

--- a/app/views/controllers/images/show/vote_panel.rb
+++ b/app/views/controllers/images/show/vote_panel.rb
@@ -128,7 +128,7 @@ module Views::Controllers::Images
               variant: :striped, identifier: "show-votes",
               class: "mt-3 mb-0") do |t|
           t.column(:USER.t) { |vote| render_vote_user_cell(vote) }
-          t.column(:VOTE.t) { |vote| short_vote_label(vote) }
+          t.column(:VOTE.t) { |vote| image_vote_as_short_string(vote.value) }
         end
       end
 
@@ -138,10 +138,6 @@ module Views::Controllers::Images
         else
           Link(type: :user, user: vote.user)
         end
-      end
-
-      def short_vote_label(vote)
-        :"image_vote_short_#{vote.value}".t
       end
     end
   end

--- a/app/views/controllers/locations/show/alt_descriptions_panel.rb
+++ b/app/views/controllers/locations/show/alt_descriptions_panel.rb
@@ -36,7 +36,7 @@ module Views::Controllers::Locations
         render(Views::Controllers::Descriptions::List.new(
                  user: @user, object: @object, type: @object.type_tag,
                  current: @current,
-                 empty_text: :"show_#{@object.type_tag}_no_descriptions".t
+                 empty_text: show_no_descriptions_as_string(@object.type_tag)
                ))
         render_projects_list if @projects.present?
       end

--- a/app/views/controllers/names/lifeforms/form.rb
+++ b/app/views/controllers/names/lifeforms/form.rb
@@ -16,10 +16,10 @@ module Views::Controllers::Names::Lifeforms
             variant: :striped, identifier: "lifeform",
             show_headers: false) do |t|
         t.column(nil) do |word|
-          checkbox_field(word.to_sym, label: :"lifeform_#{word}".l)
+          checkbox_field(word.to_sym, label: lifeform_key(word).l)
         end
         t.column(nil, class: "container-text") do |word|
-          plain(:"lifeform_help_#{word}".t)
+          plain(lifeform_help_as_string(word))
         end
       end
 

--- a/app/views/controllers/names/lifeforms/propagate/form.rb
+++ b/app/views/controllers/names/lifeforms/propagate/form.rb
@@ -29,10 +29,10 @@ module Views::Controllers::Names::Lifeforms::Propagate
             variant: :striped, identifier: "lifeform",
             show_headers: false) do |t|
         t.column(nil) do |word|
-          checkbox_field(:"add_#{word}", label: :"lifeform_#{word}".l)
+          checkbox_field(:"add_#{word}", label: lifeform_key(word).l)
         end
         t.column(nil, class: "container-text") do |word|
-          plain(:"lifeform_help_#{word}".t)
+          plain(lifeform_help_as_string(word))
         end
       end
     end
@@ -48,10 +48,10 @@ module Views::Controllers::Names::Lifeforms::Propagate
             variant: :striped, identifier: "lifeform",
             show_headers: false) do |t|
         t.column(nil) do |word|
-          checkbox_field(:"remove_#{word}", label: :"lifeform_#{word}".l)
+          checkbox_field(:"remove_#{word}", label: lifeform_key(word).l)
         end
         t.column(nil, class: "container-text") do |word|
-          plain(:"lifeform_help_#{word}".t)
+          plain(lifeform_help_as_string(word))
         end
       end
     end

--- a/app/views/controllers/names/show/lifeform_panel.rb
+++ b/app/views/controllers/names/show/lifeform_panel.rb
@@ -34,7 +34,7 @@ class Views::Controllers::Names::Show::LifeformPanel < Views::Base
   def render_lifeform_terms
     div(class: "mb-2") do
       @name.lifeform.strip.split.each do |word|
-        p { plain(:"lifeform_#{word}".t) }
+        p { plain(lifeform_key(word).t) }
       end
     end
   end

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -158,7 +158,7 @@ module Views::Layouts
 
     # Subquery: `label: [ <nested params> ]` with span wrappers.
     def render_subquery(label, hash, truncate:)
-      span { plain("#{:"query_#{label}".l}: [ ") }
+      span { plain("#{query_param_label(label)}: [ ") }
       render_params_joined(hash, truncate: truncate, wrap_tag: :span)
       span { plain(" ] ") }
     end
@@ -170,7 +170,7 @@ module Views::Layouts
       compact = hash.compact_blank
       return if compact.empty?
 
-      span { plain("#{:"query_#{label}".l}: ") }
+      span { plain("#{query_param_label(label)}: ") }
       if label == :target
         span { plain(lookup_comment_target_val(hash).to_s) }
       else
@@ -186,7 +186,7 @@ module Views::Layouts
     end
 
     def render_plain_param(key, val, truncate:)
-      label = :"query_#{key}".l
+      label = query_param_label(key)
       if val == true
         span { plain(label) }
       else


### PR DESCRIPTION
## Summary

Fixes #4679. `Components::Localization` (`app/components/base.rb` includes it into every Phlex view/component) already had 4 methods for enum-like translation-key lookups (`rank_as_string`, `image_vote_as_{long,help,short}_string`), each with real multi-site duplication removed. Audited the rest of the codebase for the same shape and added 6 more methods, each backed by genuine multi-site duplication:

- `query_field_label`/`query_param_label` — replaces two identical private `field_label` methods (`names_lookup_field_group.rb`, `search.rb`) and 3 inline `:"query_#{x}".l` sites in `filter_caption.rb`.
- `lifeform_key`/`lifeform_help_as_string` — `lifeform_key` returns the bare symbol (not resolved) since callers need both `.l` (checkbox labels) and `.t` (display text) depending on context, and `AuthorsAndEditors`'s pluralization logic elsewhere depends on the same bare-symbol pattern. `lifeform_help_as_string` bakes in `.t` since all 3 call sites use it identically.
- `prefs_filter_label` — 3 identical `:"prefs_filters_#{sym}".t` sites in `account/preferences/form.rb`.
- `show_no_descriptions_as_string` — 2 sites across `details_and_alts_panel.rb` and `locations/show/alt_descriptions_panel.rb`.

**Also fixes a real drift** found while auditing: `images/show/vote_panel.rb` had its own inline `:"image_vote_short_#{v}".t`, bypassing the existing `image_vote_as_short_string` wrapper (which uses `.l`). Confirmed safe to unify via `en.txt` — the `image_vote_short_*` values are plain single words with no textile markup, so `.t` vs `.l` renders identically here.

**Deliberately left alone**: several other single-site symbol-interpolation patterns (`show_#{type}_creator`/`_editor`, `prefs_filters_#{sym}_help`/`_#{val}`), and the issue's own example (`:"search_term_group_#{heading}".l` in `search.rb`) — all turned out to be single-call-site, so there's no duplication to eliminate and wrapping them would just be indirection for its own sake.

## Test plan

- [x] `bundle exec rubocop` clean on every touched file
- [x] Full test runs across every consumer: `names_lookup_field_group_test.rb`, `search_test.rb`, `filter_caption_test.rb`, `names/lifeforms/{form,propagate/form}_test.rb`, `account/preferences/form_test.rb`, `descriptions/details_and_alts_panel_test.rb`, `images/show/vote_panel_test.rb` (119 tests, 0 failures)
- [x] Broader controller-level runs to confirm the panels without dedicated view tests still render correctly: `names/lifeforms_controller_test.rb`, `names/lifeforms/propagate_controller_test.rb`, `locations_controller_test.rb`, `names_controller_show_test.rb` (89 tests, 0 failures)
