### PR TITLE
Skip re-sending images already in MCP

### DIFF
--- a/app/classes/report/mycoportal_image_list.rb
+++ b/app/classes/report/mycoportal_image_list.rb
@@ -44,17 +44,28 @@ module Report
 
     # --------------------
 
+    # Records every image included in the most recent #body call as
+    # exported to MyCoPortal, so future calls skip it (avoids sending
+    # images MCP already has, which it doesn't dedupe on its end).
+    # A separate step from #body/#image_list -- not automatic -- so
+    # merely computing a CSV never has the side effect of marking
+    # images as sent; only an explicit post-generation call does.
+    def mark_exported!
+      unless @exported_image_ids
+        raise("mark_exported! called before body/image_list")
+      end
+
+      site = ExternalSite.mycoportal
+      @exported_image_ids.each { |image_id| create_export_link(site, image_id) }
+    end
+
+    # --------------------
+
     private
 
     def image_list
-      rows_data =
-        Image.joins(:observations, :user, :license).
-        where(observations: { id: @query.result_ids }).
-        # MCP doesn't care about order, but our tests do.
-        order(observation_id: :asc, id: :asc).
-        pluck(:observation_id, :id,
-              Image[:copyright_holder],
-              User[:name], User[:login], License[:url])
+      rows_data = image_rows_data
+      @exported_image_ids = rows_data.pluck(1).uniq
 
       ::CSV.generate(col_sep: ",", encoding: "UTF-8") do |csv|
         csv << %w[catalogNumber imageId rights]
@@ -62,6 +73,41 @@ module Report
           csv << formatted_row(row)
         end
       end
+    end
+
+    def image_rows_data
+      Image.joins(:observations, :user, :license).
+        where(observations: { id: @query.result_ids }).
+        where.not(id: already_exported_image_ids).
+        # MCP doesn't care about order, but our tests do.
+        order(observation_id: :asc, id: :asc).
+        pluck(:observation_id, :id,
+              Image[:copyright_holder],
+              User[:name], User[:login], License[:url])
+    end
+
+    # Images already exported to MyCoPortal (any prior run, or the
+    # one-time DwC-A backfill) -- excluded so MCP never receives a
+    # duplicate media record for the same image.
+    def already_exported_image_ids
+      ExternalLink.where(external_site: ExternalSite.mycoportal,
+                         target_type: "Image", relationship: :export).
+        select(:target_id)
+    end
+
+    def create_export_link(site, image_id)
+      return if ExternalLink.exists?(target_type: "Image",
+                                     target_id: image_id,
+                                     external_site: site,
+                                     relationship: :export)
+
+      ExternalLink.create!(user: User.admin, target_type: "Image",
+                           target_id: image_id, external_site: site,
+                           relationship: :export)
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.warn(
+        "Mycoportal export link failed for Image #{image_id}: #{e.message}"
+      )
     end
 
     def formatted_row(row)

--- a/app/classes/report/mycoportal_image_list.rb
+++ b/app/classes/report/mycoportal_image_list.rb
@@ -55,13 +55,27 @@ module Report
         raise("mark_exported! called before body/image_list")
       end
 
-      site = ExternalSite.mycoportal
-      @exported_image_ids.each { |image_id| create_export_link(site, image_id) }
+      export_images!
     end
 
     # --------------------
 
     private
+
+    # Bookkeeping only -- must never let a failure here (e.g. a missing
+    # ExternalSite row, a DB error) turn an already-computed, valid CSV
+    # into a 500. #render_report has already sent the file to the
+    # caller by the time this runs, but Rails discards that response
+    # and renders an error page if the action subsequently raises, so
+    # any exception here would still cost the user their download.
+    def export_images!
+      site = ExternalSite.mycoportal
+      @exported_image_ids.each { |image_id| create_export_link(site, image_id) }
+    rescue StandardError => e
+      Rails.logger.error(
+        "MyCoPortal export-tracking failed: #{e.class}: #{e.message}"
+      )
+    end
 
     def image_list
       rows_data = image_rows_data
@@ -92,7 +106,7 @@ module Report
     def already_exported_image_ids
       ExternalLink.where(external_site: ExternalSite.mycoportal,
                          target_type: "Image", relationship: :export).
-        select(:target_id)
+        select(:target_id).distinct
     end
 
     def create_export_link(site, image_id)
@@ -106,7 +120,7 @@ module Report
                            relationship: :export)
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.warn(
-        "Mycoportal export link failed for Image #{image_id}: #{e.message}"
+        "MyCoPortal export link failed for Image #{image_id}: #{e.message}"
       )
     end
 

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -25,7 +25,7 @@ class LookupsController < ApplicationController
     lookup_general(Name)
   end
 
-  # This was created in late July 2012 to give MycoPortal a safe way to link
+  # This was created in late July 2012 to give MyCoPortal a safe way to link
   # back to MO's show_name pages.  In particular, it was not intended to be
   # used with a name ID.  It can actually return a deprecated name if you give
   # it a name ID.  This is, of course, bizarre behavior, but we're ignoring it

--- a/app/controllers/observations/downloads_controller.rb
+++ b/app/controllers/observations/downloads_controller.rb
@@ -62,6 +62,7 @@ module Observations
         query: @query, format: @format, encoding: @encoding, user: @user
       )
       render_report(report)
+      report.mark_exported! if report.respond_to?(:mark_exported!)
     end
 
     FORMATS = %w[

--- a/app/models/external_site.rb
+++ b/app/models/external_site.rb
@@ -6,12 +6,13 @@
 #  == Attributes
 #
 #  id::            Locally unique numerical id, starting at 1.
-#  name::          Name of website, e.g. "MycoPortal".
+#  name::          Name of website, e.g. "MyCoPortal".
 #  project::       Project which talks about the website and whose members
 #                  may edit external_links to this site for any observation.
 #
 class ExternalSite < AbstractModel
   INATURALIST_NAME = "iNaturalist"
+  MYCOPORTAL_NAME = "MyCoPortal"
 
   belongs_to :project
   has_many   :external_links
@@ -52,6 +53,12 @@ class ExternalSite < AbstractModel
   # by indexed unique name.
   def self.inaturalist
     find_by!(name: INATURALIST_NAME)
+  end
+
+  # The MyCoPortal site row, seeded by fixtures/migration. Cheap lookup
+  # by indexed unique name.
+  def self.mycoportal
+    find_by!(name: MYCOPORTAL_NAME)
   end
 
   # URL of the per-record page on this site for the given external_id

--- a/app/models/herbarium_record.rb
+++ b/app/models/herbarium_record.rb
@@ -36,7 +36,7 @@
 #  herbarium_label::  Initial determination + accession number.
 #  format_name::      Same as herbarium_label.
 #  accession_at_herbarium:: Format as "spec #nnnn @ Herbarium".
-#  mcp_url::          URL for corresponding MycoPortal record
+#  mcp_url::          URL for corresponding MyCoPortal record
 #
 #  == Callbacks
 #

--- a/test/classes/query/external_sites_test.rb
+++ b/test/classes/query/external_sites_test.rb
@@ -17,7 +17,7 @@ class Query::ExternalSitesTest < UnitTestCase
   end
 
   def test_external_link_name_has
-    expects = ExternalSite.name_has("MycoPortal")
-    assert_query(expects, :ExternalSite, name_has: "MycoPortal")
+    expects = ExternalSite.name_has("MyCoPortal")
+    assert_query(expects, :ExternalSite, name_has: "MyCoPortal")
   end
 end

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -960,6 +960,39 @@ class ReportTest < UnitTestCase
     assert_raises(RuntimeError) { report.mark_exported! }
   end
 
+  def test_mycoportal_image_list_mark_exported_logs_on_invalid
+    image = images(:in_situ_image)
+    report = Report::MycoportalImageList.new(query: Query.lookup(:Observation))
+    report.body
+
+    warnings = []
+    stubbed_error = lambda do |*|
+      link = ExternalLink.new
+      link.errors.add(:base, "stubbed failure")
+      raise(ActiveRecord::RecordInvalid.new(link))
+    end
+
+    Rails.logger.stub(:warn, ->(msg) { warnings << msg }) do
+      ExternalLink.stub(:create!, stubbed_error) do
+        report.mark_exported!
+      end
+    end
+
+    assert(
+      warnings.any? do |msg|
+        msg.include?("Mycoportal export link failed for Image #{image.id}")
+      end,
+      "mark_exported! should log a warning naming the failed image when " \
+      "ExternalLink.create! raises RecordInvalid"
+    )
+    assert_not(
+      ExternalLink.exists?(target: image,
+                           external_site: ExternalSite.mycoportal,
+                           relationship: :export),
+      "No ExternalLink should be created when create! raises"
+    )
+  end
+
   def hashed_expect(obs)
     obs_location = obs.location
     obs_when = obs.when

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -907,6 +907,59 @@ class ReportTest < UnitTestCase
     )
   end
 
+  def test_mycoportal_image_list_excludes_already_exported_image
+    obs = observations(:detailed_unknown_obs)
+    image = images(:in_situ_image)
+    ExternalLink.create!(user: User.admin, target: image,
+                         external_site: ExternalSite.mycoportal,
+                         relationship: :export)
+
+    row = mycoportal_image_list_row(obs, image)
+
+    assert_nil(row, "Already-exported image should be excluded from the list")
+  end
+
+  def test_mycoportal_image_list_mark_exported_creates_link
+    image = images(:in_situ_image)
+    site = ExternalSite.mycoportal
+    report = Report::MycoportalImageList.new(query: Query.lookup(:Observation))
+    report.body
+
+    report.mark_exported!
+
+    assert(
+      ExternalLink.exists?(target: image, external_site: site,
+                           relationship: :export),
+      "mark_exported! should create an export ExternalLink for image " \
+      "#{image.id}"
+    )
+  end
+
+  def test_mycoportal_image_list_mark_exported_idempotent
+    image = images(:in_situ_image)
+    site = ExternalSite.mycoportal
+
+    2.times do
+      report =
+        Report::MycoportalImageList.new(query: Query.lookup(:Observation))
+      report.body
+      report.mark_exported!
+    end
+
+    assert_equal(
+      1,
+      ExternalLink.where(target: image, external_site: site,
+                         relationship: :export).count,
+      "Running mark_exported! twice should not create duplicate export links"
+    )
+  end
+
+  def test_mycoportal_image_list_mark_exported_before_body_raises
+    report = Report::MycoportalImageList.new(query: Query.lookup(:Observation))
+
+    assert_raises(RuntimeError) { report.mark_exported! }
+  end
+
   def hashed_expect(obs)
     obs_location = obs.location
     obs_when = obs.when

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -980,7 +980,7 @@ class ReportTest < UnitTestCase
 
     assert(
       warnings.any? do |msg|
-        msg.include?("Mycoportal export link failed for Image #{image.id}")
+        msg.include?("MyCoPortal export link failed for Image #{image.id}")
       end,
       "mark_exported! should log a warning naming the failed image when " \
       "ExternalLink.create! raises RecordInvalid"
@@ -991,6 +991,18 @@ class ReportTest < UnitTestCase
                            relationship: :export),
       "No ExternalLink should be created when create! raises"
     )
+  end
+
+  def test_mycoportal_image_list_mark_exported_survives_site_lookup_failure
+    report = Report::MycoportalImageList.new(query: Query.lookup(:Observation))
+    report.body
+
+    site_lookup_fails = -> { raise(ActiveRecord::RecordNotFound) }
+    ExternalSite.stub(:mycoportal, site_lookup_fails) do
+      assert_nothing_raised do
+        report.mark_exported!
+      end
+    end
   end
 
   def hashed_expect(obs)

--- a/test/components/link/external_test.rb
+++ b/test/components/link/external_test.rb
@@ -89,7 +89,7 @@ class Components::Link::ExternalTest < ComponentTestCase
     assert_html(html,
                 "a[href='#{link.url}']" \
                 "[target='_blank'][rel='noopener noreferrer']",
-                text: "Manual link to MycoPortal")
+                text: "Manual link to MyCoPortal")
     assert_includes(html, "#{link.relationship_date.web_date}: ")
     assert_no_html(html, "small")
   end

--- a/test/controllers/observations/downloads_controller_test.rb
+++ b/test/controllers/observations/downloads_controller_test.rb
@@ -390,6 +390,30 @@ module Observations
       assert_equal(expect, rows, "Wrong MyCoPortal Image List csv")
     end
 
+    def test_mycoportal_image_list_marks_images_exported
+      query = Query.lookup_and_save(:Observation, by_users: [dick])
+      obs = Observation.joins(:images).where(id: query.results(&:id)).first
+      image = obs.images.first
+      site = ExternalSite.mycoportal
+
+      login
+      post(:create,
+           params: {
+             q: @controller.q_param(query),
+             download: { format: :mycoportal_image_list,
+                         encoding: "UTF-8" },
+             commit: "Download"
+           })
+
+      assert_response(:success)
+      assert(
+        ExternalLink.exists?(target: image, external_site: site,
+                             relationship: :export),
+        "Downloading the MyCoPortal image list should mark included " \
+        "images as exported"
+      )
+    end
+
     private
 
     def image_rights(image)

--- a/test/controllers/observations/downloads_controller_test.rb
+++ b/test/controllers/observations/downloads_controller_test.rb
@@ -393,6 +393,9 @@ module Observations
     def test_mycoportal_image_list_marks_images_exported
       query = Query.lookup_and_save(:Observation, by_users: [dick])
       obs = Observation.joins(:images).where(id: query.results(&:id)).first
+      assert_not_nil(
+        obs, "Test needs a query which results in an Observation with Images"
+      )
       image = obs.images.first
       site = ExternalSite.mycoportal
 

--- a/test/fixtures/external_sites.yml
+++ b/test/fixtures/external_sites.yml
@@ -4,7 +4,7 @@
 # See http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 mycoportal:
-  name:     MycoPortal
+  name:     MyCoPortal
   project:  empty_project # mary is only member and admin
   base_url: "https://mycoportal.org/portal/collections/"
   url_template: "https://mycoportal.org/portal/collections/individual/index.php?occid={id}"

--- a/test/models/external_link_test.rb
+++ b/test/models/external_link_test.rb
@@ -11,7 +11,7 @@ class ExternalLinkTest < UnitTestCase
     )
     # default (manual) relationship, interpolates a non-iNat site name
     assert_equal(
-      "Manual link to MycoPortal",
+      "Manual link to MyCoPortal",
       external_links(:coprinus_comatus_obs_mycoportal_link).
         relationship_description
     )

--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -271,7 +271,7 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
     assert_nil(link.url, "an external_id link stores no url")
 
     within("#observation_external_links") do
-      assert_link(text: /MycoPortal/)
+      assert_link(text: /MyCoPortal/)
       find_link(:EDIT.l).trigger("click")
     end
 
@@ -293,6 +293,6 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
       click_button(class: "btn-danger")
     end
     assert_no_selector("#mo_confirm", visible: true)
-    assert_no_link(text: /MycoPortal/)
+    assert_no_link(text: /MyCoPortal/)
   end
 end

--- a/test/views/controllers/observations/show/external_links_panel_test.rb
+++ b/test/views/controllers/observations/show/external_links_panel_test.rb
@@ -45,7 +45,7 @@ class Views::Controllers::Observations::Show::ExternalLinksPanelTest <
     # Generic sibling link (mycoportal): relationship is the link text.
     mycoportal = external_links(:coprinus_comatus_obs_mycoportal_link)
     assert_html(html, "a[href='#{mycoportal.url}']",
-                text: "Manual link to MycoPortal")
+                text: "Manual link to MyCoPortal")
     # iNaturalist sibling link: "<relationship> (<id>)"
     inat = external_links(:coprinus_comatus_obs_inaturalist_link)
     assert_html(html, "a[href='#{inat.url}']",


### PR DESCRIPTION
Resolves #4818

This is Part 1 of 3 to improve and correct the protocol for updating the MO collection in MyCoPortal

- This part prevents re-sending images already in MCP by using ExternalLink to track which images have already been sent.
- Part 2 will backfill ExternalLink.
- Part 3 will automate parts of the update protocol

Skip re-sending images already in MCP
`Report::MycoportalImageList` resent every image on every matched
observation each run, including ones already uploaded, because MCP
doesn't dedupe media by URL. Track exports via `ExternalLink`
(`relationship: :export`) so already-sent images are excluded from
future CSVs.

Also fixes "MycoPortal" -> "MyCoPortal" casing in the external_sites
fixture, model/controller comments, and the tests asserting on it —
the site's real name is "MyCoPortal", which the new
`ExternalSite.mycoportal` lookup depends on matching exactly.