### PR TITLE
API2 `set_dhash` (site-admin, fill-null-only) + local-compute/API-push mode for `backfill_image_dhashes.rb`

### DIFF
--- a/app/classes/api2/error/image_dhash_mismatch.rb
+++ b/app/classes/api2/error/image_dhash_mismatch.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class API2
+  # Refused to overwrite an image's existing (different) dhash. The API
+  # only fills missing dhashes -- a mismatch is surfaced, never clobbered
+  # (see #4585; hashes are derived data, but an unexpected difference is
+  # signal worth keeping).
+  class ImageDhashMismatch < FatalError
+    def initialize(image, submitted)
+      super()
+      args.merge!(id: image.id, existing: image.dhash, submitted: submitted)
+    end
+  end
+end

--- a/app/classes/api2/error/must_be_site_admin.rb
+++ b/app/classes/api2/error/must_be_site_admin.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class API2
+  # Request requires a site administrator's API key.
+  class MustBeSiteAdmin < FatalError
+  end
+end

--- a/app/classes/api2/image_api.rb
+++ b/app/classes/api2/image_api.rb
@@ -82,6 +82,15 @@ class API2
     end
     # rubocop:enable Layout/MultilineOperationIndentation
 
+    # Maps update_params keys (model attributes) back to the API's set_*
+    # parameter names, so a mixed-setters error names the exact
+    # parameters the caller sent (:when is set via :set_date).
+    SETTER_PARAM_NAMES = {
+      when: :set_date, notes: :set_notes,
+      copyright_holder: :set_copyright_holder, license: :set_license,
+      original_name: :set_original_name
+    }.freeze
+
     # set_dhash bypasses the normal owner-permission update path: it is
     # site-admin-only, exclusive of the other setters (different
     # permission model), and fill-null-only -- an existing different
@@ -91,7 +100,10 @@ class API2
       return super unless @set_dhash
 
       raise(MustBeSiteAdmin.new) unless user.admin
-      raise(OneOrTheOther.new([:set_dhash, :other_setters])) if params.any?
+      return if params.empty?
+
+      mixed = params.keys.map { |k| SETTER_PARAM_NAMES.fetch(k, k) }
+      raise(OneOrTheOther.new([:set_dhash] + mixed))
     end
 
     def build_setter(params)

--- a/app/classes/api2/image_api.rb
+++ b/app/classes/api2/image_api.rb
@@ -71,6 +71,7 @@ class API2
     end
 
     def update_params
+      @set_dhash = parse(:integer, :set_dhash, limit: 0..(2**64 - 1))
       {
         when: parse(:date, :set_date, help: :when_taken),
         notes: parse(:string, :set_notes),
@@ -80,6 +81,27 @@ class API2
       }
     end
     # rubocop:enable Layout/MultilineOperationIndentation
+
+    # set_dhash bypasses the normal owner-permission update path: it is
+    # site-admin-only, exclusive of the other setters (different
+    # permission model), and fill-null-only -- an existing different
+    # value raises ImageDhashMismatch rather than being overwritten
+    # (#4585's local-compute/API-push dhash backfill).
+    def validate_update_params!(params)
+      return super unless @set_dhash
+
+      raise(MustBeSiteAdmin.new) unless user.admin
+      raise(OneOrTheOther.new([:set_dhash, :other_setters])) if params.any?
+    end
+
+    def build_setter(params)
+      return super unless @set_dhash
+
+      lambda do |img|
+        fill_null_dhash(img)
+        img
+      end
+    end
 
     def validate_create_params!(_params)
       raise(MissingUpload.new) unless @upload
@@ -106,6 +128,18 @@ class API2
     ############################################################################
 
     private
+
+    # update_column, not update!: dhash is derived data -- recording it
+    # is not an edit, and bumping updated_at would flip the image's
+    # cache-busting URL token (#4808) and bust caches for an unchanged
+    # image.
+    def fill_null_dhash(img)
+      if img.dhash.nil?
+        img.update_column(:dhash, @set_dhash)
+      elsif img.dhash != @set_dhash
+        raise(ImageDhashMismatch.new(img, @set_dhash))
+      end
+    end
 
     def parse_create_params!
       @observations = parse_array(:observation, :observations,

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4738,6 +4738,7 @@
   api_file_missing: File "[file]" is missing.
   api_help_message: "Usage: [help]"
   api_herbarium_record_already_exists: There is already a record for [number] at [herbarium].
+  api_image_dhash_mismatch: Image [id] already has dhash [existing]; refusing to overwrite with [submitted].
   api_image_upload_failed: "Failed to upload image: [error]"
   api_incorrect_password: Incorrect password.
   api_lat_long_must_both_be_set: Must supply both latitude and longitude, or neither.
@@ -4752,6 +4753,7 @@
   api_must_be_member: You are not a member of [type] "[name]".
   api_must_be_only_editor: You can only edit [types] if you are the only editor.
   api_must_be_owner: You must be the owner of the [type] "[name]" to do this.
+  api_must_be_site_admin: This action requires a site administrator's API key.
   api_must_have_edit_permission: You do not have permission to edit [type] "[name]".
   api_must_have_view_permission: You do not have permission to view [type] "[name]".
   api_must_not_have_any_herbaria: You can't edit this [:location] because there is an [:herbarium] there.

--- a/script/backfill_image_dhashes.rb
+++ b/script/backfill_image_dhashes.rb
@@ -132,15 +132,27 @@ class BackfillImageDhashes
   end
 
   # Returns the API2 error codes from the response ([] on success).
+  # Timeouts keep one stalled connection from hanging the whole run.
   def request_push(image)
     uri = URI("#{@push_url}/api2/images.json")
     request = Net::HTTP::Patch.new(uri)
     request.set_form_data(id: image.id, set_dhash: image.dhash,
                           api_key: @push_key)
     response = Net::HTTP.start(uri.host, uri.port,
-                               use_ssl: uri.scheme == "https") do |http|
+                               use_ssl: uri.scheme == "https",
+                               open_timeout: 10, read_timeout: 60) do |http|
       http.request(request)
     end
+    parse_push_response(response)
+  end
+
+  # API2 reports its own errors as JSON in a 200 response; a non-2xx
+  # never reached the normal API flow (proxy error, 500, wrong path)
+  # and its body may not be JSON at all -- report the status instead
+  # of a confusing JSON parse error.
+  def parse_push_response(response)
+    return ["HTTP #{response.code}"] unless response.is_a?(Net::HTTPSuccess)
+
     body = JSON.parse(response.body)
     (body["errors"] || []).pluck("code")
   end

--- a/script/backfill_image_dhashes.rb
+++ b/script/backfill_image_dhashes.rb
@@ -3,7 +3,8 @@
 #  USAGE::
 #
 #    bin/rails runner script/backfill_image_dhashes.rb [--scope SCOPE] \
-#      [--limit N] [--rehash] [--progress-every N]
+#      [--limit N] [--rehash] [--progress-every N] \
+#      [--push-url URL --push-key-file PATH]
 #
 #  DESCRIPTION::
 #
@@ -23,8 +24,21 @@
 #    fetching the transferred medium image, so it works whether or not the
 #    originals are still on this host. An image that fails to hash is logged
 #    and skipped.
+#
+#    --push-url + --push-key-file turn on local-compute/API-push mode
+#    (#4585): each hash computed here (on a dev box, sparing the
+#    production web server the ImageMagick decode load) is also pushed to
+#    the given MO server via PATCH /api2/images set_dhash. The key file
+#    holds a site administrator's API key (the endpoint is
+#    site-admin-only) — a file, not an argument, so the key stays out of
+#    process listings. The server fills only null dhashes; a differing
+#    existing value comes back as API2::ImageDhashMismatch, which is
+#    logged here and counted as a mismatch — interesting data, never
+#    overwritten. Push failures don't abort the run.
 
 require "optparse"
+require "net/http"
+require "json"
 
 class BackfillImageDhashes
   def initialize(opts)
@@ -32,6 +46,7 @@ class BackfillImageDhashes
     @limit = opts[:limit]
     @rehash = opts[:rehash]
     @progress_every = opts[:progress_every] || 1000
+    parse_push_config(opts)
     @stats = Hash.new(0)
     @started_at = Time.current
   end
@@ -48,6 +63,14 @@ class BackfillImageDhashes
   end
 
   private
+
+  def parse_push_config(opts)
+    @push_url = opts[:push_url]&.chomp("/")
+    @push_key = opts[:push_key_file] && File.read(opts[:push_key_file]).strip
+    return unless @push_url.present? ^ @push_key.present?
+
+    abort("--push-url and --push-key-file must be given together")
+  end
 
   def scoped_images
     images = base_scope
@@ -76,9 +99,50 @@ class BackfillImageDhashes
   def hash_one(image)
     image.compute_dhash!
     @stats[:hashed] += 1
+    push_dhash(image) if @push_url
   rescue StandardError => e
     @stats[:error] += 1
     warn("  image #{image.id}: #{e.class}: #{e.message}")
+  end
+
+  # PATCH the freshly computed hash to the remote MO server. The server
+  # fills only null dhashes; API2::ImageDhashMismatch means it already
+  # holds a DIFFERENT value -- logged and counted, never overwritten.
+  # Any push failure is counted and skipped so the local hashing run
+  # continues; failed pushes can be re-driven later (the endpoint is
+  # idempotent for matching values).
+  def push_dhash(image)
+    classify_push(image, request_push(image))
+  rescue StandardError => e
+    @stats[:push_error] += 1
+    warn("  image #{image.id}: push failed: #{e.class}: #{e.message}")
+  end
+
+  def classify_push(image, error_codes)
+    if error_codes.empty?
+      @stats[:pushed] += 1
+    elsif error_codes.include?("API2::ImageDhashMismatch")
+      @stats[:push_mismatch] += 1
+      warn("  image #{image.id}: DHASH MISMATCH on server " \
+           "(local #{image.dhash})")
+    else
+      @stats[:push_error] += 1
+      warn("  image #{image.id}: push failed: #{error_codes.join(", ")}")
+    end
+  end
+
+  # Returns the API2 error codes from the response ([] on success).
+  def request_push(image)
+    uri = URI("#{@push_url}/api2/images.json")
+    request = Net::HTTP::Patch.new(uri)
+    request.set_form_data(id: image.id, set_dhash: image.dhash,
+                          api_key: @push_key)
+    response = Net::HTTP.start(uri.host, uri.port,
+                               use_ssl: uri.scheme == "https") do |http|
+      http.request(request)
+    end
+    body = JSON.parse(response.body)
+    (body["errors"] || []).pluck("code")
   end
 
   def progress(done, total)
@@ -105,6 +169,13 @@ OptionParser.new do |opts|
   end
   opts.on("--progress-every N", Integer, "Progress cadence") do |n|
     options[:progress_every] = n
+  end
+  opts.on("--push-url URL", "Push hashes to this MO server via API2") do |u|
+    options[:push_url] = u
+  end
+  opts.on("--push-key-file PATH",
+          "File holding a site admin API key for --push-url") do |p|
+    options[:push_key_file] = p
   end
 end.parse!
 

--- a/test/classes/api2/error_test.rb
+++ b/test/classes/api2/error_test.rb
@@ -115,6 +115,7 @@ class API2::ErrorTest < UnitTestCase
       API2::FieldSlipInUse => [field_slips(:field_slip_one)],
       API2::HerbariumRecordAlreadyExists =>
         [herbarium_records(:interesting_unknown)],
+      API2::ImageDhashMismatch => [images(:in_situ_image), 12_345],
       API2::ImageUploadFailed => [Image.new],
       API2::MustBeAdmin => [projects(:eol_project)],
       API2::UserAccountBlocked => [users(:rolf)],

--- a/test/classes/api2/images_test.rb
+++ b/test/classes/api2/images_test.rb
@@ -406,6 +406,59 @@ class API2::ImagesTest < UnitTestCase
     assert_equal("new name", marys_img.original_name)
   end
 
+  # set_dhash is the push half of #4585's local-compute dhash backfill:
+  # site-admin-only, exclusive of other setters, fill-null-only (a
+  # different existing value is a conflict, never overwritten), and it
+  # must not bump updated_at -- that feeds the #4808 cache-busting URL
+  # token, and recording derived data is not an edit.
+  def test_patching_image_dhash
+    admin_key = APIKey.create!(user: users(:admin), notes: "dhash backfill",
+                               verified: Time.zone.now)
+    img = images(:in_situ_image)
+    assert_nil(img.dhash)
+    params = {
+      method: :patch, action: :image, id: img.id, set_dhash: 12_345
+    }
+
+    # A regular user's key is rejected, even for their own image.
+    assert_api_fail(params.merge(api_key: @api_key.key,
+                                 id: images(:rolf_profile_image).id))
+    assert_nil(images(:rolf_profile_image).reload.dhash)
+
+    # Exclusive of the owner-permission setters.
+    assert_api_fail(params.merge(api_key: admin_key.key, set_notes: "x"))
+
+    old_updated_at = img.updated_at
+    assert_api_pass(params.merge(api_key: admin_key.key))
+    img.reload
+    assert_equal(12_345, img.dhash)
+    assert_equal(old_updated_at, img.updated_at,
+                 "recording a dhash must not bump updated_at")
+
+    # Idempotent: same value again is a no-op pass.
+    assert_api_pass(params.merge(api_key: admin_key.key))
+    assert_equal(12_345, img.reload.dhash)
+
+    # Conflict: a different value is refused and the original kept.
+    assert_api_fail(params.merge(api_key: admin_key.key, set_dhash: 999))
+    assert_equal(12_345, img.reload.dhash)
+  end
+
+  def test_patching_image_dhash_accepts_full_unsigned_64_bit_range
+    admin_key = APIKey.create!(user: users(:admin), notes: "dhash backfill",
+                               verified: Time.zone.now)
+    img = images(:in_situ_image)
+    max = (2**64) - 1
+    params = {
+      method: :patch, action: :image, id: img.id, api_key: admin_key.key
+    }
+
+    assert_api_fail(params.merge(set_dhash: -1))
+    assert_api_fail(params.merge(set_dhash: 2**64))
+    assert_api_pass(params.merge(set_dhash: max))
+    assert_equal(max, img.reload.dhash)
+  end
+
   def test_deleting_images
     rolfs_img = rolf.images.sample
     marys_img = mary.images.sample


### PR DESCRIPTION
## Summary

Part of #4585's dhash backfill. Running `script/backfill_image_dhashes.rb` on the production web server would put hundreds of thousands of ImageMagick medium-rendition decodes next to Puma (the #4796 lesson). This PR moves the heavy lifting to a dev box: hash locally, push results to production through a new API2 setter. (The images server sees the same rendition-serving load either way — that's nginx's day job, with the dev box's slower link as natural throttling; the win is keeping decode CPU off the web host.)

### `PATCH /api2/images` + `set_dhash`

- **Site-admin-only** — a non-admin key gets the new `API2::MustBeSiteAdmin` error, regardless of image ownership.
- **Exclusive** of the normal owner-permission setters (`OneOrTheOther` if mixed) — the two paths have different permission models.
- **Fill-null-only, never overwrite**: an existing equal value is an idempotent no-op; a differing value raises the new `API2::ImageDhashMismatch` (reporting both values) and leaves the stored hash untouched. Mismatches are interesting signal, and this makes the "someone overwrites our dhashes with bogus values" risk structurally impossible rather than merely unlikely.
- Writes via `update_column`: dhash is derived data — recording it is not an edit, and bumping `updated_at` would flip the image's #4808 cache-busting URL token (and bust every fragment cache) for unchanged pixels.
- Accepts the full unsigned 64-bit range (`limit: 0..2^64-1`).

### `script/backfill_image_dhashes.rb` push mode

`--push-url URL --push-key-file PATH` (key in a file so it stays out of process listings). Each locally computed hash is PATCHed to the target server; successes, server-side mismatches, and push failures are counted and logged separately, and a push failure never aborts the hashing run. Intended invocation from a dev checkout with a current DB mirror:

```
bin/rails runner script/backfill_image_dhashes.rb \
  --push-url https://mushroomobserver.org --push-key-file ~/.mo_admin_api_key
```

## Test plan

- [x] `bin/rails test test/classes/api2/images_test.rb` — new coverage: non-admin refusal, setter exclusivity, null-fill with `updated_at` pinned unchanged, idempotent re-push, mismatch refusal preserving the original, full unsigned-64-bit range accepted with out-of-range rejected
- [x] `bin/rails test test/classes/localization_files_test.rb` — new en.txt strings validate
- [x] End-to-end against a locally booted server: script `--limit 2 --push-url http://localhost:3111` → `hashed: 2, pushed: 2`; curl mismatch → `API2::ImageDhashMismatch` with both values in the message; curl with non-admin key → `API2::MustBeSiteAdmin`; stored dhash unchanged after both refusals
- [x] `bundle exec rubocop` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
