### PR TITLE
Quiet ActionCable and Solid Cable log chatter from #4825's per-image `turbo_stream_from` subscriptions

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -116,6 +116,14 @@ MushroomObserver::Application.configure do
 
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
+
+  # Quiet ActionCable's per-connection/per-subscription info chatter
+  # ("Registered connection", "Turbo::StreamsChannel is streaming
+  # from..."). Since #4825 subscribes every rendered image to a
+  # [image, :processed] stream, a single page load emits dozens of
+  # those lines. Warnings and errors still log.
+  config.action_cable.logger =
+    ActiveSupport::Logger.new($stdout, level: Logger::WARN)
   # Solid Queue as the queue adapter locally, as on production.
   config.active_job.queue_adapter = :solid_queue
   # Uncomment if queue tables are in a separate db. MO's are in the main db.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -182,6 +182,14 @@ MushroomObserver::Application.configure do
   # config.action_cable.url = "wss://localhost:28080" # use :wss in production
   config.action_cable.allowed_request_origins = [%r{http://*}, %r{https://*/}]
 
+  # Quiet ActionCable's per-connection/per-subscription info chatter
+  # ("Registered connection", "Turbo::StreamsChannel is streaming
+  # from..."). Since #4825 subscribes every rendered image to a
+  # [image, :processed] stream, every page view would emit dozens of
+  # those lines at :info. Warnings and errors still log.
+  config.action_cable.logger =
+    ActiveSupport::Logger.new("log/production.log", level: Logger::WARN)
+
   config.active_job.queue_adapter = :solid_queue
   # Uncomment if queue tables are in a separate db. MO's are in the main db.
   # config.solid_queue.connects_to = { database: { writing: :queue } }

--- a/config/initializers/solid_cable_silence_subscribe.rb
+++ b/config/initializers/solid_cable_silence_subscribe.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Solid Cable silences its recurring polling queries (Listener#listen
+# wraps them in #with_polling_volume, which uses
+# ActiveRecord::Base.logger.silence), but NOT the one-off
+# `SELECT MAX(id) FROM solid_cable_messages` that Listener#add_channel
+# runs for every new stream subscription. Since #4825 subscribes every
+# rendered image to a [image, :processed] stream, a single page load
+# emits dozens of those lines into the development log. Wrap
+# #add_channel in the same silencer the gem already uses for polling.
+#
+# Gem-version-specific (solid_cable 3.0.12) -- remove if a future
+# solid_cable release silences #add_channel itself.
+require("action_cable/subscription_adapter/solid_cable")
+
+module SolidCableSubscribeSilencer
+  def add_channel(...)
+    with_polling_volume { super }
+  end
+end
+
+ActionCable::SubscriptionAdapter::SolidCable::Listener.prepend(
+  SolidCableSubscribeSilencer
+)

--- a/test/channels/solid_cable_subscribe_silencer_test.rb
+++ b/test/channels/solid_cable_subscribe_silencer_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Covers config/initializers/solid_cable_silence_subscribe.rb: the
+# per-subscription `SELECT MAX(id)` in Solid Cable's Listener#add_channel
+# must run inside the same #with_polling_volume silencer the gem uses
+# for its recurring polling queries.
+class SolidCableSubscribeSilencerTest < UnitTestCase
+  # Probe class standing in for the gem's Listener -- records call
+  # order so we can assert add_channel runs INSIDE the silencer.
+  class ProbeListener
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def add_channel(_channel, _on_success)
+      @calls << :add_channel
+    end
+
+    private
+
+    def with_polling_volume
+      @calls << :silencer_entered
+      yield
+      @calls << :silencer_exited
+    end
+
+    prepend SolidCableSubscribeSilencer
+  end
+
+  def test_add_channel_runs_inside_the_polling_silencer
+    probe = ProbeListener.new
+
+    probe.add_channel(:some_channel, nil)
+
+    assert_equal([:silencer_entered, :add_channel, :silencer_exited],
+                 probe.calls)
+  end
+
+  def test_module_is_prepended_to_the_real_listener
+    listener = ActionCable::SubscriptionAdapter::SolidCable::Listener
+
+    assert_includes(listener.ancestors, SolidCableSubscribeSilencer)
+    assert_equal(SolidCableSubscribeSilencer,
+                 listener.instance_method(:add_channel).owner)
+  end
+end


### PR DESCRIPTION
## Summary

Since #4825 subscribes every rendered image to a `[image, :processed]` stream, a single page load floods the dev log (and would flood `production.log` on deploy — it logs at `:info`) with dozens of lines from two sources.

### 1. ActionCable info chatter

`Registered connection (...)` (ActionCable's `InternalChannel`) and `Turbo::StreamsChannel is streaming from... / transmitting the subscription confirmation` — one pair per subscription, all at `:info` through `config.action_cable.logger`. Fixed by giving ActionCable its own WARN-level logger in development (stdout) and production (`log/production.log`). Warnings and errors still log.

### 2. One `SELECT MAX(id) FROM solid_cable_messages` per subscription

Solid Cable already silences its recurring 0.1s polling queries — `Listener#listen` wraps them in `#with_polling_volume`, which uses `ActiveRecord::Base.logger.silence` — but the one-off `MAX(id)` lookup in `Listener#add_channel` (runs on every new stream subscription) is not wrapped. New initializer `config/initializers/solid_cable_silence_subscribe.rb` prepends a module wrapping `add_channel` in that same silencer. Gem-version-specific (solid_cable 3.0.12), commented for removal when fixed upstream — this is arguably a gem gap worth an upstream issue/PR.

## Test plan

- [x] `bin/rails test test/channels/solid_cable_subscribe_silencer_test.rb` — behavioral probe (add_channel runs inside the silencer) + prepend-is-active assertion against the real Listener
- [x] Verified in the development environment: module is first ancestor of the Listener, cable logger level is WARN
- [x] `bundle exec rubocop` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
