### PR TITLE
Fix `script/exiftool_remote` argument handling and `Shellwords` corruption of GPS-stripping tests

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -982,17 +982,25 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   # remotely. Returns nil if it fails. Costly.
   # @param hide_gps [Boolean, nil] Override GPS hiding. If nil, checks
   #   observations to determine whether to hide GPS.
+  #
+  # No Shellwords.escape needed here -- Open3.capture2e's array form
+  # (`cmd, *flags, path`) execs directly, bypassing the shell entirely,
+  # so nothing ever interprets shell metacharacters. Escaping anyway
+  # used to be harmless (no argument here ever contained one), but
+  # original_url now carries a `?<version>` cache-buster (#4808) --
+  # Shellwords.escape turned that `?` into a literal `\?` in the
+  # argument itself (array form never strips the backslash back out),
+  # so every remote (transferred) EXIF re-read silently 404'd.
   def read_exif_data(flags = [], hide_gps: nil)
     hide_gps = observations.any?(&:gps_hidden) if hide_gps.nil?
 
     if transferred
-      cmd = Shellwords.escape("script/exiftool_remote")
-      path = Shellwords.escape(original_url)
+      cmd = "script/exiftool_remote"
+      path = original_url
     else
-      cmd  = Shellwords.escape("exiftool")
-      path = Shellwords.escape(full_filepath("orig"))
+      cmd = "exiftool"
+      path = full_filepath("orig")
     end
-    flags.map { |flag| Shellwords.escape(flag) }
     result, status = Open3.capture2e(cmd, *flags, path)
 
     data = status.success? ? self.class.parse_exif_data(result, hide_gps) : nil

--- a/script/exiftool_remote
+++ b/script/exiftool_remote
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Usage: exiftool_remote [exiftool flags...] <url>
 #
 # Mirrors Image#read_exif_data's `cmd, *flags, path` calling
@@ -9,6 +9,15 @@
 # README_PRODUCTION_INSTALL / script/ubuntu_setup_root -- and ships
 # with macOS by default, unlike wget) and pipes the bytes into
 # exiftool reading from stdin, with those flags applied.
+#
+# pipefail so a failed curl (bad URL, HTTP error, network failure)
+# makes the whole pipeline -- and this script's own exit status, which
+# Image#read_exif_data checks via Open3.capture2e's status.success? --
+# fail too, instead of silently succeeding on whatever exiftool made
+# of empty/partial input. -f/-L: treat HTTP error responses as
+# failures rather than piping an error page's HTML into exiftool, and
+# follow redirects (CDN/S3-signed image URLs commonly redirect).
+set -euo pipefail
 url="${@: -1}"
 flags=("${@:1:$#-1}")
-curl -s "$url" | exiftool "${flags[@]}" -
+curl -fsSL -- "$url" | exiftool "${flags[@]}" -

--- a/script/exiftool_remote
+++ b/script/exiftool_remote
@@ -1,2 +1,14 @@
-#!/bin/sh
-wget -qO- "$1" | exiftool -
+#!/bin/bash
+# Usage: exiftool_remote [exiftool flags...] <url>
+#
+# Mirrors Image#read_exif_data's `cmd, *flags, path` calling
+# convention -- the same shape it uses to invoke the local `exiftool`
+# binary directly (flags first, target path/URL last). All arguments
+# except the last are exiftool flags; the last argument is the URL to
+# fetch. Fetches the URL via curl (confirmed on production -- see
+# README_PRODUCTION_INSTALL / script/ubuntu_setup_root -- and ships
+# with macOS by default, unlike wget) and pipes the bytes into
+# exiftool reading from stdin, with those flags applied.
+url="${@: -1}"
+flags=("${@:1:$#-1}")
+curl -s "$url" | exiftool "${flags[@]}" -

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -697,4 +697,56 @@ class ImageTest < UnitTestCase
     assert(img.external_links.loaded?)
     assert_equal(link, img.import_link)
   end
+
+  # ---- EXIF geocode reading (local file vs. remote via curl+exiftool) --
+
+  # The image geotagged.jpg has this data (see also
+  # ObservationFormSystemTest::GEOTAGGED_EXIF).
+  GEOTAGGED_EXIF_GPS = { lat: 25.7582, lng: -80.3731, alt: 4 }.freeze
+
+  def test_read_exif_geocode_local_file
+    img = images(:in_situ_image)
+    stage_geotagged_file(img.full_filepath("orig"))
+
+    data = img.read_exif_geocode(hide_gps: false)
+
+    assert_equal(GEOTAGGED_EXIF_GPS[:lat], data[:lat])
+    assert_equal(GEOTAGGED_EXIF_GPS[:lng], data[:lng])
+    assert_equal(GEOTAGGED_EXIF_GPS[:alt], data[:alt])
+  ensure
+    FileUtils.rm_f(img.full_filepath("orig"))
+  end
+
+  # Regression test: `script/exiftool_remote` used to only read `$1`
+  # as a bare URL (fetched via `wget`), but `Image#read_exif_data`
+  # calls it with `flags..., url` -- the same `cmd, *flags, path`
+  # shape it uses for the local `exiftool` binary directly. That
+  # argument-shape mismatch (compounded by `wget` not being installed
+  # on every dev machine, unlike `curl`) silently broke EXIF re-reads
+  # for any already-transferred image -- `read_exif_geocode` always
+  # returned nil. See the corrected `curl [flags] url`-forwarding
+  # shape in `script/exiftool_remote`.
+  def test_read_exif_geocode_transferred_image
+    img = images(:in_situ_image)
+    img.update_column(:transferred, true)
+    # original_url carries a `?<version>` cache-buster (#4808) that
+    # curl correctly strips when resolving a `file://` URL -- but it's
+    # not part of the real filesystem path, so strip it here too
+    # before using this to stage the fixture file.
+    remote_path = img.original_url.delete_prefix("file://").sub(/\?.*\z/, "")
+    stage_geotagged_file(remote_path)
+
+    data = img.read_exif_geocode(hide_gps: false)
+
+    assert_equal(GEOTAGGED_EXIF_GPS[:lat], data[:lat])
+    assert_equal(GEOTAGGED_EXIF_GPS[:lng], data[:lng])
+    assert_equal(GEOTAGGED_EXIF_GPS[:alt], data[:alt])
+  ensure
+    FileUtils.rm_f(remote_path)
+  end
+
+  def stage_geotagged_file(path)
+    FileUtils.mkdir_p(File.dirname(path))
+    FileUtils.cp(Rails.root.join("test/images/geotagged.jpg"), path)
+  end
 end

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -290,6 +290,19 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     # Create observation with two geotagged images with different coordinates
     visit(new_observation_path)
     assert_selector("body.observations__new")
+    # The new-observation form copies gps_hidden from the user's last
+    # observation (`defaults_from_last_observation_created`), with no
+    # recency window (unlike `when`) -- so it may already be checked
+    # here depending on katrina's fixture history (currently true, via
+    # the untrusted_hidden fixture). Force it off regardless: the
+    # uploaded images' GPS needs to survive (Image::Processor.
+    # strip_original_gps would otherwise permanently strip it from the
+    # originals on save). The checkbox lives inside a closed Bootstrap
+    # `.collapse` section (#observation_geolocation) not opened by
+    # anything at this point in the flow, so a real click isn't
+    # possible -- set it via JS.
+    execute_script("document.getElementById(" \
+                   "'observation_gps_hidden').checked = false")
 
     # Upload first geotagged image (Miami area)
     click_attach_file("geotagged.jpg")
@@ -375,6 +388,19 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     assert_checked_field("observation_is_collection_location", visible: :all)
     assert_no_checked_field("observation_specimen", visible: :all)
     assert_field(other_notes_id, with: "", visible: :all)
+
+    # The new-observation form copies gps_hidden from the user's last
+    # observation (`defaults_from_last_observation_created`), with no
+    # recency window (unlike `when`) -- so it may already be checked
+    # here depending on katrina's fixture history. Force it off
+    # regardless: Image::Processor.strip_original_gps would otherwise
+    # permanently strip GPS from the geotagged image uploaded below,
+    # before this test's later EXIF assertions. The checkbox lives
+    # inside a closed Bootstrap `.collapse` section
+    # (#observation_geolocation) not opened by anything at this point
+    # in the flow, so a real click isn't possible -- set it via JS.
+    execute_script("document.getElementById(" \
+                   "'observation_gps_hidden').checked = false")
 
     # Move to the previous step, Images/Details
     images_details = find_by_id("observation_images_details")


### PR DESCRIPTION
## Fixes current system test failures

- `test_edit_observation_extracts_exif_from_saved_images`
- `test_post_edit_and_destroy_with_details_and_location`

## Summary

`script/exiftool_remote` only ever read a bare URL (`$1`) via `wget`, but `Image#read_exif_data` calls it with `flags..., url` — the same `cmd, *flags, path` shape it uses for the local `exiftool` binary directly. Fixed the script to treat the last argument as the URL and every preceding argument as an exiftool flag, and to fetch via `curl` (confirmed present on both production and local dev — see `README_PRODUCTION_INSTALL` / `script/ubuntu_setup_root`) instead of `wget`.

While chasing this down on a fresh branch off a newer `main`, a second, related bug surfaced: `Shellwords.escape` in `Image#read_exif_data` is unnecessary — `Open3.capture2e`'s array-form arguments exec directly, bypassing the shell entirely, so nothing ever needed escaping. It used to be harmless because no argument ever contained a shell metacharacter. But `original_url` now carries a `?<version>` cache-buster query string (#4808), and `Shellwords.escape` was turning that `?` into a literal `\?` in the argument itself — array-form `Open3` never strips the backslash back out, so every remote (transferred) EXIF re-read was silently 404'ing. Removed the escaping.

## Root cause

Both bugs together traced to commit `7bede3e9d1`, which moved GPS-stripping out of the `Rails.env.test?`-skipped `Image::Processor#process` path into the unconditional `Image#process_image`. Combined with `defaults_from_last_observation_created` copying `gps_hidden` from the user's last observation with no recency gate (unlike `when`, which is gated to 1 hour), this interacted with katrina's `untrusted_hidden` fixture (`gps_hidden: true`) to strip GPS from freshly uploaded images before the tests' EXIF assertions ran.

Both tests now force `gps_hidden` off via JS before uploading images — the checkbox lives inside a closed Bootstrap `.collapse` section (`#observation_geolocation`) that isn't reachable through the test's UI flow at that point, so a real click isn't possible.

## Test plan

- [x] `bin/rails test test/models/image_test.rb` — 50 tests, 0 failures
- [x] `bin/rails test test/system/observation_form_system_test.rb -n "/test_edit_observation_extracts_exif_from_saved_images|test_post_edit_and_destroy_with_details_and_location/"` — 2 tests, 190 assertions, 0 failures
- [x] `bundle exec rubocop app/models/image.rb test/models/image_test.rb test/system/observation_form_system_test.rb` — no offenses
- [x] `bash -n script/exiftool_remote` — syntax OK
