### PR TITLE
Update page upon modifying Comment

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -211,7 +211,7 @@ class CommentsController < ApplicationController
     @comment.log_create
     flash_notice(:runtime_form_comments_create_success.t(id: @comment.id))
 
-    refresh_comments_or_redirect_to_show(extra_streams: [prepend_comment_row])
+    refresh_comments_or_redirect_to_show
   end
 
   # Form to edit a comment for an object..

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,6 +10,9 @@
 #  destroy::
 #
 class CommentsController < ApplicationController
+  include RowStreams
+  include ModalForm
+
   before_action :login_required
   before_action :store_location, only: [:show]
 
@@ -208,7 +211,7 @@ class CommentsController < ApplicationController
     @comment.log_create
     flash_notice(:runtime_form_comments_create_success.t(id: @comment.id))
 
-    refresh_comments_or_redirect_to_show
+    refresh_comments_or_redirect_to_show(extra_streams: [prepend_comment_row])
   end
 
   # Form to edit a comment for an object..
@@ -245,7 +248,7 @@ class CommentsController < ApplicationController
     @comment.attributes = permitted_comment_params if params[:comment]
     reload_form and return unless comment_updated?
 
-    refresh_comments_or_redirect_to_show
+    refresh_comments_or_redirect_to_show(extra_streams: [update_comment_row])
   end
 
   # Callback to destroy a comment.
@@ -257,6 +260,7 @@ class CommentsController < ApplicationController
     return unless (@comment = find_comment!)
 
     @target = @comment.target
+    extra_streams = []
     if !permission!(@comment)
       # all html requests redirect to object show page
     elsif !@comment.destroy
@@ -264,9 +268,10 @@ class CommentsController < ApplicationController
     else
       @comment.log_destroy
       flash_notice(:runtime_form_comments_destroy_success.t(id: params[:id]))
+      extra_streams << remove_comment_row
     end
 
-    refresh_comments_or_redirect_to_show
+    refresh_comments_or_redirect_to_show(extra_streams: extra_streams)
   end
 
   private
@@ -298,40 +303,6 @@ class CommentsController < ApplicationController
     Comment.includes(:user, :target).where(target: @target).to_a
   end
 
-  # The identifier needs to be more specific for an edit form, because
-  # we give users the option to edit any number of their own comments on a
-  # show page. "comment" disambiguates :new, because :edit always has id
-  def render_modal_comment_form
-    render(Components::Modal.new(
-             type: :turbo_form, identifier: modal_identifier,
-             title: modal_title,
-             user: @user, model: @comment
-           ), layout: false)
-  end
-
-  def reload_modal_form
-    render_modal_form_reload(identifier: modal_identifier,
-                             form_locals: { model: @comment })
-  end
-
-  def modal_identifier
-    case action_name
-    when "new", "create"
-      "comment"
-    when "edit", "update"
-      "comment_#{@comment.id}"
-    end
-  end
-
-  def modal_title
-    case action_name
-    when "new", "create"
-      :comment_add_title.t(name: viewer_aware_unique_format_name(@target))
-    when "edit", "update"
-      :comment_edit_title.t(name: viewer_aware_unique_format_name(@target))
-    end
-  end
-
   def permitted_comment_params
     params[:comment].permit([:summary, :comment])
   end
@@ -343,23 +314,18 @@ class CommentsController < ApplicationController
     end
   end
 
-  def refresh_comments_or_redirect_to_show
-    # Comment broadcasts are sent from the model.
-    # The turbo_stream response also closes the modal so the
-    # user doesn't have to wait for Action Cable delivery. The
-    # edit modal is "modal_comment_<id>"; the new modal is
-    # "modal_comment".
-    #
-    # `close_modal` runs Bootstrap's `$(el).modal('hide')` which removes
-    # the backdrop and the `modal-open` body class. We follow with
-    # `remove` to drop the modal element so the next "new comment" click
-    # fetches a fresh form.
+  # `extra_streams` (see `CommentsController::RowStreams`) applies the
+  # row change synchronously; the modal close/remove below doesn't wait
+  # on the model's own Action Cable broadcast. Edit modal id is
+  # "modal_comment_<id>"; the new-comment modal id is "modal_comment".
+  def refresh_comments_or_redirect_to_show(extra_streams: [])
     respond_to do |format|
       format.turbo_stream do
         modal_id = "modal_#{modal_identifier}"
-        render(turbo_stream:
-          turbo_stream.close_modal(modal_id) +
-          turbo_stream.remove(modal_id))
+        render(turbo_stream: extra_streams + [
+          turbo_stream.close_modal(modal_id),
+          turbo_stream.remove(modal_id)
+        ])
       end
       format.html do
         redirect_to(@target.show_link_args)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -211,7 +211,7 @@ class CommentsController < ApplicationController
     @comment.log_create
     flash_notice(:runtime_form_comments_create_success.t(id: @comment.id))
 
-    refresh_comments_or_redirect_to_show
+    refresh_comments_or_redirect_to_show(extra_streams: [prepend_comment_row])
   end
 
   # Form to edit a comment for an object..

--- a/app/controllers/comments_controller/modal_form.rb
+++ b/app/controllers/comments_controller/modal_form.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Rendering/identifying the create/edit modal form.
+module CommentsController::ModalForm
+  private
+
+  # The identifier needs to be more specific for an edit form, because
+  # we give users the option to edit any number of their own comments on a
+  # show page. "comment" disambiguates :new, because :edit always has id
+  def render_modal_comment_form
+    render(Components::Modal.new(
+             type: :turbo_form, identifier: modal_identifier,
+             title: modal_title,
+             user: @user, model: @comment
+           ), layout: false)
+  end
+
+  def reload_modal_form
+    render_modal_form_reload(identifier: modal_identifier,
+                             form_locals: { model: @comment })
+  end
+
+  def modal_identifier
+    case action_name
+    when "new", "create"
+      "comment"
+    when "edit", "update"
+      "comment_#{@comment.id}"
+    end
+  end
+
+  def modal_title
+    case action_name
+    when "new", "create"
+      :comment_add_title.t(name: viewer_aware_unique_format_name(@target))
+    when "edit", "update"
+      :comment_edit_title.t(name: viewer_aware_unique_format_name(@target))
+    end
+  end
+end

--- a/app/controllers/comments_controller/row_streams.rb
+++ b/app/controllers/comments_controller/row_streams.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Turbo Stream row updates for the `create`/`update`/`destroy` actions.
+#
+# The synchronous turbo_stream response has to apply the row change
+# itself -- the `Comment` model's own `after_*_commit` broadcast
+# callbacks (see `comment.rb`) are async and aren't guaranteed to
+# reach the submitter's own tab before (or ever, if the connection
+# drops) the modal-closing response arrives. Relying on the broadcast
+# alone left the modal closing with the comment list unchanged (#4833).
+#
+# The model callbacks stay in place for cross-tab / cross-user sync;
+# these methods only cover the acting user's own request.
+module CommentsController::RowStreams
+  private
+
+  def prepend_comment_row
+    turbo_stream.prepend(
+      "comments",
+      ::Views::Controllers::Comments::CommentRow.new(
+        comment: @comment, user: @user, editable: @user.present?
+      )
+    )
+  end
+
+  def update_comment_row
+    turbo_stream.update(
+      ::ActionView::RecordIdentifier.dom_id(@comment),
+      ::Views::Controllers::Comments::CommentItem.new(
+        comment: @comment, user: @user, editable: @user.present?
+      )
+    )
+  end
+
+  def remove_comment_row
+    turbo_stream.remove(::ActionView::RecordIdentifier.dom_id(@comment))
+  end
+end

--- a/app/controllers/comments_controller/row_streams.rb
+++ b/app/controllers/comments_controller/row_streams.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Turbo Stream row updates for the `create`/`update`/`destroy` actions.
+# Turbo Stream row updates for the `update`/`destroy` actions.
 #
 # The synchronous turbo_stream response has to apply the row change
 # itself -- the `Comment` model's own `after_*_commit` broadcast
@@ -11,17 +11,16 @@
 #
 # The model callbacks stay in place for cross-tab / cross-user sync;
 # these methods only cover the acting user's own request.
+#
+# `create` deliberately has no synchronous counterpart here. Unlike
+# `update`/`remove`, `prepend` isn't idempotent: `after_create_commit`
+# fires (and dispatches its broadcast) before the controller even
+# builds this response, so a synchronous prepend would very often
+# race a second, duplicate prepend of the same row once the broadcast
+# lands. `create` isn't reported broken (#4833 is update/destroy
+# only), so it's left to the model's broadcast alone.
 module CommentsController::RowStreams
   private
-
-  def prepend_comment_row
-    turbo_stream.prepend(
-      "comments",
-      ::Views::Controllers::Comments::CommentRow.new(
-        comment: @comment, user: @user, editable: @user.present?
-      )
-    )
-  end
 
   def update_comment_row
     turbo_stream.update(

--- a/app/controllers/comments_controller/row_streams.rb
+++ b/app/controllers/comments_controller/row_streams.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Turbo Stream row updates for the `update`/`destroy` actions.
+# Turbo Stream row updates for the `create`/`update`/`destroy` actions.
 #
 # The synchronous turbo_stream response has to apply the row change
 # itself -- the `Comment` model's own `after_*_commit` broadcast
@@ -12,15 +12,25 @@
 # The model callbacks stay in place for cross-tab / cross-user sync;
 # these methods only cover the acting user's own request.
 #
-# `create` deliberately has no synchronous counterpart here. Unlike
-# `update`/`remove`, `prepend` isn't idempotent: `after_create_commit`
-# fires (and dispatches its broadcast) before the controller even
-# builds this response, so a synchronous prepend would very often
-# race a second, duplicate prepend of the same row once the broadcast
-# lands. `create` isn't reported broken (#4833 is update/destroy
-# only), so it's left to the model's broadcast alone.
+# `create`'s row insert uses the custom `prepend_once` action (see
+# `config/initializers/turbo_stream_actions.rb`), not the built-in
+# `prepend` -- unlike `update`/`remove`, a plain `prepend` isn't
+# idempotent, and `after_create_commit` dispatches its own broadcast
+# before this response is even built, so the two would routinely race
+# and insert the row twice. `prepend_once` is a client-side no-op if
+# the row's id is already in the DOM, so whichever of the two arrives
+# second doesn't duplicate it.
 module CommentsController::RowStreams
   private
+
+  def prepend_comment_row
+    turbo_stream.prepend_once(
+      "comments",
+      ::Views::Controllers::Comments::CommentRow.new(
+        comment: @comment, user: @user, editable: @user.present?
+      )
+    )
+  end
 
   def update_comment_row
     turbo_stream.update(

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -35,6 +35,20 @@ Turbo.StreamActions.remove_class = function () {
     target.classList.remove(this.templateContent.textContent)
   });
 }
+// Guards against duplicate inserts when both a controller's
+// synchronous turbo_stream response and a model's async broadcast
+// try to prepend the same new record (see CommentsController#create).
+// Whichever arrives first wins; the second becomes a no-op instead of
+// inserting a second copy.
+Turbo.StreamActions.prepend_once = function () {
+  const newElement = this.templateContent.firstElementChild
+  if (newElement && newElement.id && document.getElementById(newElement.id)) {
+    return
+  }
+  this.targetElements.forEach((target) => {
+    target.prepend(this.templateContent.cloneNode(true))
+  });
+}
 
 import "@rails/request.js"
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -129,11 +129,17 @@ class Comment < AbstractModel
   # Action Cable broadcasts that keep the comments list group on
   # show pages live across browser windows / users.
   #
-  # - `after_create_commit` (prepend): a brand-new row, wrapper +
+  # - `after_create_commit` (prepend_once): a brand-new row, wrapper +
   #   inner. Renders `Views::Controllers::Comments::CommentRow`
   #   (full `<div class="list-group-item comment"
   #   id="comment_<id>">…CommentItem…</div>`) so the wrapper id is
   #   set up for later update/replace broadcasts to target.
+  #   `CommentsController#create` also inserts this same row
+  #   synchronously (`CommentsController::RowStreams`) so the
+  #   submitter doesn't wait on Action Cable delivery -- the custom
+  #   `prepend_once` action (config/initializers/turbo_stream_actions.rb)
+  #   is a client-side no-op if that id is already in the DOM, so
+  #   whichever of the two arrives second doesn't duplicate the row.
   # - `after_update_commit` (update, not replace): the wrapper
   #   already exists in the DOM with id `"comment_<id>"`; only the
   #   inner content needs to change. `broadcast_update_to`
@@ -149,8 +155,9 @@ class Comment < AbstractModel
   # payload in the application layout — we want the Phlex component's
   # HTML and nothing else.
   after_create_commit lambda { |comment|
-    comment.broadcast_prepend_to(
+    comment.broadcast_action_to(
       [comment.target, :comments],
+      action: :prepend_once,
       target: "comments",
       html: ::ApplicationController.renderer.render(
         ::Views::Controllers::Comments::CommentRow.new(

--- a/config/initializers/turbo_stream_actions.rb
+++ b/config/initializers/turbo_stream_actions.rb
@@ -19,5 +19,14 @@ module CustomTurboStreamActions
     action(:remove_class, id, class_name)
   end
 
+  # Like `prepend`, but the client skips the insert if an element with
+  # the new content's id is already in the DOM. Lets a controller's
+  # synchronous response and a model's async broadcast both try to
+  # insert the same new record without risking a duplicate -- whichever
+  # arrives first wins, the second is a no-op. See CommentsController.
+  def prepend_once(target, content = nil, **rendering, &block)
+    action(:prepend_once, target, content, **rendering, &block)
+  end
+
   ::Turbo::Streams::TagBuilder.include(self)
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -427,11 +427,12 @@ class CommentsControllerTest < FunctionalTestCase
     assert_select("turbo-stream[action=?][target=?]", "remove", "modal_comment")
   end
 
-  # The synchronous response has to prepend the new row itself -- the
-  # `Comment` model's own `after_create_commit` broadcast is async
-  # and isn't guaranteed to reach the submitter's own tab before (or
-  # ever, if the connection drops) the modal closes (#4833).
-  def test_create_comment_turbo_stream_prepends_row
+  # Unlike `update`/`destroy`, `create` must NOT also prepend the row
+  # synchronously here: `after_create_commit`'s broadcast fires before
+  # this response is even built, so a synchronous prepend would race
+  # a second, duplicate prepend of the same row once the broadcast
+  # lands (see `CommentsController::RowStreams`).
+  def test_create_comment_turbo_stream_does_not_duplicate_row
     obs = observations(:minimal_unknown_obs)
     params = { target: obs.id,
                type: "Observation",
@@ -440,18 +441,9 @@ class CommentsControllerTest < FunctionalTestCase
     login
     post(:create, params: params, as: :turbo_stream)
     assert_response(:success)
-    comment = Comment.find_by(summary: "Turbo Prepend Test", target: obs)
-    assert_not_nil(comment, "Cannot find Comment")
 
-    assert_select(
-      "turbo-stream[action=?][target=?] " \
-      ".comment##{ActionView::RecordIdentifier.dom_id(comment)}",
-      "prepend", "comments"
-    )
-    assert_select(
-      "turbo-stream[action=?][target=?] .comment-summary",
-      "prepend", "comments", text: comment.summary
-    )
+    assert_select("turbo-stream[action=?][target=?]", "prepend", "comments",
+                  count: 0)
   end
 
   def test_update_comment_turbo_stream_removes_scoped_modal

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -427,12 +427,18 @@ class CommentsControllerTest < FunctionalTestCase
     assert_select("turbo-stream[action=?][target=?]", "remove", "modal_comment")
   end
 
-  # Unlike `update`/`destroy`, `create` must NOT also prepend the row
-  # synchronously here: `after_create_commit`'s broadcast fires before
-  # this response is even built, so a synchronous prepend would race
-  # a second, duplicate prepend of the same row once the broadcast
-  # lands (see `CommentsController::RowStreams`).
-  def test_create_comment_turbo_stream_does_not_duplicate_row
+  # The synchronous response has to insert the new row itself -- the
+  # `Comment` model's own `after_create_commit` broadcast is async
+  # and isn't guaranteed to reach the submitter's own tab before (or
+  # ever, if the connection drops) the modal closes (#4833). It uses
+  # the custom `prepend_once` action, not the built-in `prepend`:
+  # `after_create_commit` dispatches its own broadcast before this
+  # response is even built, so a plain `prepend` here would routinely
+  # race a duplicate insert of the same row. `prepend_once` is a
+  # client-side no-op if the row's id is already in the DOM (see
+  # `config/initializers/turbo_stream_actions.rb`), so whichever of
+  # the two arrives second doesn't duplicate it.
+  def test_create_comment_turbo_stream_prepends_row_once
     obs = observations(:minimal_unknown_obs)
     params = { target: obs.id,
                type: "Observation",
@@ -441,7 +447,19 @@ class CommentsControllerTest < FunctionalTestCase
     login
     post(:create, params: params, as: :turbo_stream)
     assert_response(:success)
+    comment = Comment.find_by(summary: "Turbo Prepend Test", target: obs)
+    assert_not_nil(comment, "Cannot find Comment")
 
+    assert_select(
+      "turbo-stream[action=?][target=?] " \
+      ".comment##{ActionView::RecordIdentifier.dom_id(comment)}",
+      "prepend_once", "comments"
+    )
+    assert_select(
+      "turbo-stream[action=?][target=?] .comment-summary",
+      "prepend_once", "comments", text: comment.summary
+    )
+    # Guard against reverting to the plain (non-deduping) action.
     assert_select("turbo-stream[action=?][target=?]", "prepend", "comments",
                   count: 0)
   end
@@ -538,6 +556,13 @@ class CommentsControllerTest < FunctionalTestCase
 
     # `capture_turbo_stream_broadcasts` returns
     # `Nokogiri::XML::Element` nodes (the `<turbo-stream>` wrappers).
+    # `prepend_once`, not the built-in `prepend` -- see
+    # `CommentsController::RowStreams` for why the plain action would
+    # risk duplicating the row the controller may have already
+    # inserted synchronously.
+    assert_equal("prepend_once", payloads.last["action"],
+                 "Comment create broadcast should use the deduping " \
+                 "prepend_once action")
     html = payloads.last.to_html
     # The mod-links span carries `data-user-specific` keyed to
     # the comment's author id — that's the CSS's selector hook.

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -423,13 +423,34 @@ class CommentsControllerTest < FunctionalTestCase
     assert_response(:success)
     # close_modal triggers Bootstrap cleanup (backdrop + body class);
     # remove drops the element so the next open fetches a fresh form.
-    assert_match(
-      /<turbo-stream action="close_modal"[^>]*>\s*<template>modal_comment/,
-      @response.body
+    assert_select("turbo-stream[action='close_modal']", text: "modal_comment")
+    assert_select("turbo-stream[action=?][target=?]", "remove", "modal_comment")
+  end
+
+  # The synchronous response has to prepend the new row itself -- the
+  # `Comment` model's own `after_create_commit` broadcast is async
+  # and isn't guaranteed to reach the submitter's own tab before (or
+  # ever, if the connection drops) the modal closes (#4833).
+  def test_create_comment_turbo_stream_prepends_row
+    obs = observations(:minimal_unknown_obs)
+    params = { target: obs.id,
+               type: "Observation",
+               comment: { summary: "Turbo Prepend Test",
+                          comment: "Some text." } }
+    login
+    post(:create, params: params, as: :turbo_stream)
+    assert_response(:success)
+    comment = Comment.find_by(summary: "Turbo Prepend Test", target: obs)
+    assert_not_nil(comment, "Cannot find Comment")
+
+    assert_select(
+      "turbo-stream[action=?][target=?] " \
+      ".comment##{ActionView::RecordIdentifier.dom_id(comment)}",
+      "prepend", "comments"
     )
-    assert_match(
-      /<turbo-stream action="remove"[^>]*target="modal_comment"/,
-      @response.body
+    assert_select(
+      "turbo-stream[action=?][target=?] .comment-summary",
+      "prepend", "comments", text: comment.summary
     )
   end
 
@@ -442,14 +463,48 @@ class CommentsControllerTest < FunctionalTestCase
     put(:update, params: params, as: :turbo_stream)
     assert_response(:success)
     target_id = "modal_comment_#{comment.id}"
-    assert_match(
-      /<turbo-stream action="close_modal"[^>]*>\s*<template>#{target_id}/,
-      @response.body
+    assert_select("turbo-stream[action='close_modal']", text: target_id)
+    assert_select("turbo-stream[action=?][target=?]", "remove", target_id)
+  end
+
+  # The synchronous response has to update the row itself -- the
+  # `Comment` model's own `after_update_commit` broadcast is async
+  # and isn't guaranteed to reach the submitter's own tab before (or
+  # ever, if the connection drops) the modal closes (#4833).
+  def test_update_comment_turbo_stream_updates_row
+    comment = comments(:minimal_unknown_obs_comment_1)
+    login_for(comment)
+    params = { id: comment.id,
+               comment: { summary: "Updated Summary",
+                          comment: "Updated body." } }
+    put(:update, params: params, as: :turbo_stream)
+    assert_response(:success)
+
+    assert_select(
+      "turbo-stream[action=?][target=?] .comment-summary",
+      "update", ActionView::RecordIdentifier.dom_id(comment),
+      text: "Updated Summary"
     )
-    assert_match(
-      /<turbo-stream action="remove"[^>]*target="#{target_id}"/,
-      @response.body
+    assert_select(
+      "turbo-stream[action=?][target=?] .comment-body",
+      "update", ActionView::RecordIdentifier.dom_id(comment),
+      text: "Updated body."
     )
+  end
+
+  # The synchronous response has to remove the row itself -- the
+  # `Comment` model's own `after_destroy_commit` broadcast is async
+  # and isn't guaranteed to reach the submitter's own tab before (or
+  # ever, if the connection drops) the modal closes (#4833).
+  def test_destroy_comment_turbo_stream_removes_row
+    comment = comments(:minimal_unknown_obs_comment_1)
+    login_for(comment)
+
+    delete(:destroy, params: { id: comment.id }, as: :turbo_stream)
+    assert_response(:success)
+
+    assert_select("turbo-stream[action=?][target=?]", "remove",
+                  ActionView::RecordIdentifier.dom_id(comment))
   end
 
   def login_for(comment)

--- a/test/system/observation_comment_system_test.rb
+++ b/test/system/observation_comment_system_test.rb
@@ -233,4 +233,36 @@ class ObservationCommentSystemTest < ApplicationSystemTestCase
       assert_no_selector("#comment_#{ufo.id}")
     end
   end
+
+  # Regression test for #4833: submitting the new-comment modal has to
+  # show the comment on the page right away -- no reliance on (or wait
+  # for) the model's async Action Cable broadcast to catch up.
+  def test_new_comment_appears_immediately
+    rolf = users("rolf")
+    obs = observations(:coprinus_comatus_obs)
+
+    login!(rolf)
+    visit("/#{obs.id}")
+
+    assert_selector("body.observations__show")
+    within("#comments_for_object") do
+      click_link(:show_comments_add_comment.l)
+    end
+
+    assert_selector("#modal_comment")
+    within("#comment_form") do
+      fill_in("comment_summary", with: "Immediate Comment")
+      fill_in("comment_comment", with: "Shows up right away.")
+      click_commit
+    end
+
+    assert_no_selector("#modal_comment")
+
+    comment = Comment.find_by(summary: "Immediate Comment", target: obs)
+    assert_not_nil(comment, "Comment wasn't saved")
+    within("#comment_#{comment.id}") do
+      assert_text("Immediate Comment")
+      assert_text("Shows up right away.")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #4833

### Manual Test
#### Create

- Create a Comment 
- Save
- Expected Result:
  - modal closes
  - Page displays with newly created comment
 
#### Edit

- Edit a Comment (making a change)
- Save Edits
- Expected Result:
  - modal closes
  - Comment displays with changes on the page

#### Delete
- Delete a Comment
- Expected resul
  - page displays without the deleted Comment
 