### PR TITLE
Scope `[image, :processed]` broadcasts/subscriptions to the image-show page only

### DIFF
--- a/app/components/image_gallery.rb
+++ b/app/components/image_gallery.rb
@@ -34,9 +34,9 @@ class Components::ImageGallery < Components::Base
     @carousel_id ||= generate_carousel_id
     # Deliberately NOT subscribed to [image, :processed] broadcasts:
     # rotate/mirror only happens on the image-show page, so only that
-    # page (Images::Show::ImagePanel) live-updates. Cross-tab updates
-    # aren't a supported config; this page catches up on the next load
-    # via the #4808 cache-busting URL token.
+    # page (Views::Controllers::Images::Show::ImagePanel) live-updates.
+    # Cross-tab updates aren't a supported config; this page catches
+    # up on the next load via the #4808 cache-busting URL token.
     Panel(panel_id: @panel_id) do |panel|
       panel.with_heading { @title } if @thumbnails
       # `@links` is a `SafeBuffer` from a Rails `capture { … }` block;

--- a/app/components/image_gallery.rb
+++ b/app/components/image_gallery.rb
@@ -32,12 +32,11 @@ class Components::ImageGallery < Components::Base
 
   def view_template
     @carousel_id ||= generate_carousel_id
-    # Rendered as a plain top-level statement, not inside the Carousel
-    # builder block below -- that block is `vanish`ed (its direct
-    # output discarded; only the registered item/thumb blocks survive
-    # to render later), so a `turbo_stream_from` call placed inside it
-    # would silently never emit anything.
-    register_stream_subscriptions
+    # Deliberately NOT subscribed to [image, :processed] broadcasts:
+    # rotate/mirror only happens on the image-show page, so only that
+    # page (Images::Show::ImagePanel) live-updates. Cross-tab updates
+    # aren't a supported config; this page catches up on the next load
+    # via the #4808 cache-busting URL token.
     Panel(panel_id: @panel_id) do |panel|
       panel.with_heading { @title } if @thumbnails
       # `@links` is a `SafeBuffer` from a Rails `capture { … }` block;
@@ -70,18 +69,6 @@ class Components::ImageGallery < Components::Base
            )) do |c|
       register_slides(c)
       register_thumbnails(c) if @thumbnails
-    end
-  end
-
-  # Subscribes this page to Image#broadcast_processed_update's
-  # carousel-slide broadcast, which updates the inside of each
-  # "carousel_item_<id>" wrapper (registered below) once processing
-  # finishes.
-  def register_stream_subscriptions
-    @images.each do |image|
-      next unless image
-
-      turbo_stream_from([image, :processed])
     end
   end
 

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -62,12 +62,13 @@ class Components::Matrix::Box < Components::Base
       id: "box_#{@data[:id]}",
       class: class_names("matrix-box", @columns, @extra_class)
     ) do
-      # Rendered here, not inside the Panel(...) block below -- that
-      # block is `vanish`ed (its direct output discarded; only the
-      # `with_thumbnail`/etc. slot registrations survive to render
-      # later), so a `turbo_stream_from` call placed there would
-      # silently never emit anything.
-      turbo_stream_from([@data[:image], :processed]) if @data[:image]
+      # Deliberately NOT subscribed to [image, :processed] broadcasts:
+      # rotate/mirror only happens on the image-show page, so only that
+      # page (Images::Show::ImagePanel) live-updates. An index page
+      # with dozens of boxes would otherwise open a websocket
+      # subscription (plus a solid_cable MAX(id) query) per thumbnail
+      # for an event that can't happen from this page; it catches up
+      # on the next load via the #4808 cache-busting URL token.
       Panel(sizing: true) do |panel|
         render_thumbnail_section(panel)
         render_details_section(panel)

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -63,8 +63,9 @@ class Components::Matrix::Box < Components::Base
       class: class_names("matrix-box", @columns, @extra_class)
     ) do
       # Deliberately NOT subscribed to [image, :processed] broadcasts:
-      # rotate/mirror only happens on the image-show page, so only that
-      # page (Images::Show::ImagePanel) live-updates. An index page
+      # rotate/mirror only happens on the image-show page, so only
+      # that page (Views::Controllers::Images::Show::ImagePanel)
+      # live-updates. An index page
       # with dozens of boxes would otherwise open a websocket
       # subscription (plus a solid_cable MAX(id) query) per thumbnail
       # for an event that can't happen from this page; it catches up

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -247,10 +247,10 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   after_update :track_copyright_changes
   before_destroy :update_thumbnails
 
-  # Turbo Stream broadcasts that keep every rendered copy of this image
-  # (matrix boxes, side panels, the observation-show carousel) live once
-  # background processing (RotateImageJob/TransferImagesJob) finishes,
-  # without a full page reload. Fires only on the columns processing
+  # Turbo Stream broadcasts that keep the image-show page (the only
+  # subscriber -- see broadcast_processed_update) live once background
+  # processing (RotateImageJob/TransferImagesJob) finishes, without a
+  # full page reload. Fires only on the columns processing
   # flips -- an unrelated Image edit (copyright, notes, vote) never
   # re-renders anything. (gps_stripped currently only changes
   # synchronously at upload, before any page could be subscribed --
@@ -277,9 +277,16 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   # per-user customization (vote highlighting, an admin-only
   # affordance) catches up on the next real page load, not via this
   # broadcast.
+  #
+  # The only subscriber is the image-show page
+  # (Views::Controllers::Images::Show::ImagePanel) -- rotate/mirror
+  # only happens there, so only there does a live update make sense.
+  # Index matrix boxes and the obs-show carousel deliberately do NOT
+  # subscribe (cross-tab updates aren't a supported config; those
+  # pages catch up on the next load via the #4808 URL token), which is
+  # also why there is no carousel-slide broadcast here.
   def broadcast_processed_update
     broadcast_interactive_sizes
-    broadcast_carousel_slide
   end
 
   # One broadcast per size Interactive might be showing on any given
@@ -313,26 +320,6 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
         html: html
       )
     end
-  end
-
-  # `Components::ImageGallery`'s carousel slide: `broadcast_update_to`
-  # (not replace) targeting the existing "carousel_item_<id>" wrapper
-  # that `Components::Carousel` already renders -- an inner-only swap
-  # so the carousel's own .active/.item classing (which slide is
-  # currently showing) is untouched by this broadcast. `Carousel::Item`
-  # itself renders no outer wrapper, just the img/overlays/caption that
-  # belong inside that wrapper, so ImageGallery::Item's own output is
-  # already exactly the right payload.
-  def broadcast_carousel_slide
-    html = ApplicationController.renderer.render(
-      Components::ImageGallery::Item.new(user: nil, image: self),
-      layout: false
-    )
-    broadcast_update_to(
-      [self, :processed],
-      target: "carousel_item_#{id}",
-      html: html
-    )
   end
 
   # Array of all observations, users and glossary terms using this image.
@@ -423,12 +410,11 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   ALL_SIZES = ALL_SIZES_INDEX.keys.freeze
 
   # Sizes `Components::Image::Interactive` gets broadcast for by
-  # Image#broadcast_processed_update. Every call site using the
-  # component's default id_prefix (all but glossary_terms/show.rb,
-  # which overrides it) picks up a live update regardless of which of
-  # these sizes that page happens to render -- a call site with a
-  # custom id_prefix simply has no matching element in its DOM, so its
-  # broadcast is a silent no-op there.
+  # Image#broadcast_processed_update. All non-full_size sizes, not just
+  # one, because the image-show page (the only subscriber) renders at
+  # a size chosen by the viewer's image-size preference -- the
+  # broadcasts for sizes a given page isn't showing have no matching
+  # element in its DOM and are silent no-ops there.
   INTERACTIVE_BROADCAST_SIZES = (ALL_SIZES - [:full_size]).freeze
 
   # Return an Array of all image sizes as pixels (Integer) instead of Symbol's.

--- a/test/components/image_gallery_test.rb
+++ b/test/components/image_gallery_test.rb
@@ -180,22 +180,17 @@ class ImageGalleryTest < ComponentTestCase
     assert_includes(html, "custom_panel_id")
   end
 
-  # The `turbo_stream_from([image, :processed])` cable subscription is
-  # what makes Image#broadcast_processed_update's carousel-slide
-  # broadcast (an inner-only `broadcast_update_to` on
-  # "carousel_item_<id>") reach the page.
-  def test_subscribes_to_action_cable_for_each_image_processed_stream
+  # The carousel deliberately does NOT subscribe to
+  # [image, :processed] broadcasts -- rotate/mirror only happens on
+  # the image-show page, so only that page live-updates; this one
+  # catches up on the next load via the #4808 cache-busting URL token.
+  def test_does_not_subscribe_to_action_cable_for_image_streams
     component = Components::ImageGallery.new(
       user: @user, images: @images, object: @obs
     )
     html = render(component)
 
-    assert_html(html, "turbo-cable-stream-source")
-    # One subscription tag per image, not just one for the whole page.
-    assert_equal(
-      @images.length,
-      Nokogiri::HTML5.fragment(html).css("turbo-cable-stream-source").length
-    )
+    assert_no_html(html, "turbo-cable-stream-source")
   end
 
   def test_filters_nil_images

--- a/test/components/matrix/box_test.rb
+++ b/test/components/matrix/box_test.rb
@@ -19,20 +19,14 @@ class MatrixBoxTest < ComponentTestCase
     assert_includes(html, "image_#{obs.thumb_image_id}")
   end
 
-  # The `turbo_stream_from([image, :processed])` cable subscription is
-  # what makes Image#broadcast_processed_update's interactive-size
-  # broadcast reach the page. Only rendered when there's a thumbnail
-  # to subscribe for.
-  def test_subscribes_to_action_cable_for_thumb_image_processed_stream
+  # Matrix boxes deliberately do NOT subscribe to
+  # [image, :processed] broadcasts -- rotate/mirror only happens on
+  # the image-show page, and an index page with dozens of boxes would
+  # otherwise open a websocket subscription per thumbnail for an event
+  # that can't happen from this page.
+  def test_does_not_subscribe_to_action_cable_even_with_a_thumbnail
     obs = observations(:coprinus_comatus_obs)
-    component = Components::Matrix::Box.new(user: @user, object: obs)
-    html = render(component)
-
-    assert_html(html, "turbo-cable-stream-source")
-  end
-
-  def test_does_not_subscribe_to_action_cable_without_a_thumbnail
-    obs = observations(:minimal_unknown_obs)
+    assert_not_nil(obs.thumb_image)
     component = Components::Matrix::Box.new(user: @user, object: obs)
     html = render(component)
 

--- a/test/jobs/rotate_image_job_test.rb
+++ b/test/jobs/rotate_image_job_test.rb
@@ -38,7 +38,7 @@ class RotateImageJobTest < ActiveJob::TestCase
 
     Image::Processor.stub(:new, fake_processor) do
       assert_broadcasts(stream,
-                        Image::INTERACTIVE_BROADCAST_SIZES.length + 1) do
+                        Image::INTERACTIVE_BROADCAST_SIZES.length) do
         RotateImageJob.perform_now(image.id, "jpg", "-h")
       end
     end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -610,18 +610,17 @@ class ImageTest < UnitTestCase
     # `<turbo-stream ...>` HTML string ActionCable stores it as.
     messages = capture_broadcasts(stream) { image.update(transferred: true) }
 
-    # One broadcast_replace_to per INTERACTIVE_BROADCAST_SIZES entry,
-    # plus one broadcast_update_to for the carousel slide.
-    assert_equal(Image::INTERACTIVE_BROADCAST_SIZES.length + 1,
+    # One broadcast_replace_to per INTERACTIVE_BROADCAST_SIZES entry --
+    # and nothing else (the carousel-slide broadcast was removed along
+    # with the obs-show carousel's subscription; only the image-show
+    # page subscribes).
+    assert_equal(Image::INTERACTIVE_BROADCAST_SIZES.length,
                  messages.length)
     Image::INTERACTIVE_BROADCAST_SIZES.each do |size|
       target = "interactive_image_#{image.id}_#{size}_media"
       assert(messages.any? { |m| m.include?(%(target="#{target}")) },
              "Expected a broadcast targeting #{target}")
     end
-    carousel_target = "carousel_item_#{image.id}"
-    assert(messages.any? { |m| m.include?(%(target="#{carousel_target}")) },
-           "Expected a broadcast targeting #{carousel_target}")
   end
 
   # Processing STARTS by flipping transferred true->false, BEFORE the
@@ -667,7 +666,7 @@ class ImageTest < UnitTestCase
     image.update_column(:gps_stripped, false)
     stream = Turbo::StreamsChannel.send(:stream_name_from, [image, :processed])
 
-    assert_broadcasts(stream, Image::INTERACTIVE_BROADCAST_SIZES.length + 1) do
+    assert_broadcasts(stream, Image::INTERACTIVE_BROADCAST_SIZES.length) do
       image.update(gps_stripped: true)
     end
   end


### PR DESCRIPTION
## Summary

Nathan spotted this while investigating the log-noise burst on index pages after #4825 merged: the subscription volume revealed the broadcasts were touching far more pages than the feature warrants.

#4825 inherited #4752's subscription placement wholesale — `turbo_stream_from([image, :processed])` in every `Matrix::Box` with a thumbnail (24+ per index page) and on every obs-show carousel slide. That placement was designed for #4749's async-upload world, where index pages would live-fill thumbnails as `ProcessImageJob` completed. #4749 was closed and uploads are synchronous again, so the only broadcast-worthy event left is rotate/mirror — which happens exclusively on the image-show page. Every index page load was opening dozens of websocket subscriptions (each with an ActionCable confirmation and a `solid_cable` `MAX(id)` query) for an event that cannot affect that page, and cross-tab live updates aren't a supported configuration.

### Changes

- `turbo_stream_from` removed from `Components::Matrix::Box` and `Components::ImageGallery`; kept in `Views::Controllers::Images::Show::ImagePanel` (the only page where rotate/mirror happens). Comments at both removal sites record the decision so it doesn't creep back.
- `Image#broadcast_carousel_slide` removed (no subscribers left); `broadcast_processed_update` now sends only the interactive-size replaces. All `INTERACTIVE_BROADCAST_SIZES` stay — the image-show page renders at the viewer's image-size preference, so any of the five sizes can be on screen.
- Everything independent of subscription placement is untouched: the `Matrix::Table` cache-key fixes, `RotateImageJob`'s end-of-processing broadcast, and the transferred-becoming-true callback gating.

De-scoped pages catch up on the next load via #4824's cache-busting URL token — the mechanism that actually fixed the original stale-image bug.

This also supersedes #4829 (closed unmerged): with the index-page subscriptions gone, the log noise it was silencing largely disappears, and its approach — hiding queries and cable chatter — was the wrong trade anyway, since visible dev-log queries are exactly what surfaced this design problem.

## Test plan

- [x] `bin/rails test test/models/image_test.rb test/jobs/rotate_image_job_test.rb test/components/matrix/box_test.rb test/components/image_gallery_test.rb test/components/image/interactive_test.rb` — 93 tests, 0 failures; subscription tests inverted to pin the deliberate absence, broadcast counts updated (sizes only, no carousel message)
- [x] `bundle exec rubocop` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
