### PR TITLE
Silence the deliberate `boom` backtrace `test_process_image_command_failure` dumps into every suite run

### DIFF
--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -365,14 +365,24 @@ class ImageTest < UnitTestCase
       raise("boom")
     end
 
+    # Capture the rescue's Rails.logger.error call instead of letting it
+    # through -- the test logger writes to $stdout, so the deliberate
+    # "boom" backtrace otherwise dumps into the suite's console output
+    # looking like a real failure. Capturing also pins the logging
+    # contract itself, which the old passthrough never asserted.
+    logged = nil
     img.stub(:move_original, true) do
       Image::Processor.stub(:new, failing_processor) do
         Rails.env.stub(:test?, false) do
-          assert_not(img.process_image)
+          Rails.logger.stub(:error, ->(msg) { logged = msg }) do
+            assert_not(img.process_image)
+          end
         end
       end
     end
     assert(img.errors[:image].any?)
+    assert_includes(logged, "Image::Processor failed for image #{img.id}")
+    assert_includes(logged, "boom")
   end
 
   # Transfer-to-image-server is no longer part of Image::Processor#process


### PR DESCRIPTION
## Summary

Every full-suite run has been dumping an `ERROR ... Image::Processor failed for image ...: boom (RuntimeError)` plus a full backtrace into the console mid-run, looking like a real failure despite 0 failures.

It's `test_process_image_command_failure` doing its job loudly: the test deliberately raises `"boom"` inside a stubbed `Image::Processor#process` to exercise `Image#process_and_enqueue_jobs`'s rescue, and that rescue (correctly, for production) logs `e.full_message` via `Rails.logger.error`. The test environment's logger is `Logger.new($stdout)` (`config/environments/test.rb`), so the log lands in the terminal. The noise got dramatically worse on 2026-07-14 when `#{e}` became `#{e.full_message(highlight: false)}` (`0889d8b2eb`, Copilot-review pass on #4751) — message-only became message + backtrace.

The fix stubs `Rails.logger.error` in the test, captures the message, and asserts the logging contract (image id + error message present) — which the old passthrough never checked. No production code change.

## Test plan

- [x] `bin/rails test test/models/image_test.rb` — 48 tests, 0 failures
- [x] Verified the `Image::Processor failed` trace no longer appears anywhere in the run output
- [x] `bundle exec rubocop` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
