### PR TITLE
Cache-bust image rendition URLs with an `updated_at` token in `Image::URL#source_url`

### DIFF
--- a/app/components/matrix/table.rb
+++ b/app/components/matrix/table.rb
@@ -37,7 +37,10 @@ class Components::Matrix::Table < Components::Base
   # read this through `cache_key_for`. Phlex's automatic class +
   # method + line digest doesn't survive into the controller's
   # check, so we encode the version explicitly.
-  CACHE_VERSION = "v1"
+  # v2: image URLs in the fragment now carry a cache-busting
+  # ?<updated_at> token (#4808) -- fragments cached under v1 embed
+  # tokenless URLs and must be regenerated.
+  CACHE_VERSION = "v2"
 
   # The cache key MatrixBox fragments are stored under, used by
   # both the Phlex `low_level_cache` write inside this component and

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -358,7 +358,8 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
       size: size,
       id: id,
       transferred: transferred,
-      extension: extension(size)
+      extension: extension(size),
+      version: updated_at&.to_i
     )
   end
 
@@ -367,7 +368,8 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
       size: size,
       id: id,
       transferred: args.fetch(:transferred, true),
-      extension: args.fetch(:extension, "jpg")
+      extension: args.fetch(:extension, "jpg"),
+      version: args[:version]
     )
   end
 

--- a/app/models/image/processor.rb
+++ b/app/models/image/processor.rb
@@ -255,9 +255,16 @@ class Image
 
     # This also sets transferred to false to save db writes.
     # Needed in rotate, and later overwritten in process.
+    # updated_at is forced explicitly: a mirror (or 180/vertical flip)
+    # leaves width/height unchanged, and transferred can already be
+    # false -- with no dirty attribute Rails skips the UPDATE entirely,
+    # so updated_at (and the #4808 cache-busting URL token derived from
+    # it) would never change and browsers would keep the pre-transform
+    # bytes. Rotations dodge this only by luck (width/height swap).
     def update_image_record_width_height_and_transferred
       width, height = FastImage.size(full_size_filepath)
-      @image.update(width: width, height: height, transferred: false)
+      @image.update(width: width, height: height, transferred: false,
+                    updated_at: Time.zone.now)
     end
 
     def make_file_sizes

--- a/app/models/image/url.rb
+++ b/app/models/image/url.rb
@@ -25,7 +25,7 @@ class Image
       small: "/place_holder_320.jpg"
     }.freeze
 
-    attr_accessor :size, :id, :transferred, :extension
+    attr_accessor :size, :id, :transferred, :extension, :version
 
     def initialize(args)
       size = args[:size]
@@ -35,6 +35,7 @@ class Image
       self.id          = args[:id]
       self.transferred = args[:transferred]
       self.extension   = args[:extension]
+      self.version     = args[:version]
     end
 
     def url
@@ -69,8 +70,17 @@ class Image
       result.code == 200
     end
 
+    # Renditions live at stable paths keyed only on id + size, so a
+    # rotate/mirror (or any reprocessing) rewrites the file contents
+    # under an unchanged URL and browsers/CDNs keep serving the old
+    # cached bytes until a hard refresh (#4808). Appending a version
+    # token that changes with the image record makes the URL flip once
+    # reprocessing finishes. The token stays out of full_filepath --
+    # that also builds local filesystem paths, where a query string
+    # would be wrong.
     def source_url(source)
-      full_filepath(format_spec(source, :read))
+      url = full_filepath(format_spec(source, :read))
+      version ? "#{url}?#{version}" : url
     end
 
     def full_filepath(path)

--- a/test/models/image/processor_test.rb
+++ b/test/models/image/processor_test.rb
@@ -332,6 +332,32 @@ class Image::ProcessorTest < UnitTestCase
     assert_equal(500, image.height)
   end
 
+  # Regression for a bug found testing #4824: a mirror leaves
+  # width/height unchanged, and transferred can already be false (any
+  # environment with no writable image servers, or a not-yet-transferred
+  # image) -- with no dirty attribute, Rails skipped the UPDATE
+  # entirely, so updated_at (and the #4808 cache-busting URL token
+  # derived from it) never changed and browsers kept serving the
+  # pre-mirror bytes. Rotations dodged this only because width/height
+  # swap. The record must be touched whenever the files are rewritten.
+  def test_rotate_mirror_bumps_updated_at_when_no_attribute_changes
+    image = images(:in_situ_image)
+    FileUtils.cp(JPG_FIXTURE, "#{local_root}/orig/#{image.id}.jpg")
+    width, height = FastImage.size("#{local_root}/orig/#{image.id}.jpg")
+    image.update_columns(transferred: false, width: width, height: height,
+                         updated_at: 1.day.ago)
+    old_updated_at = image.reload.updated_at
+    old_url = image.url(:small)
+
+    Image::Processor.new(image: image, ext: "jpg").rotate("-h")
+
+    image.reload
+    assert_operator(image.updated_at, :>, old_updated_at,
+                    "mirror must bump updated_at so the cache-busting " \
+                    "URL token changes")
+    assert_not_equal(old_url, image.url(:small))
+  end
+
   def test_salvage_first_layer_if_multilayer_picks_one_and_cleans_up
     image = images(:in_situ_image)
     processor = Image::Processor.new(image: image, ext: "tiff")

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -543,6 +543,53 @@ class ImageTest < UnitTestCase
     assert_not_equal("/place_holder_320.jpg", url.url)
   end
 
+  # Rendition URLs are cache-busted with an updated_at token (#4808):
+  # reprocessing (rotate/mirror) rewrites file contents under an
+  # otherwise-stable path, so without the token browsers/CDNs keep
+  # serving the old bytes until a hard refresh.
+  def test_url_includes_updated_at_cache_busting_token
+    img = images(:in_situ_image)
+    img.transferred = true
+    token = img.updated_at.to_i
+
+    Image::ALL_SIZES.each do |size|
+      url = img.url(size)
+      assert(url.end_with?("/#{img.id}.jpg?#{token}"),
+             "Expected #{size} URL #{url.inspect} to end with " \
+             "cache-busting token ?#{token}")
+    end
+  end
+
+  def test_url_cache_busting_token_changes_when_image_is_updated
+    img = images(:in_situ_image)
+    img.update_column(:transferred, true)
+    old_url = img.reload.url(:medium)
+
+    img.update_column(:updated_at, img.updated_at + 1.hour)
+
+    assert_not_equal(old_url, img.reload.url(:medium),
+                     "Expected URL to change when updated_at changes")
+  end
+
+  def test_url_placeholders_never_get_a_cache_busting_token
+    url = Image::URL.new(size: :thumbnail, id: 999_999, transferred: false,
+                         extension: "jpg", version: 123)
+
+    assert_equal("/place_holder_thumb.jpg", url.url)
+  end
+
+  # Class-level Image.url (id-only call sites: textile embeds, map
+  # popups, data exports) has no record to read updated_at from --
+  # no token unless the caller passes one. Reports in particular
+  # depend on these URLs staying stable.
+  def test_class_level_url_has_no_token_unless_version_passed
+    img = images(:in_situ_image)
+
+    assert_not_includes(Image.url(:full_size, img.id, transferred: true), "?")
+    assert(Image.url(:full_size, img.id,
+                     transferred: true, version: 123).end_with?("?123"))
+  end
+
   def test_import_link
     img = images(:in_situ_image)
     assert_nil(img.import_link, "Image starts with no import link")


### PR DESCRIPTION
## Summary

Fixes #4808. First of two PRs replacing the closed #4752 (whose base branch died with #4749's closing) — this is the cache-busting prerequisite; the surviving Turbo-broadcast work follows in a PR stacked on this one.

Image renditions live at stable URLs keyed only on id + size (`.../320/<id>.jpg`), so a rotate/mirror — async in production since #4751's `RotateImageJob` — rewrites the file contents under an unchanged URL, and browsers/CDNs keep serving the previously-cached bytes until a hard refresh. Manually reproduced on both the show-image and show-observation pages (see #4808).

### Change

`Image::URL#source_url` now appends `?<version>` when a version token is present, and `Image#image_url` threads `updated_at.to_i` through as that token. The rotate pipeline bumps `updated_at` when processing finishes, so the URL flips exactly when fresh bytes exist — a page load *during* processing still shows the old image (it genuinely isn't done yet), and any load after completion fetches fresh. This fixes normal reloads everywhere an `Image` record is rendered (show pages, matrix boxes, carousels).

### What deliberately does NOT get a token

- **Class-level `Image.url`/`Image.all_urls`** (id-only call sites: textile `!image>` embeds, map popups, comment-user thumbnails, data exports) — no record in hand to read `updated_at` from, so no token unless the caller passes `version:` explicitly. The Fundis/report exports in particular depend on stable URLs.
- **Placeholder URLs** (`/place_holder_*.jpg`) — static assets.
- **`Image::URL#full_filepath`** — also builds local *filesystem* paths (`Image#full_filepath`, `source_exists?`), where a query string would be wrong. The token is applied only in `source_url`.

### Caveat to verify at deploy time (from #4808)

The buster only works if nginx on `images.mushroomobserver.org` (and any CDN in front of it) varies its cache by query string — the common default. Worth confirming that vhost config before relying on this in production; if query strings are stripped there, the token needs to move into a path segment instead.

## Test plan

- [x] `bin/rails test test/models/image_test.rb` — new coverage: every size's instance URL carries the `?<updated_at.to_i>` token; token changes when `updated_at` changes; placeholders never get a token; class-level `Image.url` is token-free without `version:` and tokened with it
- [x] `bin/rails test test/models/image_test.rb test/components/ test/classes/report_test.rb` — 1005 tests, 0 failures (report URL stability confirmed)
- [x] `bin/rails test test/controllers/observations/downloads_controller_test.rb` — the one controller test asserting exact rendition URLs
- [x] `bundle exec rubocop` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
