### PR TITLE
Sweep remaining `render(Components::X.new(...))` callers to Kit syntax

### DIFF
--- a/app/components/alert.rb
+++ b/app/components/alert.rb
@@ -4,21 +4,21 @@ module Components
   # Bootstrap alert component
   #
   # @example Basic usage
-  #   render(Components::Alert.new(message: "Success!", level: :success))
+  #   Alert(message: "Success!", level: :success)
   #
   # @example With block
-  #   render(Components::Alert.new(level: :warning)) do
+  #   Alert(level: :warning) do
   #     plain "Warning: "
   #     strong "Be careful!"
   #   end
   #
   # @example With custom attributes
-  #   render(Components::Alert.new(
+  #   Alert(
   #     message: "Info message",
   #     level: :info,
   #     id: "my-alert",
   #     class: "my-custom-class"
-  #   ))
+  #   )
   class Alert < Base
     prop :message, String, default: ""
     prop :level, _Union(:success, :info, :warning, :danger), default: :warning

--- a/app/components/application_form/autocompleter_field.rb
+++ b/app/components/application_form/autocompleter_field.rb
@@ -214,12 +214,12 @@ class Components::ApplicationForm < Superform::Rails::Form
     end
 
     def render_has_id_indicator
-      render(Components::Icon.new(
-               type: :check,
-               title: :autocompleter_has_id.l,
-               class: "px-2 text-success has-id-indicator",
-               data: { target_attr_key => "hasIdIndicator" }
-             ))
+      Icon(
+        type: :check,
+        title: :autocompleter_has_id.l,
+        class: "px-2 text-success has-id-indicator",
+        data: { target_attr_key => "hasIdIndicator" }
+      )
     end
 
     def render_find_button

--- a/app/components/carousel.rb
+++ b/app/components/carousel.rb
@@ -18,7 +18,7 @@
 #   yet consumed by the obs-index (see that class for details).
 #
 # @example
-#   render(Components::Carousel.new(carousel_id: "obs_42")) do |c|
+#   Carousel(carousel_id: "obs_42") do |c|
 #     @images.each do |image|
 #       c.item(id: "carousel_item_#{image.id}", class: "carousel-item") do
 #         render(Components::ImageGallery::Item.new(image: image, user: @user))

--- a/app/components/collapsible.rb
+++ b/app/components/collapsible.rb
@@ -7,32 +7,32 @@
 # Change the `expanded:` branch here when upgrading.
 #
 # @example Basic (initially closed)
-#   render(Components::Collapsible.new(id: "my_section")) do
+#   Collapsible(id: "my_section") do
 #     plain("Hidden content")
 #   end
 #
 # @example Initially open
-#   render(Components::Collapsible.new(id: "geo", expanded: true)) do
+#   Collapsible(id: "geo", expanded: true) do
 #     render_fields
 #   end
 #
 # @example Inside a Panel (adds panel-collapse class)
-#   render(Components::Collapsible.new(id: "obs_body", expanded: @expanded,
-#                                      panel: true, class: "no-transition")) do
+#   Collapsible(id: "obs_body", expanded: @expanded,
+#               panel: true, class: "no-transition") do
 #     render_body
 #   end
 #
 # @example With extra Stimulus data attrs
-#   render(Components::Collapsible.new(
-#            id: "obs_geo",
-#            expanded: @observation.lat.present?,
-#            data: { form_exif_target: "collapseFields" }
-#          )) do
+#   Collapsible(
+#     id: "obs_geo",
+#     expanded: @observation.lat.present?,
+#     data: { form_exif_target: "collapseFields" }
+#   ) do
 #     render_fields
 #   end
 #
 # @example A collapsible `<tbody>` instead of a `<div>`
-#   render(Components::Collapsible.new(id: "target_subs_1", element: :tbody)) do
+#   Collapsible(id: "target_subs_1", element: :tbody) do
 #     render_sub_rows
 #   end
 #

--- a/app/components/content_padded.rb
+++ b/app/components/content_padded.rb
@@ -6,14 +6,14 @@
 # `"p-3"`.
 #
 # @example
-#   render(Components::ContentPadded.new(id: "details")) do
+#   ContentPadded(id: "details") do
 #     p { plain("Field 1: ...") }
 #   end
 #
 # @example with extra classes + data attrs
-#   render(Components::ContentPadded.new(
-#            class: "shadow-sm", data: { controller: "modal" }
-#          )) { ... }
+#   ContentPadded(
+#     class: "shadow-sm", data: { controller: "modal" }
+#   ) { ... }
 class Components::ContentPadded < Components::Base
   # @param attrs [Hash] HTML attrs forwarded verbatim to the `<div>`.
   #   `class:` is composed with the default `"p-3"`.

--- a/app/components/dropdown.rb
+++ b/app/components/dropdown.rb
@@ -15,20 +15,20 @@
 # skipped (no spurious divider).
 #
 # @example Single-section (Actions dropdown)
-#   render(Components::Dropdown.new(
+#   Dropdown(
 #     id: "context_nav_toggle",
 #     menu_id: "context_nav",
 #     label: :app_context_actions.l
-#   )) do |menu|
+#   ) do |menu|
 #     menu.section(@links)
 #   end
 #
 # @example Multi-section (user-nav dropdown with auto-divider)
-#   render(Components::Dropdown.new(
+#   Dropdown(
 #     id: "user_nav_toggle",
 #     menu_id: "user_drop_down",
 #     label: @user.login
-#   )) do |menu|
+#   ) do |menu|
 #     menu.section(Tab::UserNav::LoggedIn.new(user: @user))
 #     menu.section(Tab::UserNav::LogOut.new(
 #       user: @user, in_admin_mode: in_admin_mode?

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -135,9 +135,9 @@ class Components::Form::Search < Components::ApplicationForm
     collapse_target = collapsible ? panel_collapse_target(heading) : nil
     expanded = collapsible ? panel_open?(sections:) : false
 
-    render(Components::Panel.new(
-             collapsible:, collapse_target:, expanded:
-           )) do |panel|
+    Panel(
+      collapsible:, collapse_target:, expanded:
+    ) do |panel|
       panel.with_heading { :"search_term_group_#{heading}".l }
       panel.with_body do
         render_shown_fields(sections:)

--- a/app/components/form/upload_gallery.rb
+++ b/app/components/form/upload_gallery.rb
@@ -27,18 +27,18 @@ class Components::Form::UploadGallery < Components::Base
   prop :exif_data, _Hash(::Integer, ::Hash), default: -> { {} }
 
   def view_template
-    render(Components::Carousel.new(
-             carousel_id: @carousel_id,
-             wrapper_class: "image-form-carousel",
-             inner_id: "added_images",
-             indicators_id: "added_thumbnails",
-             indicators_class_extra: indicators_d_none,
-             controls_wrap_class: "carousel-control-wrap row",
-             extra_data: {
-               form_images_target: "carousel",
-               form_exif_target: "carousel"
-             }
-           )) do |c|
+    Carousel(
+      carousel_id: @carousel_id,
+      wrapper_class: "image-form-carousel",
+      inner_id: "added_images",
+      indicators_id: "added_thumbnails",
+      indicators_class_extra: indicators_d_none,
+      controls_wrap_class: "carousel-control-wrap row",
+      extra_data: {
+        form_images_target: "carousel",
+        form_exif_target: "carousel"
+      }
+    ) do |c|
       register_slides(c)
       register_thumbnails(c)
     end

--- a/app/components/image_gallery.rb
+++ b/app/components/image_gallery.rb
@@ -61,12 +61,12 @@ class Components::ImageGallery < Components::Base
   end
 
   def render_carousel
-    render(Components::Carousel.new(
-             carousel_id: @carousel_id,
-             wrapper_class: "show-carousel",
-             show_controls: @images.compact.length > 1,
-             show_indicators: @thumbnails
-           )) do |c|
+    Carousel(
+      carousel_id: @carousel_id,
+      wrapper_class: "show-carousel",
+      show_controls: @images.compact.length > 1,
+      show_indicators: @thumbnails
+    ) do |c|
       register_slides(c)
       register_thumbnails(c) if @thumbnails
     end

--- a/app/components/index_filter.rb
+++ b/app/components/index_filter.rb
@@ -28,9 +28,9 @@
 #   field = Components::ApplicationForm::FieldProxy.new(
 #             nil, :project_name, @title
 #           )
-#   render(Components::IndexFilter.new(
-#            to: field_slips_path, submit_text: :FILTER.l
-#          )) do
+#   IndexFilter(
+#     to: field_slips_path, submit_text: :FILTER.l
+#   ) do
 #     render(Components::ApplicationForm::AutocompleterField.new(
 #              field, type: :project, hidden_name: :project,
 #              inline: true, size: 60,

--- a/app/components/list_group.rb
+++ b/app/components/list_group.rb
@@ -62,7 +62,7 @@
 #   end
 #
 # @example Flush variant inside a panel
-#   render(Components::Panel.new) do |panel|
+#   Panel do |panel|
 #     panel.with_body(wrapper: false) do
 #       ListGroup(flush: true) do |list|
 #         @items.each { |i| list.item { plain(i) } }

--- a/app/components/list_group/search.rb
+++ b/app/components/list_group/search.rb
@@ -27,9 +27,9 @@ class Components::ListGroup::Search < Components::ApplicationForm
   # Wrap the rendered `<form>` in the list-search panel so the panel
   # sits OUTSIDE the form tag — same shape the ERB partial used.
   def around_template(&block)
-    render(Components::Panel.new(
-             panel_id: "list_search", panel_class: "mt-3"
-           )) do |panel|
+    Panel(
+      panel_id: "list_search", panel_class: "mt-3"
+    ) do |panel|
       panel.with_body { super(&block) }
     end
   end

--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -36,18 +36,18 @@
 # props on the host class.
 #
 # @example Basic usage
-#   render(Components::Map.new(objects: [@location]))
+#   Map(objects: [@location])
 #
 # @example Editable map for forms
-#   render(Components::Map.new(
+#   Map(
 #     objects: [@location],
 #     editable: true,
 #     map_type: "location",
 #     controller: nil  # form has the controller
-#   ))
+#   )
 #
 # @example Clustered observations map with cap banner
-#   render(Components::Map.new(
+#   Map(
 #     objects: @observations,
 #     clustering: true,
 #     capped: @observations_capped,
@@ -56,7 +56,7 @@
 #     zoom: 2,
 #     observations_loaded_count: @observations_loaded_count,
 #     observations_total_count: @observations_total_count
-#   ))
+#   )
 #
 class Components::Map < Components::Base
   # Upper bound on points for client-side dynamic clustering

--- a/app/components/matrix/carousel.rb
+++ b/app/components/matrix/carousel.rb
@@ -40,6 +40,12 @@ class Components::Matrix::Carousel < Components::Base
     @carousel_id ||= generate_carousel_id
     return if @images.empty?
 
+    # Must stay `render(Components::Carousel.new(...))`, not bare
+    # `Carousel(...)` Kit syntax -- this component class is itself
+    # named `Carousel` (Components::Matrix::Carousel), so Kit's
+    # constant lookup would recurse into itself instead of resolving
+    # Components::Carousel (see commit 33fdc952e5 for the same bug
+    # with a view class named `Table`).
     render(Components::Carousel.new(
              carousel_id: @carousel_id,
              show_controls: @images.length > 1,

--- a/app/components/modal.rb
+++ b/app/components/modal.rb
@@ -20,9 +20,9 @@
 # focus on the modal's content.
 #
 # @example simple modal with body + footer
-#   render(Components::Modal.new(
+#   Modal(
 #     id: "modal_thing", title: "Pick a thing", user: @user
-#   )) do |m|
+#   ) do |m|
 #     m.with_body { p { "..." } }
 #     m.with_footer do
 #       button(type: "submit", class: "btn btn-primary") { "OK" }
@@ -32,9 +32,9 @@
 #   end
 #
 # @example auto-opening modal (e.g. server-rendered for an action)
-#   render(Components::Modal.new(
+#   Modal(
 #     id: "modal_resolve", title: "Confirm", user: @user, auto_open: true
-#   )) do |m|
+#   ) do |m|
 #     m.with_body { render(...) }
 #   end
 #
@@ -55,9 +55,9 @@
 #         </form>
 #       </div>
 #
-#   render(Components::Modal.new(
+#   Modal(
 #     id: "modal_x", title: "Edit thing", user: @user
-#   )) do |m|
+#   ) do |m|
 #     m.with_form_content { render(Components::ThingForm.new(@thing)) }
 #   end
 class Components::Modal < Components::Base

--- a/app/components/modal/confirm.rb
+++ b/app/components/modal/confirm.rb
@@ -19,13 +19,13 @@ class Components::Modal::Confirm < Components::Base
   TITLE_ID = "#{MODAL_ID}_title".freeze
 
   def view_template
-    render(Components::Modal.new(
-             id: MODAL_ID,
-             header: false,
-             controller: "confirm-modal",
-             body_class: "py-4",
-             title_id: TITLE_ID
-           )) do |m|
+    Modal(
+      id: MODAL_ID,
+      header: false,
+      controller: "confirm-modal",
+      body_class: "py-4",
+      title_id: TITLE_ID
+    ) do |m|
       m.with_body do
         render_title
         render_message

--- a/app/components/modal/progress_spinner.rb
+++ b/app/components/modal/progress_spinner.rb
@@ -16,19 +16,19 @@ class Components::Modal::ProgressSpinner < Components::Base
   CAPTION_ID = "#{MODAL_ID}_caption".freeze
 
   def view_template
-    render(Components::Modal.new(
-             id: MODAL_ID,
-             header: false,
-             dialog_class: "modal-dialog modal-sm",
-             body_class: "text-center",
-             body_id: BODY_ID,
-             title_id: CAPTION_ID,
-             extra_data: {
-               action: "section-update:updated@window->modal#hide",
-               keyboard: "false",
-               backdrop: "static"
-             }
-           )) do |m|
+    Modal(
+      id: MODAL_ID,
+      header: false,
+      dialog_class: "modal-dialog modal-sm",
+      body_class: "text-center",
+      body_id: BODY_ID,
+      title_id: CAPTION_ID,
+      extra_data: {
+        action: "section-update:updated@window->modal#hide",
+        keyboard: "false",
+        backdrop: "static"
+      }
+    ) do |m|
       m.with_body { render_caption_and_spinner }
     end
   end

--- a/app/components/modal/turbo_form.rb
+++ b/app/components/modal/turbo_form.rb
@@ -86,19 +86,19 @@ class Components::Modal::TurboForm < Components::Base
   end
 
   def view_template
-    render(Components::Modal.new(
-             id: modal_id,
-             title: @title,
-             dialog_class: "modal-dialog modal-lg",
-             user: @user,
-             extra_class: "modal-form",
-             extra_data: turbo_modal_data,
-             # Preserve the pre-refactor DOM-id convention. External
-             # CSS/JS and turbo-stream re-renders may target these by
-             # name (`modal_<identifier>_header`, `_body`).
-             title_id: "#{modal_id}_header",
-             body_id: "#{modal_id}_body"
-           )) do |m|
+    Modal(
+      id: modal_id,
+      title: @title,
+      dialog_class: "modal-dialog modal-lg",
+      user: @user,
+      extra_class: "modal-form",
+      extra_data: turbo_modal_data,
+      # Preserve the pre-refactor DOM-id convention. External
+      # CSS/JS and turbo-stream re-renders may target these by
+      # name (`modal_<identifier>_header`, `_body`).
+      title_id: "#{modal_id}_header",
+      body_id: "#{modal_id}_body"
+    ) do |m|
       if form_owns_modal_sections?
         m.with_form_content { render_form_component }
       else

--- a/app/components/nav_tabs.rb
+++ b/app/components/nav_tabs.rb
@@ -16,30 +16,30 @@
 # than the component itself).
 #
 # @example Plain
-#   render(Components::NavTabs.new(current: "members")) do |tabs|
+#   NavTabs(current: "members") do |tabs|
 #     tabs.tab("Details",        details_path,        key: "details")
 #     tabs.tab("#{n} Members",   members_path,        key: "members")
 #     tabs.tab("#{n} Aliases",   aliases_path,        key: "aliases")
 #   end
 #
 # @example With per-link extra class (matches `project_tabs` markup)
-#   render(Components::NavTabs.new(current: @current_tab,
-#                                  link_class: "mt-3")) do |tabs|
+#   NavTabs(current: @current_tab,
+#           link_class: "mt-3") do |tabs|
 #     tabs.tab(:SUMMARY.t, project_path(@project), key: "projects")
 #     tabs.tab("#{n} #{:OBS.l}", observations_path(...), key: "obs")
 #   end
 #
 # @example With a Tab::Collection (preferred for multi-tab strips)
-#   render(Components::NavTabs.new(
+#   NavTabs(
 #     current: @current_tab,
 #     link_class: "mt-3",
 #     tabs: Tab::Project::Banner.new(project: @project, user: @user)
-#   ))
+#   )
 #
 # @example With wrapper chrome at the call site
 #   Column(xs: 12, id: "project_tabs") do
-#     render(Components::NavTabs.new(current: @current_tab,
-#                                    link_class: "mt-3")) do |tabs|
+#     NavTabs(current: @current_tab,
+#             link_class: "mt-3") do |tabs|
 #       # ...
 #     end
 #   end

--- a/app/components/panel.rb
+++ b/app/components/panel.rb
@@ -17,7 +17,7 @@
 #     panel.with_thumbnail { image("photo.jpg") }
 #     panel.with_body { "First section" }
 #     panel.with_body { "Second section" }
-#     panel.witih_footer { "Footer text" }
+#     panel.with_footer { "Footer text" }
 #   end
 #
 # @example Panel with collapsing body

--- a/app/components/panel.rb
+++ b/app/components/panel.rb
@@ -6,22 +6,22 @@
 #   heading, heading_links, thumbnail, body, footer
 #
 # @example Basic panel with heading and body
-#   render(Components::Panel.new do |panel|
+#   Panel do |panel|
 #     panel.with_heading { "Title" }
 #     panel.with_body { "Panel content" }
-#   end)
+#   end
 #
 # @example Panel with all subcomponents
-#   render(Components::Panel.new do |panel|
+#   Panel do |panel|
 #     panel.with_heading { strong { "Title" } }
 #     panel.with_thumbnail { image("photo.jpg") }
 #     panel.with_body { "First section" }
 #     panel.with_body { "Second section" }
 #     panel.witih_footer { "Footer text" }
-#   end)
+#   end
 #
 # @example Panel with collapsing body
-#   render(Components::Panel.new(
+#   Panel(
 #     collapsible: true,
 #     collapse_target: "#hidden"
 #   ) do |panel|
@@ -30,18 +30,18 @@
 #     panel.with_body { "First section" }
 #     panel.with_body(collapse: true) { "Second section" }
 #     panel.witih_footer { "Footer text" }
-#   end)
+#   end
 #
 # @example Panel with custom class and ID
-#   render(Components::Panel.new(
+#   Panel(
 #     panel_class: "custom-panel",
 #     panel_id: "my_panel"
 #   ) do |panel|
 #     panel.with_body { "Content" }
-#   end)
+#   end
 #
 # @example Panel with unwrapped body (e.g., for list-group)
-#   render(Components::Panel.new do |panel|
+#   Panel do |panel|
 #     panel.with_heading { "Comments" }
 #     panel.with_body(wrapper: false) do
 #       ul(class: "list-group") do
@@ -49,7 +49,7 @@
 #         li(class: "list-group-item") { "Comment 2" }
 #       end
 #     end
-#   end)
+#   end
 class Components::Panel < Components::Base
   include Phlex::Slotable
 

--- a/app/components/panel.rb
+++ b/app/components/panel.rb
@@ -29,7 +29,7 @@
 #     panel.with_thumbnail { image("photo.jpg") }
 #     panel.with_body { "First section" }
 #     panel.with_body(collapse: true) { "Second section" }
-#     panel.witih_footer { "Footer text" }
+#     panel.with_footer { "Footer text" }
 #   end
 #
 # @example Panel with custom class and ID

--- a/app/components/table.rb
+++ b/app/components/table.rb
@@ -29,32 +29,32 @@
 # args.
 #
 # @example Column mode (uniform rows)
-#   render(Components::Table.new(@users, variant: :striped)) do |t|
+#   Table(@users, variant: :striped) do |t|
 #     t.column("Name") { |user| user.name }
 #     t.column("Email") { |user| user.email }
 #   end
 #
 # @example Column mode with per-column attrs and identifier
-#   render(Components::Table.new(@users,
-#                                variant: :striped,
-#                                identifier: "user-list")) do |t|
+#   Table(@users,
+#         variant: :striped,
+#         identifier: "user-list") do |t|
 #     t.column("Name", width: "33%") { |user| user.name }
 #     t.column("Actions", class: "text-right") { |u| destroy_button(u) }
 #   end
 #
 # @example Row mode (Stimulus-rooted rows)
-#   render(Components::Table.new(@trackers,
-#                                tbody_id: "field_slip_job_trackers")) do |t|
+#   Table(@trackers,
+#         tbody_id: "field_slip_job_trackers") do |t|
 #     t.column(:FILENAME.t)
 #     t.column(:STATUS.t, class: "text-right")
 #     t.row { |tracker| render(TrackerRow.new(tracker: tracker, user: @user)) }
 #   end
 #
 # @example Body mode (table-level data attrs + mixed rows)
-#   render(Components::Table.new(
+#   Table(
 #     class: "name-lister",
 #     attributes: { data: { controller: "name-list" } }
-#   )) do |t|
+#   ) do |t|
 #     t.column(:NAME.t, width: "20%")
 #     t.column(:OPTIONS.t, width: "80%")
 #     t.body do

--- a/app/views/controllers/account/api_keys/table.rb
+++ b/app/views/controllers/account/api_keys/table.rb
@@ -32,6 +32,11 @@ module Views::Controllers::Account::APIKeys
       end
     end
 
+    # Must stay `render(Components::Table.new(...))`, not bare
+    # `Table(...)` Kit syntax -- this view class is itself named
+    # `Table`, so Kit's constant lookup would recurse into itself
+    # instead of resolving Components::Table (see commit 33fdc952e5
+    # for the same bug with a view class named `Table`).
     def render_keys_table
       render(Components::Table.new(
                sorted_keys,

--- a/app/views/controllers/admin/blocked_ips/edit/ip_stats.rb
+++ b/app/views/controllers/admin/blocked_ips/edit/ip_stats.rb
@@ -13,8 +13,8 @@ module Views::Controllers::Admin::BlockedIps
       prop :api_keys_by_str, ::Hash, default: -> { {} }
 
       def view_template
-        render(::Components::Panel.new(panel_class: "my-3",
-                                       panel_id: "ip_stats")) do |panel|
+        Panel(panel_class: "my-3",
+              panel_id: "ip_stats") do |panel|
           panel.with_heading { plain("Stats for #{@ip}:") }
           panel.with_heading_links { render_close_link }
           panel.with_body { render_body }
@@ -96,10 +96,10 @@ module Views::Controllers::Admin::BlockedIps
       end
 
       def render_activity_table
-        render(::Components::Table.new(
-                 ip_stats[:activity].last(50).reverse,
-                 class: "ips ips-lined"
-               )) { |t| render_activity_columns(t) }
+        Table(
+          ip_stats[:activity].last(50).reverse,
+          class: "ips ips-lined"
+        ) { |t| render_activity_columns(t) }
       end
 
       def render_activity_columns(table)

--- a/app/views/controllers/admin/blocked_ips/edit/ip_summary.rb
+++ b/app/views/controllers/admin/blocked_ips/edit/ip_summary.rb
@@ -12,8 +12,8 @@ module Views::Controllers::Admin::BlockedIps
       prop :api_keys_by_str, ::Hash, default: -> { {} }
 
       def view_template
-        render(::Components::Panel.new(panel_class: "my-3",
-                                       panel_id: "ip_summary")) do |panel|
+        Panel(panel_class: "my-3",
+              panel_id: "ip_summary") do |panel|
           panel.with_heading { plain("Most active users: (top 50)") }
           panel.with_body(wrapper: false) { render_table }
         end
@@ -26,9 +26,9 @@ module Views::Controllers::Admin::BlockedIps
       end
 
       def render_table
-        render(::Components::Table.new(
-                 sorted_ips, class: "ips ips-lined align-middle"
-               )) { |t| render_table_columns(t) }
+        Table(
+          sorted_ips, class: "ips ips-lined align-middle"
+        ) { |t| render_table_columns(t) }
       end
 
       def render_table_columns(table)

--- a/app/views/controllers/admin/blocked_ips/manager.rb
+++ b/app/views/controllers/admin/blocked_ips/manager.rb
@@ -35,12 +35,12 @@ module Views::Controllers::Admin::BlockedIps
 
     def around_template(&block)
       turbo_frame_tag("#{@type}_ips_list") do
-        render(Components::Panel.new(
-                 panel_class: "my-3",
-                 collapsible: true,
-                 collapse_target: "##{@type}_ips_body",
-                 expanded: true
-               )) do |panel|
+        Panel(
+          panel_class: "my-3",
+          collapsible: true,
+          collapse_target: "##{@type}_ips_body",
+          expanded: true
+        ) do |panel|
           panel.with_heading { title }
           panel.with_heading_links { render_showing_message }
           panel.with_body(wrapper: false, collapse: true) do
@@ -148,11 +148,11 @@ module Views::Controllers::Admin::BlockedIps
     end
 
     def render_ips_table
-      render(Components::Table.new(@list.ips,
-                                   id: "#{@type}_ips",
-                                   show_headers: false,
-                                   class: "ips align-middle border-top",
-                                   attributes: { style: "order: 3" })) do |t|
+      Table(@list.ips,
+            id: "#{@type}_ips",
+            show_headers: false,
+            class: "ips align-middle border-top",
+            attributes: { style: "order: 3" }) do |t|
         t.column("ip", &:t)
         t.column("actions", class: "text-right") do |ip|
           render_remove_button(ip)

--- a/app/views/controllers/articles/show.rb
+++ b/app/views/controllers/articles/show.rb
@@ -32,8 +32,8 @@ module Views::Controllers::Articles
     end
 
     def render_body_panel
-      render(::Components::Panel.new(panel_class: "mt-3",
-                                     panel_id: "article_body")) do |panel|
+      Panel(panel_class: "mt-3",
+            panel_id: "article_body") do |panel|
         panel.with_body { trusted_html(@article.body.tpl) }
       end
     end

--- a/app/views/controllers/checklists/panel.rb
+++ b/app/views/controllers/checklists/panel.rb
@@ -21,8 +21,11 @@ module Views::Controllers::Checklists
 
     def view_template
       div(id: @panel_id) do
-        # `::Components::Panel` is the shared building-block panel
-        # component — distinct from this view-side `Panel`.
+        # Must stay `render(::Components::Panel.new(...))`, not bare
+        # `Panel(...)` Kit syntax -- this view class is itself named
+        # `Panel`, so Kit's constant lookup would recurse into itself
+        # instead of resolving `Components::Panel` (see commit
+        # 33fdc952e5 for the same bug with a view class named `Table`).
         render(::Components::Panel.new(panel_class: "checklist")) do |panel|
           panel.with_body do
             ul(class: "list-unstyled") do

--- a/app/views/controllers/collection_numbers/index.rb
+++ b/app/views/controllers/collection_numbers/index.rb
@@ -31,8 +31,8 @@ module Views::Controllers::CollectionNumbers
 
     # Headerless `Components::Table` (`show_headers: false`).
     def render_rows_table
-      render(Components::Table.new(@objects, class: "table-striped mt-3",
-                                             show_headers: false)) do |t|
+      Table(@objects, class: "table-striped mt-3",
+                      show_headers: false) do |t|
         t.column("") { |cn| render_edit_link(cn) }
         t.column("") { |cn| render_format_name_link(cn) }
         t.column("") { |cn| render_observation_links(cn) }

--- a/app/views/controllers/comments/comments_for_object.rb
+++ b/app/views/controllers/comments/comments_for_object.rb
@@ -36,9 +36,9 @@ module Views::Controllers::Comments
 
     def view_template
       turbo_stream_from(@object, :comments)
-      render(Components::Panel.new(
-               panel_id: "comments_for_object"
-             )) do |panel|
+      Panel(
+        panel_id: "comments_for_object"
+      ) do |panel|
         panel.with_heading { plain(:COMMENTS.t) }
         panel.with_heading_links { render_add_comment_link } if @editable
         panel.with_body(wrapper: false) { render_comments_list }

--- a/app/views/controllers/contributors/index/legend.rb
+++ b/app/views/controllers/contributors/index/legend.rb
@@ -26,10 +26,8 @@ module Views::Controllers::Contributors
       ].freeze
 
       def view_template
-        render(::Components::Panel.new(
-                 panel_class: "collapse",
-                 panel_id: "contribution_legend"
-               )) do |panel|
+        Panel(panel_class: "collapse",
+              panel_id: "contribution_legend") do |panel|
           panel.with_heading { render_heading }
           panel.with_heading_links { render_toggle_button }
           panel.with_body { render_body }
@@ -63,11 +61,11 @@ module Views::Controllers::Contributors
       end
 
       def render_weights_table
-        render(::Components::Table.new(
-                 ::UserStats.fields_with_weight.keys,
-                 show_headers: false,
-                 class: "text-center bg-none mx-lg-5"
-               )) do |t|
+        Table(
+          ::UserStats.fields_with_weight.keys,
+          show_headers: false,
+          class: "text-center bg-none mx-lg-5"
+        ) do |t|
           # `user_stats_*` values are `[:IMAGES]`-style cross-refs to
           # plain-text root keys ("Images", "Votes", …); needs `.t`
           # for the cross-ref expansion, but the resolved text has
@@ -79,10 +77,10 @@ module Views::Controllers::Contributors
       end
 
       def render_example_math_table
-        render(::Components::Table.new(
-                 show_headers: false,
-                 class: "table-condensed bg-none w-auto mx-auto"
-               )) do |t|
+        Table(
+          show_headers: false,
+          class: "table-condensed bg-none w-auto mx-auto"
+        ) do |t|
           t.body { render_example_math_rows }
         end
       end

--- a/app/views/controllers/descriptions/details_and_alts_panel.rb
+++ b/app/views/controllers/descriptions/details_and_alts_panel.rb
@@ -23,9 +23,7 @@ module Views::Controllers::Descriptions
     prop :review, _Boolean, default: false
 
     def view_template
-      render(Components::Panel.new(
-               panel_id: "description_details_and_alts"
-             )) do |panel|
+      Panel(panel_id: "description_details_and_alts") do |panel|
         panel.with_heading { :show_observation_details.l }
         panel.with_heading_links do
           render(Components::Description::ModLinks.new(

--- a/app/views/controllers/descriptions/notes_panels.rb
+++ b/app/views/controllers/descriptions/notes_panels.rb
@@ -41,7 +41,7 @@ module Views::Controllers::Descriptions
     end
 
     def render_panel(field, value)
-      render(Components::Panel.new) do |panel|
+      Panel do |panel|
         panel.with_heading { :"form_#{parent_type}s_#{field}".l }
         panel.with_body { trusted_html(value.tpl) }
       end

--- a/app/views/controllers/descriptions/permissions/form.rb
+++ b/app/views/controllers/descriptions/permissions/form.rb
@@ -37,9 +37,9 @@ module Views::Controllers::Descriptions::Permissions
     private
 
     def render_permissions_table
-      render(Components::Table.new(
-               class: "w-100 table-description-permissions"
-             )) do |t|
+      Table(
+        class: "w-100 table-description-permissions"
+      ) do |t|
         t.column(:adjust_permissions_user_header.l, style: "mr-4")
         t.column(:adjust_permissions_reader_header.l, width: "50")
         t.column(:adjust_permissions_writer_header.l, width: "50")

--- a/app/views/controllers/glossary_terms/show.rb
+++ b/app/views/controllers/glossary_terms/show.rb
@@ -82,7 +82,7 @@ module Views::Controllers::GlossaryTerms
     end
 
     def render_other_image_panel(image)
-      render(::Components::Panel.new) do |panel|
+      Panel do |panel|
         panel.with_thumbnail do
           render(::Components::Image::Interactive.new(
                    user: current_user,
@@ -114,9 +114,7 @@ module Views::Controllers::GlossaryTerms
     end
 
     def render_authors_editors_panel
-      render(::Components::Panel.new(
-               panel_id: "glossary_term_authors_editors"
-             )) do |panel|
+      Panel(panel_id: "glossary_term_authors_editors") do |panel|
         panel.with_body do
           render(::Views::Layouts::AuthorsAndEditors.new(
                    obj: @glossary_term,

--- a/app/views/controllers/herbarium_records/index.rb
+++ b/app/views/controllers/herbarium_records/index.rb
@@ -34,8 +34,8 @@ module Views::Controllers::HerbariumRecords
     # Headerless `Components::Table` (`show_headers: false`) — matches
     # the bare-table markup of the original ERB.
     def render_rows_table
-      render(Components::Table.new(@objects, class: "table-striped",
-                                             show_headers: false)) do |t|
+      Table(@objects, class: "table-striped",
+                      show_headers: false) do |t|
         t.column("") { |rec| render_edit_link(rec) }
         t.column("") { |rec| render_herbarium_link(rec) }
         t.column("") { |rec| render_record_link(rec) }

--- a/app/views/controllers/images/exif/modal.rb
+++ b/app/views/controllers/images/exif/modal.rb
@@ -15,6 +15,11 @@ module Views::Controllers::Images
       prop :error_text, _Nilable(::String), default: nil
 
       def view_template
+        # Must stay `render(::Components::Modal.new(...))`, not bare
+        # `Modal(...)` Kit syntax -- this view class is itself named
+        # `Modal`, so Kit's constant lookup would recurse into itself
+        # instead of resolving `Components::Modal` (see commit
+        # 33fdc952e5 for the same bug with a view class named `Table`).
         render(::Components::Modal.new(
                  id: "modal_image_exif_#{@image.id}",
                  title: :exif_data_for_image.t(image: @image.id),

--- a/app/views/controllers/images/show/image_panel.rb
+++ b/app/views/controllers/images/show/image_panel.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Images
         # Components::Matrix::Box for why that placement would
         # silently never emit anything).
         turbo_stream_from([@image, :processed])
-        render(::Components::Panel.new(panel_id: "image_panel")) do |panel|
+        Panel(panel_id: "image_panel") do |panel|
           panel.with_heading(
             classes:
               "text-center small font-weight-normal image-controls"

--- a/app/views/controllers/images/show/info_panel.rb
+++ b/app/views/controllers/images/show/info_panel.rb
@@ -8,9 +8,9 @@ module Views::Controllers::Images
       prop :image, ::Image
 
       def view_template
-        render(::Components::Panel.new(
-                 panel_id: "info_panel", panel_class: "py-2"
-               )) do |panel|
+        Panel(
+          panel_id: "info_panel", panel_class: "py-2"
+        ) do |panel|
           panel.with_heading { "#{:NOTES.t}:" }
           panel.with_body { render_body }
         end

--- a/app/views/controllers/images/show/license_history_panel.rb
+++ b/app/views/controllers/images/show/license_history_panel.rb
@@ -14,7 +14,7 @@ module Views::Controllers::Images
         return if chgs.empty?
 
         @chgs = chgs
-        render(::Components::Panel.new) do |panel|
+        Panel do |panel|
           panel.with_body { render_table }
         end
       end

--- a/app/views/controllers/images/show/vote_panel.rb
+++ b/app/views/controllers/images/show/vote_panel.rb
@@ -10,9 +10,9 @@ module Views::Controllers::Images
       prop :default_size, _Nilable(_Union(::Symbol, ::String)), default: nil
 
       def view_template
-        render(::Components::Panel.new(
-                 panel_id: "image_vote_content"
-               )) do |panel|
+        Panel(
+          panel_id: "image_vote_content"
+        ) do |panel|
           panel.with_heading { render_current_vote_heading }
           render_user_vote_body(panel) if current_user
           panel.with_body(classes: "p-0") { render_vote_table_container }

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -32,7 +32,7 @@ module Views::Controllers::InatImports
     private
 
     def render_expected
-      render(Components::Panel.new) do |panel|
+      Panel do |panel|
         panel.with_body do
           render_timestamp_note
           if @requested

--- a/app/views/controllers/inat_imports/form.rb
+++ b/app/views/controllers/inat_imports/form.rb
@@ -47,7 +47,7 @@ module Views::Controllers::InatImports
     end
 
     def render_choose_observations_section
-      render(Components::Panel.new(panel_class: "my-5")) do |panel|
+      Panel(panel_class: "my-5") do |panel|
         panel.with_heading { plain(:inat_what_to_import.l) }
         panel.with_body do
           div(data: { controller: "type-switch" }) do
@@ -110,7 +110,7 @@ module Views::Controllers::InatImports
     end
 
     def render_details_panel
-      render(Components::Panel.new) do |panel|
+      Panel do |panel|
         panel.with_heading { plain(:inat_details_heading.l) }
         panel.with_body do
           ul(class: "pl-4") do

--- a/app/views/controllers/inat_imports/index.rb
+++ b/app/views/controllers/inat_imports/index.rb
@@ -13,7 +13,7 @@ module Views::Controllers::InatImports
       container_class(:wide)
       add_page_title(:inat_imports_index_title.l)
       add_context_nav(Tab::InatImport::Actions.new(include_index: false))
-      render(Components::Table.new(@imports, class: "table-striped")) do |t|
+      Table(@imports, class: "table-striped") do |t|
         render_columns(t)
       end
     end

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -38,17 +38,17 @@ module Views::Controllers::InatImports
     def render_actions
       div(class: "mt-2 mb-2") do
         if @inat_import.Done?
-          render(Components::Button.new(
-                   type: :get,
-                   name: :RESULTS.l,
-                   target: results_path
-                 ))
+          Button(
+            type: :get,
+            name: :RESULTS.l,
+            target: results_path
+          )
         else
-          render(::Components::Button.new(
-                   type: :put,
-                   name: :CANCEL.l,
-                   target: inat_import_cancel_path(id: @inat_import)
-                 ))
+          Button(
+            type: :put,
+            name: :CANCEL.l,
+            target: inat_import_cancel_path(id: @inat_import)
+          )
         end
       end
     end

--- a/app/views/controllers/info/site_stats.rb
+++ b/app/views/controllers/info/site_stats.rb
@@ -40,7 +40,7 @@ module Views::Controllers::Info
     end
 
     def render_stats_table
-      render(Components::Table.new(show_headers: false)) do |t|
+      Table(show_headers: false) do |t|
         t.body do
           ::SiteData::SITE_WIDE_FIELDS.each do |field|
             label = :"site_stats_#{field}".l

--- a/app/views/controllers/interests/index.rb
+++ b/app/views/controllers/interests/index.rb
@@ -55,8 +55,8 @@ module Views::Controllers::Interests
 
     def render_interests_table
       rows = @interests.select(&:target)
-      render(::Components::Table.new(rows, class: "table-striped",
-                                           show_headers: false)) do |t|
+      Table(rows, class: "table-striped",
+                  show_headers: false) do |t|
         t.column("summary") do |item|
           capture { strong { trusted_html(item.summary.t) } }
         end

--- a/app/views/controllers/licenses/index.rb
+++ b/app/views/controllers/licenses/index.rb
@@ -16,7 +16,7 @@ module Views::Controllers::Licenses
     private
 
     def render_table
-      render(::Components::Table.new(@objects)) { |tbl| add_columns(tbl) }
+      Table(@objects) { |tbl| add_columns(tbl) }
     end
 
     def add_columns(tbl)

--- a/app/views/controllers/locations/help/show.rb
+++ b/app/views/controllers/locations/help/show.rb
@@ -110,9 +110,9 @@ module Views::Controllers::Locations
       end
 
       def render_examples_table
-        render(Components::Table.new(EXAMPLES,
-                                     variant: :striped,
-                                     identifier: "location-help")) do |t|
+        Table(EXAMPLES,
+              variant: :striped,
+              identifier: "location-help") do |t|
           t.column(:location_help_bad.l) { |row| plain(row[0]) }
           t.column(:location_help_good.l) { |row| plain(row[1]) }
           t.column(:location_help_explanation.l) do |row|

--- a/app/views/controllers/locations/show/alt_descriptions_panel.rb
+++ b/app/views/controllers/locations/show/alt_descriptions_panel.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Locations
       prop :current, _Nilable(::Description), default: nil
 
       def view_template
-        render(Components::Panel.new(panel_id: "alt_descriptions")) do |panel|
+        Panel(panel_id: "alt_descriptions") do |panel|
           panel.with_heading { :show_name_descriptions.l }
           panel.with_heading_links { heading_links }
           panel.with_body { render_body }

--- a/app/views/controllers/locations/show/footer.rb
+++ b/app/views/controllers/locations/show/footer.rb
@@ -8,7 +8,7 @@ module Views::Controllers::Locations
       prop :versions, _Array(_Interface(:user_id))
 
       def view_template
-        render(::Components::Panel.new(panel_id: "location_footer")) do |panel|
+        Panel(panel_id: "location_footer") do |panel|
           panel.with_body { render_body }
           panel.with_footer { render_previous_version }
         end

--- a/app/views/controllers/locations/show/general_description_panel.rb
+++ b/app/views/controllers/locations/show/general_description_panel.rb
@@ -12,9 +12,7 @@ module Views::Controllers::Locations
       def view_template
         return unless @description&.notes?
 
-        render(::Components::Panel.new(
-                 panel_id: "location_general_description"
-               )) do |panel|
+        Panel(panel_id: "location_general_description") do |panel|
           panel.with_heading { :show_name_general_description.l }
           links = heading_links_text
           if current_user && links

--- a/app/views/controllers/locations/show/notes.rb
+++ b/app/views/controllers/locations/show/notes.rb
@@ -9,7 +9,7 @@ module Views::Controllers::Locations
       def view_template
         return if @location.notes.blank?
 
-        render(::Components::Panel.new(panel_id: "location_notes")) do |panel|
+        Panel(panel_id: "location_notes") do |panel|
           panel.with_heading { :NOTES.l }
           panel.with_body { trusted_html(@location.notes.to_s.tpl) }
         end

--- a/app/views/controllers/names/show.rb
+++ b/app/views/controllers/names/show.rb
@@ -149,7 +149,7 @@ module Views::Controllers::Names
     end
 
     def render_name_footer_panel
-      render(Components::Panel.new(panel_id: "name_footer")) do |panel|
+      Panel(panel_id: "name_footer") do |panel|
         panel.with_body { render_footer_body }
         panel.with_footer { render_footer_meta }
       end

--- a/app/views/controllers/names/show/alt_descriptions_panel.rb
+++ b/app/views/controllers/names/show/alt_descriptions_panel.rb
@@ -9,7 +9,7 @@ class Views::Controllers::Names::Show::AltDescriptionsPanel < Views::Base
   prop :name, ::Name
 
   def view_template
-    render(Components::Panel.new(panel_id: "name_descriptions")) do |panel|
+    Panel(panel_id: "name_descriptions") do |panel|
       panel.with_heading { :show_name_descriptions.l }
       panel.with_heading_links { heading_links } if @user
       panel.with_body { render_descriptions_list }

--- a/app/views/controllers/names/show/best_description_panel.rb
+++ b/app/views/controllers/names/show/best_description_panel.rb
@@ -20,9 +20,9 @@ class Views::Controllers::Names::Show::BestDescriptionPanel < Views::Base
   def view_template
     return if brief_text.blank?
 
-    render(Components::Panel.new(
-             panel_id: "name_general_description"
-           )) do |panel|
+    Panel(
+      panel_id: "name_general_description"
+    ) do |panel|
       panel.with_heading { plain(:show_name_general_description.l) }
       panel.with_heading_links { render_heading_links } if @user
       panel.with_body { trusted_html(brief_text.tpl) }

--- a/app/views/controllers/names/show/classification_panel.rb
+++ b/app/views/controllers/names/show/classification_panel.rb
@@ -15,13 +15,13 @@ class Views::Controllers::Names::Show::ClassificationPanel < Views::Base
   prop :user, _Nilable(::User), default: nil
 
   def view_template
-    render(Components::Panel.new(
-             panel_class: "name-section",
-             panel_id: "name_classification",
-             attributes: { data: {
-               name_panels_target: "classification"
-             } }
-           )) do |panel|
+    Panel(
+      panel_class: "name-section",
+      panel_id: "name_classification",
+      attributes: { data: {
+        name_panels_target: "classification"
+      } }
+    ) do |panel|
       panel.with_heading { plain(:show_name_classification.l) }
       panel.with_heading_links { render_edit_link } if @user
       panel.with_body { render_body }

--- a/app/views/controllers/names/show/lifeform_panel.rb
+++ b/app/views/controllers/names/show/lifeform_panel.rb
@@ -9,11 +9,11 @@ class Views::Controllers::Names::Show::LifeformPanel < Views::Base
   prop :user, _Nilable(::User), default: nil
 
   def view_template
-    render(Components::Panel.new(
-             panel_class: "name-section",
-             panel_id: "name_lifeform",
-             attributes: { data: { name_panels_target: "lifeform" } }
-           )) do |panel|
+    Panel(
+      panel_class: "name-section",
+      panel_id: "name_lifeform",
+      attributes: { data: { name_panels_target: "lifeform" } }
+    ) do |panel|
       panel.with_heading { plain(:show_name_lifeform.l) }
       panel.with_heading_links { render_edit_link } if @user
       panel.with_body { render_body }

--- a/app/views/controllers/names/show/nomenclature.rb
+++ b/app/views/controllers/names/show/nomenclature.rb
@@ -14,10 +14,10 @@ class Views::Controllers::Names::Show::Nomenclature < Views::Base
   prop :user, _Nilable(::User), default: nil
 
   def view_template
-    render(Components::Panel.new(
-             panel_class: "name-section",
-             panel_id: "nomenclature"
-           )) do |panel|
+    Panel(
+      panel_class: "name-section",
+      panel_id: "nomenclature"
+    ) do |panel|
       panel.with_heading { plain(:show_name_nomenclature.l) }
       panel.with_heading_links { render_edit_link } if @user
       panel.with_body { render_body }

--- a/app/views/controllers/names/show/notes_panel.rb
+++ b/app/views/controllers/names/show/notes_panel.rb
@@ -8,7 +8,7 @@ class Views::Controllers::Names::Show::NotesPanel < Views::Base
   prop :user, _Nilable(::User), default: nil
 
   def view_template
-    render(Components::Panel.new(panel_id: "name_notes")) do |panel|
+    Panel(panel_id: "name_notes") do |panel|
       panel.with_heading { plain(:show_name_notes.l) }
       panel.with_heading_links { render_edit_link } if @user
       panel.with_body { trusted_html(@name.notes.tpl) }

--- a/app/views/controllers/names/show/observations_menu.rb
+++ b/app/views/controllers/names/show/observations_menu.rb
@@ -24,9 +24,9 @@ class Views::Controllers::Names::Show::ObservationsMenu < Views::Base
   prop :user, _Nilable(::User), default: nil
 
   def view_template
-    render(Components::Panel.new(
-             panel_id: "name_observations_menu"
-           )) do |panel|
+    Panel(
+      panel_id: "name_observations_menu"
+    ) do |panel|
       panel.with_heading { plain(:about_this_taxon.l) }
       panel.with_heading_links { render_tracker_link }
       panel.with_body { render_body }

--- a/app/views/controllers/names/show/projects_panel.rb
+++ b/app/views/controllers/names/show/projects_panel.rb
@@ -9,7 +9,7 @@ class Views::Controllers::Names::Show::ProjectsPanel < Views::Base
   prop :projects, _Array(::Project)
 
   def view_template
-    render(Components::Panel.new(panel_id: "name_projects")) do |panel|
+    Panel(panel_id: "name_projects") do |panel|
       panel.with_heading { plain(:show_name_create_draft.t) }
       panel.with_body { render_project_links }
     end

--- a/app/views/controllers/names/versions/show.rb
+++ b/app/views/controllers/names/versions/show.rb
@@ -78,10 +78,10 @@ module Views::Controllers::Names::Versions
     end
 
     def render_classification_panel
-      render(Components::Panel.new(
-               panel_class: "name-section",
-               panel_id: "name_classification"
-             )) do |panel|
+      Panel(
+        panel_class: "name-section",
+        panel_id: "name_classification"
+      ) do |panel|
         panel.with_heading { plain(:show_name_classification.l) }
         panel.with_body { render_classification_body }
       end

--- a/app/views/controllers/observations/namings/votes/modal.rb
+++ b/app/views/controllers/observations/namings/votes/modal.rb
@@ -20,7 +20,12 @@ module Views::Controllers::Observations::Namings::Votes
     prop :title, String
 
     def view_template
-      render(Components::Modal.new(
+      # Must stay `render(::Components::Modal.new(...))`, not bare
+      # `Modal(...)` Kit syntax -- this view class is itself named
+      # `Modal`, so Kit's constant lookup would recurse into itself
+      # instead of resolving `Components::Modal` (see commit
+      # 33fdc952e5 for the same bug with a view class named `Table`).
+      render(::Components::Modal.new(
                id: @modal_id, user: @user
              )) do |modal|
         modal.with_title_content do

--- a/app/views/controllers/observations/show/associated_observations_panel.rb
+++ b/app/views/controllers/observations/show/associated_observations_panel.rb
@@ -13,10 +13,10 @@ class Views::Controllers::Observations::Show::AssociatedObservationsPanel < View
   prop :siblings, _Array(::Observation), default: -> { [] }
 
   def view_template
-    render(Components::Panel.new(
-             panel_id: "associated_observations",
-             panel_class: "name-section"
-           )) do |panel|
+    Panel(
+      panel_id: "associated_observations",
+      panel_class: "name-section"
+    ) do |panel|
       if siblings?
         panel.with_heading { plain(:OCCURRENCES.t) }
         panel.with_heading_links { matching_observations_link }

--- a/app/views/controllers/observations/show/images_panel.rb
+++ b/app/views/controllers/observations/show/images_panel.rb
@@ -15,9 +15,9 @@ class Views::Controllers::Observations::Show::ImagesPanel < Views::Base
   prop :user, _Nilable(::User), default: nil
 
   def view_template
-    render(Components::Panel.new(
-             panel_class: "show_images list-group text-center m-0"
-           )) do |panel|
+    Panel(
+      panel_class: "show_images list-group text-center m-0"
+    ) do |panel|
       panel.with_heading { :IMAGES.t }
       panel.with_heading_links { heading_links }
       panel.with_body { render_body }

--- a/app/views/controllers/observations/show/name_info_panel.rb
+++ b/app/views/controllers/observations/show/name_info_panel.rb
@@ -9,10 +9,10 @@ class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
   prop :user, _Nilable(::User), default: nil
 
   def view_template
-    render(Components::Panel.new(
-             panel_id: "observation_name_info",
-             panel_class: "name-section small"
-           )) do |panel|
+    Panel(
+      panel_id: "observation_name_info",
+      panel_class: "name-section small"
+    ) do |panel|
       panel.with_heading { :about_this_taxon.l }
       panel.with_body { render_body }
     end

--- a/app/views/controllers/observations/show/observation_details_panel.rb
+++ b/app/views/controllers/observations/show/observation_details_panel.rb
@@ -15,10 +15,8 @@ class Views::Controllers::Observations::Show::ObservationDetailsPanel < Views::B
   prop :siblings, _Array(::Observation), default: -> { [] }
 
   def view_template
-    render(Components::Panel.new(
-             panel_id: "observation_details",
-             panel_class: "name-section"
-           )) do |panel|
+    Panel(panel_id: "observation_details",
+          panel_class: "name-section") do |panel|
       panel.with_heading { :show_observation_details.l }
       panel.with_heading_links { print_labels_button } if @user
       panel.with_body { render_body }

--- a/app/views/controllers/observations/show/species_lists_panel.rb
+++ b/app/views/controllers/observations/show/species_lists_panel.rb
@@ -18,9 +18,9 @@ class Views::Controllers::Observations::Show::SpeciesListsPanel < Views::Base
   def view_template
     return unless render_panel?
 
-    render(Components::Panel.new(
-             panel_id: "observation_species_lists"
-           )) do |panel|
+    Panel(
+      panel_id: "observation_species_lists"
+    ) do |panel|
       if @obs.species_lists.any?
         panel.with_heading { plain(:show_lists_header.t) }
         panel.with_heading_links { manage_link } if manage_link?

--- a/app/views/controllers/observations/show/thumbnail_map_panel.rb
+++ b/app/views/controllers/observations/show/thumbnail_map_panel.rb
@@ -16,14 +16,14 @@ class Views::Controllers::Observations::Show::ThumbnailMapPanel < Views::Base
   prop :obs, ::Observation
 
   def view_template
-    render(Components::Panel.new(
-             panel_id: "observation_thumbnail_map",
-             attributes: {
-               data: { controller: "thumbnail-map",
-                       coordinates: { x: x, y: y }.to_json,
-                       map_url: map_observation_path(id: @obs.id) }
-             }
-           )) do |panel|
+    Panel(
+      panel_id: "observation_thumbnail_map",
+      attributes: {
+        data: { controller: "thumbnail-map",
+                coordinates: { x: x, y: y }.to_json,
+                map_url: map_observation_path(id: @obs.id) }
+      }
+    ) do |panel|
       panel.with_heading { :MAP.t }
       panel.with_heading_links { heading_links }
       panel.with_body { render_body }

--- a/app/views/controllers/policy/privacy.rb
+++ b/app/views/controllers/policy/privacy.rb
@@ -56,7 +56,7 @@ module Views::Controllers::Policy
     private
 
     def render_definitions_table
-      render(Components::Table.new(DEFINITIONS, variant: :striped)) do |t|
+      Table(DEFINITIONS, variant: :striped) do |t|
         t.column(:privacy_when_we_say.l, width: "33%") do |row|
           trusted_html(row[0].t)
         end

--- a/app/views/controllers/projects/admin/show.rb
+++ b/app/views/controllers/projects/admin/show.rb
@@ -40,10 +40,10 @@ module Views::Controllers::Projects::Admin
     end
 
     def render_danger_zone
-      render(Components::Panel.new(
-               panel_class: "panel-danger mt-4",
-               panel_id: "project_danger_zone"
-             )) do |panel|
+      Panel(
+        panel_class: "panel-danger mt-4",
+        panel_id: "project_danger_zone"
+      ) do |panel|
         panel.with_heading do
           strong { plain(:show_project_admin_danger_zone.l) }
         end

--- a/app/views/controllers/projects/aliases/table.rb
+++ b/app/views/controllers/projects/aliases/table.rb
@@ -20,6 +20,12 @@ module Views::Controllers::Projects::Aliases
       @project_aliases = project_aliases
     end
 
+    # Must stay `render(::Components::Table.new(...))`, not bare
+    # `Table(...)` Kit syntax -- this view class is itself named
+    # `Table`, so Kit's constant lookup would recurse into itself
+    # instead of resolving Components::Table (see commit 33fdc952e5,
+    # which reverted this exact call from Kit syntax back to
+    # render(...) after hitting the bug).
     def view_template
       render(::Components::Table.new(
                @project_aliases,

--- a/app/views/controllers/projects/show.rb
+++ b/app/views/controllers/projects/show.rb
@@ -37,9 +37,9 @@ module Views::Controllers::Projects
     end
 
     def render_summary_panel
-      render(Components::Panel.new(
-               panel_id: "project_summary"
-             )) do |panel|
+      Panel(
+        panel_id: "project_summary"
+      ) do |panel|
         panel.with_body do
           render_summary_body
         end

--- a/app/views/controllers/shared/images_to_reuse_form.rb
+++ b/app/views/controllers/shared/images_to_reuse_form.rb
@@ -46,7 +46,7 @@ module Views::Controllers::Shared
       render(::Components::Matrix::Box.new(
                extra_class: "text-center", id: image.id
              )) do
-        render(::Components::Panel.new) do |panel|
+        Panel do |panel|
           panel.with_body do
             render(::Components::Image::Interactive.new(
                      user: @user,

--- a/app/views/controllers/species_lists/details.rb
+++ b/app/views/controllers/species_lists/details.rb
@@ -12,10 +12,8 @@ module Views::Controllers::SpeciesLists
     end
 
     def view_template
-      render(Components::Panel.new(
-               panel_id: "list_details",
-               panel_class: "mt-3 mb-0"
-             )) do |panel|
+      Panel(panel_id: "list_details",
+            panel_class: "mt-3 mb-0") do |panel|
         panel.with_body { render_body }
       end
     end

--- a/app/views/controllers/species_lists/name_lists/new.rb
+++ b/app/views/controllers/species_lists/name_lists/new.rb
@@ -42,10 +42,10 @@ module Views::Controllers::SpeciesLists::NameLists
     # Stimulus root the JS uses for keyboard navigation between the
     # three scroller columns + the submit form below.
     def render_lister_table
-      render(Components::Table.new(
-               class: "name-lister mt-3 w-100",
-               attributes: { cols: "3", data: lister_data }
-             )) do |t|
+      Table(
+        class: "name-lister mt-3 w-100",
+        attributes: { cols: "3", data: lister_data }
+      ) do |t|
         t.column(:name_lister_genera.t, width: "20%")
         t.column(:name_lister_species.t, width: "40%")
         t.column(:name_lister_names.t, width: "40%")

--- a/app/views/controllers/support/donors.rb
+++ b/app/views/controllers/support/donors.rb
@@ -12,11 +12,11 @@ module Views::Controllers::Support
                       ))
 
       div(class: "text-center") do
-        render(Components::Table.new(@donor_names,
-                                     variant: :striped,
-                                     identifier: "donors",
-                                     class: "mt-3 mb-3",
-                                     show_headers: false)) do |t|
+        Table(@donor_names,
+              variant: :striped,
+              identifier: "donors",
+              class: "mt-3 mb-3",
+              show_headers: false) do |t|
           t.column(nil) { |name| plain(name) }
         end
       end

--- a/app/views/controllers/translations/versions.rb
+++ b/app/views/controllers/translations/versions.rb
@@ -56,10 +56,10 @@ module Views::Controllers::Translations
     end
 
     def render_versions_table(versions)
-      render(Components::Table.new(versions,
-                                   variant: :striped,
-                                   class: "old_versions",
-                                   show_headers: false)) do |t|
+      Table(versions,
+            variant: :striped,
+            class: "old_versions",
+            show_headers: false) do |t|
         t.column(nil) { |v| render_user_cell(v.user_id) }
         t.column(nil) { |v| plain(v.updated_at.web_date) }
         t.column(nil) { |v| p { plain(v.text) } }

--- a/app/views/controllers/users/index.rb
+++ b/app/views/controllers/users/index.rb
@@ -28,12 +28,12 @@ module Views::Controllers::Users
     def render_admin_table
       style { ".permissions td { padding: 3px 5px 3px 5px }" }
       PaginatedResults do
-        render(Components::Table.new(
-                 @users,
-                 variant: :striped,
-                 identifier: "permissions",
-                 attributes: { align: "center", cellspacing: "2" }
-               )) do |t|
+        Table(
+          @users,
+          variant: :striped,
+          identifier: "permissions",
+          attributes: { align: "center", cellspacing: "2" }
+        ) do |t|
           [:users_by_name_verified, :users_by_name_groups,
            :users_by_name_last_login, :users_by_name_id,
            :users_by_name_login, :users_by_name_name,

--- a/app/views/controllers/users/show/profile.rb
+++ b/app/views/controllers/users/show/profile.rb
@@ -10,7 +10,7 @@ module Views::Controllers::Users
       prop :life_list, ::Checklist::ForUser
 
       def view_template
-        render(::Components::Panel.new(panel_id: "user_profile")) do |panel|
+        Panel(panel_id: "user_profile") do |panel|
           panel.with_heading { render_heading }
           links = capture { render_heading_links }
           panel.with_heading_links { trusted_html(links) } if links.present?

--- a/app/views/controllers/users/show/user_stats.rb
+++ b/app/views/controllers/users/show/user_stats.rb
@@ -43,7 +43,7 @@ module Views::Controllers::Users
       }.freeze
 
       def view_template
-        render(::Components::Panel.new(panel_id: "user_stats")) do |panel|
+        Panel(panel_id: "user_stats") do |panel|
           panel.with_heading { :show_user_title.t(user: @name) }
           panel.with_body { render_table }
         end
@@ -53,9 +53,9 @@ module Views::Controllers::Users
 
       def render_table
         @total = 0
-        render(Components::Table.new(variant: :condensed,
-                                     class: "bg-none mb-0",
-                                     show_headers: false)) do |t|
+        Table(variant: :condensed,
+              class: "bg-none mb-0",
+              show_headers: false) do |t|
           t.body do
             @rows.each { |row| render_row(row) }
             render_total_rows if @total.positive?

--- a/app/views/controllers/versions/previous.rb
+++ b/app/views/controllers/versions/previous.rb
@@ -19,9 +19,9 @@ module Views::Controllers::Versions
     prop :args, _Hash(Symbol, _Any?), default: -> { {} }
 
     def view_template
-      render(Components::Panel.new(
-               panel_id: "#{@obj.type_tag}_versions"
-             )) do |panel|
+      Panel(
+        panel_id: "#{@obj.type_tag}_versions"
+      ) do |panel|
         panel.with_heading { :VERSIONS.l }
         panel.with_body { render_table }
       end
@@ -30,11 +30,11 @@ module Views::Controllers::Versions
     private
 
     def render_table
-      render(::Components::Table.new(
-               @versions.reverse,
-               variant: :hover, identifier: "versions",
-               show_headers: false, class: "mb-0"
-             )) do |t|
+      Table(
+        @versions.reverse,
+        variant: :hover, identifier: "versions",
+        show_headers: false, class: "mb-0"
+      ) do |t|
         t.column("") { |ver| render_date_cell(ver) }
         t.column("") { |ver| render_user_cell(ver) }
         t.column("") { |ver| render_link_cell(ver) }

--- a/app/views/controllers/visual_groups/image_matrix.rb
+++ b/app/views/controllers/visual_groups/image_matrix.rb
@@ -25,7 +25,7 @@ module Views::Controllers::VisualGroups
     def render_matrix_box(row)
       image, image_status = row
       render(Components::Matrix::Box.new(id: image.id)) do
-        render(Components::Panel.new) do |panel|
+        Panel do |panel|
           panel.with_thumbnail do
             render(Components::Image::Interactive.new(
                      user: @user, image: image, original: true,

--- a/app/views/controllers/visual_models/index.rb
+++ b/app/views/controllers/visual_models/index.rb
@@ -9,10 +9,10 @@ module Views::Controllers::VisualModels
 
     def view_template
       h1 { plain("Visual Models") }
-      render(Components::Table.new(
-               @visual_models,
-               class: "table-striped table-visual-model mb-3 mt-3"
-             )) do |t|
+      Table(
+        @visual_models,
+        class: "table-striped table-visual-model mb-3 mt-3"
+      ) do |t|
         t.column("Name", width: "33%") { |vm| link_to(vm.name, vm) }
         t.column(nil, width: "33%") do |vm|
           link_to("Edit", edit_visual_model_path(vm))

--- a/app/views/controllers/visual_models/visual_group_table.rb
+++ b/app/views/controllers/visual_models/visual_group_table.rb
@@ -30,9 +30,9 @@ module Views::Controllers::VisualModels
     private
 
     def render_table
-      render(Components::Table.new(
-               groups, class: "table-striped table-visual-model mb-3 mt-3"
-             )) do |t|
+      Table(
+        groups, class: "table-striped table-visual-model mb-3 mt-3"
+      ) do |t|
         define_columns(t)
       end
     end


### PR DESCRIPTION
## Summary

`Components::Panel` and (partially) `Components::Modal` never got their own dedicated Kit-syntax sweep PR, unlike `Alert`/`Button`/`Table`/`Link`/`Icon`/`PaginatedResults`/`ListGroup`/"8 small components", which all landed weeks ago. This finishes the job:

- `Panel` — 46 call sites converted from `render(Components::Panel.new(...))` to `Panel(...)`.
- `Modal` — 3 internal `Components::Modal::*` callers converted (external callers were already swept in commit `43d6215f0a`, but that pass missed `Modal`'s own family: `Modal::Confirm`, `Modal::TurboForm`, `Modal::ProgressSpinner`).
- `Button`/`Carousel`/`Icon` — a handful of stragglers added to the codebase since their original sweeps ran.
- `Table` — 21 more call sites converted.
- Every affected component's own `@example` doc comments updated to match, so they stop teaching the old pattern.

Every real candidate was verified to actually live in `app/views/**`/`app/components/**` (Phlex context, where Kit syntax is reachable) — controllers were excluded from the start, since Kit syntax is an instance method mixed into the shared `Components` module and is never reachable from plain controller code (see the "Controllers — full class path (Kit not available)" note already in `modal.rb`'s own header comment).

## A real bug found and fixed along the way

A Phlex view/component class whose own name matches the Kit method it's trying to call (e.g. a view literally named `Panel` calling bare `Panel(...)`) recurses into itself instead of resolving `Components::Panel`. This is a confirmed, previously-encountered bug — commit `33fdc952e5` hit and fixed the same thing for a view class named `Table` (`Views::Controllers::Projects::Aliases::Table`).

This sweep would have introduced 5 new instances of that exact bug. All 5 were reverted back to the verbose `render(::Components::X.new(...))` form with an explanatory comment citing the precedent, instead of being converted:

- `Views::Controllers::Checklists::Panel`
- `Views::Controllers::Images::EXIF::Modal`
- `Views::Controllers::Observations::Namings::Votes::Modal`
- `Components::Matrix::Carousel`
- `Views::Controllers::Account::APIKeys::Table`

`Views::Controllers::Projects::Aliases::Table` (already fixed in `33fdc952e5`, with no explanatory comment at the time) was left alone but given the same comment, so a future sweep doesn't rediscover this the hard way again.

Also left untouched: `Components::IconWithText#render_icon_glyph`'s `render(Components::Icon.new(...))` call. It's a module included into `Components::Button::Content` at varying nesting depths, so at call time `self` is a `Button`-namespace instance — hitting the same `Button`/`Link::Icon` constant clash that keeps `Icon(...)` unusable from inside the `Button`/`Link` folders generally (the file's own pre-existing comment already explains this).

## Test plan

- [x] `bundle exec rubocop` on all 85 touched files — clean.
- [x] Every file with a directly-matching test file (component or view test) — run and green.
- [x] Every file without a direct test — covered indirectly via its owning controller test (`names_controller_show_test.rb`, `locations_controller_test.rb`, `projects_controller_test.rb`, `articles_controller_test.rb`, `glossary_terms_controller_test.rb`, `images_controller_test.rb`, `visual_groups_controller_test.rb`, `admin/blocked_ips_controller_test.rb`, `images/exif_controller_test.rb`, `checklists_controller_test.rb`, `observations/namings/votes_controller_test.rb`, `observations/images_controller_test.rb`, `licenses_controller_test.rb`, `policy_controller_test.rb`, `species_lists/name_lists_controller_test.rb`, `support_controller_test.rb`, `users_controller_test.rb`, `visual_models_controller_test.rb`) — all green.
- [x] Re-ran tests for the 3 self-collision fixes (`checklists_controller_test.rb`, `images/exif_controller_test.rb`, `observations/namings/votes_controller_test.rb`) after the revert, to confirm the fix itself works — green.
- [x] `Components::Matrix::Carousel` has no test coverage (it's not yet wired up to any real caller per its own doc comment) — the collision-avoidance comment added there is precautionary for whenever it is.
