### PR TITLE
Broadcast `Image` processing completion via Turbo Streams + `Matrix::Table` cache-key fixes

### DIFF
--- a/app/components/image/base.rb
+++ b/app/components/image/base.rb
@@ -86,7 +86,13 @@ class Components::Image::Base < Components::Base
       img_class: build_image_classes,
       img_data: build_data_attributes(img_urls),
       img_id: img_id,
-      html_id: "#{@id_prefix}_#{img_id}",
+      # Size-scoped so a broadcast re-render of one size (see
+      # Image#broadcast_processed_update) targets only the element
+      # actually showing that size -- the same image can be on-screen
+      # at different sizes on different pages (matrix-box thumbnail
+      # vs. image-show huge vs. edit-page medium), all sharing the
+      # same default id_prefix.
+      html_id: "#{@id_prefix}_#{img_id}_#{@size}",
       proportion: sizing[:proportion],
       width: sizing[:width],
       image_link: normalize_link(@image_link) || image_path(img_id),

--- a/app/components/image/interactive.rb
+++ b/app/components/image/interactive.rb
@@ -69,7 +69,15 @@ class Components::Image::Interactive < Components::Image::Base
     div(
       id: "#{@data[:html_id]}_media",
       class: "image-lazy-sizer overflow-hidden",
-      style: "padding-bottom: #{@data[:proportion]}%;"
+      style: "padding-bottom: #{@data[:proportion]}%;",
+      # The lazyload Stimulus controller (re-)runs
+      # window.lazyLoadInstance.update() on connect. The layout-level
+      # instance only fires on full page loads, so the img.lazy inside
+      # a fragment swapped in by Image#broadcast_processed_update's
+      # Turbo Stream would otherwise stay stuck on placeholder.svg.
+      # Only needed on the broadcast variant -- initial page renders
+      # are covered by the layout.
+      data: (@media_only ? { controller: "lazyload" } : {})
     ) do
       render_lazy_image
       render_noscript_image

--- a/app/components/image/interactive.rb
+++ b/app/components/image/interactive.rb
@@ -21,6 +21,14 @@ class Components::Image::Interactive < Components::Image::Base
   # images with provisional IDs.
   prop :image, _Nilable(::Image)
 
+  # Image#broadcast_processed_update re-renders with this true, to
+  # refresh only the image itself (src/data-src, once resized copies
+  # exist) -- never the link/votes/overlays, which are page-specific
+  # (image_link, votes, extra_classes, identify all vary by call site;
+  # the model has no way to know which page's props to replay). See
+  # the comment on Image::INTERACTIVE_BROADCAST_SIZES.
+  prop :media_only, _Boolean, default: false
+
   def view_template
     return if @upload && @image.blank?
 
@@ -30,8 +38,11 @@ class Components::Image::Interactive < Components::Image::Base
     # Build render data
     @data = build_render_data(@img_instance, @img_id)
 
-    # Render the interactive image
-    render_interactive_image
+    if @media_only
+      render_image_container
+    else
+      render_interactive_image
+    end
   end
 
   private
@@ -56,6 +67,7 @@ class Components::Image::Interactive < Components::Image::Base
 
   def render_image_container
     div(
+      id: "#{@data[:html_id]}_media",
       class: "image-lazy-sizer overflow-hidden",
       style: "padding-bottom: #{@data[:proportion]}%;"
     ) do

--- a/app/components/image_gallery.rb
+++ b/app/components/image_gallery.rb
@@ -32,6 +32,12 @@ class Components::ImageGallery < Components::Base
 
   def view_template
     @carousel_id ||= generate_carousel_id
+    # Rendered as a plain top-level statement, not inside the Carousel
+    # builder block below -- that block is `vanish`ed (its direct
+    # output discarded; only the registered item/thumb blocks survive
+    # to render later), so a `turbo_stream_from` call placed inside it
+    # would silently never emit anything.
+    register_stream_subscriptions
     Panel(panel_id: @panel_id) do |panel|
       panel.with_heading { @title } if @thumbnails
       # `@links` is a `SafeBuffer` from a Rails `capture { … }` block;
@@ -64,6 +70,18 @@ class Components::ImageGallery < Components::Base
            )) do |c|
       register_slides(c)
       register_thumbnails(c) if @thumbnails
+    end
+  end
+
+  # Subscribes this page to Image#broadcast_processed_update's
+  # carousel-slide broadcast, which updates the inside of each
+  # "carousel_item_<id>" wrapper (registered below) once processing
+  # finishes.
+  def register_stream_subscriptions
+    @images.each do |image|
+      next unless image
+
+      turbo_stream_from([image, :processed])
     end
   end
 

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -62,6 +62,12 @@ class Components::Matrix::Box < Components::Base
       id: "box_#{@data[:id]}",
       class: class_names("matrix-box", @columns, @extra_class)
     ) do
+      # Rendered here, not inside the Panel(...) block below -- that
+      # block is `vanish`ed (its direct output discarded; only the
+      # `with_thumbnail`/etc. slot registrations survive to render
+      # later), so a `turbo_stream_from` call placed there would
+      # silently never emit anything.
+      turbo_stream_from([@data[:image], :processed]) if @data[:image]
       Panel(sizing: true) do |panel|
         render_thumbnail_section(panel)
         render_details_section(panel)

--- a/app/components/matrix/table.rb
+++ b/app/components/matrix/table.rb
@@ -47,8 +47,21 @@ class Components::Matrix::Table < Components::Base
   # the controller's `Rails.cache.exist?` pre-check in
   # `ApplicationController::Indexes#object_fragment_exist?`. Keeping
   # both ends on one method ensures they agree on the key shape.
+  #
+  # Folds in the thumb image record itself so the expanded key tracks
+  # the thumb's updated_at (cache_versioning is off in MO, so an AR
+  # object in the key array expands via cache_key, which embeds its
+  # updated_at timestamp). The rendered HTML embeds the thumb's URL,
+  # tokened on that same updated_at (#4808), so the fragment must bust
+  # whenever it changes. `object` alone isn't enough:
+  # Verifier#mark_transferred touch_all's related Observations when a
+  # transfer completes, but RssLogs are never touched, so an RssLog
+  # box cached before a rotate would otherwise serve the pre-rotate
+  # URL token indefinitely. (An `Image` object IS its own thumb and
+  # already keys on its own timestamp via `object` --
+  # `try(:thumb_image)` is nil there, which is fine.)
   def self.cache_key_for(object, locale)
-    ["MatrixBox", CACHE_VERSION, locale, object]
+    ["MatrixBox", CACHE_VERSION, locale, object, object.try(:thumb_image)]
   end
 
   # Per-object predicate the render path uses to decide whether to
@@ -57,8 +70,12 @@ class Components::Matrix::Table < Components::Base
   # (`ApplicationController::Indexes#object_fragment_exist?`).
   # Objects with an untransferred thumb_image are skipped — the
   # rendered HTML embeds the image URL, which would be wrong (and
-  # the wrong-cached) until the transfer completes.
+  # wrongly cached) until the transfer completes. An `Image` object
+  # itself (images/index) has no `thumb_image` to defer to -- it IS
+  # the thumb -- so check its own `transferred` directly instead of
+  # falling through the `respond_to?` guard to an unconditional true.
   def self.should_cache_object?(object)
+    return object.transferred != false if object.is_a?(::Image)
     return true unless object.respond_to?(:thumb_image)
 
     object.thumb_image&.transferred != false

--- a/app/jobs/rotate_image_job.rb
+++ b/app/jobs/rotate_image_job.rb
@@ -14,6 +14,14 @@ class RotateImageJob < ApplicationJob
     return unless image
 
     Image::Processor.new(image: image, ext: ext).rotate(orientation)
+    # The rewritten renditions are servable locally right now -- push
+    # them to subscribed pages without waiting for the transfer.
+    # Image's after_update_commit broadcast only fires on a transferred
+    # flip, which happens when TransferImagesJob completes (never, in
+    # environments with no writable image servers, e.g. development) --
+    # and a transform that changes no dimensions (mirror) on a
+    # not-yet-transferred image flips nothing at all.
+    image.reload.broadcast_processed_update
     TransferImagesJob.perform_later(image_ids: [image_id])
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -255,9 +255,20 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   # re-renders anything. (gps_stripped currently only changes
   # synchronously at upload, before any page could be subscribed --
   # kept as a trigger so the pages catch up if that ever goes async.)
+  # Gated on transferred becoming TRUE (not any flip): processing
+  # starts by setting transferred false (Image::Processor#
+  # update_image_record_width_height_and_transferred) BEFORE the
+  # renditions are regenerated, so broadcasting there would push a
+  # new-token URL at stale files -- and would duplicate the explicit
+  # end-of-processing broadcast RotateImageJob already sends. The two
+  # files-consistent moments are processing completion (explicit, in
+  # the job) and transfer completion (this callback).
   after_update_commit lambda { |image|
-    image.broadcast_processed_update if image.saved_change_to_transferred? ||
-                                        image.saved_change_to_gps_stripped?
+    became_transferred = image.saved_change_to_transferred? &&
+                         image.transferred
+    if became_transferred || image.saved_change_to_gps_stripped?
+      image.broadcast_processed_update
+    end
   }
 
   # Renders for an anonymous viewer -- there's no request-scoped

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -247,6 +247,83 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   after_update :track_copyright_changes
   before_destroy :update_thumbnails
 
+  # Turbo Stream broadcasts that keep every rendered copy of this image
+  # (matrix boxes, side panels, the observation-show carousel) live once
+  # background processing (RotateImageJob/TransferImagesJob) finishes,
+  # without a full page reload. Fires only on the columns processing
+  # flips -- an unrelated Image edit (copyright, notes, vote) never
+  # re-renders anything. (gps_stripped currently only changes
+  # synchronously at upload, before any page could be subscribed --
+  # kept as a trigger so the pages catch up if that ever goes async.)
+  after_update_commit lambda { |image|
+    image.broadcast_processed_update if image.saved_change_to_transferred? ||
+                                        image.saved_change_to_gps_stripped?
+  }
+
+  # Renders for an anonymous viewer -- there's no request-scoped
+  # current_user to reflect here, same limitation Comment's and
+  # InatImport's own broadcasts accept. A call site with heavier
+  # per-user customization (vote highlighting, an admin-only
+  # affordance) catches up on the next real page load, not via this
+  # broadcast.
+  def broadcast_processed_update
+    broadcast_interactive_sizes
+    broadcast_carousel_slide
+  end
+
+  # One broadcast per size Interactive might be showing on any given
+  # page (see INTERACTIVE_BROADCAST_SIZES). `media_only: true` limits
+  # the re-render to just the image itself (src/data-src) -- the model
+  # has no way to know which page-specific image_link/votes/
+  # extra_classes/identify props a given subscriber originally
+  # rendered with, so replaying the *whole* Interactive with defaults
+  # would silently change those (e.g. a matrix-box thumbnail's
+  # image_link falls back to the image's own show page instead of the
+  # parent Observation it was actually pointing at). The link/votes/
+  # overlays stay exactly as the page first rendered them; only the
+  # image source needs to catch up once resized copies exist.
+  #
+  # This is a deliberate tradeoff, not an oversight: carrying every
+  # subscriber's original per-page props through the broadcast (rather
+  # than falling back to media_only) isn't possible without threading
+  # that context through the model layer. Whether media_only is the
+  # right long-term answer (vs. e.g. a per-page prop cache) is still
+  # open.
+  def broadcast_interactive_sizes
+    INTERACTIVE_BROADCAST_SIZES.each do |size|
+      html = ApplicationController.renderer.render(
+        Components::Image::Interactive.new(user: nil, image: self,
+                                           size: size, media_only: true),
+        layout: false
+      )
+      broadcast_replace_to(
+        [self, :processed],
+        target: "interactive_image_#{id}_#{size}_media",
+        html: html
+      )
+    end
+  end
+
+  # `Components::ImageGallery`'s carousel slide: `broadcast_update_to`
+  # (not replace) targeting the existing "carousel_item_<id>" wrapper
+  # that `Components::Carousel` already renders -- an inner-only swap
+  # so the carousel's own .active/.item classing (which slide is
+  # currently showing) is untouched by this broadcast. `Carousel::Item`
+  # itself renders no outer wrapper, just the img/overlays/caption that
+  # belong inside that wrapper, so ImageGallery::Item's own output is
+  # already exactly the right payload.
+  def broadcast_carousel_slide
+    html = ApplicationController.renderer.render(
+      Components::ImageGallery::Item.new(user: nil, image: self),
+      layout: false
+    )
+    broadcast_update_to(
+      [self, :processed],
+      target: "carousel_item_#{id}",
+      html: html
+    )
+  end
+
   # Array of all observations, users and glossary terms using this image.
   def all_subjects
     observations + profile_users + glossary_terms
@@ -333,6 +410,15 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
 
   # Return an Array of all image sizes from +:thumbnail+ to +:full_size+.
   ALL_SIZES = ALL_SIZES_INDEX.keys.freeze
+
+  # Sizes `Components::Image::Interactive` gets broadcast for by
+  # Image#broadcast_processed_update. Every call site using the
+  # component's default id_prefix (all but glossary_terms/show.rb,
+  # which overrides it) picks up a live update regardless of which of
+  # these sizes that page happens to render -- a call site with a
+  # custom id_prefix simply has no matching element in its DOM, so its
+  # broadcast is a silent no-op there.
+  INTERACTIVE_BROADCAST_SIZES = (ALL_SIZES - [:full_size]).freeze
 
   # Return an Array of all image sizes as pixels (Integer) instead of Symbol's.
   ALL_SIZES_IN_PIXELS = ALL_SIZES_INDEX.values.freeze

--- a/app/views/controllers/images/show/image_panel.rb
+++ b/app/views/controllers/images/show/image_panel.rb
@@ -11,6 +11,12 @@ module Views::Controllers::Images
       prop :size, _Nilable(_Union(::Symbol, ::String)), default: nil
 
       def view_template
+        # Subscribes this page to Image#broadcast_processed_update's
+        # interactive-size broadcast (rendered as a plain top-level
+        # statement, not inside the Panel(...) block below -- see
+        # Components::Matrix::Box for why that placement would
+        # silently never emit anything).
+        turbo_stream_from([@image, :processed])
         render(::Components::Panel.new(panel_id: "image_panel")) do |panel|
           panel.with_heading(
             classes:

--- a/test/components/image/interactive_test.rb
+++ b/test/components/image/interactive_test.rb
@@ -76,17 +76,29 @@ class InteractiveImageTest < ComponentTestCase
     assert_includes(sub_html, "lightbox_link")
   end
 
+  # Image#broadcast_interactive_sizes renders with media_only: true so a
+  # background-processing broadcast never touches page-specific link/
+  # votes/overlay markup -- see the comment on Image#broadcast_interactive_
+  # sizes for why. Confirms only the image container itself renders.
+  def test_media_only_renders_just_the_image_container
+    html = render_image(votes: true, image_link: "/custom/path",
+                        media_only: true)
+    media_id = "interactive_image_#{@image.id}_medium_media"
+
+    assert_html(html, "div##{media_id}.image-lazy-sizer")
+    assert_html(html, "img.image_#{@image.id}")
+    assert_no_html(html, ".image-sizer")
+    assert_no_html(html, "a.stretched-link")
+    assert_no_html(html, ".vote-section")
+    assert_not_includes(html, "/custom/path")
+  end
+
   private
 
-  def render_image(image: @image, size: :medium, votes: false,
-                   image_link: nil, upload: false)
+  def render_image(image: @image, size: :medium, **)
     render(Components::Image::Interactive.new(
-             user: @user,
-             image: image,
-             size: size,
-             votes: votes,
-             image_link: image_link,
-             upload: upload
+             user: @user, image: image, size: size, votes: false,
+             image_link: nil, upload: false, media_only: false, **
            ))
   end
 end

--- a/test/components/image/interactive_test.rb
+++ b/test/components/image/interactive_test.rb
@@ -91,6 +91,14 @@ class InteractiveImageTest < ComponentTestCase
     assert_no_html(html, "a.stretched-link")
     assert_no_html(html, ".vote-section")
     assert_not_includes(html, "/custom/path")
+    # The broadcast-swapped fragment must re-trigger LazyLoad itself --
+    # the layout-level lazyload controller only fires on full page
+    # loads, so without this the swapped img.lazy stays on the
+    # placeholder. Initial (non-media_only) renders are covered by the
+    # layout and don't need it.
+    assert_html(html, "div##{media_id}[data-controller='lazyload']")
+    normal_html = render_image(votes: false)
+    assert_no_html(normal_html, "[data-controller='lazyload']")
   end
 
   private

--- a/test/components/image_gallery_test.rb
+++ b/test/components/image_gallery_test.rb
@@ -180,6 +180,24 @@ class ImageGalleryTest < ComponentTestCase
     assert_includes(html, "custom_panel_id")
   end
 
+  # The `turbo_stream_from([image, :processed])` cable subscription is
+  # what makes Image#broadcast_processed_update's carousel-slide
+  # broadcast (an inner-only `broadcast_update_to` on
+  # "carousel_item_<id>") reach the page.
+  def test_subscribes_to_action_cable_for_each_image_processed_stream
+    component = Components::ImageGallery.new(
+      user: @user, images: @images, object: @obs
+    )
+    html = render(component)
+
+    assert_html(html, "turbo-cable-stream-source")
+    # One subscription tag per image, not just one for the whole page.
+    assert_equal(
+      @images.length,
+      Nokogiri::HTML5.fragment(html).css("turbo-cable-stream-source").length
+    )
+  end
+
   def test_filters_nil_images
     # Create array with nils mixed in
     images_with_nil = [@images.first, nil, nil]

--- a/test/components/matrix/box_test.rb
+++ b/test/components/matrix/box_test.rb
@@ -19,6 +19,26 @@ class MatrixBoxTest < ComponentTestCase
     assert_includes(html, "image_#{obs.thumb_image_id}")
   end
 
+  # The `turbo_stream_from([image, :processed])` cable subscription is
+  # what makes Image#broadcast_processed_update's interactive-size
+  # broadcast reach the page. Only rendered when there's a thumbnail
+  # to subscribe for.
+  def test_subscribes_to_action_cable_for_thumb_image_processed_stream
+    obs = observations(:coprinus_comatus_obs)
+    component = Components::Matrix::Box.new(user: @user, object: obs)
+    html = render(component)
+
+    assert_html(html, "turbo-cable-stream-source")
+  end
+
+  def test_does_not_subscribe_to_action_cable_without_a_thumbnail
+    obs = observations(:minimal_unknown_obs)
+    component = Components::Matrix::Box.new(user: @user, object: obs)
+    html = render(component)
+
+    assert_no_html(html, "turbo-cable-stream-source")
+  end
+
   def test_renders_observation_without_thumbnail
     obs = observations(:minimal_unknown_obs)
     component = Components::Matrix::Box.new(user: @user, object: obs)

--- a/test/components/matrix/table_test.rb
+++ b/test/components/matrix/table_test.rb
@@ -106,6 +106,96 @@ class MatrixTableTest < ComponentTestCase
     )
   end
 
+  # A bare Image object (images/index's matrix table) has no
+  # `thumb_image` to defer to -- it IS the thumb. should_cache_object?
+  # must check the Image's own `transferred` directly instead of
+  # falling through the `respond_to?(:thumb_image)` guard to an
+  # unconditional true (the gap this test guards against).
+  def test_caches_image_objects_with_transferred_true
+    image = images(:connected_coprinus_comatus_image)
+    image.stub(:transferred, true) do
+      component = Components::Matrix::Table.new(
+        objects: [image], user: @user, cached: true
+      )
+
+      cache_called = false
+      component.stub(:low_level_cache, lambda { |_key, &block|
+        cache_called = true
+        block.call
+      }) do
+        render(component)
+      end
+
+      assert(cache_called,
+             "Expected cache to be called for a transferred Image object")
+    end
+  end
+
+  def test_does_not_cache_image_objects_with_transferred_false
+    image = images(:connected_coprinus_comatus_image)
+    image.stub(:transferred, false) do
+      component = Components::Matrix::Table.new(
+        objects: [image], user: @user, cached: true
+      )
+
+      cache_called = false
+      component.stub(:low_level_cache, lambda { |_key, &block|
+        cache_called = true
+        block.call
+      }) do
+        html = render(component)
+        assert_includes(html, "box_#{image.id}")
+      end
+
+      assert_not(cache_called,
+                 "Expected cache NOT to be called for an untransferred " \
+                 "Image object")
+    end
+  end
+
+  # cache_key_for folds in the thumb image record so the expanded key
+  # tracks the thumb's updated_at (its cache_key embeds the timestamp)
+  # -- reprocessing bumps it, and the cached HTML embeds a URL token
+  # derived from it (#4808). Nothing touches an RssLog when its thumb
+  # finishes processing, so the thumb must appear in the key itself.
+  def test_cache_key_for_includes_the_thumb_image_record
+    obs = observations(:coprinus_comatus_obs)
+
+    key = Components::Matrix::Table.cache_key_for(obs, I18n.locale)
+
+    assert_equal(
+      ["MatrixBox", Components::Matrix::Table::CACHE_VERSION,
+       I18n.locale, obs, obs.thumb_image],
+      key
+    )
+
+    # The expanded key must change when the thumb's updated_at does --
+    # this is the mechanism the fragment busting relies on.
+    store = ActiveSupport::Cache::MemoryStore.new
+    old_expanded = store.send(:normalize_key, key, {})
+    obs.thumb_image.updated_at += 1.hour
+    new_expanded = store.send(
+      :normalize_key,
+      Components::Matrix::Table.cache_key_for(obs, I18n.locale), {}
+    )
+
+    assert_not_equal(old_expanded, new_expanded)
+  end
+
+  # A bare Image object IS its own thumb: it has no thumb_image, and
+  # its own timestamp already participates in the key via `object`.
+  def test_cache_key_for_image_object_keys_on_the_image_itself
+    image = images(:connected_coprinus_comatus_image)
+
+    key = Components::Matrix::Table.cache_key_for(image, I18n.locale)
+
+    assert_equal(
+      ["MatrixBox", Components::Matrix::Table::CACHE_VERSION,
+       I18n.locale, image, nil],
+      key
+    )
+  end
+
   def test_caches_observations_with_nil_thumb_image
     obs = observations(:minimal_unknown_obs)
     assert_nil(obs.thumb_image,

--- a/test/jobs/rotate_image_job_test.rb
+++ b/test/jobs/rotate_image_job_test.rb
@@ -4,6 +4,7 @@ require("test_helper")
 
 class RotateImageJobTest < ActiveJob::TestCase
   include ActiveJob::TestHelper
+  include ActionCable::TestHelper
 
   # Rotation rehashes the image inline via Image::Processor#process
   # (#4796), so there is no separate dhash job -- only a transfer.
@@ -20,6 +21,27 @@ class RotateImageJobTest < ActiveJob::TestCase
       end
     end
     assert_equal("+90", rotated_with)
+  end
+
+  # The job broadcasts the re-processed image itself, without waiting
+  # for a transferred flip -- a mirror on a not-yet-transferred image
+  # changes no broadcast-triggering column at all, and environments
+  # with no writable image servers (development) never flip transferred
+  # in the first place. Without this, subscribed pages only catch up on
+  # the next full reload.
+  def test_broadcasts_processed_update_after_rotating
+    image = images(:in_situ_image)
+    stream = Turbo::StreamsChannel.send(:stream_name_from,
+                                        [image, :processed])
+    fake_processor = Object.new
+    fake_processor.define_singleton_method(:rotate) { |_o| nil }
+
+    Image::Processor.stub(:new, fake_processor) do
+      assert_broadcasts(stream,
+                        Image::INTERACTIVE_BROADCAST_SIZES.length + 1) do
+        RotateImageJob.perform_now(image.id, "jpg", "-h")
+      end
+    end
   end
 
   def test_missing_image_is_a_noop

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -614,6 +614,20 @@ class ImageTest < UnitTestCase
            "Expected a broadcast targeting #{carousel_target}")
   end
 
+  # Processing STARTS by flipping transferred true->false, BEFORE the
+  # renditions are regenerated -- broadcasting at that moment would
+  # push a new-token URL at stale files, and would duplicate
+  # RotateImageJob's explicit end-of-processing broadcast (Copilot
+  # review finding on #4825). Only the completion flip (false->true)
+  # broadcasts.
+  def test_broadcast_does_not_fire_when_transferred_becomes_false
+    image = images(:in_situ_image)
+    image.update_column(:transferred, true)
+    stream = Turbo::StreamsChannel.send(:stream_name_from, [image, :processed])
+
+    assert_no_broadcasts(stream) { image.update(transferred: false) }
+  end
+
   # The broadcast must not replay a page-specific image_link/votes/
   # extra_classes/identify combination -- it only knows the model, not
   # which page's props a given subscriber originally rendered with (a

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -4,6 +4,7 @@ require("test_helper")
 
 class ImageTest < UnitTestCase
   include ActiveJob::TestHelper
+  include ActionCable::TestHelper
 
   # log_update/log_destroy/log_create_for/log_reuse_for/log_remove_from
   # attribute to `current_user` (the acting/editing user), not `user`
@@ -588,6 +589,70 @@ class ImageTest < UnitTestCase
     assert_not_includes(Image.url(:full_size, img.id, transferred: true), "?")
     assert(Image.url(:full_size, img.id,
                      transferred: true, version: 123).end_with?("?123"))
+  end
+
+  def test_broadcast_processed_update_fires_on_transferred_change
+    image = images(:in_situ_image)
+    image.update_column(:transferred, false)
+    stream = Turbo::StreamsChannel.send(:stream_name_from, [image, :processed])
+
+    # `capture_broadcasts` JSON-decodes each message back to the raw
+    # `<turbo-stream ...>` HTML string ActionCable stores it as.
+    messages = capture_broadcasts(stream) { image.update(transferred: true) }
+
+    # One broadcast_replace_to per INTERACTIVE_BROADCAST_SIZES entry,
+    # plus one broadcast_update_to for the carousel slide.
+    assert_equal(Image::INTERACTIVE_BROADCAST_SIZES.length + 1,
+                 messages.length)
+    Image::INTERACTIVE_BROADCAST_SIZES.each do |size|
+      target = "interactive_image_#{image.id}_#{size}_media"
+      assert(messages.any? { |m| m.include?(%(target="#{target}")) },
+             "Expected a broadcast targeting #{target}")
+    end
+    carousel_target = "carousel_item_#{image.id}"
+    assert(messages.any? { |m| m.include?(%(target="#{carousel_target}")) },
+           "Expected a broadcast targeting #{carousel_target}")
+  end
+
+  # The broadcast must not replay a page-specific image_link/votes/
+  # extra_classes/identify combination -- it only knows the model, not
+  # which page's props a given subscriber originally rendered with (a
+  # matrix-box thumbnail's real image_link, votes: false on the
+  # image-show page, etc). Confirms the fix for the bug where
+  # rebroadcasting the *whole* Interactive component with defaults
+  # would silently swap a thumbnail's link target to the image's own
+  # show page, or make hidden votes reappear.
+  def test_broadcast_interactive_sizes_omits_link_and_votes_markup
+    image = images(:in_situ_image)
+    image.update_column(:transferred, false)
+    stream = Turbo::StreamsChannel.send(:stream_name_from, [image, :processed])
+
+    messages = capture_broadcasts(stream) { image.update(transferred: true) }
+
+    media_messages = messages.select { |m| m.include?("_media") }
+    assert_equal(Image::INTERACTIVE_BROADCAST_SIZES.length,
+                 media_messages.length)
+    media_messages.each do |m|
+      assert_not_includes(m, "stretched-link")
+      assert_not_includes(m, "image-vote-section")
+    end
+  end
+
+  def test_broadcast_processed_update_fires_on_gps_stripped_change
+    image = images(:in_situ_image)
+    image.update_column(:gps_stripped, false)
+    stream = Turbo::StreamsChannel.send(:stream_name_from, [image, :processed])
+
+    assert_broadcasts(stream, Image::INTERACTIVE_BROADCAST_SIZES.length + 1) do
+      image.update(gps_stripped: true)
+    end
+  end
+
+  def test_broadcast_processed_update_does_not_fire_on_unrelated_changes
+    image = images(:in_situ_image)
+    stream = Turbo::StreamsChannel.send(:stream_name_from, [image, :processed])
+
+    assert_no_broadcasts(stream) { image.update(notes: "new notes") }
   end
 
   def test_import_link


### PR DESCRIPTION
## Summary

Second of two PRs replacing #4752, whose base branch died when #4749 was closed. Stacked on #4824 (the #4808 cache-busting prerequisite) — without the URL token, this PR's broadcast would swap in visually-identical markup pointing at the same stable URL and the updated image would never appear (see the review comment on #4752).

This carries over the parts of #4752 that survive #4749's closing, rebuilt on `main`. The original motivation ("live-update the freshly uploaded thumbnail once `ProcessImageJob` finishes") is gone — uploads resize synchronously again — but two async paths remain on `main` and both flip `transferred` out-of-request: `TransferImagesJob` (the tail of every upload) and `RotateImageJob` (#4751). This PR makes subscribed pages catch up the moment those finish.

### `Image#broadcast_processed_update`

An `after_update_commit` fires when `saved_change_to_transferred?` or `saved_change_to_gps_stripped?` — an unrelated `Image` edit (copyright, notes, a vote) never re-renders anything. (`gps_stripped` currently only changes synchronously at upload, before any page could be subscribed; it's kept as a trigger so pages catch up if that ever goes async.) Two broadcasts, unchanged from #4752:

- One `broadcast_replace_to` per `Components::Image::Interactive` size (`Image::INTERACTIVE_BROADCAST_SIZES`), targeting the new size-scoped `interactive_image_<id>_<size>_media` element. Re-renders are `media_only` — just the image container, never the page-specific link/votes/overlays, which the model can't reconstruct per subscriber (the deliberate tradeoff documented at `Image#broadcast_interactive_sizes`).
- One `broadcast_update_to` (inner swap) targeting the `carousel_item_<id>` wrapper `Components::Carousel` already renders, so the carousel's own `.active` classing is untouched.

Renders go through `ApplicationController.renderer` for an anonymous viewer — same limitation `Comment`'s and `InatImport`'s broadcasts already accept. Production uses the `solid_cable` adapter (DB-backed), so broadcasts fired from SolidQueue workers do reach web clients.

Subscriptions (`turbo_stream_from([image, :processed])`) live in `Components::ImageGallery` (obs-show carousel), `Components::Matrix::Box` (gated on a thumbnail being present), and `Views::Controllers::Images::Show::ImagePanel` — and deliberately not in the no-JS/non-upload-adjacent views, same reasoning as #4752's "where the subscription deliberately doesn't live" section.

### `Matrix::Table` caching fixes (adapted from #4752)

- `should_cache_object?`: a bare `Image` object (images/index) has no `thumb_image` to defer to — it IS the thumb — so check its own `transferred` directly instead of falling through the `respond_to?` guard to an unconditional `true`. Unchanged from #4752.
- `cache_key_for`: **adapted** — #4752 folded in the `transferred`/`gps_stripped` booleans, but those don't change across a completed rotate (`true` before, `true` after), so they'd never bust a fragment cached pre-rotate. Instead the key now folds in the thumb `Image` record itself: with `cache_versioning` off in MO, an AR object in the key array expands via `cache_key`, which embeds its `updated_at` — exactly the value #4824's URL token derives from. This matters specifically for **RssLog** boxes: `Verifier#mark_transferred` `touch_all`'s related Observations when a transfer completes, but RssLogs are never touched, so an RssLog fragment cached before a rotate would otherwise serve the pre-rotate URL token indefinitely.

### `Components::Image::Base` — size-scoped `html_id`

`html_id` is now `"<id_prefix>_<img_id>_<size>"` (was un-scoped), so a broadcast re-render at one size targets only elements actually showing that size — the same image renders at different sizes on different pages under the same default `id_prefix`. Carried over from #4752 unchanged.

## Test plan

- [x] `bin/rails test test/models/image_test.rb` — broadcast coverage via `ActionCable::TestHelper`: fires on `transferred`/`gps_stripped` change with one message per size + one carousel message; `media_only` payloads omit link/votes markup; no broadcast on unrelated changes
- [x] `bin/rails test test/components/matrix/table_test.rb` — new key shape pinned for Observation and bare-`Image` objects; expanded-key-changes-when-thumb-`updated_at`-changes asserted through `ActiveSupport::Cache`'s own key normalization; `should_cache_object?` coverage for transferred/untransferred `Image` objects
- [x] `bin/rails test test/components/matrix/box_test.rb test/components/image_gallery_test.rb test/components/image/interactive_test.rb` — subscription-tag and `media_only` render coverage
- [x] `bundle exec rubocop` clean on all changed files

Still to do before merge (the manual check requested on #4752): rotate an image in a dev/staging browser and confirm the rendered `src` changes and the image visibly updates when the broadcast lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
