### PR TITLE
Extract `CoordinateFormat` module; dedupe coordinate/collection/query logic out of `Observation` and `Mappable`

### DIFF
--- a/app/classes/coordinate_format.rb
+++ b/app/classes/coordinate_format.rb
@@ -13,7 +13,7 @@
 module CoordinateFormat
   # Full-precision (unrounded) lat/lng pair -- "34.1622°N 118.3521°W".
   def display_lat_lng(lat, lng)
-    return "" unless lat
+    return "" unless lat && lng
 
     "#{lat.abs}°#{lat.negative? ? "S" : "N"} " \
       "#{lng.abs}°#{lng.negative? ? "W" : "E"}"

--- a/app/classes/coordinate_format.rb
+++ b/app/classes/coordinate_format.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Shared "how do lat/lng/alt display" formatting -- pure string
+# presentation, no model/business logic. Mixed into Components::Base
+# so Phlex views/components can call these directly, matching
+# ViewerAwareFormat's precedent for presentational logic that used to
+# live on individual models (Observation#display_lat_lng /
+# #display_alt / #place_name_and_coordinates / #format_coordinate),
+# and consolidating three more copies of the same format_coordinate /
+# format_latitude / format_longitude algorithm that had accumulated
+# independently in Mappable::ClusteredCollection, Components::Map,
+# and Components::Map::Popup.
+module CoordinateFormat
+  # Full-precision (unrounded) lat/lng pair -- "34.1622°N 118.3521°W".
+  def display_lat_lng(lat, lng)
+    return "" unless lat
+
+    "#{lat.abs}°#{lat.negative? ? "S" : "N"} " \
+      "#{lng.abs}°#{lng.negative? ? "W" : "E"}"
+  end
+
+  def display_alt(alt)
+    return "" unless alt
+
+    "#{alt.round}m"
+  end
+
+  # place_name is a caller-supplied string (Observation#place_name,
+  # Location#display_name, etc.) rather than computed here -- keeps
+  # this module free of any dependency on a specific model's own
+  # naming logic.
+  def place_name_and_coordinates(place_name, lat, lng)
+    return place_name unless lat.present? && lng.present?
+
+    "#{place_name} (#{format_latitude(lat)} #{format_longitude(lng)})"
+  end
+
+  def format_latitude(val)
+    format_coordinate(val, "N", "S")
+  end
+
+  def format_longitude(val)
+    format_coordinate(val, "E", "W")
+  end
+
+  # Rounded-to-4-decimal-places coordinate, e.g. "34.1622°N".
+  def format_coordinate(val, positive_dir, negative_dir)
+    deg = val.abs.round(4)
+    "#{deg}°#{val.negative? ? negative_dir : positive_dir}"
+  end
+end

--- a/app/classes/mappable/clustered_collection.rb
+++ b/app/classes/mappable/clustered_collection.rb
@@ -15,7 +15,8 @@
 
 module Mappable
   class ClusteredCollection
-    attr_accessor :sets, :extents, :representative_points
+    include Mappable::Collection
+    include CoordinateFormat
 
     # Build a clustered collection directly from a list of mappable
     # objects (no geographic bucketing — one MapSet per object).
@@ -41,10 +42,6 @@ module Mappable
       @extents = calc_extents
       @representative_points =
         [@extents.north_west, @extents.center, @extents.south_east]
-    end
-
-    def mapsets
-      @sets.values
     end
 
     private
@@ -117,25 +114,6 @@ module Mappable
       return "" unless obs.lat
 
       "#{format_latitude(obs.lat)} #{format_longitude(obs.lng)}"
-    end
-
-    def format_latitude(val)
-      format_coordinate(val, "N", "S")
-    end
-
-    def format_longitude(val)
-      format_coordinate(val, "E", "W")
-    end
-
-    def format_coordinate(val, positive_dir, negative_dir)
-      deg = val.abs.round(4)
-      "#{deg}°#{val.negative? ? negative_dir : positive_dir}"
-    end
-
-    def calc_extents
-      result = Mappable::MapSet.new
-      mapsets.each { |mapset| result.update_extents_with_box(mapset) }
-      result
     end
   end
 end

--- a/app/classes/mappable/collapsible_collection_of_objects.rb
+++ b/app/classes/mappable/collapsible_collection_of_objects.rb
@@ -46,17 +46,13 @@
 
 module Mappable
   class CollapsibleCollectionOfObjects
-    attr_accessor :sets, :extents, :representative_points
+    include Mappable::Collection
 
     def initialize(objects, max_objects = MO.max_map_objects)
       @max_objects = max_objects
       init_sets(objects)
       group_objects_into_sets
       init_derived_attributes
-    end
-
-    def mapsets
-      @sets.values
     end
 
     def init_derived_attributes
@@ -204,14 +200,6 @@ module Mappable
          lat <= -45 ? -90 : 0
        end,
        lng >= 150 || lng <= -150 ? 180 : round_number(lng, prec)]
-    end
-
-    def calc_extents
-      result = Mappable::MapSet.new
-      mapsets.each do |mapset|
-        result.update_extents_with_box(mapset)
-      end
-      result
     end
   end
 end

--- a/app/classes/mappable/collection.rb
+++ b/app/classes/mappable/collection.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Shared `sets` / `extents` / `representative_points` accessors plus
+# the `mapsets` / `calc_extents` methods every Mappable collection
+# class (ClusteredCollection, CollapsibleCollectionOfObjects) needs --
+# both had accumulated byte-identical copies of these independently.
+module Mappable
+  module Collection
+    def self.included(base)
+      base.attr_accessor(:sets, :extents, :representative_points)
+    end
+
+    def mapsets
+      @sets.values
+    end
+
+    def calc_extents
+      result = Mappable::MapSet.new
+      mapsets.each { |mapset| result.update_extents_with_box(mapset) }
+      result
+    end
+  end
+end

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -31,6 +31,9 @@ class Components::Base < Phlex::HTML
   # viewer_aware_format.rb for why this isn't a register_value_helper
   # instead).
   include ViewerAwareFormat
+  # `display_lat_lng`, `display_alt`, `place_name_and_coordinates`,
+  # `format_coordinate` — see app/classes/coordinate_format.rb.
+  include CoordinateFormat
 
   # Register custom value helpers (return values)
   register_value_helper :permission?

--- a/app/components/image/lightbox/caption.rb
+++ b/app/components/image/lightbox/caption.rb
@@ -166,10 +166,10 @@ class Components::Image::Lightbox::Caption < Components::Base
 
   def render_gps_link
     link_text = [
-      @obs.display_lat_lng.t,
-      @obs.display_alt.t,
+      display_lat_lng(@obs.lat, @obs.lng).t,
+      display_alt(@obs.alt).t,
       "[#{:click_for_map.t}]"
-    ].join(" ")
+    ].compact_blank.join(" ")
     a(href: map_observation_path(id: @obs.id)) { link_text }
   end
 

--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -269,34 +269,9 @@ class Components::Map < Components::Base
     end
   end
 
-  # The query the user is navigating — explicit `@query` prop when
-  # given, otherwise the controller's `current_query` (session +
-  # `params[:q]`-derived). Memoized so popup builders don't re-ask
-  # per mapset.
-  def effective_query
-    @effective_query ||= @query || current_query
-  end
-
   # The URL `q=` Hash, derived from `effective_query.q_param`.
   def effective_query_param
     @effective_query_param ||= effective_query&.q_param
-  end
-
-  # Plain-text coordinate formatters for marker titles. The popup
-  # uses the same shape via `Components::Map::Popup`; kept here too
-  # so the marker title computed by `mapset_marker_title` doesn't
-  # need the popup class loaded.
-  def format_latitude(val)
-    format_coordinate(val, "N", "S")
-  end
-
-  def format_longitude(val)
-    format_coordinate(val, "E", "W")
-  end
-
-  def format_coordinate(val, positive_dir, negative_dir)
-    deg = val.abs.round(4)
-    "#{deg}°#{val.negative? ? negative_dir : positive_dir}"
   end
 
   # Rendering modules live in their own files (`app/components/map/`).
@@ -305,4 +280,5 @@ class Components::Map < Components::Base
   # first execute.
   include Clustering
   include Legend
+  include EffectiveQuery
 end

--- a/app/components/map/effective_query.rb
+++ b/app/components/map/effective_query.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Shared `effective_query` -- the Query the user is navigating,
+# explicit `query:` prop when given, else the controller's
+# `current_query`. Mixed into both Components::Map and
+# Components::Map::Popup, which each need the same fallback for
+# minting `?q=…` on their own links.
+module Components::Map::EffectiveQuery
+  private
+
+  def effective_query
+    @effective_query ||= @query || current_query
+  end
+end

--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -50,10 +50,6 @@ class Components::Map::Popup < Components::Base
     @set.observations.length == 1 && @set.observations.first&.id
   end
 
-  def effective_query
-    @effective_query ||= @query || current_query
-  end
-
   def query_path_params
     q = effective_query&.q_param
     q ? { q: q } : {}
@@ -282,22 +278,11 @@ class Components::Map::Popup < Components::Base
     end
   end
 
-  def format_latitude(val)
-    format_coordinate(val, "N", "S")
-  end
-
-  def format_longitude(val)
-    format_coordinate(val, "E", "W")
-  end
-
-  def format_coordinate(val, positive_dir, negative_dir)
-    deg = val.abs.round(4)
-    "#{deg}°#{val.negative? ? negative_dir : positive_dir}"
-  end
-
   # Phlex 2.x doesn't ship `<center>` since it's a deprecated HTML
   # element, but the Google Maps popup historically uses it to stack
   # the box-coord lines on top of each other (the popup's tiny visual
   # vocabulary). Register it so `center { ... }` emits the tag.
   register_element :center
+
+  include Components::Map::EffectiveQuery
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -688,22 +688,6 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       will_save_change_to_attribute?(:location_id)
   end
 
-  def place_name_and_coordinates(user = nil)
-    if lat.present? && lng.present?
-      lat_string = format_coordinate(lat, "N", "S")
-      lng_string = format_coordinate(lng, "E", "W")
-      "#{place_name(user)} (#{lat_string} #{lng_string})"
-    else
-      place_name(user)
-    end
-  end
-
-  def format_coordinate(value, positive_point, negative_point)
-    return "#{-value.round(4)}°#{negative_point}" if value.negative?
-
-    "#{value.round(4)}°#{positive_point}"
-  end
-
   # Returns latitude if public or if the current user owns the observation.
   # The user should also be able to see hidden latitudes if they are an admin
   # or they are members of a project that the observation belongs to, but
@@ -718,19 +702,6 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
 
   def reveal_location?(user)
     !gps_hidden || can_edit?(user) || project_admin?(user)
-  end
-
-  def display_lat_lng
-    return "" unless lat
-
-    "#{lat.abs}°#{lat.negative? ? "S" : "N"} " \
-      "#{lng.abs}°#{lng.negative? ? "W" : "E"}"
-  end
-
-  def display_alt
-    return "" unless alt
-
-    "#{alt.round}m"
   end
 
   def saved_change_to_place?

--- a/app/views/controllers/observations/show/observation_details_panel.rb
+++ b/app/views/controllers/observations/show/observation_details_panel.rb
@@ -111,8 +111,8 @@ class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::B
   def render_gps_display_link
     a(href: map_observation_path(id: @obs.id)) do
       trusted_html(
-        [@obs.display_lat_lng.t, @obs.display_alt.t,
-         "[#{:click_for_map.t}]"].join(" ")
+        [display_lat_lng(@obs.lat, @obs.lng).t, display_alt(@obs.alt).t,
+         "[#{:click_for_map.t}]"].compact_blank.join(" ")
       )
     end
   end

--- a/test/classes/coordinate_format_test.rb
+++ b/test/classes/coordinate_format_test.rb
@@ -24,6 +24,12 @@ class CoordinateFormatTest < UnitTestCase
     assert_equal("", stub.display_lat_lng(nil, nil))
   end
 
+  # lat present but lng missing (partial/legacy data) must not raise.
+  def test_display_lat_lng_no_lng
+    stub = Stub.new
+    assert_equal("", stub.display_lat_lng(34.1622, nil))
+  end
+
   def test_display_alt
     stub = Stub.new
     assert_equal("", stub.display_alt(nil))

--- a/test/classes/coordinate_format_test.rb
+++ b/test/classes/coordinate_format_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class CoordinateFormatTest < UnitTestCase
+  class Stub
+    include CoordinateFormat
+  end
+
+  def test_display_lat_lng_north_west
+    stub = Stub.new
+    assert_equal("34.1622°N 118.3521°W",
+                 stub.display_lat_lng(34.1622, -118.3521))
+  end
+
+  def test_display_lat_lng_south_east
+    stub = Stub.new
+    assert_equal("34.1622°S 118.3521°E",
+                 stub.display_lat_lng(-34.1622, 118.3521))
+  end
+
+  def test_display_lat_lng_no_lat
+    stub = Stub.new
+    assert_equal("", stub.display_lat_lng(nil, nil))
+  end
+
+  def test_display_alt
+    stub = Stub.new
+    assert_equal("", stub.display_alt(nil))
+    assert_equal("1234m", stub.display_alt(1234))
+  end
+
+  def test_place_name_and_coordinates_with_values
+    stub = Stub.new
+    assert_equal(
+      "Pasadena, California, USA (34.1622°N 118.3521°W)",
+      stub.place_name_and_coordinates(
+        "Pasadena, California, USA", 34.1622, -118.3521
+      )
+    )
+  end
+
+  def test_place_name_and_coordinates_no_coordinates
+    stub = Stub.new
+    assert_equal(
+      "Who knows where",
+      stub.place_name_and_coordinates("Who knows where", nil, nil)
+    )
+  end
+
+  def test_format_latitude
+    stub = Stub.new
+    assert_equal("34.1622°N", stub.format_latitude(34.1622))
+    assert_equal("34.1622°S", stub.format_latitude(-34.1622))
+  end
+
+  def test_format_longitude
+    stub = Stub.new
+    assert_equal("118.3521°E", stub.format_longitude(118.3521))
+    assert_equal("118.3521°W", stub.format_longitude(-118.3521))
+  end
+end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1198,17 +1198,6 @@ class ObservationTest < UnitTestCase
     assert_in_delta(-118.3521, obs.public_lng)
   end
 
-  def test_place_name_and_coordinates_with_values
-    obs = observations(:amateur_obs)
-    assert_equal("Pasadena, California, USA (34.1622°N 118.3521°W)",
-                 obs.place_name_and_coordinates)
-  end
-
-  def test_place_name_and_coordinates_has_no_values
-    obs = observations(:unknown_with_no_naming)
-    assert_equal("Who knows where", obs.place_name_and_coordinates)
-  end
-
   def test_check_requirements_no_user
     fungi = names(:fungi)
     exception = assert_raise(ActiveRecord::RecordInvalid) do
@@ -2156,16 +2145,6 @@ class ObservationTest < UnitTestCase
   def test_when_str_falls_back_to_formatted_when
     obs = observations(:minimal_unknown_obs)
     assert_equal(obs.when.strftime("%Y-%m-%d"), obs.when_str)
-  end
-
-  # display_alt formats altitude in meters when present (line 579)
-  # and returns "" when nil.
-  def test_display_alt
-    obs = observations(:minimal_unknown_obs)
-    obs.alt = nil
-    assert_equal("", obs.display_alt)
-    obs.alt = 1234
-    assert_equal("1234m", obs.display_alt)
   end
 
   # other_notes reads the canonical "Other" key (line 673) and


### PR DESCRIPTION
## Summary

`Observation#display_lat_lng`, `#display_alt`, `#place_name_and_coordinates`, and `#format_coordinate` were pure string presentation with no model/business logic, only ever called from Phlex view classes. Moved them into a new `CoordinateFormat` module (mirroring `ViewerAwareFormat`'s existing precedent), mixed into `Components::Base` so they're available directly from any Phlex view/component without living on the model.

While tracing every caller, `format_coordinate` turned out to be an identical algorithm independently duplicated three more times (`Mappable::ClusteredCollection`, `Components::Map`, `Components::Map::Popup`), each with its own `format_latitude`/`format_longitude` wrappers — folded all three into `CoordinateFormat` too.

Two more exact duplicates turned up in the same area, each given its own shared home:
- `Mappable::ClusteredCollection` and `Mappable::CollapsibleCollectionOfObjects` had byte-identical `sets`/`extents`/`representative_points` accessors plus `mapsets`/`calc_extents` methods — extracted into a new `Mappable::Collection` mixin.
- `Components::Map` and `Components::Map::Popup` had byte-identical `effective_query` methods — extracted into a new `Components::Map::EffectiveQuery` mixin.

## Bug fix

Found and fixed a trailing-space bug along the way: the Phlex callers joined `[lat_lng_string, alt_string]` with `" "`, which left a stray trailing space whenever an observation had no altitude (`alt_string` blank). All three call sites (`Views::Controllers::Observations::Show::Details`'s pre-rename `ObservationDetailsPanel`, and `Components::Image::Lightbox::Caption`) now filter blanks before joining.

## Test plan

- [x] `bin/rails test test/classes/coordinate_format_test.rb` — new module coverage (Stub-class pattern matching `viewer_aware_format_test.rb`)
- [x] `bin/rails test test/models/observation_test.rb` — 136 tests, 0 failures (includes the moved `display_alt`/`place_name_and_coordinates` cases, now in `coordinate_format_test.rb` instead)
- [x] `bin/rails test test/views/controllers/observations/show/observation_details_panel_test.rb test/controllers/observations_controller_show_test.rb` — 44 tests, 0 failures
- [x] `bin/rails test test/components/image/lightbox/caption_test.rb test/classes/collapsible_map_test.rb` — 34 tests, 0 failures
- [x] `bin/rails test test/classes/map_set_test.rb test/components/map_test.rb test/components/form/location_map_test.rb test/controllers/names/maps_controller_test.rb test/controllers/locations/maps_controller_test.rb test/controllers/observations/maps_controller_test.rb test/views/controllers/observations/show/thumbnail_map_panel_test.rb` — 71 tests, 0 failures
- [x] `bundle exec rubocop` clean on every touched/new Ruby file
