### PR TITLE
Centralize field label resolution and colon-appending (`FieldLabelRow`, #4687)

### DIFF
--- a/app/components/application_form/checkbox_field.rb
+++ b/app/components/application_form/checkbox_field.rb
@@ -18,7 +18,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   class CheckboxField < Superform::Rails::Components::Checkbox
     include Phlex::Slotable
     include FieldWithHelp
-    include Phlex::TrustedHtml
+    include FieldLabelRow
 
     slot :between
     slot :append
@@ -244,11 +244,12 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_options[:label_position] == :before
     end
 
+    # Checkbox labels read as a clickable sentence next to the checkbox
+    # itself, not a field prompt -- never gets FieldLabelRow's colon.
     def label_text
-      label_option = wrapper_options[:label]
-      return if label_option == false
+      return if wrapper_options[:label] == false
 
-      label_option.is_a?(String) ? label_option : field.key.to_s.humanize
+      resolved_label_text
     end
 
     def boolean_wrap_class

--- a/app/components/application_form/date_field.rb
+++ b/app/components/application_form/date_field.rb
@@ -5,7 +5,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Compatible with Rails date_select parameter format.
   #
   # @example
-  #   field(:when).date(wrapper_options: { label: "Date:" })
+  #   field(:when).date(wrapper_options: { label: "Date" })
   #
   class DateField < Phlex::HTML
     include Phlex::Rails::Helpers::ClassNames
@@ -37,21 +37,18 @@ class Components::ApplicationForm < Superform::Rails::Form
     private
 
     def render_with_wrapper
-      label_option = wrapper_options[:label]
-      show_label = label_option != false
-      label_text = label_option.is_a?(String) ? label_option : default_label
       wrap_class = wrapper_options[:wrap_class]
 
       div(class: form_group_class(wrap_class)) do
-        render_label_row(label_text, false) if show_label
+        render_label_row(label_text, false) if show_label?
         yield
         render_help_after_field
         render(append_slot) if append_slot
       end
     end
 
-    def default_label
-      field.key.to_s.humanize
+    def show_label?
+      wrapper_options[:label] != false
     end
 
     def form_group_class(wrap_class)

--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -11,8 +11,8 @@ class Components::ApplicationForm < Superform::Rails::Form
     include Components::Button::Styling
 
     # Wrapper option keys that should not be passed to the field itself
-    WRAPPER_OPTIONS = [:label, :help, :help_collapse, :prefs, :inline,
-                       :wrap_class, :wrap_data, :between, :button,
+    WRAPPER_OPTIONS = [:label, :label_colon, :help, :help_collapse, :prefs,
+                       :inline, :wrap_class, :wrap_data, :between, :button,
                        :button_data, :button_text, :button_href,
                        :button_variant, :button_size, :button_target,
                        :button_rel, :button_title, :button_icon, :addon,
@@ -463,10 +463,18 @@ class Components::ApplicationForm < Superform::Rails::Form
     # drop the `:prefs` option so it doesn't flow downstream. Used by the
     # same set of helpers the ERB applies it to: text, textarea, select,
     # checkbox, radio, number.
+    #
+    # Passes the bare Symbol through -- FieldLabelRow#resolved_label_text
+    # resolves it via `.t`, which is what makes this safe even though
+    # `field_name` is a runtime value (the actual `prefs_<field>` key
+    # isn't known statically here): `.t` renders any real textile markup
+    # correctly (e.g. `prefs_no_emails`, "Opt out of _all_ email from
+    # MO.") instead of leaving literal asterisks/underscores, with no
+    # per-key auditing needed.
     def auto_label_for_prefs(field_name, options)
       return options if options[:prefs].blank?
 
-      options.merge(label: :"prefs_#{field_name}".t).except(:prefs)
+      options.merge(label: :"prefs_#{field_name}").except(:prefs)
     end
 
     # Resolve a field name to a field object the factory methods can

--- a/app/components/application_form/field_label_row.rb
+++ b/app/components/application_form/field_label_row.rb
@@ -30,6 +30,66 @@ class Components::ApplicationForm < Superform::Rails::Form
       text.html_safe? ? trusted_html(text) : plain(text)
     end
 
+    # Resolves `wrapper_options[:label]` to display text: an explicit
+    # String wins as-is, a Symbol is translated via `.t` (the common
+    # case -- callers just pass `label: :SOME_KEY`, no need to spell
+    # out `.t`/`.l` themselves), otherwise the field's key, humanized.
+    # Shared by every field type that takes a `label:` option --
+    # previously duplicated near-identically across text_field.rb,
+    # textarea_field.rb, select_field.rb, and file_field.rb.
+    #
+    # `.t` (not `.l`) deliberately: some translations carry real
+    # bold/italic textile markup (e.g. `prefs_no_emails`, "Opt out of
+    # _all_ email from MO.") that needs textile rendering to display
+    # correctly rather than as literal asterisks/underscores -- for
+    # plain-text labels (the vast majority) `.t` and `.l` render
+    # identically, so this is strictly safer with no downside.
+    def resolved_label_text
+      label_option = wrapper_options[:label]
+      case label_option
+      when Symbol then label_option.t
+      when String then label_option
+      else field.key.to_s.humanize
+      end
+    end
+
+    # A resolved label containing a real link -- a field-PROMPT label
+    # secretly doubling as a clickable link is a UX smell (not obviously
+    # clickable, easy to miss). Route link content through a help icon
+    # instead (see Components::Form::UploadGallery::Fields#render_license_field
+    # for the established pattern) rather than embedding it in the label.
+    #
+    # Only guards `label_text` below (the colon-suffixed prompt path),
+    # NOT `resolved_label_text` itself -- CheckboxField#label_text calls
+    # `resolved_label_text` directly, bypassing this guard, because a
+    # checkbox's label can be rich content rather than a plain text
+    # prompt (e.g. a name link + copy-id badge next to a
+    # synonym-selection checkbox -- see names/synonyms/form.rb).
+    LINK_IN_LABEL_RE = /<a[\s>]/
+
+    def raise_if_label_has_link(text)
+      return unless text.is_a?(String) && text.match?(LINK_IN_LABEL_RE)
+
+      raise("Field label contains a link -- move it into help: " \
+            "content instead of embedding it in the label: #{text.inspect}")
+    end
+
+    # The standard trailing ":" on field-prompt labels (#4687) -- the
+    # one place to change or delete it site-wide if we ever decide to.
+    def append_colon(text)
+      "#{text}:"
+    end
+
+    # Default label text: resolved text + colon, unless the caller
+    # opts out via `label_colon: false` (e.g. SelectRangeField's "to"
+    # connector between two selects, which reads as a word, not a
+    # field prompt).
+    def label_text
+      text = resolved_label_text
+      raise_if_label_has_link(text)
+      wrapper_options[:label_colon] == false ? text : append_colon(text)
+    end
+
     def label_end_present?
       respond_to?(:label_end_slot) && label_end_slot
     end

--- a/app/components/application_form/field_label_row.rb
+++ b/app/components/application_form/field_label_row.rb
@@ -76,8 +76,15 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     # The standard trailing ":" on field-prompt labels (#4687) -- the
     # one place to change or delete it site-wide if we ever decide to.
+    #
+    # `[text, ":"].safe_join` rather than `"#{text}:"`: plain string
+    # interpolation coerces an html_safe SafeBuffer label (e.g. Textile
+    # markup from `resolved_label_text`'s `.t` call) back into an
+    # unsafe String, so render_label_content would then escape it --
+    # `safe_join` preserves the html_safe flag when `text` already
+    # carries one, and safely escapes it when it doesn't.
     def append_colon(text)
-      "#{text}:"
+      [text, ":"].safe_join
     end
 
     # Default label text: resolved text + colon, unless the caller

--- a/app/components/application_form/file_field.rb
+++ b/app/components/application_form/file_field.rb
@@ -19,6 +19,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   #
   class FileField < Superform::Rails::Components::Input
     include Phlex::Slotable
+    include FieldLabelRow
 
     slot :between
     slot :append
@@ -62,11 +63,6 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     def show_label?
       wrapper_options[:label] != false
-    end
-
-    def label_text
-      label_option = wrapper_options[:label]
-      label_option.is_a?(String) ? label_option : field.key.to_s.humanize
     end
 
     def render_label_row

--- a/app/components/application_form/read_only_field.rb
+++ b/app/components/application_form/read_only_field.rb
@@ -8,12 +8,13 @@
 #
 # @example Basic usage
 #   field(:user_id).read_only(
-#     wrapper_options: { label: "User:", value: "John Doe" }
+#     wrapper_options: { label: "User", value: "John Doe" }
 #   )
 class Components::ApplicationForm < Superform::Rails::Form
   class ReadOnlyField < Phlex::HTML
     include Phlex::Slotable
     include FieldWithHelp
+    include FieldLabelRow
 
     slot :help
 
@@ -31,10 +32,9 @@ class Components::ApplicationForm < Superform::Rails::Form
     def view_template
       inline = @wrapper_options[:inline] || false
       wrap_class = @wrapper_options[:wrap_class]
-      label_text = @wrapper_options[:label]
 
       div(class: form_group_class("form-group", inline, wrap_class)) do
-        render_label(label_text, inline) if label_text
+        render_label(label_text, inline) if show_label?
         p(class: "form-control-static") do
           @wrapper_options[:value] || @wrapper_options[:text] || ""
         end
@@ -43,6 +43,10 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     private
+
+    def show_label?
+      wrapper_options[:label] != false
+    end
 
     def form_group_class(base, inline, wrap_class)
       classes = base

--- a/app/components/application_form/select_field.rb
+++ b/app/components/application_form/select_field.rb
@@ -119,11 +119,6 @@ class Components::ApplicationForm < Superform::Rails::Form
       end
     end
 
-    def label_text
-      label_option = wrapper_options[:label]
-      label_option.is_a?(String) ? label_option : field.key.to_s.humanize
-    end
-
     def form_group_class(base, inline, wrap_class)
       classes = base
       classes += " form-inline" if inline && base == "form-group"

--- a/app/components/application_form/select_range_field.rb
+++ b/app/components/application_form/select_range_field.rb
@@ -51,7 +51,8 @@ class Components::ApplicationForm < Superform::Rails::Form
         end
         div(class: "d-inline-block") do
           @form.select_field(:"#{@field_name}_range", @options,
-                             label: :to.l,
+                             label: :to,
+                             label_colon: false,
                              inline: true,
                              selected: @range_value)
         end

--- a/app/components/application_form/static_text_field.rb
+++ b/app/components/application_form/static_text_field.rb
@@ -7,12 +7,13 @@
 #
 # @example Basic usage
 #   field(:name).static(
-#     wrapper_options: { label: "Name:", value: "John Doe" }
+#     wrapper_options: { label: "Name", value: "John Doe" }
 #   )
 class Components::ApplicationForm < Superform::Rails::Form
   class StaticTextField < Phlex::HTML
     include Phlex::Slotable
     include FieldWithHelp
+    include FieldLabelRow
 
     slot :help
 
@@ -30,15 +31,18 @@ class Components::ApplicationForm < Superform::Rails::Form
     def view_template
       inline = @wrapper_options[:inline] || false
       wrap_class = @wrapper_options[:wrap_class]
-      label_text = @wrapper_options[:label]
 
       div(class: form_group_class("form-group", inline, wrap_class)) do
-        render_label(label_text, inline) if label_text
+        render_label(label_text, inline) if show_label?
         p(class: "form-control-static") { display_text }
       end
     end
 
     private
+
+    def show_label?
+      wrapper_options[:label] != false
+    end
 
     def display_text
       @wrapper_options[:value] || @wrapper_options[:text] || ""

--- a/app/components/application_form/text_field.rb
+++ b/app/components/application_form/text_field.rb
@@ -55,11 +55,6 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_options[:label] != false
     end
 
-    def label_text
-      label_option = wrapper_options[:label]
-      label_option.is_a?(String) ? label_option : field.key.to_s.humanize
-    end
-
     def inline?
       wrapper_options[:inline] || false
     end

--- a/app/components/application_form/textarea_field.rb
+++ b/app/components/application_form/textarea_field.rb
@@ -55,11 +55,6 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_options[:label] != false
     end
 
-    def label_text
-      label_option = wrapper_options[:label]
-      label_option.is_a?(String) ? label_option : field.key.to_s.humanize
-    end
-
     def inline?
       wrapper_options[:inline] || false
     end

--- a/app/components/application_form/upload_helpers.rb
+++ b/app/components/application_form/upload_helpers.rb
@@ -8,7 +8,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     # Renders image upload fields in a :upload namespace.
     # Creates params[:model][:upload][image], etc. (nested under form model)
     # Pass a block to render content in the file field's between slot.
-    def upload_fields(file_field_label: "#{:IMAGE.l}:", **args, &between_block)
+    def upload_fields(file_field_label: :IMAGE.l, **args, &between_block)
       args => {
         copyright_holder:, copyright_year:, licenses:, upload_license_id:
       }
@@ -45,7 +45,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     def render_upload_copyright_holder(upload, holder)
       render(
         upload.field(:copyright_holder).text(
-          wrapper_options: { label: "#{:image_copyright_holder.l}:",
+          wrapper_options: { label: :image_copyright_holder,
                              inline: true },
           value: holder
         )
@@ -56,7 +56,7 @@ class Components::ApplicationForm < Superform::Rails::Form
       render(
         upload.field(:copyright_year).select(
           upload_year_options,
-          wrapper_options: { label: "#{:WHEN.l}:", inline: true },
+          wrapper_options: { label: :WHEN, inline: true },
           selected: year
         )
       )
@@ -67,7 +67,7 @@ class Components::ApplicationForm < Superform::Rails::Form
       # `License.available_names_and_ids`); pass through.
       license_select = upload.field(:license_id).select(
         licenses,
-        wrapper_options: { label: "#{:LICENSE.l}:", inline: true },
+        wrapper_options: { label: :LICENSE, inline: true },
         selected: selected_id
       )
 

--- a/app/components/form/checkbox_collapse.rb
+++ b/app/components/form/checkbox_collapse.rb
@@ -12,14 +12,16 @@
 # @param form [Components::ApplicationForm] the parent form
 # @param field [Symbol] the field name
 # @param target_id [String] id of the collapse target (no leading #)
-# @param label [String] the label text
+# @param label [String, Symbol] the label text, or a translation key --
+#   passed straight through to checkbox_field, which resolves a Symbol
+#   via `.l` itself (see FieldLabelRow#resolved_label_text).
 # @param expanded [Boolean] initial expanded state (default: false)
 # @param attributes [Hash] extra options forwarded to checkbox_field
 class Components::Form::CheckboxCollapse < Components::Base
   prop :form, ::Components::ApplicationForm
   prop :field, Symbol
   prop :target_id, String
-  prop :label, String
+  prop :label, _Union(String, Symbol)
   prop :expanded, _Boolean, default: false
   prop :attributes, _Hash(Symbol, _Any), default: -> { {} }
 

--- a/app/components/form/checkbox_collapse.rb
+++ b/app/components/form/checkbox_collapse.rb
@@ -14,7 +14,7 @@
 # @param target_id [String] id of the collapse target (no leading #)
 # @param label [String, Symbol] the label text, or a translation key --
 #   passed straight through to checkbox_field, which resolves a Symbol
-#   via `.l` itself (see FieldLabelRow#resolved_label_text).
+#   via `.t` itself (see FieldLabelRow#resolved_label_text).
 # @param expanded [Boolean] initial expanded state (default: false)
 # @param attributes [Hash] extra options forwarded to checkbox_field
 class Components::Form::CheckboxCollapse < Components::Base

--- a/app/components/form/compass_fields.rb
+++ b/app/components/form/compass_fields.rb
@@ -49,7 +49,7 @@ class Components::Form::CompassFields < Components::Base
     @form.text_field(
       direction,
       value: @location.send(direction).to_s,
-      label: "#{direction.upcase.to_sym.t}:",
+      label: direction.upcase.to_sym,
       addon: "º",
       wrap_class: "text-left",
       data: {

--- a/app/components/form/elevation_fields.rb
+++ b/app/components/form/elevation_fields.rb
@@ -25,7 +25,7 @@ class Components::Form::ElevationFields < Components::Base
     @form.text_field(
       direction,
       value: @location.send(direction)&.to_s,
-      label: :"show_location_#{direction}est".t,
+      label: :"show_location_#{direction}est",
       addon: "m",
       wrap_class: "text-left",
       data: {

--- a/app/components/form/names_lookup_field_group.rb
+++ b/app/components/form/names_lookup_field_group.rb
@@ -34,7 +34,7 @@ class Components::Form::NamesLookupFieldGroup < Components::Base
     field_component = @names_namespace.field(:lookup).autocompleter(
       type: :name,
       textarea: true,
-      wrapper_options: { label: :NAMES.l },
+      wrapper_options: { label: :NAMES },
       value: prefilled_lookup_value,
       hidden_value: prefilled_lookup_ids
     )

--- a/app/components/form/region_with_box_fields.rb
+++ b/app/components/form/region_with_box_fields.rb
@@ -35,7 +35,7 @@ class Components::Form::RegionWithBoxFields < Components::Base
     @form_namespace.autocompleter_field(
       :region,
       type: :region,
-      label: "#{:REGION.t}:",
+      label: :REGION,
       value: @query&.region,
       button: :form_locations_find_on_map.l,
       button_data: { map_target: "showBoxBtn", action: "map#showBox" },
@@ -90,7 +90,7 @@ class Components::Form::RegionWithBoxFields < Components::Base
     Column(xs: 4, offset_xs: centered ? 4 : nil) do
       field_component = in_box_ns.field(direction).text(
         wrapper_options: {
-          label: "#{direction.upcase.to_sym.t}:",
+          label: direction.upcase.to_sym,
           addon: "º"
         },
         value: box_value(direction),

--- a/app/components/form/upload_gallery/fields.rb
+++ b/app/components/form/upload_gallery/fields.rb
@@ -54,7 +54,7 @@ class Components::Form::UploadGallery::Fields < Components::Base
     render(Components::ApplicationForm::TextareaField.new(
              field,
              rows: 2,
-             wrapper_options: { label: :form_images_notes.l }
+             wrapper_options: { label: :form_images_notes }
            ))
   end
 
@@ -63,7 +63,7 @@ class Components::Form::UploadGallery::Fields < Components::Base
     render(Components::ApplicationForm::DateField.new(
              field,
              value: @image&.when,
-             wrapper_options: { label: :form_images_when_taken.l }
+             wrapper_options: { label: :form_images_when_taken }
            ))
   end
 
@@ -71,17 +71,19 @@ class Components::Form::UploadGallery::Fields < Components::Base
     field = image_field_proxy(:copyright_holder, @image&.copyright_holder)
     render(Components::ApplicationForm::TextField.new(
              field,
-             wrapper_options: { label: :form_images_copyright_holder.l }
+             wrapper_options: { label: :form_images_copyright_holder }
            ))
   end
 
   def render_license_field
     field = image_field_proxy(:license_id, selected_license)
-    render(Components::ApplicationForm::SelectField.new(
-             field,
-             collection: license_options,
-             wrapper_options: { label: :form_images_select_license.t.html_safe } # rubocop:disable Rails/OutputSafety
-           ))
+    field_component = Components::ApplicationForm::SelectField.new(
+      field,
+      collection: license_options,
+      wrapper_options: { label: :LICENSE, help_collapse: true }
+    )
+    field_component.with_help { trusted_html(:form_images_license_help.t) }
+    render(field_component)
   end
 
   def render_original_name_field
@@ -89,7 +91,7 @@ class Components::Form::UploadGallery::Fields < Components::Base
     render(Components::ApplicationForm::TextField.new(
              field,
              size: 40,
-             wrapper_options: { label: :form_images_original_name.l }
+             wrapper_options: { label: :form_images_original_name }
            ))
   end
 

--- a/app/components/image/reuse_form.rb
+++ b/app/components/image/reuse_form.rb
@@ -52,7 +52,7 @@ class Components::Image::ReuseForm < Components::ApplicationForm
 
   def render_id_field_row
     div(class: "form-group form-inline") do
-      text_field(:img_id, label: "#{:image_reuse_id.t}:",
+      text_field(:img_id, label: :image_reuse_id,
                           inline: true, size: 8,
                           data: { autofocus: "true" })
       submit(:image_reuse_reuse.l, as: :button,

--- a/app/components/index_filter.rb
+++ b/app/components/index_filter.rb
@@ -34,7 +34,7 @@
 #     render(Components::ApplicationForm::AutocompleterField.new(
 #              field, type: :project, hidden_name: :project,
 #              inline: true, size: 60,
-#              label: "#{:field_slip_filter_by.l}:"
+#              label: :field_slip_filter_by
 #            ))
 #   end
 class Components::IndexFilter < Components::Base

--- a/app/components/list_group/search.rb
+++ b/app/components/list_group/search.rb
@@ -103,7 +103,7 @@ class Components::ListGroup::Search < Components::ApplicationForm
     # form-group wrapper — matched here with `wrap_class:` so the
     # margin sits on `.form-group.dropdown`, not on the `<input>`.
     autocompleter_field(
-      "name", type: :name, label: "#{:SEARCH.l}:", wrap_class: "mb-2",
+      "name", type: :name, label: :SEARCH, wrap_class: "mb-2",
               data: {
                 search_status_target: "input",
                 action: [

--- a/app/views/controllers/account/api_keys/form.rb
+++ b/app/views/controllers/account/api_keys/form.rb
@@ -84,7 +84,7 @@ module Views::Controllers::Account::APIKeys
     end
 
     def render_standalone_layout
-      text_field(:notes, label: :account_api_keys_notes_label.t,
+      text_field(:notes, label: :account_api_keys_notes_label,
                          wrap_class: "mt-3")
 
       submit(submit_text, center: true, submits_with: submits_text,
@@ -93,7 +93,7 @@ module Views::Controllers::Account::APIKeys
 
     def render_edit_layout
       render_metadata_table
-      text_field(:notes, label: "#{:NOTES.t}:", wrap_class: "mt-3")
+      text_field(:notes, label: :NOTES, wrap_class: "mt-3")
       div(class: "text-center mt-3") do
         submit(:UPDATE.l)
         # A plain link (not a submit button) — Cancel should navigate

--- a/app/views/controllers/account/form.rb
+++ b/app/views/controllers/account/form.rb
@@ -40,24 +40,24 @@ module Views::Controllers::Account
     def render_login_field
       text_field(
         :login,
-        label: "#{:signup_login.l}:",
+        label: :signup_login,
         data: { autofocus: true }
       )
     end
 
     def render_password_fields
-      password_field(:password, label: "#{:signup_choose_password.l}:")
+      password_field(:password, label: :signup_choose_password)
       password_field(
         :password_confirmation,
-        label: "#{:signup_confirm_password.l}:"
+        label: :signup_confirm_password
       )
     end
 
     def render_email_fields
-      text_field(:email, label: "#{:signup_email_address.l}:")
+      text_field(:email, label: :signup_email_address)
       text_field(
         :email_confirmation,
-        label: "#{:signup_email_confirmation.l}:"
+        label: :signup_email_confirmation
       ) do |f|
         f.with_append { render_email_help }
       end
@@ -70,14 +70,14 @@ module Views::Controllers::Account
     end
 
     def render_name_field
-      text_field(:name, label: "#{:signup_name.l}:")
+      text_field(:name, label: :signup_name)
     end
 
     def render_theme_field
       select_field(
         :theme,
         theme_options,
-        label: "#{:signup_preferred_theme.l}:"
+        label: :signup_preferred_theme
       )
     end
 

--- a/app/views/controllers/account/login/email_new_password_form.rb
+++ b/app/views/controllers/account/login/email_new_password_form.rb
@@ -7,7 +7,7 @@ module Views::Controllers::Account::Login
   # controller has multiple form-bearing pages.
   class EmailNewPasswordForm < ::Components::ApplicationForm
     def view_template
-      text_field(:login, label: "#{:login_user.t}:", wrap_class: "mt-3",
+      text_field(:login, label: :login_user, wrap_class: "mt-3",
                          data: { autofocus: true })
 
       submit(:SEND.l, center: true)

--- a/app/views/controllers/account/login/form.rb
+++ b/app/views/controllers/account/login/form.rb
@@ -16,18 +16,18 @@ module Views::Controllers::Account::Login
     private
 
     def render_login_field
-      text_field(:login, label: "#{:login_user.t}:", wrap_class: "mt-3",
+      text_field(:login, label: :login_user, wrap_class: "mt-3",
                          data: { autofocus: @model.login.blank? })
     end
 
     def render_password_field
-      password_field(:password, label: "#{:login_password.t}:",
+      password_field(:password, label: :login_password,
                                 wrap_class: "mt-3",
                                 data: { autofocus: @model.login.present? })
     end
 
     def render_remember_me_field
-      checkbox_field(:remember_me, label: :login_remember_me.t,
+      checkbox_field(:remember_me, label: :login_remember_me,
                                    wrap_class: "mt-3")
     end
 

--- a/app/views/controllers/account/preferences/form.rb
+++ b/app/views/controllers/account/preferences/form.rb
@@ -48,9 +48,9 @@ class Views::Controllers::Account::Preferences::Form <
   def render_login_section
     text_field(:login, prefs: true)
     text_field(:email, prefs: true)
-    password_field(:password, label: "#{:prefs_password_new.t}:")
+    password_field(:password, label: :prefs_password_new)
     password_field(:password_confirmation,
-                   label: "#{:prefs_password_confirm.t}:")
+                   label: :prefs_password_confirm)
     submit(:SAVE_EDITS.l, center: true)
   end
 
@@ -89,7 +89,7 @@ class Views::Controllers::Account::Preferences::Form <
     # "destructive button" read. No target=_blank / rel / new-tab
     # title here — those would be lies.
     select_field(:keep_filenames, filename_values,
-                 label: :prefs_keep_image_filenames.l,
+                 label: :prefs_keep_image_filenames,
                  **addon_button_defaults,
                  button: :prefs_purge_filenames.t,
                  button_href: images_bulk_filename_purge_path,
@@ -105,7 +105,7 @@ class Views::Controllers::Account::Preferences::Form <
     addon = external_addon(:prefs_apply_to_images.t,
                            images_edit_licenses_path)
     select_field(:license_id, @licenses,
-                 label: "#{:LICENSE.l}:", **addon) do |f|
+                 label: :LICENSE, **addon) do |f|
       f.with_between { render_license_note }
     end
   end
@@ -283,7 +283,7 @@ class Views::Controllers::Account::Preferences::Form <
 
   def render_boolean_checkbox_filter(filter)
     checkbox_field(filter.sym,
-                   label: :"prefs_filters_#{filter.sym}".t,
+                   label: :"prefs_filters_#{filter.sym}",
                    checked: model.content_filter[filter.sym] ==
                             filter.prefs_vals.first)
   end
@@ -294,14 +294,14 @@ class Views::Controllers::Account::Preferences::Form <
                 [:"prefs_filters_#{filter.sym}_#{val}".t, val]
               end
     select_field(filter.sym, options,
-                 label: "#{:"prefs_filters_#{filter.sym}".t}:",
+                 label: :"prefs_filters_#{filter.sym}",
                  selected: model.content_filter[filter.sym],
                  inline: true)
   end
 
   def render_string_filter(filter)
     text_field(filter.sym,
-               label: "#{:"prefs_filters_#{filter.sym}".t}:",
+               label: :"prefs_filters_#{filter.sym}",
                value: model.content_filter[filter.sym]) do |f|
       f.with_between { render_string_filter_help(filter) }
     end

--- a/app/views/controllers/account/profile/form.rb
+++ b/app/views/controllers/account/profile/form.rb
@@ -42,17 +42,17 @@ module Views::Controllers::Account::Profile
     private
 
     def render_name_field
-      text_field(:name, label: "#{:Name.l}:")
+      text_field(:name, label: :Name)
     end
 
     def render_place_name_field
       autocompleter_field(:place_name, type: :location,
-                                       label: "#{:profile_location.t}:",
+                                       label: :profile_location,
                                        between: "(33%)")
     end
 
     def render_notes_field
-      textarea_field(:notes, label: "#{:profile_notes.t}:",
+      textarea_field(:notes, label: :profile_notes,
                              rows: 10, between: "(33%)")
     end
 
@@ -68,7 +68,7 @@ module Views::Controllers::Account::Profile
 
     def render_mailing_address_field
       textarea_field(:mailing_address,
-                     label: "#{:profile_mailing_address.t}:", rows: 5)
+                     label: :profile_mailing_address, rows: 5)
     end
 
     def render_file_field_between

--- a/app/views/controllers/admin/donations/form.rb
+++ b/app/views/controllers/admin/donations/form.rb
@@ -7,11 +7,11 @@ module Views::Controllers::Admin::Donations
   class Form < ::Components::ApplicationForm
     def view_template
       super do
-        text_field(:amount, size: 7, label: "#{:confirm_amount.t}:",
+        text_field(:amount, size: 7, label: :confirm_amount,
                             inline: true)
-        text_field(:who, size: 50, label: "#{:WHO.t}:", inline: true)
-        checkbox_field(:anonymous, label: :donate_anonymous.t)
-        text_field(:email, size: 50, label: "#{:EMAIL.t}:", inline: true)
+        text_field(:who, size: 50, label: :WHO, inline: true)
+        checkbox_field(:anonymous, label: :donate_anonymous)
+        text_field(:email, size: 50, label: :EMAIL, inline: true)
         submit(:create_donation_add.l, center: true)
       end
     end

--- a/app/views/controllers/admin/emails/merge_requests/form.rb
+++ b/app/views/controllers/admin/emails/merge_requests/form.rb
@@ -27,10 +27,10 @@ module Views::Controllers::Admin::Emails::MergeRequests
     private
 
     def render_object_fields
-      static_field(:old_obj, label: "#{type_label}:",
+      static_field(:old_obj, label: type_label,
                              value: viewer_aware_format_name(@old_obj),
                              inline: true)
-      static_field(:new_obj, label: "#{type_label}:",
+      static_field(:new_obj, label: type_label,
                              value: viewer_aware_format_name(@new_obj),
                              inline: true)
     end
@@ -42,12 +42,12 @@ module Views::Controllers::Admin::Emails::MergeRequests
     end
 
     def render_message_field
-      textarea_field(:message, label: "#{:Notes.t}:", rows: 10,
+      textarea_field(:message, label: :Notes, rows: 10,
                                value: "", data: { autofocus: true })
     end
 
     def type_label
-      @model_class.type_tag.to_s.upcase.to_sym.t
+      @model_class.type_tag.to_s.upcase.to_sym
     end
 
     def form_action

--- a/app/views/controllers/admin/emails/name_change_requests/form.rb
+++ b/app/views/controllers/admin/emails/name_change_requests/form.rb
@@ -24,7 +24,7 @@ module Views::Controllers::Admin::Emails::NameChangeRequests
     private
 
     def render_name_field
-      static_field(:name, label: "#{:NAME.t}:",
+      static_field(:name, label: :NAME,
                           value: "#{@name.unique_search_name}" \
                                  "[##{@name.icn_id}]",
                           inline: true)
@@ -32,13 +32,13 @@ module Views::Controllers::Admin::Emails::NameChangeRequests
 
     def render_new_name_field
       read_only_field(:new_name_with_icn_id,
-                      label: "#{:new_name.t}:",
+                      label: :new_name,
                       value: @new_name_with_icn_id,
                       inline: true)
     end
 
     def render_message_field
-      textarea_field(:message, label: "#{:Notes.t}:", rows: 10,
+      textarea_field(:message, label: :Notes, rows: 10,
                                value: "", data: { autofocus: true })
     end
 

--- a/app/views/controllers/admin/emails/webmaster_questions/form.rb
+++ b/app/views/controllers/admin/emails/webmaster_questions/form.rb
@@ -33,7 +33,7 @@ module Views::Controllers::Admin::Emails::WebmasterQuestions
 
     def render_email_field
       autofocus = model.reply_to.blank? || @email_error
-      text_field(:reply_to, label: "#{:ask_webmaster_your_email.t}:",
+      text_field(:reply_to, label: :ask_webmaster_your_email,
                             size: 60,
                             data: { autofocus: autofocus })
     end
@@ -41,7 +41,7 @@ module Views::Controllers::Admin::Emails::WebmasterQuestions
     def render_message_field
       autofocus = model.reply_to.present? && !@email_error
       textarea_field(:message,
-                     label: "#{:ask_webmaster_question.t}:", rows: 10,
+                     label: :ask_webmaster_question, rows: 10,
                      data: { autofocus: autofocus })
     end
 

--- a/app/views/controllers/admin/session/form.rb
+++ b/app/views/controllers/admin/session/form.rb
@@ -14,7 +14,7 @@ module Views::Controllers::Admin::Session
         autocompleter_field(
           :user,
           type: :user,
-          label: "#{:LOGIN_NAME.l}:",
+          label: :LOGIN_NAME,
           value: model.user,
           size: 42,
           autofocus: true

--- a/app/views/controllers/articles/form.rb
+++ b/app/views/controllers/articles/form.rb
@@ -16,7 +16,7 @@ module Views::Controllers::Articles
     private
 
     def render_title_field
-      text_field(:title, label: "#{:article_title.t}:",
+      text_field(:title, label: :article_title,
                          data: { autofocus: true }) do |field_component|
         field_component.with_append do
           Help(content: [:form_article_title_help.t,
@@ -26,7 +26,7 @@ module Views::Controllers::Articles
     end
 
     def render_body_field
-      textarea_field(:body, label: "#{:article_body.t}:",
+      textarea_field(:body, label: :article_body,
                             rows: 10) do |field_component|
         field_component.with_append do
           Help(content: :field_textile_link.t)

--- a/app/views/controllers/collection_numbers/form.rb
+++ b/app/views/controllers/collection_numbers/form.rb
@@ -38,14 +38,14 @@ module Views::Controllers::CollectionNumbers
 
     def render_name_field
       text_field(:name,
-                 label: :collection_number_name.l,
+                 label: :collection_number_name,
                  between: :required,
                  data: { autofocus: true })
     end
 
     def render_number_field
       text_field(:number,
-                 label: :collection_number_number.l,
+                 label: :collection_number_number,
                  between: :required)
     end
 

--- a/app/views/controllers/comments/form.rb
+++ b/app/views/controllers/comments/form.rb
@@ -23,13 +23,13 @@ module Views::Controllers::Comments
     end
 
     def render_summary_field
-      text_field(:summary, label: "#{:form_comments_summary.t}:",
+      text_field(:summary, label: :form_comments_summary,
                            size: 80,
                            data: { autofocus: true })
     end
 
     def render_comment_field
-      textarea_field(:comment, label: "#{:form_comments_comment.t}:",
+      textarea_field(:comment, label: :form_comments_comment,
                                rows: 10) do |f|
         f.with_help { :shared_textile_help.l }
       end

--- a/app/views/controllers/descriptions/author_requests/form.rb
+++ b/app/views/controllers/descriptions/author_requests/form.rb
@@ -23,12 +23,12 @@ module Views::Controllers::Descriptions::AuthorRequests
     end
 
     def render_subject_field
-      text_field(:subject, label: "#{:request_subject.t}:",
+      text_field(:subject, label: :request_subject,
                            data: { autofocus: true })
     end
 
     def render_message_field
-      textarea_field(:message, label: "#{:request_message.t}:", rows: 10)
+      textarea_field(:message, label: :request_message, rows: 10)
     end
   end
 end

--- a/app/views/controllers/descriptions/form.rb
+++ b/app/views/controllers/descriptions/form.rb
@@ -89,9 +89,9 @@ module Views::Controllers::Descriptions
       div(class: "form-group") do
         b { "#{:form_description_permissions.l}:" }
         checkbox_field(:public_write,
-                       label: :form_description_public_writable.l,
+                       label: :form_description_public_writable,
                        disabled: permissions_disabled?)
-        checkbox_field(:public, label: :form_description_public_readable.l,
+        checkbox_field(:public, label: :form_description_public_readable,
                                 disabled: permissions_disabled?)
         Help(element: :p, content: :form_description_permissions_help.t)
       end
@@ -106,7 +106,7 @@ module Views::Controllers::Descriptions
     def render_license_field
       # `@licenses` is Rails-shape `[[label, id], ...]` from
       # `License.available_names_and_ids`; pass through.
-      select_field(:license_id, @licenses, label: "#{:License.l}:") do
+      select_field(:license_id, @licenses, label: :License) do
         Help(element: :p, content: :form_description_license_help.t)
       end
     end

--- a/app/views/controllers/descriptions/merges/form.rb
+++ b/app/views/controllers/descriptions/merges/form.rb
@@ -48,7 +48,7 @@ module Views::Controllers::Descriptions::Merges
     end
 
     def render_delete_checkbox
-      checkbox_field(:delete, label: :merge_descriptions_delete_after.t)
+      checkbox_field(:delete, label: :merge_descriptions_delete_after)
     end
 
     def render_submit

--- a/app/views/controllers/descriptions/moves/form.rb
+++ b/app/views/controllers/descriptions/moves/form.rb
@@ -47,7 +47,7 @@ module Views::Controllers::Descriptions::Moves
     end
 
     def render_delete_checkbox
-      checkbox_field(:delete, label: :merge_descriptions_delete_after.t)
+      checkbox_field(:delete, label: :merge_descriptions_delete_after)
     end
 
     def render_submit

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -54,7 +54,7 @@ module Views::Controllers::FieldSlips
     # --- "Code only" form: no field-slip code yet, just collect one.
 
     def render_code_only_form
-      text_field(:code, label: "#{:field_slip_code.t}:")
+      text_field(:code, label: :field_slip_code)
       submit(:field_slip_create_obs.t, class: "mt-5")
     end
 
@@ -106,7 +106,7 @@ module Views::Controllers::FieldSlips
     # --- Left-column field-slip attribute fields ---
 
     def render_left_column_fields
-      text_field(:code, label: "#{:field_slip_code.t}:")
+      text_field(:code, label: :field_slip_code)
       render_project_select if model.projects.present?
       render_date_field
       render_collector_field
@@ -114,9 +114,9 @@ module Views::Controllers::FieldSlips
       render_field_slip_name_field
       render_field_slip_id_by_field
       text_field(:other_codes,
-                 label: "#{:field_slip_other_codes.t} " \
-                        "(#{:field_slip_other_example.t}):")
-      checkbox_field(:inat, label: :field_slip_other_inat.t)
+                 label: "#{:field_slip_other_codes.l} " \
+                        "(#{:field_slip_other_example.l})")
+      checkbox_field(:inat, label: :field_slip_other_inat)
     end
 
     def render_project_select
@@ -124,14 +124,14 @@ module Views::Controllers::FieldSlips
       # — pass through to SelectField.
       select_field(:project_id, model.projects,
                    inline: true,
-                   label: "#{:Project.t}:",
+                   label: :Project,
                    selected: model.project&.id)
     end
 
     def render_date_field
       today = Time.zone.today
       date_field(:date,
-                 label: "#{:DATE.t}:",
+                 label: :DATE,
                  inline: true,
                  start_year: today.year - 10,
                  end_year: today.year + 10)
@@ -140,13 +140,13 @@ module Views::Controllers::FieldSlips
     def render_collector_field
       autocompleter_field(:collector,
                           type: :user,
-                          label: "#{:COLLECTOR.t}:")
+                          label: :COLLECTOR)
     end
 
     def render_location_field
       autocompleter_field(:location,
                           type: :location,
-                          label: "#{:LOCATION.t}:",
+                          label: :LOCATION,
                           value: model.location_name,
                           hidden_value: model.location_id)
     end
@@ -154,13 +154,13 @@ module Views::Controllers::FieldSlips
     def render_field_slip_name_field
       autocompleter_field(:field_slip_name,
                           type: :name,
-                          label: "#{:ID.t}:")
+                          label: :ID)
     end
 
     def render_field_slip_id_by_field
       autocompleter_field(:field_slip_id_by,
                           type: :user,
-                          label: "#{:ID_BY.t}:")
+                          label: :ID_BY)
     end
 
     # --- Notes ---
@@ -182,7 +182,7 @@ module Views::Controllers::FieldSlips
         Components::Form::Notes::Part.new(
           key: part.name,
           value: part.value,
-          label: "#{part.label}:"
+          label: part.label
         )
       end
     end

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -90,7 +90,7 @@ module Views::Controllers::FieldSlips
                  project_field,
                  type: :project, hidden_name: :project, inline: true,
                  size: 60, class: "mb-0",
-                 label: "#{:field_slip_filter_by.l}:"
+                 label: :field_slip_filter_by
                ))
       end
     end

--- a/app/views/controllers/field_slips/qr_reader/form.rb
+++ b/app/views/controllers/field_slips/qr_reader/form.rb
@@ -12,7 +12,7 @@ module Views::Controllers::FieldSlips::QRReader
     end
 
     def view_template
-      text_field(:code, label: :app_qrcode.t,
+      text_field(:code, label: :app_qrcode,
                         data: { qr_reader_target: "input",
                                 action: "qr-reader#handleInput" })
     end

--- a/app/views/controllers/glossary_terms/form.rb
+++ b/app/views/controllers/glossary_terms/form.rb
@@ -29,12 +29,12 @@ module Views::Controllers::GlossaryTerms
     end
 
     def render_locked_checkbox
-      checkbox_field(:locked, label: :edit_glossary_term_locked.l,
+      checkbox_field(:locked, label: :edit_glossary_term_locked,
                               wrap_class: "mt-3")
     end
 
     def render_name_field
-      text_field(:name, label: "#{:glossary_term_name.l}:",
+      text_field(:name, label: :glossary_term_name,
                         data: { autofocus: true }) do |f|
         f.with_append do
           p do
@@ -48,7 +48,7 @@ module Views::Controllers::GlossaryTerms
 
     def render_description_field
       textarea_field(:description,
-                     label: "#{:glossary_term_description.l}:",
+                     label: :glossary_term_description,
                      rows: 16) do |f|
         f.with_append do
           p do

--- a/app/views/controllers/glossary_terms/images/remove_form.rb
+++ b/app/views/controllers/glossary_terms/images/remove_form.rb
@@ -70,7 +70,7 @@ module Views::Controllers::GlossaryTerms::Images
     # checkbox in MO's standard `.checkbox` BS3 markup.
     def render_select_checkbox(image)
       checkbox_field("selected[#{image.id}]",
-                     label: "#{:image.t} ##{image.id}",
+                     label: "#{:image.l} ##{image.id}",
                      wrap_class: "my-0",
                      checked_value: "yes",
                      unchecked_value: "no")

--- a/app/views/controllers/herbaria/curator_requests/form.rb
+++ b/app/views/controllers/herbaria/curator_requests/form.rb
@@ -25,7 +25,7 @@ module Views::Controllers::Herbaria::CuratorRequests
         plain(@herbarium.name)
       end
 
-      textarea_field(:notes, label: "#{:NOTES.l}:", rows: 10,
+      textarea_field(:notes, label: :NOTES, rows: 10,
                              data: { autofocus: true })
 
       submit(:SEND.l, center: true)

--- a/app/views/controllers/herbaria/form.rb
+++ b/app/views/controllers/herbaria/form.rb
@@ -42,7 +42,7 @@ module Views::Controllers::Herbaria
     private
 
     def render_name_field
-      text_field(:name, label: "#{:NAME.t}:") do |f|
+      text_field(:name, label: :NAME) do |f|
         f.with_between { render_name_between }
       end
     end
@@ -73,7 +73,7 @@ module Views::Controllers::Herbaria
       autocompleter_field(
         :personal_user_name,
         type: :user,
-        label: :edit_herbarium_admin_make_personal.t,
+        label: :edit_herbarium_admin_make_personal,
         inline: true
       ) do |f|
         f.with_help { admin_help_text } if admin_help_text
@@ -102,7 +102,7 @@ module Views::Controllers::Herbaria
     def render_personal_checkbox
       checkbox_field(
         :personal,
-        label: :create_herbarium_personal.l,
+        label: :create_herbarium_personal,
         help: personal_checkbox_help,
         help_collapse: true
       )
@@ -119,7 +119,7 @@ module Views::Controllers::Herbaria
 
       text_field(
         :code,
-        label: "#{:create_herbarium_code.l}:",
+        label: :create_herbarium_code,
         inline: true
       ) do |f|
         f.with_help { code_help }
@@ -178,18 +178,18 @@ module Views::Controllers::Herbaria
     end
 
     def render_contact_fields
-      text_field(:email, label: "#{:create_herbarium_email.l}:",
+      text_field(:email, label: :create_herbarium_email,
                          between: :optional)
       textarea_field(
         :mailing_address,
-        label: "#{:create_herbarium_mailing_address.l}:",
+        label: :create_herbarium_mailing_address,
         rows: 5,
         between: :optional
       )
     end
 
     def render_notes_field
-      textarea_field(:description, label: "#{:NOTES.l}:", rows: 10,
+      textarea_field(:description, label: :NOTES, rows: 10,
                                    between: :optional)
     end
 

--- a/app/views/controllers/herbarium_records/form.rb
+++ b/app/views/controllers/herbarium_records/form.rb
@@ -37,19 +37,19 @@ module Views::Controllers::HerbariumRecords
     def render_herbarium_name_field
       autocompleter_field(:herbarium_name,
                           type: :herbarium,
-                          label: :NAME.l,
+                          label: :NAME,
                           between: :required)
     end
 
     def render_initial_det_field
       text_field(:initial_det,
-                 label: :herbarium_record_initial_det.l,
+                 label: :herbarium_record_initial_det,
                  between: :optional)
     end
 
     def render_accession_number_field
       text_field(:accession_number,
-                 label: :herbarium_record_accession_number.l,
+                 label: :herbarium_record_accession_number,
                  between: :required)
     end
 
@@ -61,7 +61,7 @@ module Views::Controllers::HerbariumRecords
     def render_notes_field
       textarea_field(:notes,
                      rows: 6,
-                     label: :NOTES.l,
+                     label: :NOTES,
                      between: :optional)
     end
 

--- a/app/views/controllers/images/emails/form.rb
+++ b/app/views/controllers/images/emails/form.rb
@@ -45,7 +45,7 @@ module Views::Controllers::Images::Emails
     end
 
     def render_message_field
-      textarea_field(:message, label: "#{:ask_user_question_message.t}:",
+      textarea_field(:message, label: :ask_user_question_message,
                                rows: 10)
     end
 

--- a/app/views/controllers/inat_imports/form.rb
+++ b/app/views/controllers/inat_imports/form.rb
@@ -31,18 +31,18 @@ module Views::Controllers::InatImports
 
     def render_inat_username_field
       text_field(:inat_username,
-                 label: "#{:inat_username.l}: ", size: 10, wrap_class: "mb-0")
+                 label: :inat_username, size: 10, wrap_class: "mb-0")
     end
 
     def render_import_others_field
       checkbox_field(:import_others,
-                     label: :inat_import_others.l,
+                     label: :inat_import_others,
                      wrap_class: "mt-1")
     end
 
     def render_skip_writeback_field
       checkbox_field(:skip_inat_writeback,
-                     label: :inat_skip_writeback.l,
+                     label: :inat_skip_writeback,
                      wrap_class: "mt-3")
     end
 
@@ -98,14 +98,14 @@ module Views::Controllers::InatImports
     # Applies to "all" and URL imports; id lists always re-check (#4565).
     def render_recheck_all_field
       checkbox_field(:recheck_all,
-                     label: :inat_recheck_all.l,
+                     label: :inat_recheck_all,
                      help: :inat_recheck_all_help.l,
                      wrap_class: "mt-4")
     end
 
     def render_consent_checkbox
       checkbox_field(:consent,
-                     label: :inat_import_consent.l,
+                     label: :inat_import_consent,
                      wrap_class: "mt-3")
     end
 

--- a/app/views/controllers/info/textile_sandbox_form.rb
+++ b/app/views/controllers/info/textile_sandbox_form.rb
@@ -63,7 +63,7 @@ module Views::Controllers::Info
     end
 
     def render_code_field
-      textarea_field(:code, label: "#{:sandbox_enter.l}:", rows: 8)
+      textarea_field(:code, label: :sandbox_enter, rows: 8)
     end
 
     def render_submit_buttons

--- a/app/views/controllers/licenses/form.rb
+++ b/app/views/controllers/licenses/form.rb
@@ -22,7 +22,7 @@ module Views::Controllers::Licenses
     end
 
     def render_display_name_field
-      text_field(:display_name, label: "#{:license_display_name.t}:",
+      text_field(:display_name, label: :license_display_name,
                                 data: { autofocus: true }) do |f|
         f.with_append do
           Help(content: :license_display_name_help.t)
@@ -31,7 +31,7 @@ module Views::Controllers::Licenses
     end
 
     def render_url_field
-      text_field(:url, label: "#{:license_url.t}:") do |f|
+      text_field(:url, label: :license_url) do |f|
         f.with_append do
           Help(content: :license_url_help.t)
         end
@@ -39,7 +39,7 @@ module Views::Controllers::Licenses
     end
 
     def render_deprecated_checkbox
-      checkbox_field(:deprecated, label: :license_form_checkbox_deprecated.t)
+      checkbox_field(:deprecated, label: :license_form_checkbox_deprecated)
     end
   end
 end

--- a/app/views/controllers/locations/form.rb
+++ b/app/views/controllers/locations/form.rb
@@ -79,7 +79,7 @@ module Views::Controllers::Locations
     end
 
     def render_display_name_field
-      text_field(:display_name, value: @display_name, label: "#{:WHERE.t}:",
+      text_field(:display_name, value: @display_name, label: :WHERE,
                                 data: display_name_data,
                                 help: :form_locations_help.t,
                                 help_collapse: true,
@@ -108,7 +108,7 @@ module Views::Controllers::Locations
     end
 
     def render_locked_checkbox
-      checkbox_field(:locked, label: :form_locations_locked.t,
+      checkbox_field(:locked, label: :form_locations_locked,
                               wrap_class: "mt-3")
     end
 
@@ -117,12 +117,12 @@ module Views::Controllers::Locations
         p { :form_locations_notes_help.t }
         p { trusted_html(:shared_textile_help.l) }
       end
-      textarea_field(:notes, label: "#{:NOTES.t}:", help: notes_help,
+      textarea_field(:notes, label: :NOTES, help: notes_help,
                              help_collapse: true)
     end
 
     def render_hidden_checkbox
-      checkbox_field(:hidden, label: :form_locations_hidden.t,
+      checkbox_field(:hidden, label: :form_locations_hidden,
                               wrap_class: "mt-3 mr-3",
                               help: :form_locations_hidden_doc.t,
                               help_collapse: true)

--- a/app/views/controllers/names/classification/form.rb
+++ b/app/views/controllers/names/classification/form.rb
@@ -10,7 +10,7 @@ module Views::Controllers::Names::Classification
     end
 
     def view_template
-      textarea_field(:classification, label: "#{:form_names_classification.l}:",
+      textarea_field(:classification, label: :form_names_classification,
                                       rows: 10,
                                       between: classification_help,
                                       data: { autofocus: true })

--- a/app/views/controllers/names/classification/inherit/form.rb
+++ b/app/views/controllers/names/classification/inherit/form.rb
@@ -21,7 +21,7 @@ module Views::Controllers::Names::Classification::Inherit
     def view_template
       render_candidates_alert if @candidates
 
-      text_field(:parent, label: "#{:inherit_classification_parent_name.l}:",
+      text_field(:parent, label: :inherit_classification_parent_name,
                           data: { autofocus: true }, inline: true)
 
       submit(:SUBMIT.l, center: true)

--- a/app/views/controllers/names/form.rb
+++ b/app/views/controllers/names/form.rb
@@ -47,7 +47,7 @@ module Views::Controllers::Names
     end
 
     def render_admin_locked_checkbox
-      checkbox_field(:locked, label: :form_names_locked.l, wrap_class: "mt-3")
+      checkbox_field(:locked, label: :form_names_locked, wrap_class: "mt-3")
     end
 
     def render_editable_fields
@@ -62,7 +62,7 @@ module Views::Controllers::Names
     def render_icn_id_field
       div(class: "form-inline my-3") do
         text_field(:icn_id,
-                   label: "#{:form_names_icn_id.l}:",
+                   label: :form_names_icn_id,
                    inline: true,
                    size: 8) do |f|
           f.with_append do
@@ -75,19 +75,19 @@ module Views::Controllers::Names
     def render_rank_and_status_fields
       div(class: "form-inline my-3") do
         select_field(:rank, rank_options,
-                     label: "#{:Rank.l}:",
+                     label: :Rank,
                      wrap_class: "mr-4",
                      selected: @model.rank)
 
         select_field(:deprecated, status_options,
-                     label: "#{:Status.l}:",
+                     label: :Status,
                      selected: (@model.deprecated || false).to_s)
       end
     end
 
     def render_text_name_field
       textarea_field(:text_name,
-                     label: "#{:form_names_text_name.l}:",
+                     label: :form_names_text_name,
                      value: @name_string,
                      rows: 1,
                      data: { autofocus: true }) do |f|
@@ -99,7 +99,7 @@ module Views::Controllers::Names
 
     def render_author_field
       textarea_field(:author,
-                     label: "#{:Authority.l}:",
+                     label: :Authority,
                      rows: 2) do |f|
         f.with_append do
           Help(element: :p, content: :form_names_author_help.l)
@@ -119,7 +119,7 @@ module Views::Controllers::Names
 
     def render_locked_rank_field
       read_only_field(:rank,
-                      label: "#{:Rank.l}:",
+                      label: :Rank,
                       inline: true,
                       wrap_class: "mb-0",
                       text: :"Rank_#{@model.rank.to_s.downcase}".l)
@@ -127,7 +127,7 @@ module Views::Controllers::Names
 
     def render_locked_status_field
       read_only_field(:deprecated,
-                      label: "#{:Status.l}:",
+                      label: :Status,
                       inline: true,
                       wrap_class: "mb-0",
                       text: @model.deprecated ? :DEPRECATED.l : :ACCEPTED.l)
@@ -135,7 +135,7 @@ module Views::Controllers::Names
 
     def render_locked_text_name_field
       read_only_field(:text_name,
-                      label: "#{:Name.l}:",
+                      label: :Name,
                       inline: true,
                       wrap_class: "mb-0",
                       text: @name_string,
@@ -144,7 +144,7 @@ module Views::Controllers::Names
 
     def render_locked_author_field
       read_only_field(:author,
-                      label: "#{:Authority.l}:",
+                      label: :Authority,
                       inline: true,
                       wrap_class: "mb-0",
                       text: @model.author)
@@ -152,7 +152,7 @@ module Views::Controllers::Names
 
     def render_citation_field
       textarea_field(:citation,
-                     label: "#{:Citation.l}:",
+                     label: :Citation,
                      rows: 3) do |f|
         f.with_append do
           Help(element: :p,
@@ -165,14 +165,14 @@ module Views::Controllers::Names
     def render_misspelling_fields
       div(class: "my-4 mx-0") do
         checkbox_field(:misspelling,
-                       label: :form_names_misspelling.l,
+                       label: :form_names_misspelling,
                        checked: @misspelling)
 
         autocompleter_field(
           :correct_spelling,
           type: :name,
           value: @correct_spelling,
-          label: "#{:form_names_misspelling_it_should_be.l}:",
+          label: :form_names_misspelling_it_should_be,
           help: :form_names_misspelling_note.l,
           help_collapse: true
         )
@@ -181,7 +181,7 @@ module Views::Controllers::Names
 
     def render_notes_field
       textarea_field(:notes,
-                     label: "#{:form_names_taxonomic_notes.l}:",
+                     label: :form_names_taxonomic_notes,
                      rows: 6,
                      help: :shared_textile_help.l,
                      help_collapse: true) do |f|

--- a/app/views/controllers/names/lifeforms/form.rb
+++ b/app/views/controllers/names/lifeforms/form.rb
@@ -16,7 +16,7 @@ module Views::Controllers::Names::Lifeforms
             variant: :striped, identifier: "lifeform",
             show_headers: false) do |t|
         t.column(nil) do |word|
-          checkbox_field(word.to_sym, label: :"lifeform_#{word}".l)
+          checkbox_field(word.to_sym, label: :"lifeform_#{word}")
         end
         t.column(nil, class: "container-text") do |word|
           plain(:"lifeform_help_#{word}".t)

--- a/app/views/controllers/names/lifeforms/propagate/form.rb
+++ b/app/views/controllers/names/lifeforms/propagate/form.rb
@@ -29,7 +29,7 @@ module Views::Controllers::Names::Lifeforms::Propagate
             variant: :striped, identifier: "lifeform",
             show_headers: false) do |t|
         t.column(nil) do |word|
-          checkbox_field(:"add_#{word}", label: :"lifeform_#{word}".l)
+          checkbox_field(:"add_#{word}", label: :"lifeform_#{word}")
         end
         t.column(nil, class: "container-text") do |word|
           plain(:"lifeform_help_#{word}".t)
@@ -48,7 +48,7 @@ module Views::Controllers::Names::Lifeforms::Propagate
             variant: :striped, identifier: "lifeform",
             show_headers: false) do |t|
         t.column(nil) do |word|
-          checkbox_field(:"remove_#{word}", label: :"lifeform_#{word}".l)
+          checkbox_field(:"remove_#{word}", label: :"lifeform_#{word}")
         end
         t.column(nil, class: "container-text") do |word|
           plain(:"lifeform_help_#{word}".t)

--- a/app/views/controllers/names/synonyms/approve/form.rb
+++ b/app/views/controllers/names/synonyms/approve/form.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Names::Synonyms::Approve
 
       Help(content: :name_approve_deprecate_help.tp)
 
-      textarea_field(:comment, label: "#{:name_approve_comments.l}:",
+      textarea_field(:comment, label: :name_approve_comments,
                                cols: 80, rows: 5, inline: true,
                                data: { autofocus: true })
       Help(
@@ -31,7 +31,7 @@ module Views::Controllers::Names::Synonyms::Approve
     private
 
     def render_approved_names_section
-      checkbox_field(:deprecate_others, label: :name_approve_deprecate.l)
+      checkbox_field(:deprecate_others, label: :name_approve_deprecate)
       p do
         @approved_names.each do |n|
           trusted_html(n.display_name(@user).t)

--- a/app/views/controllers/names/synonyms/deprecate/form.rb
+++ b/app/views/controllers/names/synonyms/deprecate/form.rb
@@ -37,7 +37,7 @@ module Views::Controllers::Names::Synonyms::Deprecate
     def render_proposed_field
       autocompleter_field(:proposed_name,
                           type: :name,
-                          label: "#{:name_deprecate_preferred.l}:",
+                          label: :name_deprecate_preferred,
                           inline: true, data: { autofocus: true })
       Help(
         content: :name_deprecate_preferred_help.tp
@@ -45,11 +45,11 @@ module Views::Controllers::Names::Synonyms::Deprecate
     end
 
     def render_misspelling_field
-      checkbox_field(:is_misspelling, label: :form_names_misspelling.l)
+      checkbox_field(:is_misspelling, label: :form_names_misspelling)
     end
 
     def render_comment_field
-      textarea_field(:comment, label: "#{:name_deprecate_comments.l}:",
+      textarea_field(:comment, label: :name_deprecate_comments,
                                cols: 80, rows: 5, inline: true)
       Help(content: deprecate_comments_help)
     end

--- a/app/views/controllers/names/synonyms/form.rb
+++ b/app/views/controllers/names/synonyms/form.rb
@@ -102,11 +102,11 @@ module Views::Controllers::Names::Synonyms
     def render_members_section
       render_new_names_alert if @new_names.present?
 
-      checkbox_field(:deprecate_all, label: :form_synonyms_deprecate_synonyms.l)
+      checkbox_field(:deprecate_all, label: :form_synonyms_deprecate_synonyms)
       Help(element: :p, content: :form_synonyms_deprecate_synonyms_help.t)
 
       textarea_field(:synonym_members,
-                     label: "#{:form_synonyms_names.l}:",
+                     label: :form_synonyms_names,
                      data: { autofocus: true }) do |f|
         f.with_between do
           Help(element: :p, content: members_help)

--- a/app/views/controllers/names/trackers/form.rb
+++ b/app/views/controllers/names/trackers/form.rb
@@ -34,7 +34,7 @@ module Views::Controllers::Names::Trackers
 
     def render_tracker_fields
       checkbox_field(:note_template_enabled,
-                     label: :email_tracking_note.t,
+                     label: :email_tracking_note,
                      wrap_class: "mt-5")
 
       Help(class: "mt-2 mb-5",

--- a/app/views/controllers/observations/emails/form.rb
+++ b/app/views/controllers/observations/emails/form.rb
@@ -31,7 +31,7 @@ module Views::Controllers::Observations::Emails
     end
 
     def render_message_field
-      textarea_field(:message, label: "#{:ask_user_question_message.t}:",
+      textarea_field(:message, label: :ask_user_question_message,
                                rows: 6, data: { autofocus: true })
     end
 

--- a/app/views/controllers/observations/external_links/form.rb
+++ b/app/views/controllers/observations/external_links/form.rb
@@ -36,7 +36,7 @@ module Views::Controllers::Observations::ExternalLinks
     def render_external_id_field
       text_field(:external_id,
                  size: 40,
-                 label: :EXTERNAL_ID.l,
+                 label: :EXTERNAL_ID,
                  wrap_class: "w-100",
                  data: field_data("externalId"))
     end
@@ -45,7 +45,7 @@ module Views::Controllers::Observations::ExternalLinks
       text_field(:url,
                  size: 40,
                  value: url_seed,
-                 label: :URL.l,
+                 label: :URL,
                  wrap_class: "w-100",
                  data: field_data("url")) do |f|
         f.with_append { :show_observation_add_link_dialog.l }
@@ -66,7 +66,7 @@ module Views::Controllers::Observations::ExternalLinks
     def render_relationship_field
       select_field(:relationship,
                    ExternalLink.relationships.keys.map { |k| [k.humanize, k] },
-                   label: :RELATIONSHIP.l,
+                   label: :RELATIONSHIP,
                    inline: true,
                    selected: model.relationship)
     end
@@ -79,7 +79,7 @@ module Views::Controllers::Observations::ExternalLinks
     def render_site_select
       select_field(:external_site_id,
                    @sites.sort_by(&:name).map { |site| [site.name, site.id] },
-                   label: :EXTERNAL_SITE.l,
+                   label: :EXTERNAL_SITE,
                    inline: true,
                    selected: (@site || @sites.first)&.id,
                    data: { external_link_form_target: "site",

--- a/app/views/controllers/observations/form/details.rb
+++ b/app/views/controllers/observations/form/details.rb
@@ -43,7 +43,7 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   end
 
   def render_date_field
-    @form.date_field(:when, label: "#{:WHEN.l}:", wrap_class: "mb-3")
+    @form.date_field(:when, label: :WHEN, wrap_class: "mb-3")
   end
 
   # User autocompleter: selecting a suggestion fills the visible field
@@ -55,7 +55,7 @@ class Views::Controllers::Observations::Form::Details < Views::Base
     render(@form.field(:collector).autocompleter(
              type: :user,
              wrapper_options: {
-               label: "#{:COLLECTOR.l}:",
+               label: :COLLECTOR,
                wrap_class: "mb-3",
                help: :form_observations_collector_help.t,
                help_collapse: true
@@ -137,7 +137,7 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   def render_is_collection_location
     @form.checkbox_field(
       :is_collection_location,
-      label: :form_observations_is_collection_location.l,
+      label: :form_observations_is_collection_location,
       wrap_class: "ml-5 mb-5",
       help: :form_observations_is_collection_location_help.t,
       help_collapse: true
@@ -154,7 +154,7 @@ class Views::Controllers::Observations::Form::Details < Views::Base
              form: @form,
              field: :has_geolocation,
              target_id: "observation_geolocation",
-             label: "#{:GEOLOCATION.l}:",
+             label: :GEOLOCATION,
              expanded: @observation.lat.present?,
              attributes: {
                help: :form_observations_lat_long_help.t,
@@ -211,7 +211,7 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   def render_gps_hidden_checkbox
     @form.checkbox_field(
       :gps_hidden,
-      label: :form_observations_gps_hidden.l,
+      label: :form_observations_gps_hidden,
       wrap_class: "ml-5 mb-5"
     )
   end
@@ -219,7 +219,7 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   def render_log_change
     @form.checkbox_field(
       :log_change,
-      label: :form_observations_log_change.t,
+      label: :form_observations_log_change,
       checked: true
     )
   end

--- a/app/views/controllers/observations/form/notes_panel.rb
+++ b/app/views/controllers/observations/form/notes_panel.rb
@@ -32,7 +32,7 @@ module Views::Controllers::Observations
           Components::Form::Notes::Part.new(
             key: model.notes_normalized_key(part),
             value: model.notes_part_value(part),
-            label: single_notes_part? ? "#{:NOTES.l}:" : "#{part}:"
+            label: single_notes_part? ? :NOTES : part
           )
         end
       end

--- a/app/views/controllers/observations/form/projects.rb
+++ b/app/views/controllers/observations/form/projects.rb
@@ -118,7 +118,7 @@ class Views::Controllers::Observations::Form::Projects < Views::Base
   def render_ignore_checkbox
     @form.checkbox_field(
       :ignore_proj_conflicts,
-      label: :form_observations_projects_ignore_project_constraints.t
+      label: :form_observations_projects_ignore_project_constraints
     )
   end
 

--- a/app/views/controllers/observations/form/specimen.rb
+++ b/app/views/controllers/observations/form/specimen.rb
@@ -44,7 +44,7 @@ class Views::Controllers::Observations::Form::Specimen < Views::Base
              form: @form,
              field: :specimen,
              target_id: "specimen_fields",
-             label: :form_observations_specimen_available.l,
+             label: :form_observations_specimen_available,
              expanded: @observation.specimen,
              attributes: {
                wrap_class: "mt-0",
@@ -77,7 +77,7 @@ class Views::Controllers::Observations::Form::Specimen < Views::Base
   def render_collector_name_field(cn_ns)
     help = :form_observations_collection_number_help.t
     render(cn_ns.field(:name).text(
-             wrapper_options: { label: "#{:collection_number_name.l}:",
+             wrapper_options: { label: :collection_number_name,
                                 help: help, help_collapse: true },
              value: @collectors_name
            ))
@@ -85,7 +85,7 @@ class Views::Controllers::Observations::Form::Specimen < Views::Base
 
   def render_collector_number_field(cn_ns)
     render(cn_ns.field(:number).text(
-             wrapper_options: { label: "#{:collection_number_number.l}:" },
+             wrapper_options: { label: :collection_number_number },
              value: @collectors_number,
              data: { action: "specimen#checkCheckbox" }
            ))
@@ -127,7 +127,7 @@ class Views::Controllers::Observations::Form::Specimen < Views::Base
 
   def render_herbarium_notes(hr_ns)
     render(hr_ns.field(:notes).text(
-             wrapper_options: { label: "#{:herbarium_record_notes.l}:" },
+             wrapper_options: { label: :herbarium_record_notes },
              value: ""
            ))
   end

--- a/app/views/controllers/observations/form/upload.rb
+++ b/app/views/controllers/observations/form/upload.rb
@@ -28,7 +28,7 @@ class Views::Controllers::Observations::Form::Upload < Views::Base
         multiple: true,
         controller: "form-images",
         action: "change->form-images#addSelectedFiles",
-        wrapper_options: { label: "#{:IMAGES.l}:", class: "my-3" }
+        wrapper_options: { label: :IMAGES, class: "my-3" }
       )
     )
   end

--- a/app/views/controllers/observations/images/form.rb
+++ b/app/views/controllers/observations/images/form.rb
@@ -43,20 +43,20 @@ module Views::Controllers::Observations::Images
 
     def render_image_fields
       text_field(:copyright_holder,
-                 label: "#{:form_images_copyright_holder.t}:")
+                 label: :form_images_copyright_holder)
       text_field(:original_name,
-                 label: "#{:form_images_original_name.t}:")
+                 label: :form_images_original_name)
       date_field(:when, inline: true,
-                        label: "#{:form_images_when_taken.l}:",
+                        label: :form_images_when_taken,
                         help: :form_images_when_help.t,
                         help_collapse: true)
       select_field(:license_id, @licenses,
-                   label: "#{:LICENSE.t}:",
+                   label: :LICENSE,
                    help: :form_images_license_help.t,
                    help_collapse: true)
       # Two-paragraph help: notes-specific + textile-syntax help.
       textarea_field(:notes,
-                     label: "#{:NOTES.t}:",
+                     label: :NOTES,
                      help: textile_help,
                      help_collapse: true,
                      data: { autofocus: true })

--- a/app/views/controllers/observations/namings/fields.rb
+++ b/app/views/controllers/observations/namings/fields.rb
@@ -46,7 +46,7 @@ class Views::Controllers::Observations::Namings::Fields < Views::Base
     @naming_ns = naming_ns
     name_field = naming_ns.field(:name).autocompleter(
       type: :name,
-      wrapper_options: { label: "#{:WHAT.t}:" },
+      wrapper_options: { label: :WHAT },
       value: @given_name,
       autofocus: focus_on_name?
     )
@@ -70,7 +70,7 @@ class Views::Controllers::Observations::Namings::Fields < Views::Base
       render(vote_ns.field(:value).select(
                menu,
                wrapper_options: {
-                 label: "#{:form_naming_confidence.t}:",
+                 label: :form_naming_confidence,
                  wrap_class: "mt-3"
                },
                selected: @vote&.value,

--- a/app/views/controllers/observations/namings/reasons_fields.rb
+++ b/app/views/controllers/observations/namings/reasons_fields.rb
@@ -46,7 +46,7 @@ class Views::Controllers::Observations::Namings::ReasonsFields < Views::Base
   def render_checkbox(reason_ns, reason)
     render(reason_ns.field(:check).checkbox(
              wrapper_options: {
-               label: reason.label.t,
+               label: reason.label,
                label_data: checkbox_label_data(reason),
                label_aria: checkbox_label_aria(reason)
              },

--- a/app/views/controllers/occurrences/form.rb
+++ b/app/views/controllers/occurrences/form.rb
@@ -168,13 +168,13 @@ module Views::Controllers::Occurrences
       # `distinct_locations` — pass straight through to SelectField.
       render(attrs_ns.field(:location_id).select(
                locations,
-               wrapper_options: { label: :edit_occurrence_location.l }
+               wrapper_options: { label: :edit_occurrence_location }
              ))
     end
 
     def render_date_field(attrs_ns)
       render(attrs_ns.field(:when).date(
-               wrapper_options: { label: :WHEN.l, inline: true }
+               wrapper_options: { label: :WHEN, inline: true }
              ))
     end
 

--- a/app/views/controllers/projects/admin_requests/form.rb
+++ b/app/views/controllers/projects/admin_requests/form.rb
@@ -24,12 +24,12 @@ module Views::Controllers::Projects::AdminRequests
     private
 
     def render_subject_field
-      text_field(:subject, label: "#{:request_subject.t}:", wrap_class: "mt-3",
+      text_field(:subject, label: :request_subject, wrap_class: "mt-3",
                            data: { autofocus: true })
     end
 
     def render_message_field
-      textarea_field(:message, label: "#{:request_message.t}:", rows: 5)
+      textarea_field(:message, label: :request_message, rows: 5)
     end
 
     def form_action

--- a/app/views/controllers/projects/aliases/form.rb
+++ b/app/views/controllers/projects/aliases/form.rb
@@ -57,14 +57,14 @@ module Views::Controllers::Projects::Aliases
     end
 
     def render_name_field
-      text_field(:name, label: "#{:Name.t}:", inline: true)
+      text_field(:name, label: :Name, inline: true)
     end
 
     def render_target_type_select
       select_field(
         :target_type,
         target_type_options,
-        label: "#{:project_alias_type.t}:",
+        label: :project_alias_type,
         inline: true,
         data: {
           type_switch_target: "select",
@@ -87,7 +87,7 @@ module Views::Controllers::Projects::Aliases
         autocompleter_field(
           :term,
           type: :user,
-          label: "#{:USER.l}:",
+          label: :USER,
           value: user_term_value,
           hidden_name: :user_id,
           hidden_value: user_hidden_value
@@ -102,7 +102,7 @@ module Views::Controllers::Projects::Aliases
         autocompleter_field(
           :term,
           type: :location,
-          label: "#{:LOCATION.l}:",
+          label: :LOCATION,
           value: location_term_value,
           hidden_name: :location_id,
           hidden_value: location_hidden_value

--- a/app/views/controllers/projects/field_slips/form.rb
+++ b/app/views/controllers/projects/field_slips/form.rb
@@ -11,10 +11,10 @@ module Views::Controllers::Projects::FieldSlips
 
     def view_template
       super do
-        number_field(:field_slips, label: :field_slips.l,
+        number_field(:field_slips, label: :field_slips,
                                    inline: true, min: 0)
         checkbox_field(:one_per_page,
-                       label: :field_slips_one_per_page.t)
+                       label: :field_slips_one_per_page)
         submit(:CREATE.l, class: "ml-3")
       end
     end

--- a/app/views/controllers/projects/form.rb
+++ b/app/views/controllers/projects/form.rb
@@ -52,30 +52,30 @@ module Views::Controllers::Projects
 
     def render_open_membership
       checkbox_field(:open_membership,
-                     label: :form_projects_open_membership.t)
+                     label: :form_projects_open_membership)
     end
 
     def render_title
       text_field(:title,
-                 label: "#{:form_projects_title.t}:",
+                 label: :form_projects_title,
                  data: { autofocus: true })
     end
 
     def render_summary
       textarea_field(:summary, rows: 5,
-                               label: "#{:SUMMARY.t}:") do |f|
+                               label: :SUMMARY) do |f|
         f.with_help { :shared_textile_help.l }
       end
     end
 
     def render_field_slip_prefix
       text_field(:field_slip_prefix,
-                 label: "#{:FIELD_SLIP_PREFIX.t}:")
+                 label: :FIELD_SLIP_PREFIX)
     end
 
     def render_location
       autocompleter_field(:place_name, type: :location,
-                                       label: "#{:WHERE.t}:")
+                                       label: :WHERE)
     end
 
     def render_dates_section
@@ -85,10 +85,10 @@ module Views::Controllers::Projects
       end
       Container(width: :text, class: "ml-4") do
         date_field(:start_date,
-                   label: "#{:form_projects_start_date.t}: ",
+                   label: :form_projects_start_date,
                    wrap_class: "mb-2")
         date_field(:end_date,
-                   label: "#{:form_projects_end_date.t}: ")
+                   label: :form_projects_end_date)
         render_dates_any_radios
       end
     end

--- a/app/views/controllers/projects/members/form.rb
+++ b/app/views/controllers/projects/members/form.rb
@@ -28,7 +28,7 @@ module Views::Controllers::Projects::Members
           autocompleter_field(
             :candidate,
             type: :user,
-            label: "#{:add_object.t(type: :user)}:",
+            label: :add_object.l(type: :user),
             inline: true,
             size: 40
           )

--- a/app/views/controllers/publications/form.rb
+++ b/app/views/controllers/publications/form.rb
@@ -24,7 +24,7 @@ module Views::Controllers::Publications
     end
 
     def render_full_field
-      textarea_field(:full, rows: 10, label: "#{:publication_full.t}:",
+      textarea_field(:full, rows: 10, label: :publication_full,
                             wrap_class: "mt-3") do |f|
         f.with_between do
           Help(element: :span, content: :publication_full_help.t)
@@ -33,20 +33,20 @@ module Views::Controllers::Publications
     end
 
     def render_link_field
-      text_field(:link, label: "#{:publication_link.t}:")
+      text_field(:link, label: :publication_link)
     end
 
     def render_peer_reviewed_field
-      checkbox_field(:peer_reviewed, label: :publication_peer_reviewed.t)
+      checkbox_field(:peer_reviewed, label: :publication_peer_reviewed)
     end
 
     def render_how_helped_field
       textarea_field(:how_helped, rows: 10,
-                                  label: "#{:publication_how_helped.t}:")
+                                  label: :publication_how_helped)
     end
 
     def render_mo_mentioned_field
-      checkbox_field(:mo_mentioned, label: :publication_mo_mentioned.t)
+      checkbox_field(:mo_mentioned, label: :publication_mo_mentioned)
     end
 
     def submit_text

--- a/app/views/controllers/sequences/form.rb
+++ b/app/views/controllers/sequences/form.rb
@@ -28,7 +28,7 @@ module Views::Controllers::Sequences
     def render_locus_field
       textarea_field(:locus,
                      rows: 1,
-                     label: :LOCUS.l,
+                     label: :LOCUS,
                      between: :required,
                      wrap_class: "w-100")
     end
@@ -41,7 +41,7 @@ module Views::Controllers::Sequences
     end
 
     def render_bases_field
-      textarea_field(:bases, cols: 80, rows: 5, label: :BASES.l,
+      textarea_field(:bases, cols: 80, rows: 5, label: :BASES,
                              class: "font-monospace") do |f|
         f.with_between do
           Help(element: :span,
@@ -68,14 +68,14 @@ module Views::Controllers::Sequences
 
     def render_archive_select
       select_field(:archive, [nil] + sequence_archive_options,
-                   label: :ARCHIVE.l,
+                   label: :ARCHIVE,
                    inline: true,
                    wrap_class: "ml-5")
     end
 
     def render_accession_field
       text_field(:accession,
-                 label: :form_sequence_accession.l,
+                 label: :form_sequence_accession,
                  inline: true,
                  wrap_class: "ml-5")
     end
@@ -88,7 +88,7 @@ module Views::Controllers::Sequences
     def render_notes_field
       textarea_field(:notes,
                      rows: 3,
-                     label: :NOTES.l,
+                     label: :NOTES,
                      between: :optional)
     end
 

--- a/app/views/controllers/species_lists/form.rb
+++ b/app/views/controllers/species_lists/form.rb
@@ -90,21 +90,21 @@ module Views::Controllers::SpeciesLists
     end
 
     def render_visible_fields
-      text_field(:title, label: "#{:form_species_lists_title.l}:")
+      text_field(:title, label: :form_species_lists_title)
       textarea_field(
         :notes, rows: 12,
-                label: "#{:form_species_lists_list_notes.l}:",
+                label: :form_species_lists_list_notes,
                 help: :shared_textile_help.l,
                 help_collapse: true
       )
-      date_field(:when, inline: true, label: "#{:WHEN.l}:")
+      date_field(:when, inline: true, label: :WHEN)
       render(Components::Form::LocationFeedback.new(
                dubious_where_reasons: @dubious_where_reasons,
                button: @button
              ))
       autocompleter_field(:place_name, type: :location,
                                        value: model.place_name(current_user),
-                                       label: "#{:WHERE.l}:")
+                                       label: :WHERE)
     end
 
     def render_project_checkboxes

--- a/app/views/controllers/species_lists/observations/form.rb
+++ b/app/views/controllers/species_lists/observations/form.rb
@@ -26,7 +26,7 @@ module Views::Controllers::SpeciesLists::Observations
         autocompleter_field(
           :title,
           type: :species_list,
-          label: "#{:species_list_add_remove_label.t}:"
+          label: :species_list_add_remove_label
         )
         div(class: "form-group center-block") do
           submit(:ADD.l)

--- a/app/views/controllers/species_lists/projects/form.rb
+++ b/app/views/controllers/species_lists/projects/form.rb
@@ -43,13 +43,13 @@ module Views::Controllers::SpeciesLists::Projects
           plain(:species_list_projects_which_objects.t)
         end
         checkbox_field(:objects_list,
-                       label: :species_list_projects_this_list.t,
+                       label: :species_list_projects_this_list,
                        checked_value: "1", unchecked_value: "0")
         checkbox_field(:objects_obs,
-                       label: :species_list_projects_observations.t,
+                       label: :species_list_projects_observations,
                        checked_value: "1", unchecked_value: "0")
         checkbox_field(:objects_img,
-                       label: :species_list_projects_images.t,
+                       label: :species_list_projects_images,
                        checked_value: "1", unchecked_value: "0")
       end
     end

--- a/app/views/controllers/species_lists/uploads/form.rb
+++ b/app/views/controllers/species_lists/uploads/form.rb
@@ -12,7 +12,7 @@ module Views::Controllers::SpeciesLists::Uploads
 
     def view_template
       super do
-        file_field(:file, label: "#{:species_list_upload_label.t}:")
+        file_field(:file, label: :species_list_upload_label)
         Help(content: :species_list_upload_help.tp)
         submit(:UPLOAD.l, center: true)
       end

--- a/app/views/controllers/species_lists/write_in/form.rb
+++ b/app/views/controllers/species_lists/write_in/form.rb
@@ -97,7 +97,7 @@ module Views::Controllers::SpeciesLists::WriteIn
                             textarea: true,
                             rows: 8,
                             value: @list_members,
-                            label: "#{:form_species_lists_write_in_species.t}:")
+                            label: :form_species_lists_write_in_species)
       end
     end
 
@@ -109,7 +109,7 @@ module Views::Controllers::SpeciesLists::WriteIn
       autocompleter_field(:place_name,
                           type: :location,
                           value: model.place_name(current_user),
-                          label: "#{:WHERE.l}:")
+                          label: :WHERE)
     end
 
     def render_member_fields_section
@@ -133,7 +133,7 @@ module Views::Controllers::SpeciesLists::WriteIn
       select_field("member[value]",
                    Vote.confidence_menu,
                    value: @member_vote,
-                   label: "#{:form_species_lists_confidence.t}:",
+                   label: :form_species_lists_confidence,
                    inline: true)
     end
 
@@ -157,14 +157,14 @@ module Views::Controllers::SpeciesLists::WriteIn
                      value: @member_notes[part.to_sym],
                      rows: 1,
                      class: "form-control mb-3",
-                     label: "#{strip_tags(part.tl)}:")
+                     label: strip_tags(part.tl))
     end
 
     def render_coord_fields
       div(class: "form-group form-inline") do
-        render_coord_field(:lat, @member_lat, "#{:LATITUDE.t}:", 8)
-        render_coord_field(:lng, @member_lng, "#{:LONGITUDE.t}:", 8)
-        render_coord_field(:alt, @member_alt, "#{:ALTITUDE.t}:", 6)
+        render_coord_field(:lat, @member_lat, :LATITUDE, 8)
+        render_coord_field(:lng, @member_lng, :LONGITUDE, 8)
+        render_coord_field(:alt, @member_alt, :ALTITUDE, 6)
       end
     end
 
@@ -180,14 +180,14 @@ module Views::Controllers::SpeciesLists::WriteIn
       checkbox_field("member[is_collection_location]",
                      value: "1",
                      checked: @member_is_collection_location,
-                     label: :form_observations_is_collection_location.t)
+                     label: :form_observations_is_collection_location)
     end
 
     def render_specimen_checkbox
       checkbox_field("member[specimen]",
                      value: "1",
                      checked: @member_specimen,
-                     label: :form_observations_specimen_available.t)
+                     label: :form_observations_specimen_available)
     end
   end
 end

--- a/app/views/controllers/support/form.rb
+++ b/app/views/controllers/support/form.rb
@@ -20,10 +20,10 @@ module Views::Controllers::Support
       super do
         render_amount_row
         render_other_amount_inputs
-        checkbox_field(:recurring, label: :donate_recurring.l)
-        text_field(:who, size: 30, label: :donate_who.l, inline: true)
-        checkbox_field(:anonymous, label: :donate_anonymous.l)
-        text_field(:email, size: 30, label: :donate_email.l, inline: true)
+        checkbox_field(:recurring, label: :donate_recurring)
+        text_field(:who, size: 30, label: :donate_who, inline: true)
+        checkbox_field(:anonymous, label: :donate_anonymous)
+        text_field(:email, size: 30, label: :donate_email, inline: true)
         submit(:donate_confirm.l, center: true)
       end
     end

--- a/app/views/controllers/users/emails/form.rb
+++ b/app/views/controllers/users/emails/form.rb
@@ -31,12 +31,12 @@ module Views::Controllers::Users::Emails
     private
 
     def render_subject_field
-      text_field(:subject, label: "#{:ask_user_question_subject.t}:",
+      text_field(:subject, label: :ask_user_question_subject,
                            size: 70, data: { autofocus: true })
     end
 
     def render_message_field
-      textarea_field(:message, label: "#{:ask_user_question_message.t}:",
+      textarea_field(:message, label: :ask_user_question_message,
                                rows: 10)
     end
 

--- a/app/views/controllers/visual_groups/form.rb
+++ b/app/views/controllers/visual_groups/form.rb
@@ -16,8 +16,8 @@ module Views::Controllers::VisualGroups
         render_errors if model.errors.any?
         render_name_field
         textarea_field(:description, cols: 60, rows: 10,
-                                     label: :DESCRIPTION.t)
-        checkbox_field(:approved, label: :APPROVED.t)
+                                     label: :DESCRIPTION)
+        checkbox_field(:approved, label: :APPROVED)
         submit(:SUBMIT.t, center: true)
       end
     end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1754,7 +1754,6 @@
   form_images_notes_help: Enter notes that are specific to this particular image.
   form_images_copyright_holder: "[:COPYRIGHT_HOLDER]"
   form_images_original_name: Original file name
-  form_images_select_license: Select a "License":/info/how_to_use#license
   form_images_license_help: Select "license":/info/how_to_use#license you want to give for this image.
   form_images_project_help: Check any projects you wish to attach this image to.
   form_images_camera_date: Camera date

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -110,13 +110,19 @@ class ApplicationFormTest < ComponentTestCase
     assert_html(form, "label", text: "Login")
   end
 
+  # Regression: `prefs_no_emails` ("Opt out of _all_ email from MO.")
+  # carries real textile italic markup -- FieldLabelRow#resolved_label_text
+  # resolves bare Symbol labels via `.t`, not `.l`, specifically so this
+  # renders as an actual <em> tag (MO's Textile class's italic output)
+  # instead of literal underscores.
   def test_checkbox_field_prefs_auto_resolves_label_from_i18n
     form = render_form do
       checkbox_field(:no_emails, prefs: true)
     end
 
-    # `:prefs_no_emails.t` → "Opt out of _all_ email from MO."
     assert_includes(form, "Opt out of")
+    assert_html(form, "label em", text: "all")
+    assert_no_html(form, "label", text: "_all_")
   end
 
   def test_auto_label_for_prefs_returns_options_unchanged_when_no_prefs
@@ -128,18 +134,35 @@ class ApplicationFormTest < ComponentTestCase
                  "Without :prefs, options should be untouched")
   end
 
+  # auto_label_for_prefs itself resolves to the bare translation-key
+  # Symbol, not a String -- resolution to actual display text (via
+  # `.t`) happens downstream in FieldLabelRow#resolved_label_text.
   def test_auto_label_for_prefs_drops_prefs_key_when_resolving
     form = Components::ApplicationForm.new(@collection_number,
                                            action: "/test_form_path")
 
     result = form.send(:auto_label_for_prefs, :login,
                        prefs: true, class: "extra")
-    assert_equal("Login", result[:label])
+    assert_equal(:prefs_login, result[:label])
     assert_not(result.key?(:prefs),
                ":prefs should be removed after resolution so it " \
                "doesn't leak into wrapper_options downstream")
     assert_equal("extra", result[:class],
                  "Unrelated options should pass through")
+  end
+
+  # A field label secretly doubling as a clickable link is a UX smell
+  # (not obviously clickable, easy to miss) -- FieldLabelRow raises
+  # rather than silently rendering one. Route link content through
+  # help: instead (see Components::Form::UploadGallery::Fields#
+  # render_license_field for the established pattern).
+  def test_label_containing_a_link_raises
+    error = assert_raises(RuntimeError) do
+      render_form do
+        text_field(:name, label: '<a href="/x">Click</a>'.html_safe)
+      end
+    end
+    assert_match(/contains a link/, error.message)
   end
 
   # Checkbox field tests - CollectionNumber doesn't have boolean fields,
@@ -175,6 +198,21 @@ class ApplicationFormTest < ComponentTestCase
 
     # wrap_class should be on wrapper div, not the input
     assert_html(form, "div.checkbox.mt-3")
+  end
+
+  # Unlike text_field/select_field/etc's colon-suffixed prompt label
+  # (see test_label_containing_a_link_raises above), a checkbox label
+  # can be rich content -- e.g. names/synonyms/form.rb's
+  # synonym-selection checkboxes, whose label is a name link plus a
+  # copy-id badge. CheckboxField#label_text calls resolved_label_text
+  # directly, bypassing FieldLabelRow#label_text's link guard
+  # entirely, so this must render without raising.
+  def test_checkbox_field_label_with_link_does_not_raise
+    form = render_form do
+      checkbox_field(:placeholder, label: '<a href="/x">Click</a>'.html_safe)
+    end
+
+    assert_html(form, "label a[href='/x']", text: "Click")
   end
 
   # Collection mode: `checkbox_field(:field, [label, value], ...)`

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -110,6 +110,21 @@ class ApplicationFormTest < ComponentTestCase
     assert_html(form, "label", text: "Login")
   end
 
+  # Regression (Copilot review on #4687): FieldLabelRow#append_colon used
+  # to interpolate the resolved text into a new String ("#{text}:"),
+  # which strips the html_safe flag off a Textile-rendered label --
+  # render_label_content would then re-escape the already-safe <em>
+  # markup instead of rendering it. Unlike checkbox_field's label_text
+  # (which never appends a colon), text_field goes through the
+  # colon-appending path, so this exercises append_colon directly.
+  def test_label_text_preserves_textile_markup_through_colon
+    form = render_form do
+      text_field(:name, label: :prefs_no_emails)
+    end
+
+    assert_html(form, "label em", text: "all")
+  end
+
   # Regression: `prefs_no_emails` ("Opt out of _all_ email from MO.")
   # carries real textile italic markup -- FieldLabelRow#resolved_label_text
   # resolves bare Symbol labels via `.t`, not `.l`, specifically so this

--- a/test/components/form/checkbox_collapse_test.rb
+++ b/test/components/form/checkbox_collapse_test.rb
@@ -73,9 +73,18 @@ class FormCheckboxCollapseTest < ComponentTestCase
                 "[data-extra='val']")
   end
 
+  # Regression test: label: also accepts a bare Symbol translation key,
+  # resolved via .l by the underlying checkbox_field/FieldLabelRow --
+  # not just an explicit String (#4687).
+  def test_label_accepts_bare_symbol
+    html = render_collapse(label: :APPROVED)
+
+    assert_html(html, "label", text: :APPROVED.l)
+  end
+
   private
 
-  def render_collapse(expanded: false, attributes: {})
+  def render_collapse(expanded: false, attributes: {}, label: "Specimen")
     form = TestForm.new(@obs, action: "/observations")
     the_form = form
     form.render_block = proc do
@@ -83,7 +92,7 @@ class FormCheckboxCollapseTest < ComponentTestCase
                form: the_form,
                field: :specimen,
                target_id: "specimen_fields",
-               label: "Specimen",
+               label: label,
                expanded: expanded,
                attributes: attributes
              ))

--- a/test/components/form/checkbox_collapse_test.rb
+++ b/test/components/form/checkbox_collapse_test.rb
@@ -74,12 +74,12 @@ class FormCheckboxCollapseTest < ComponentTestCase
   end
 
   # Regression test: label: also accepts a bare Symbol translation key,
-  # resolved via .l by the underlying checkbox_field/FieldLabelRow --
+  # resolved via .t by the underlying checkbox_field/FieldLabelRow --
   # not just an explicit String (#4687).
   def test_label_accepts_bare_symbol
     html = render_collapse(label: :APPROVED)
 
-    assert_html(html, "label", text: :APPROVED.l)
+    assert_html(html, "label", text: :APPROVED.t)
   end
 
   private

--- a/test/components/form/upload_gallery/fields_test.rb
+++ b/test/components/form/upload_gallery/fields_test.rb
@@ -79,6 +79,20 @@ module Form
         assert_html(html, "select option")
       end
 
+      # Regression test: the license field's label used to be a whole
+      # sentence with an embedded link ("Select a License:", where
+      # "License" itself was the link) -- refactored to a plain label
+      # plus a separate collapsible help icon so the label isn't a
+      # disguised link. See #4687 (field-label-colon standardization)
+      # and the discussion that prompted this specific split.
+      def test_license_field_has_plain_label_and_help_link
+        html = render_fields(image: @image, img_id: @image.id, upload: false)
+
+        assert_html(html, "label", text: "License:")
+        assert_html(html, "a.info-collapse-trigger")
+        assert_html(html, "a[href='/info/how_to_use#license']")
+      end
+
       private
 
       def render_fields(image:, img_id:, upload:)


### PR DESCRIPTION
## Summary

Centralizes the manual `label: "#{:KEY.l}:"` pattern into `Components::ApplicationForm::FieldLabelRow`, resolving #4687. About 130 call sites across `app/components` and `app/views/controllers` are converted to pass a bare `label:` (a `Symbol`, a `String`, or nothing) and let the shared module resolve and colon-suffix it.

- `FieldLabelRow#resolved_label_text` resolves `wrapper_options[:label]`: a `Symbol` via `.t`, a `String` as-is, otherwise the field's key humanized. `.t` (not `.l`) is deliberate — some translations carry real textile markup (e.g. `prefs_no_emails`, "Opt out of _all_ email from MO.") that needs rendering, and for plain-text labels (the vast majority) `.t`/`.l` render identically.
- `FieldLabelRow#append_colon` is a one-line seam so the trailing `:` convention can be changed or dropped site-wide later without another sweep.
- `FieldLabelRow#label_text` (the default "field prompt" path used by `text_field`/`textarea_field`/`select_field`/`file_field`/`date_field`/`static_text_field`/`read_only_field`) now raises if the resolved label contains a real `<a>` link — a label secretly doubling as a clickable link is a UX smell that should go through `help:` instead. `SelectRangeField`'s "to" connector opts out of the trailing colon via a new `label_colon: false`.
- `CheckboxField#label_text` calls `resolved_label_text` directly, bypassing the link guard — checkbox labels are established as rich, clickable content in places (e.g. `names/synonyms/form.rb`'s synonym-selection checkboxes, whose label is a name link plus a copy-id badge), not plain text prompts.
- `Components::Form::UploadGallery::Fields#render_license_field` is refactored from an embedded link-as-label (the one genuine instance of the smell the new guard targets) to a plain label + help icon linking to `/info/how_to_use#license`. The now-dead `form_images_select_license` translation key is removed.
- `Components::Form::CheckboxCollapse#label` now accepts a bare `Symbol` too, since it passes straight through to `checkbox_field`.

### Incidental cleanup from merging `main`

Merging `main` conflicted with #4679 (`Use Components::Localization more widely`) at three call sites (`account/preferences/form.rb`, `names/lifeforms/form.rb`, `names/lifeforms/propagate/form.rb`) that both PRs touched independently. Resolved in favor of the bare-symbol form (consistent with this PR's design — the central `.t` resolution makes the extra helper call unnecessary for these), which left `Components::Localization#prefs_filter_label` with no remaining callers, so it's deleted.

## Test plan

- [x] `bin/rails test test/components/application_form_test.rb` — includes new `test_label_containing_a_link_raises` and `test_checkbox_field_label_with_link_does_not_raise`, plus updated assertions for `.t`-based textile rendering (`prefs_no_emails`) and bare-symbol `auto_label_for_prefs`.
- [x] `bin/rails test test/components/form/checkbox_collapse_test.rb` — new `test_label_accepts_bare_symbol`.
- [x] `bin/rails test test/components/form/upload_gallery/fields_test.rb` — new `test_license_field_has_plain_label_and_help_link`.
- [x] Full suite run by the PR author locally, green.
- [x] `bundle exec rubocop` clean on touched files.
