### PR TITLE
Fix `ImageDhashJob` racing `script/process_image`'s async resize/transfer

### DIFF
--- a/app/jobs/image_dhash_job.rb
+++ b/app/jobs/image_dhash_job.rb
@@ -7,10 +7,33 @@
 class ImageDhashJob < ApplicationJob
   queue_as(:default)
 
-  def perform(image_id)
+  # `process_image` enqueues this job as soon as it backgrounds
+  # script/process_image (fire-and-forget, does not wait for the resize/
+  # transfer to finish) -- so no rendition may be available yet
+  # (Image#dhash_source_ready?, #4799). Not urgent, so reschedule with
+  # exponential backoff instead of hashing a placeholder URL. Six
+  # attempts spans 30s + 1m + 2m + 4m + 8m ≈ 15 minutes, comfortably
+  # longer than script/process_image ever takes; give up silently past
+  # that rather than retrying forever (e.g. the transfer permanently
+  # failed).
+  MAX_ATTEMPTS = 6
+  INITIAL_WAIT = 30.seconds
+
+  def perform(image_id, attempt: 1)
     image = Image.find_by(id: image_id)
     return unless image
 
-    image.compute_dhash!
+    if image.dhash_source_ready?
+      image.compute_dhash!
+    elsif attempt < MAX_ATTEMPTS
+      reschedule(image_id, attempt)
+    end
+  end
+
+  private
+
+  def reschedule(image_id, attempt)
+    wait = INITIAL_WAIT * (2**(attempt - 1))
+    ImageDhashJob.set(wait: wait).perform_later(image_id, attempt: attempt + 1)
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -855,21 +855,33 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   # serves: hash the small (then medium) local rendition and NEVER the
   # full-size original — decoding a large original with ImageMagick can
   # exhaust the host (a routine 25 MP upload froze the site for ~3.5 min,
-  # #4796). The small rendition is generated before ImageDhashJob is
-  # enqueued (Image#process_image), so it is present on fresh
-  # uploads. With no local rendition (e.g. after the originals are
-  # cleaned up), fall back to fetching the transferred small rendition.
+  # #4796). Call only when dhash_source_ready? -- see that method for why
+  # the small rendition is not guaranteed to exist yet when this is
+  # called (#4799).
   def compute_dhash!
-    source = [:small, :medium].
-             map { |size| full_filepath(size) }.
-             find { |path| File.exist?(path) }
-    value = if source
-              Image::Dhash.from_file(source)
-            else
-              Image::Dhash.from_url(small_url)
-            end
+    source = local_dhash_source
+    value = source ? Image::Dhash.from_file(source) : Image::Dhash.from_url(small_url)
     update_column(:dhash, value)
     value
+  end
+
+  # Is a rendition of this image available to hash yet? `process_image`
+  # backgrounds `script/process_image` (its command string ends in "&"),
+  # so the resize-and-transfer script is often still running when
+  # ImageDhashJob picks up the job it enqueued -- neither a local small/
+  # medium rendition nor the remote transfer may exist yet. Calling
+  # compute_dhash! in that window falls through Image::URL#url to
+  # PLACEHOLDER_URLS (a hostless relative path), and RestClient.get
+  # raises trying to parse it as a URI (#4799). ImageDhashJob checks this
+  # and reschedules itself with backoff instead of hashing prematurely.
+  def dhash_source_ready?
+    local_dhash_source.present? || transferred
+  end
+
+  def local_dhash_source
+    [:small, :medium].
+      map { |size| full_filepath(size) }.
+      find { |path| File.exist?(path) }
   end
 
   # Attempt to strip GPS data from original image. Returns error message as

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -860,7 +860,11 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   # called (#4799).
   def compute_dhash!
     source = local_dhash_source
-    value = source ? Image::Dhash.from_file(source) : Image::Dhash.from_url(small_url)
+    value = if source
+              Image::Dhash.from_file(source)
+            else
+              Image::Dhash.from_url(small_url)
+            end
     update_column(:dhash, value)
     value
   end

--- a/test/jobs/image_dhash_job_test.rb
+++ b/test/jobs/image_dhash_job_test.rb
@@ -24,4 +24,61 @@ class ImageDhashJobTest < ActiveJob::TestCase
   def test_missing_image_is_a_noop
     assert_nothing_raised { ImageDhashJob.perform_now(-1) }
   end
+
+  # process_image backgrounds script/process_image and enqueues this job
+  # immediately, without waiting for the resize/transfer to finish -- so
+  # the source may not be ready yet. Reschedule with backoff instead of
+  # hashing a placeholder URL (#4799).
+  def test_reschedules_when_source_not_ready
+    image = images(:in_situ_image) # transferred: false
+    image.stub(:full_filepath, "/no/such/file.jpg") do
+      Image.stub(:find_by, image) do
+        assert_enqueued_with(
+          job: ImageDhashJob,
+          args: lambda { |args|
+            args[0] == image.id && args[1] == { attempt: 2 }
+          }
+        ) do
+          ImageDhashJob.perform_now(image.id)
+        end
+      end
+    end
+    assert_nil(image.reload.dhash)
+  end
+
+  def test_reschedule_wait_doubles_each_attempt
+    image = images(:in_situ_image) # transferred: false
+    waits = []
+    scheduled_job = Object.new
+    def scheduled_job.perform_later(*, **); end
+
+    image.stub(:full_filepath, "/no/such/file.jpg") do
+      Image.stub(:find_by, image) do
+        ImageDhashJob.stub(:set, lambda { |wait:|
+          waits << wait
+          scheduled_job
+        }) do
+          (1..5).each do |attempt|
+            ImageDhashJob.perform_now(image.id, attempt: attempt)
+          end
+        end
+      end
+    end
+
+    assert_equal([30.seconds, 1.minute, 2.minutes, 4.minutes, 8.minutes], waits)
+  end
+
+  def test_gives_up_after_max_attempts
+    image = images(:in_situ_image) # transferred: false
+    image.stub(:full_filepath, "/no/such/file.jpg") do
+      Image.stub(:find_by, image) do
+        ImageDhashJob.stub(:set, lambda { |*|
+          flunk("Should not reschedule again")
+        }) do
+          ImageDhashJob.perform_now(image.id, attempt: ImageDhashJob::MAX_ATTEMPTS)
+        end
+      end
+    end
+    assert_nil(image.reload.dhash)
+  end
 end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -219,6 +219,38 @@ class ImageTest < UnitTestCase
     assert_equal(123, img.reload.dhash)
   end
 
+  # ImageDhashJob's readiness gate (#4799): a local small/medium
+  # rendition is a ready source, whether or not the transfer to the
+  # remote image server(s) has happened yet.
+  def test_dhash_source_ready_when_local_file_exists
+    img = images(:in_situ_image) # transferred: false
+    small = img.full_filepath(:small)
+    File.stub(:exist?, ->(path) { path == small }) do
+      assert(img.dhash_source_ready?)
+    end
+  end
+
+  # A `transferred` image is ready even with no local rendition -- the
+  # small rendition can be fetched remotely (#4799).
+  def test_dhash_source_ready_when_transferred_with_no_local_file
+    # transferred: true (fixture default -- unlike in_situ_image/
+    # turned_over_image, which both explicitly override it to false)
+    img = images(:connected_coprinus_comatus_image)
+    img.stub(:full_filepath, "/no/such/file.jpg") do
+      assert(img.dhash_source_ready?)
+    end
+  end
+
+  # Neither a local rendition nor a completed transfer -- process_image's
+  # backgrounded resize/transfer script (script/process_image) may still
+  # be running. Not ready; ImageDhashJob must not hash this yet (#4799).
+  def test_dhash_source_not_ready_without_local_file_or_transfer
+    img = images(:in_situ_image) # transferred: false
+    img.stub(:full_filepath, "/no/such/file.jpg") do
+      assert_not(img.dhash_source_ready?)
+    end
+  end
+
   def test_validate_vote_rescues_non_numeric
     assert_nil(Image.validate_vote(Object.new))
   end


### PR DESCRIPTION
## Summary

Fixes an `ArgumentError: no host component for URI ...` cropping up in the background exception log for `ImageDhashJob`, introduced by #4799 (`Hash the small rendition, never the full-size original`).

- `Image#process_image` backgrounds `script/process_image` — `MO.process_image_command` ends its command string with `&` — and enqueues `ImageDhashJob` immediately afterward, without waiting for the resize/transfer to finish. `script/process_image`'s own usage docs say as much: "It is intended to run asynchronously."
- When the job runs before the resize/transfer completes, `compute_dhash!` finds no local `small`/`medium` rendition and the image isn't `transferred` yet, so it falls back to `Image::Dhash.from_url(small_url)`. `Image::URL#url` then falls through every source to `PLACEHOLDER_URLS[:small]` ("/place_holder_320.jpg" — no scheme, no host), and `RestClient.get` blows up trying to parse that as a URI.

## Fix

- `Image#dhash_source_ready?` — true once a local `small`/`medium` rendition file exists, or the image has been `transferred`.
- `ImageDhashJob` checks this before hashing. If not ready, it reschedules itself with exponential backoff (30s/1m/2m/4m/8m across 6 attempts, ≈15 minutes) rather than hashing prematurely — the hash isn't urgent, so waiting out the resize/transfer window is fine (per Nathan's suggestion on the original report). Gives up silently past 6 attempts rather than retrying forever if the transfer never completes (e.g. permanently failed).

## Test plan

- [x] `bin/rails test test/models/image_test.rb` — new `test_dhash_source_ready_when_local_file_exists`, `test_dhash_source_ready_when_transferred_with_no_local_file`, `test_dhash_source_not_ready_without_local_file_or_transfer`; existing `compute_dhash!` tests unchanged and still pass (the readiness gate lives in the job, not `compute_dhash!` itself).
- [x] `bin/rails test test/jobs/image_dhash_job_test.rb` — new `test_reschedules_when_source_not_ready`, `test_reschedule_wait_doubles_each_attempt`, `test_gives_up_after_max_attempts`; existing tests unchanged.
- [x] `bundle exec rubocop` clean on touched files.
