### PR TITLE
Confirm image transfers in the same run so fresh uploads don't stay `transferred=false`

### DIFF
--- a/app/models/image/processor/verifier.rb
+++ b/app/models/image/processor/verifier.rb
@@ -59,15 +59,25 @@ class Image
         # completion, exactly the window #4791's race used to exploit.
         return if local_sizes.value?(nil)
 
-        remote_sizes = @image_servers.index_with do |server|
-          remote_sizes_for(server, paths_for_server(server, paths))
-        end
-
-        upload_mismatches(image, paths, local_sizes, remote_sizes)
+        remote_sizes = remote_snapshot(paths)
+        # Re-read the servers after uploading: a file just pushed here must
+        # be confirmed present by an independent `find` before its local
+        # copy is deleted. Without the re-read, all_synced? compares against
+        # the pre-upload snapshot and can never confirm a first-time upload,
+        # so the image sits uploaded-but-unmarked forever -- nothing
+        # schedules a second pass (TransferImagesJob runs once per image).
+        remote_sizes = remote_snapshot(paths) if
+          upload_mismatches(image, paths, local_sizes, remote_sizes)
         return unless all_synced?(paths, local_sizes, remote_sizes)
 
         delete_local_copies(image, paths)
         mark_transferred(image)
+      end
+
+      def remote_snapshot(paths)
+        @image_servers.index_with do |server|
+          remote_sizes_for(server, paths_for_server(server, paths))
+        end
       end
 
       def paths_for(image)
@@ -84,14 +94,20 @@ class Image
         File.exist?(full) ? File.size(full) : nil
       end
 
+      # Uploads every path whose remote size doesn't match local. Returns
+      # true if it attempted any upload, so the caller knows to re-read the
+      # servers before trusting all_synced? (see transfer_image).
       def upload_mismatches(image, paths, local_sizes, remote_sizes)
+        attempted = false
         @image_servers.each do |server|
           paths_for_server(server, paths).each do |path|
             next if remote_sizes[server][path] == local_sizes[path]
 
+            attempted = true
             upload_one_file(image, server, path)
           end
         end
+        attempted
       end
 
       # One file's transfer failing (returned false, or raised -- e.g.
@@ -111,12 +127,12 @@ class Image
         log("Failed to upload #{path} to #{server}: #{e.message}")
       end
 
-      # Deliberately checks against the PRE-upload remote_sizes snapshot --
-      # a file just uploaded above isn't re-verified in the same run before
-      # being trusted; it waits for the next run's fresh remote check. That
-      # keeps a routine upload failure and a routine "just fixed it" both
-      # inconclusive here (safe either way: nothing gets deleted or marked
-      # transferred on unverified data).
+      # Checks against a snapshot taken AFTER any upload in this run
+      # (transfer_image re-reads the servers when it uploaded anything), so
+      # a first-time upload is confirmed by an independent `find` on the
+      # server before its local copy is deleted -- not trusted on the
+      # uploader's own say-so. A silently-failed upload shows as still
+      # missing here and is safely left unmarked.
       #
       # `[].all?` is vacuously true -- guard against @image_servers being
       # empty (development's :mycolab has no :write target, so

--- a/app/models/image/processor/verifier.rb
+++ b/app/models/image/processor/verifier.rb
@@ -66,8 +66,8 @@ class Image
         # the pre-upload snapshot and can never confirm a first-time upload,
         # so the image sits uploaded-but-unmarked forever -- nothing
         # schedules a second pass (TransferImagesJob runs once per image).
-        remote_sizes = remote_snapshot(paths) if
-          upload_mismatches(image, paths, local_sizes, remote_sizes)
+        uploaded = upload_mismatches(image, paths, local_sizes, remote_sizes)
+        remote_sizes = remote_snapshot(paths) if uploaded
         return unless all_synced?(paths, local_sizes, remote_sizes)
 
         delete_local_copies(image, paths)

--- a/test/models/image/processor/verifier_test.rb
+++ b/test/models/image/processor/verifier_test.rb
@@ -43,11 +43,12 @@ class Image::Processor::VerifierTest < UnitTestCase
     super
   end
 
-  # A mismatch gets uploaded, but the image isn't trusted as complete on
-  # the same run that just fixed it -- deliberate (see Verifier's
-  # all_synced? comment): a freshly-uploaded file isn't re-verified until
-  # the next run's fresh remote check.
-  def test_uploads_mismatch_but_does_not_yet_mark_transferred
+  # A first-time upload is confirmed and marked complete on the SAME run:
+  # transfer_image re-reads the servers after uploading, so all_synced?
+  # sees the just-uploaded file. Without the re-read the image would sit
+  # uploaded-but-unmarked forever, since TransferImagesJob runs only once
+  # per image and nothing schedules a second pass.
+  def test_uploads_mismatch_then_marks_transferred_same_run
     image = images(:turned_over_image)
     seed_locally_complete(image)
     seed_remote(1, image, %w[thumb 320 640 1280 orig])
@@ -57,10 +58,31 @@ class Image::Processor::VerifierTest < UnitTestCase
 
     assert_includes(result[:uploaded],
                     [image.id, :remote1, "960/#{image.id}.jpg"])
-    assert_not(image.reload.transferred)
-    assert_empty(result[:completed])
-    assert_path_exists("#{local_root}/960/#{image.id}.jpg",
-                       "not deleted -- upload isn't verified yet this run")
+    assert_includes(result[:completed], image.id)
+    assert(image.reload.transferred)
+    assert_not(File.exist?("#{local_root}/960/#{image.id}.jpg"),
+               "uploaded and confirmed this run -- local copy deleted")
+  end
+
+  # The post-upload re-read is genuine verification, not blind trust in the
+  # uploader's return value: a copy that reports success but didn't
+  # actually land (still missing on the re-read) leaves the image unmarked
+  # and its local copy intact.
+  def test_upload_reporting_success_but_not_present_is_not_marked
+    image = images(:turned_over_image)
+    seed_locally_complete(image)
+    seed_remote(1, image, %w[thumb 320 640 1280 orig])
+    seed_remote(2, image, %w[thumb 320 640])
+
+    # copy_file_to_server claims success but writes nothing to the server.
+    Image::Processor::FileTransfer.stub(:copy_file_to_server, true) do
+      result = Image::Processor.transfer_images([image.id])
+
+      assert_empty(result[:completed])
+      assert_not(image.reload.transferred)
+      assert_path_exists("#{local_root}/960/#{image.id}.jpg",
+                         "not deleted -- re-read never confirmed the upload")
+    end
   end
 
   # Nothing to upload from the start (already fully synced) -- completes


### PR DESCRIPTION
## Summary

Fixes a bug in the #4751 transfer pipeline where **every fresh image upload landed on the server but stayed `transferred=false` with its local copies intact**, until `StaleImageFilesJob` flagged it an hour later.

`Image::Processor::Verifier#transfer_image` computed the remote snapshot once, *before* uploading, then checked `all_synced?` against that same pre-upload snapshot. For a first-time upload that snapshot is all-missing, so `all_synced?` was always false on the run that did the upload — the code deliberately deferred confirmation to "the next run's fresh remote check." But `TransferImagesJob` is enqueued exactly once per image (image.rb:785) and never re-enqueues, `Image::Processor.transfer_images` is a single `Verifier` pass, and nothing polls for `transferred=false` images. So the second run never happened: the file was uploaded, but never marked transferred and never cleaned up locally.

This was masked until now by the `ssh_sizes` `-printf` bug (fixed separately) — while that was live, everything stuck for *that* reason. Once the remote check started returning accurate data, fresh uploads began sticking for *this* reason instead, which is what the `StaleImageFilesJob` alerts surfaced (e.g. a clean block of 16 images all `t=false` but already present `5/5` on the server).

## Fix

Re-read the servers *after* uploading (only when something was actually uploaded) and check `all_synced?` against that fresh snapshot. A file just pushed is now confirmed present by an independent `find` on the server before its local copy is deleted — it is still **not** trusted on the uploader's own return value, so a silently-failed upload (reports success but the file isn't really there) shows as still-missing on the re-read and is safely left unmarked. When nothing needed uploading (the already-synced case: retries, gap-detector regen), no second read is issued.

This reverses the previously-documented "confirm on the next run" choice on `all_synced?`, on the reasoning that a post-upload `find` is itself an independent verification — it checks the server actually has the file, rather than trusting rsync's exit code. @nimmo is aware.

## Test plan

- [x] `bin/rails test test/models/image/processor/verifier_test.rb` — rewrote `test_uploads_mismatch_but_does_not_yet_mark_transferred` into `test_uploads_mismatch_then_marks_transferred_same_run` (the mismatch is now uploaded *and* marked complete on the same run, local copy deleted), plus new `test_upload_reporting_success_but_not_present_is_not_marked` (a copy that reports success but writes nothing leaves the image unmarked and the local copy intact).
- [x] `bin/rails test test/jobs/transfer_images_job_test.rb test/models/image/processor/gap_detector_test.rb test/models/image/processor_test.rb` — the other `Verifier` consumers, unaffected.
- [x] `bundle exec rubocop` clean on both files.

Context: #4791 (transfer-pipeline target design), #4735 (job-ify uploads).
