### PR TITLE
Reflection comparator + classification report for iNat reflection resolution (#4585)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,3 @@ public/test_images-*
 
 # iNat import audit (#4213) CSV outputs — data, not code
 inat_import_audit*.csv
-
-# Generated report / data output (CSVs etc.) — data, not code
-/reports/

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ public/test_images-*
 
 # iNat import audit (#4213) CSV outputs — data, not code
 inat_import_audit*.csv
+
+# Generated report / data output (CSVs etc.) — data, not code
+/reports/

--- a/app/classes/inat/reflection_comparator.rb
+++ b/app/classes/inat/reflection_comparator.rb
@@ -30,6 +30,11 @@ class Inat
     # location_meters is reported raw so this can be tuned from the data.
     BASE_MATCH_RADIUS = 1_000
 
+    # Degrees-to-radians, and meters per degree of latitude (constant; a
+    # degree of longitude shrinks by cos(lat), applied where used).
+    RAD = Math::PI / 180
+    METERS_PER_DEGREE = 111_320.0
+
     # Field statuses are tri-state (:match / :differ / :na) so "nothing to
     # compare" stays distinct from "compared and differs" in the report.
     Result = Struct.new(
@@ -39,11 +44,15 @@ class Inat
       keyword_init: true
     )
 
-    def initialize(mo_obs:, extract:, mo_hashes:, inat_hashes:)
+    def initialize(mo_obs:, extract:, mo_hashes:, inat_hashes:, mo_box: nil)
       @obs = mo_obs
       @extract = extract
       @mo_hashes = mo_hashes.compact
       @inat_hashes = inat_hashes.compact
+      # The MO named Location's bounding box (responds to
+      # north/south/east/west), or nil. Not denormalized onto the obs, so
+      # the caller supplies it; nil disables box-aware location judgments.
+      @box = mo_box
     end
 
     def compare
@@ -144,23 +153,91 @@ class Inat
         haversine_m(mo_lat, mo_lng, @extract.lat, @extract.lng).round
     end
 
-    # Obscured iNat coords match if the MO point is within the obscuring
-    # radius (not a real edit); otherwise within BASE_MATCH_RADIUS.
+    # :match | :differ | :mo_gps_suspect | :na. An MO point that sits
+    # outside its own named Location is corrupt (e.g. a South-Pole point on
+    # a US observation); iNat's coordinate is authoritative there, so that's
+    # a data error to fix, not a location edit to preserve.
     def location_status
-      meters = location_meters
-      return :na if meters.nil?
+      return :na if location_meters.nil?
+      return :match if location_meters <= tolerance_meters
+      return :mo_gps_suspect if mo_gps_suspect?
 
-      meters <= tolerance_meters ? :match : :differ
+      :differ
     end
 
+    # A centroid (no obs point) is compared against a coarse named area, so
+    # its tolerance is that Location's own radius — a point anywhere in the
+    # box is the same place. A real obs point keeps the tight base radius.
+    # iNat's obscuring displacement is added on top in either case.
     def tolerance_meters
-      return BASE_MATCH_RADIUS unless @extract.obscured
+      base = if centroid_source? && @box
+               location_radius_meters
+             else
+               BASE_MATCH_RADIUS
+             end
+      base + obscuring_slop
+    end
+
+    def centroid_source? = mo_coord_source == :location
+
+    # iNat shifts obscured points randomly by up to public_accuracy meters.
+    def obscuring_slop
+      return 0 unless @extract.obscured
 
       if @extract.public_accuracy&.positive?
         @extract.public_accuracy
       else
         DEFAULT_OBSCURED_RADIUS
       end
+    end
+
+    # Centroid-to-NE-corner: the half-diagonal of the named Location's box.
+    def location_radius_meters
+      haversine_m(@obs.location_lat, @obs.location_lng,
+                  @box.north, @box.east).round
+    end
+
+    # A stored point outside its own named Location can't be trusted; when
+    # iNat's point does fall inside that Location (fuzzily, see
+    # inat_in_mo_box?) the place still agrees and only the point is bad.
+    def mo_gps_suspect?
+      @box && mo_coord_source == :point &&
+        !point_in_box?(@obs.lat, @obs.lng) && inat_in_mo_box?
+    end
+
+    # Fuzzy so iNat's obscuring displacement doesn't push a genuinely-inside
+    # point just outside a small box. A point well inside is unambiguous;
+    # one comfortably outside stays a plain differ.
+    def inat_in_mo_box?
+      point_in_box?(@extract.lat, @extract.lng,
+                    BASE_MATCH_RADIUS + obscuring_slop)
+    end
+
+    # Point within the box, expanded by buffer_m meters on every side. The
+    # longitude buffer widens with latitude (a degree of longitude shrinks
+    # toward the poles); the box's own mid-latitude is the reference.
+    def point_in_box?(lat, lng, buffer_m = 0)
+      return false unless lat && lng
+
+      dlat, dlng = buffer_degrees(buffer_m)
+      lat.to_f.between?(@box.south - dlat, @box.north + dlat) &&
+        lng_in_box?(lng.to_f, dlng)
+    end
+
+    # buffer_m in [lat, lng] degrees; a degree of longitude shrinks by
+    # cos(lat), taken at the box's mid-latitude.
+    def buffer_degrees(buffer_m)
+      ref_lat = (@box.north + @box.south) / 2.0
+      [buffer_m / METERS_PER_DEGREE,
+       buffer_m / (METERS_PER_DEGREE * Math.cos(ref_lat * RAD))]
+    end
+
+    def lng_in_box?(lng, buf = 0)
+      west = @box.west - buf
+      east = @box.east + buf
+      return lng.between?(west, east) if @box.west <= @box.east
+
+      lng >= west || lng <= east # box straddles the antimeridian
     end
 
     def taxon_status
@@ -170,9 +247,8 @@ class Inat
     end
 
     def haversine_m(lat1, lng1, lat2, lng2)
-      rad = Math::PI / 180
-      a = haversine_a((lat2 - lat1) * rad, (lng2 - lng1) * rad,
-                      lat1 * rad, lat2 * rad)
+      a = haversine_a((lat2 - lat1) * RAD, (lng2 - lng1) * RAD,
+                      lat1 * RAD, lat2 * RAD)
       6_371_000 * 2 * Math.asin(Math.sqrt(a))
     end
 

--- a/app/classes/inat/reflection_comparator.rb
+++ b/app/classes/inat/reflection_comparator.rb
@@ -40,19 +40,25 @@ class Inat
     Result = Struct.new(
       :image_relation, :case_number, :mo_image_count, :inat_photo_count,
       :matched_image_count, :date_status, :location_status, :taxon_status,
-      :location_meters, :mo_coord_source,
+      :collector_status, :location_meters, :mo_coord_source,
       keyword_init: true
     )
 
-    def initialize(mo_obs:, extract:, mo_hashes:, inat_hashes:, mo_box: nil)
+    # mo_context carries pre-resolved MO-side reference data that isn't on
+    # the observation's own columns, so the class stays pure and testable:
+    #   :box    — the named Location's bounding box (responds to
+    #             north/south/east/west); nil disables box-aware location
+    #             judgments.
+    #   :logins — the MO side's iNat login(s): the owner's, plus the
+    #             collector's when set. Compared against the extract's
+    #             inat_login for the collector/observer check.
+    def initialize(mo_obs:, extract:, mo_hashes:, inat_hashes:, mo_context: {})
       @obs = mo_obs
       @extract = extract
       @mo_hashes = mo_hashes.compact
       @inat_hashes = inat_hashes.compact
-      # The MO named Location's bounding box (responds to
-      # north/south/east/west), or nil. Not denormalized onto the obs, so
-      # the caller supplies it; nil disables box-aware location judgments.
-      @box = mo_box
+      @box = mo_context[:box]
+      @mo_logins = Array(mo_context[:logins]).compact
     end
 
     def compare
@@ -66,6 +72,7 @@ class Inat
         date_status: date_status,
         location_status: location_status,
         taxon_status: taxon_status,
+        collector_status: collector_status,
         location_meters: location_meters,
         mo_coord_source: mo_coord_source
       )
@@ -244,6 +251,19 @@ class Inat
       return :na if @extract.taxon_name.blank? || @obs.text_name.blank?
 
       @extract.taxon_name.casecmp?(@obs.text_name) ? :match : :differ
+    end
+
+    # Does the MO observation's owner (or collector) correspond to the iNat
+    # observer? Match on any candidate MO login equal to the extract's
+    # inat_login, case-insensitively.
+    def collector_status
+      return :na if @extract.inat_login.blank? || @mo_logins.empty?
+
+      if @mo_logins.any? { |login| login.casecmp?(@extract.inat_login) }
+        :match
+      else
+        :differ
+      end
     end
 
     def haversine_m(lat1, lng1, lat2, lng2)

--- a/app/classes/inat/reflection_comparator.rb
+++ b/app/classes/inat/reflection_comparator.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+class Inat
+  # Classifies an MO observation against its cached iNat counterpart for
+  # reflection resolution (#4585). The image-set relation is the primary
+  # signal — computed on perceptual-hash (dHash) identity so it survives the
+  # resolution difference between MO originals and iNat renditions — and
+  # drives the #4585 case number. Field diffs are secondary, reported for
+  # distribution analysis so the deferred per-field rules can be specified
+  # from real data.
+  #
+  # Inputs are pre-resolved so the class stays pure and testable: the caller
+  # supplies the two dHash lists (nil entries — un-hashable images — count as
+  # unmatched) plus the MO observation and the InatObsExtract for the field
+  # comparison.
+  class ReflectionComparator
+    # Max Hamming distance for two dHashes to count as the same photo. 0 is
+    # identical; a few bits absorb resolution/recompression. Provisional —
+    # the point of the first report is to pick this from the distribution.
+    SAME_PHOTO_MAX_DISTANCE = 8
+
+    # iNat obscures coordinates of sensitive taxa; the public point can sit
+    # anywhere within public_accuracy meters of the truth. Never call a
+    # difference inside that radius a location edit. Fallback radius (meters)
+    # when an obscured obs reports no accuracy.
+    DEFAULT_OBSCURED_RADIUS = 30_000
+
+    # Meters within which two unobscured points count as the same place —
+    # absorbs coordinate precision/rounding between MO and iNat. Provisional;
+    # location_meters is reported raw so this can be tuned from the data.
+    BASE_MATCH_RADIUS = 1_000
+
+    # Field statuses are tri-state (:match / :differ / :na) so "nothing to
+    # compare" stays distinct from "compared and differs" in the report.
+    Result = Struct.new(
+      :image_relation, :case_number, :mo_image_count, :inat_photo_count,
+      :matched_image_count, :date_status, :location_status, :taxon_status,
+      :location_meters, :mo_coord_source,
+      keyword_init: true
+    )
+
+    def initialize(mo_obs:, extract:, mo_hashes:, inat_hashes:)
+      @obs = mo_obs
+      @extract = extract
+      @mo_hashes = mo_hashes.compact
+      @inat_hashes = inat_hashes.compact
+    end
+
+    def compare
+      relation = image_relation
+      Result.new(
+        image_relation: relation,
+        case_number: case_number_for(relation),
+        mo_image_count: @mo_hashes.size,
+        inat_photo_count: @inat_hashes.size,
+        matched_image_count: matched_count,
+        date_status: date_status,
+        location_status: location_status,
+        taxon_status: taxon_status,
+        location_meters: location_meters,
+        mo_coord_source: mo_coord_source
+      )
+    end
+
+    # :identical | :mo_subset_of_inat | :inat_subset_of_mo | :overlapping |
+    # :disjoint | :no_images
+    def image_relation
+      return :no_images if @mo_hashes.empty? && @inat_hashes.empty?
+
+      relation_for(matched_count,
+                   @mo_hashes.size - matched_count,
+                   @inat_hashes.size - matched_count)
+    end
+
+    private
+
+    def relation_for(matched, extra_mo, extra_inat)
+      return :identical if extra_mo.zero? && extra_inat.zero?
+      return :mo_subset_of_inat if extra_mo.zero?
+      return :inat_subset_of_mo if extra_inat.zero?
+      # Both sides have unmatched images from here.
+      return :disjoint if matched.zero?
+
+      :overlapping
+    end
+
+    # Greedy bipartite match: each MO image claims at most one still-unclaimed
+    # iNat photo within threshold. Photo counts are tiny, so greedy is fine.
+    def matched_count
+      return @matched_count if defined?(@matched_count)
+
+      used = Array.new(@inat_hashes.size, false)
+      @matched_count = @mo_hashes.count do |mo|
+        idx = @inat_hashes.each_index.find do |i|
+          !used[i] && Image::Dhash.distance(mo, @inat_hashes[i]) <=
+            SAME_PHOTO_MAX_DISTANCE
+        end
+        used[idx] = true if idx
+        idx
+      end
+    end
+
+    # #4585 cases: 1 identical/MO⊆iNat, 2 iNat⊊MO, 3 disjoint, 4 overlapping.
+    def case_number_for(relation)
+      case relation
+      when :identical, :mo_subset_of_inat then 1
+      when :inat_subset_of_mo then 2
+      when :disjoint then 3
+      when :overlapping then 4
+      end
+    end
+
+    def date_status
+      return :na unless @obs.when && @extract.observed_on
+
+      @obs.when == @extract.observed_on ? :match : :differ
+    end
+
+    # MO's effective coordinates: the observation's own GPS point when set,
+    # else its named Location's centroid (many MO obs — including imports —
+    # carry only a Location, no point). Tracked so the report can tell point
+    # comparisons from coarser centroid ones.
+    def mo_lat = @obs.lat || @obs.location_lat
+    def mo_lng = @obs.lng || @obs.location_lng
+
+    def mo_coord_source
+      return :point if @obs.lat && @obs.lng
+      return :location if @obs.location_lat && @obs.location_lng
+
+      :none
+    end
+
+    # Great-circle meters between the MO and iNat points, or nil if either
+    # side lacks coordinates. Reported raw so the match threshold can be
+    # tuned from the distribution.
+    def location_meters
+      return @location_meters if defined?(@location_meters)
+      return @location_meters = nil unless mo_lat && mo_lng &&
+                                           @extract.lat && @extract.lng
+
+      @location_meters =
+        haversine_m(mo_lat, mo_lng, @extract.lat, @extract.lng).round
+    end
+
+    # Obscured iNat coords match if the MO point is within the obscuring
+    # radius (not a real edit); otherwise within BASE_MATCH_RADIUS.
+    def location_status
+      meters = location_meters
+      return :na if meters.nil?
+
+      meters <= tolerance_meters ? :match : :differ
+    end
+
+    def tolerance_meters
+      return BASE_MATCH_RADIUS unless @extract.obscured
+
+      if @extract.public_accuracy&.positive?
+        @extract.public_accuracy
+      else
+        DEFAULT_OBSCURED_RADIUS
+      end
+    end
+
+    def taxon_status
+      return :na if @extract.taxon_name.blank? || @obs.text_name.blank?
+
+      @extract.taxon_name.casecmp?(@obs.text_name) ? :match : :differ
+    end
+
+    def haversine_m(lat1, lng1, lat2, lng2)
+      rad = Math::PI / 180
+      a = haversine_a((lat2 - lat1) * rad, (lng2 - lng1) * rad,
+                      lat1 * rad, lat2 * rad)
+      6_371_000 * 2 * Math.asin(Math.sqrt(a))
+    end
+
+    def haversine_a(dlat, dlng, lat1_rad, lat2_rad)
+      (Math.sin(dlat / 2)**2) +
+        (Math.cos(lat1_rad) * Math.cos(lat2_rad) * (Math.sin(dlng / 2)**2))
+    end
+  end
+end

--- a/app/classes/inat/reflection_comparator.rb
+++ b/app/classes/inat/reflection_comparator.rb
@@ -92,7 +92,9 @@ class Inat
       used = Array.new(@inat_hashes.size, false)
       @matched_count = @mo_hashes.count do |mo|
         idx = @inat_hashes.each_index.find do |i|
-          !used[i] && Image::Dhash.distance(mo, @inat_hashes[i]) <=
+          # Each iNat entry is a single dHash or its four rotation dHashes;
+          # match against the closest so a rotated copy still counts.
+          !used[i] && Image::Dhash.min_distance(mo, @inat_hashes[i]) <=
             SAME_PHOTO_MAX_DISTANCE
         end
         used[idx] = true if idx

--- a/app/classes/inat/reflection_comparator.rb
+++ b/app/classes/inat/reflection_comparator.rb
@@ -254,8 +254,15 @@ class Inat
     end
 
     # Does the MO observation's owner (or collector) correspond to the iNat
-    # observer? Match on any candidate MO login equal to the extract's
-    # inat_login, case-insensitively.
+    # observer? Match on any candidate MO login (from the curated
+    # users.inat_username mapping) equal to the extract's inat_login,
+    # case-insensitively.
+    #
+    # Deliberately strict: :na means "no curated identity link" and must not
+    # be resolved by inferring identity from MO login == iNat login, even on
+    # an exact match. Identity comes from explicit user claiming of iNat
+    # ids, not automated inference. :na is a signal to leave alone, not a
+    # gap for the comparator to paper over.
     def collector_status
       return :na if @extract.inat_login.blank? || @mo_logins.empty?
 

--- a/app/models/image/dhash.rb
+++ b/app/models/image/dhash.rb
@@ -18,6 +18,12 @@ class Image
     HEIGHT = 8
     USER_AGENT = "MushroomObserver (+https://mushroomobserver.org)"
 
+    # dHash is not rotation-invariant: a 90/180/270 rotation (common between
+    # an MO copy and its iNat copy) yields a completely different hash. To
+    # match rotated copies, hash a photo at all four rotations and compare
+    # against the whole set.
+    ROTATIONS = [0, 90, 180, 270].freeze
+
     # Raised when ImageMagick fails or produces unexpected output.
     # (Multi-line, not `class Error < ...; end` on one line, so the
     # localization_files_test class/end nesting scanner stays balanced.)
@@ -25,16 +31,20 @@ class Image
     end
 
     class << self
-      def from_file(path)
-        bits_from(grayscale_pixels(path))
+      def from_file(path, rotate: 0)
+        bits_from(grayscale_pixels(path, rotate: rotate))
       end
 
       # Fetch a remote rendition to a tempfile and hash it.
       def from_url(url)
-        Tempfile.create(["dhash", ".img"], binmode: true) do |file|
-          file.write(RestClient.get(url, user_agent: USER_AGENT).body)
-          file.flush
-          from_file(file.path)
+        with_downloaded(url) { |path| from_file(path) }
+      end
+
+      # The image's dHash at each of the four rotations (downloaded once),
+      # for rotation-invariant matching.
+      def rotations_from_url(url)
+        with_downloaded(url) do |path|
+          ROTATIONS.map { |deg| from_file(path, rotate: deg) }
         end
       end
 
@@ -43,7 +53,21 @@ class Image
         (hash_a ^ hash_b).to_s(2).count("1")
       end
 
+      # Smallest Hamming distance between a hash and any of a set of
+      # candidate hashes (e.g. the rotations of another image).
+      def min_distance(hash, candidates)
+        Array(candidates).map { |c| distance(hash, c) }.min
+      end
+
       private
+
+      def with_downloaded(url)
+        Tempfile.create(["dhash", ".img"], binmode: true) do |file|
+          file.write(RestClient.get(url, user_agent: USER_AGENT).body)
+          file.flush
+          yield(file.path)
+        end
+      end
 
       # Each bit records whether a pixel is brighter than its right-hand
       # neighbor, row by row: 8 rows x 8 comparisons = 64 bits.
@@ -70,11 +94,12 @@ class Image
       # (Image#full_filepath, or a Tempfile) so it can't begin with "-"
       # and be mistaken for an option. (Brakeman command-injection warning
       # ignored on this basis in config/brakeman.ignore.)
-      def grayscale_pixels(path)
-        out, err, status = Open3.capture3(
-          "convert", "#{path}[0]", "-auto-orient", "-colorspace", "Gray",
-          "-resize", "#{WIDTH}x#{HEIGHT}!", "-depth", "8", "gray:-"
-        )
+      def grayscale_pixels(path, rotate: 0)
+        args = ["convert", "#{path}[0]", "-auto-orient"]
+        args += ["-rotate", rotate.to_s] unless rotate.zero?
+        args += ["-colorspace", "Gray", "-resize", "#{WIDTH}x#{HEIGHT}!",
+                 "-depth", "8", "gray:-"]
+        out, err, status = Open3.capture3(*args)
         unless status.success? && out.bytesize == WIDTH * HEIGHT
           raise(Error.new("ImageMagick failed for #{path} " \
                           "(status #{status.exitstatus}): #{err.strip}"))

--- a/app/models/inat_obs_extract.rb
+++ b/app/models/inat_obs_extract.rb
@@ -48,8 +48,12 @@ class InatObsExtract < ApplicationRecord
       lng: obs.lng,
       public_accuracy: raw[:public_positional_accuracy],
       obscured: raw[:obscured] || false,
-      taxon_name: obs.inat_taxon_name,
-      taxon_rank: obs.inat_taxon_rank,
+      # Read the taxon straight from raw (equivalent to Inat::Obs's
+      # #inat_taxon_name/#inat_taxon_rank) so an unidentified iNat obs — one
+      # with no :taxon, which the importer never sees but the extract builder
+      # must handle — yields nil instead of raising a delegation error.
+      taxon_name: raw.dig(:taxon, :name),
+      taxon_rank: raw.dig(:taxon, :rank),
       place_guess: obs.where,
       description: raw[:description],
       photos: photos_from(raw),

--- a/script/claim_inat_username.rb
+++ b/script/claim_inat_username.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+#  USAGE::
+#
+#    bin/rails runner script/claim_inat_username.rb -- \
+#      --user <login|id> --inat <inat_username> [--dry-run]
+#
+#  DESCRIPTION::
+#
+#    Manual stand-in for an iNat user "claim" (no OAuth confirmation):
+#    records that an MO user is a given iNat user and propagates that
+#    identity the same way an import would, for observations that predate
+#    the claim.
+#
+#    1. Sets users.inat_username -- only when currently nil; never clobbers
+#       an existing value; aborts if another user already holds the login.
+#    2. Re-links observations whose free-text `collector` is that iNat login
+#       but whose collector_user_id is nil (e.g. obs another user imported
+#       before this observer was known), via Observation.resolve_collector
+#       -- the same resolver the importer uses.
+#
+#    Not recoverable by a claim, and therefore untouched: namings and
+#    comments imported before the claim were attributed to the importer
+#    (namer_for => importer when the suggester was unclaimed) and store no
+#    iNat identifier, so there is nothing to match on. Those are correct
+#    only if the identity existed at import time.
+#
+#    Idempotent and safe to re-run. --dry-run runs the whole thing in a
+#    rolled-back transaction, so the reported counts are exact.
+
+require "optparse"
+
+class ClaimInatUsername
+  def initialize(opts)
+    @user_ref = opts[:user]
+    @inat = opts[:inat]
+    @dry_run = opts[:dry_run]
+  end
+
+  def run
+    @user = find_user
+    return warn("No MO user matching #{@user_ref.inspect}") unless @user
+
+    puts("#{"[dry-run] " if @dry_run}claim #{@inat.inspect} for " \
+         "##{@user.id} #{@user.login}")
+    ActiveRecord::Base.transaction do
+      relink_collectors if ensure_inat_username
+      raise(ActiveRecord::Rollback) if @dry_run
+    end
+  end
+
+  private
+
+  def find_user
+    if /\A\d+\z/.match?(@user_ref.to_s)
+      User.find_by(id: @user_ref)
+    else
+      User.find_by(login: @user_ref)
+    end
+  end
+
+  # Returns the user when the claim may proceed to the collector re-link,
+  # or nil when it aborts.
+  def ensure_inat_username
+    current = @user.inat_username
+    return proceed_with_existing(current) if current.present?
+
+    holder = holder_of_inat_username
+    if holder
+      puts("  inat_username: #{@inat.inspect} already held by " \
+           "##{holder.id} #{holder.login}; aborting")
+      return nil
+    end
+
+    @user.update!(inat_username: @inat)
+    puts("  inat_username: set -> #{@inat.inspect}")
+    @user
+  end
+
+  # An already-set username is fine (idempotent) only when it's the same
+  # login; a different one means this claim is wrong, so bail out.
+  def proceed_with_existing(current)
+    if current.casecmp?(@inat)
+      puts("  inat_username: already #{current.inspect} (idempotent)")
+      return @user
+    end
+    puts("  inat_username: user has DIFFERENT #{current.inspect}; aborting")
+    nil
+  end
+
+  def holder_of_inat_username
+    User.where.not(id: @user.id).
+      find_by("LOWER(inat_username) = ?", @inat.downcase)
+  end
+
+  def relink_collectors
+    candidates = Observation.where(collector_user_id: nil).
+                 where("LOWER(collector) = ?", @inat.downcase).to_a
+    linked = candidates.count { |obs| relink(obs) }
+    verb = @dry_run ? "would re-link" : "re-linked"
+    puts("  collector: #{verb} #{linked} of #{candidates.size} candidate obs")
+  end
+
+  # Re-links one observation when its collector resolves to the claimed
+  # user; returns the obs id (truthy) when it did, else nil.
+  def relink(obs)
+    resolved = Observation.resolve_collector(
+      obs.collector, owner: obs.user, existing: obs.collector_user,
+                     match_inat: true
+    )
+    return unless resolved[:collector_user_id] == @user.id
+
+    obs.update!(collector: resolved[:collector],
+                collector_user_id: resolved[:collector_user_id])
+    puts("    obs #{obs.id}: collector -> ##{@user.id} #{@user.login}")
+    obs.id
+  end
+end
+
+options = {}
+OptionParser.new do |opts|
+  opts.on("--user REF", "MO user login or id") { |v| options[:user] = v }
+  opts.on("--inat NAME", "iNat username to claim") { |v| options[:inat] = v }
+  opts.on("--dry-run", "Report without writing (rolled back)") do
+    options[:dry_run] = true
+  end
+end.parse!
+
+if options[:user].to_s.empty? || options[:inat].to_s.empty?
+  abort("Usage: --user <login|id> --inat <username> [--dry-run]")
+end
+
+ClaimInatUsername.new(options).run

--- a/script/inat_reflection_report.rb
+++ b/script/inat_reflection_report.rb
@@ -14,11 +14,14 @@
 #    to stdout: how many pairs are identical / subset / overlapping /
 #    disjoint by images, and how often date / location / taxon differ.
 #
-#    Self-hashing: for the sampled observations it fills any missing MO image
-#    dHashes (Image#compute_dhash!) and iNat photo dHashes (InatPhotoHash)
-#    on the fly, so it does not depend on the full hashing backfills having
-#    run — only the extract build. Read-only against iNat/MO otherwise;
-#    writes only dHash rows.
+#    Hashes come from the pre-computed caches: images.dhash (MO side) and
+#    the InatPhotoHash table (iNat side), both backfilled corpus-wide, so
+#    the report is a pure DB read + compare with no image downloads. A
+#    missing MO hash is computed on the fly as a fallback (rare — a newly
+#    added image); a missing iNat hash (un-fetchable private/deleted
+#    photo) counts as unmatched. Single-rotation compare only: rotated
+#    copies land in the non-match buckets and are reviewed afterward
+#    (see inat_hashes). Read-only apart from the rare MO fallback hash.
 #
 #    Multi-link MO obs (several iNat links) pick one reflection extract per
 #    #4585: the import link if present, else the highest iNat id.
@@ -107,14 +110,21 @@ class InatReflectionReport
     obs.images.map { |img| img.dhash || safe_hash { img.compute_dhash! } }
   end
 
-  # Each photo hashes to its four rotation dHashes (downloaded once), so an
-  # MO image that is a rotated copy still matches. The single-column
-  # InatPhotoHash cache can't hold a rotation set, so these are computed
-  # fresh per run (the download — the costly part — happens once either way).
+  # Reads the pre-computed single (rotation-0) hash from the
+  # InatPhotoHash cache — the whole corpus is backfilled
+  # (script/hash_inat_photos.rb), so the report is a pure DB compare, no
+  # re-download. A photo with no cached hash (un-fetchable: private or
+  # deleted iNat photos) maps to nil and the comparator counts it
+  # unmatched. Rotation-invariant matching is intentionally NOT done
+  # here: rotated copies are rare, a rotated pair simply falls into the
+  # non-match bucket, and those residuals get a targeted rotation pass
+  # after this report (decided 2026-07-18). Image::Dhash.rotations_from_url
+  # stays in the model for that later pass.
   def inat_hashes(extract)
-    Array(extract.photos).map do |photo|
-      safe_hash { Image::Dhash.rotations_from_url(photo["url"]) }
-    end
+    ids = Array(extract.photos).filter_map { |photo| photo["id"] }
+    cached = InatPhotoHash.where(inat_photo_id: ids).pluck(:inat_photo_id,
+                                                           :dhash).to_h
+    ids.map { |id| cached[id] }
   end
 
   def safe_hash

--- a/script/inat_reflection_report.rb
+++ b/script/inat_reflection_report.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+#  USAGE::
+#
+#    bin/rails runner script/inat_reflection_report.rb -- \
+#      [--limit N] [--seed S] [--out PATH]
+#
+#  DESCRIPTION::
+#
+#    First classification report for reflection resolution (#4585). Samples
+#    linked MO observations that have a cached iNat extract
+#    (build_inat_obs_extracts.rb), runs Inat::ReflectionComparator against
+#    each, and writes one CSV row per observation plus a distribution summary
+#    to stdout: how many pairs are identical / subset / overlapping /
+#    disjoint by images, and how often date / location / taxon differ.
+#
+#    Self-hashing: for the sampled observations it fills any missing MO image
+#    dHashes (Image#compute_dhash!) and iNat photo dHashes (InatPhotoHash)
+#    on the fly, so it does not depend on the full hashing backfills having
+#    run — only the extract build. Read-only against iNat/MO otherwise;
+#    writes only dHash rows.
+#
+#    Multi-link MO obs (several iNat links) pick one reflection extract per
+#    #4585: the import link if present, else the highest iNat id.
+
+require "csv"
+require "optparse"
+
+class InatReflectionReport
+  def initialize(opts)
+    @limit = opts[:limit] || 200
+    @seed = opts[:seed]
+    @out = opts[:out] || "inat_reflection_report.csv"
+    @stats = Hash.new(0)
+    @field = Hash.new(0)
+    @started_at = Time.current
+  end
+
+  def run
+    ids = sample_obs_ids
+    puts("Comparing #{ids.length} linked observations (of #{@candidates} " \
+         "with cached extracts)")
+    rows = ids.each_with_index.filter_map do |id, i|
+      warn("  #{i + 1}/#{ids.length}") if ((i + 1) % 25).zero?
+      compare_one(id)
+    end
+    CSV.open(@out, "w") { |csv| write_csv(csv, rows) }
+    summarize(rows)
+  end
+
+  private
+
+  def inat_site_id
+    @inat_site_id ||= ExternalSite.inaturalist.id
+  end
+
+  def obs_links
+    ExternalLink.where(external_site_id: inat_site_id,
+                       target_type: "Observation").where.not(external_id: nil)
+  end
+
+  # Random sample of MO obs ids whose (chosen) iNat link is cached.
+  def sample_obs_ids
+    cached = InatObsExtract.pluck(:inat_id).to_set
+    by_obs = obs_links.pluck(:target_id, :external_id, :relationship).
+             group_by(&:first)
+    @extract_for = by_obs.filter_map do |obs_id, links|
+      chosen = choose_link(links)
+      [obs_id, chosen] if chosen && cached.include?(chosen)
+    end.to_h
+    @candidates = @extract_for.size
+    rng = @seed ? Random.new(@seed) : Random.new
+    @extract_for.keys.sample(@limit, random: rng)
+  end
+
+  # [target_id, external_id, relationship] triples -> chosen iNat id.
+  def choose_link(links)
+    imported = links.find { |l| l[2] == ExternalLink.relationships[:import] }
+    (imported || links.max_by { |l| l[1].to_i })&.at(1)&.to_i
+  end
+
+  def compare_one(obs_id)
+    obs = Observation.includes(:images).find(obs_id)
+    extract = InatObsExtract.find_by(inat_id: @extract_for[obs_id])
+    return nil unless extract
+
+    result = Inat::ReflectionComparator.new(
+      mo_obs: obs, extract: extract,
+      mo_hashes: mo_hashes(obs), inat_hashes: inat_hashes(extract)
+    ).compare
+    tally(result)
+    row(obs_id, extract, result)
+  rescue StandardError => e
+    @stats[:error] += 1
+    warn("  obs #{obs_id}: #{e.class}: #{e.message}")
+    nil
+  end
+
+  def mo_hashes(obs)
+    obs.images.map { |img| img.dhash || safe_hash { img.compute_dhash! } }
+  end
+
+  def inat_hashes(extract)
+    Array(extract.photos).map do |photo|
+      record = InatPhotoHash.find_by(inat_photo_id: photo["id"])
+      next record.dhash if record
+
+      safe_hash { hash_inat_photo(photo) }
+    end
+  end
+
+  def hash_inat_photo(photo)
+    dhash = Image::Dhash.from_url(photo["url"])
+    InatPhotoHash.create!(inat_photo_id: photo["id"], dhash: dhash,
+                          fetched_at: Time.current)
+    dhash
+  end
+
+  def safe_hash
+    yield
+  rescue StandardError => e
+    @stats[:hash_error] += 1
+    warn("    hash failed: #{e.class}: #{e.message}")
+    nil
+  end
+
+  def tally(result)
+    @stats[result.image_relation] += 1
+    [:date, :location, :taxon].each do |f|
+      @field[:"#{f}_#{result[:"#{f}_status"]}"] += 1
+    end
+  end
+
+  def row(obs_id, extract, result)
+    { mo_obs_id: obs_id, inat_id: extract.inat_id,
+      image_relation: result.image_relation, case_number: result.case_number,
+      mo_images: result.mo_image_count, inat_photos: result.inat_photo_count,
+      matched: result.matched_image_count, date_status: result.date_status,
+      location_status: result.location_status,
+      location_meters: result.location_meters,
+      mo_coord_source: result.mo_coord_source,
+      taxon_status: result.taxon_status }
+  end
+
+  def write_csv(csv, rows)
+    return if rows.empty?
+
+    csv << rows.first.keys
+    rows.each { |r| csv << r.values }
+  end
+
+  def summarize(rows)
+    elapsed = (Time.current - @started_at).round
+    puts("\nWrote #{rows.length} rows to #{@out} (#{elapsed}s)")
+    print_group("Image relation", relation_counts)
+    print_group("Field diffs (match / differ / n-a)", @field.sort)
+    puts("\nErrors: #{@stats[:error]}, hash failures: #{@stats[:hash_error]}")
+  end
+
+  def relation_counts
+    relations = @stats.except(:error, :hash_error)
+    relations.sort_by { |_, v| -v }
+  end
+
+  def print_group(title, pairs)
+    puts("\n#{title}:")
+    pairs.each { |k, v| puts("  #{k}: #{v}") }
+  end
+end
+
+options = {}
+OptionParser.new do |opts|
+  opts.on("--limit N", Integer, "Sample size (default 200)") do |n|
+    options[:limit] = n
+  end
+  opts.on("--seed S", Integer, "Random seed for the sample") do |s|
+    options[:seed] = s
+  end
+  opts.on("--out PATH", "CSV output path") { |p| options[:out] = p }
+end.parse!
+
+InatReflectionReport.new(options).run

--- a/script/inat_reflection_report.rb
+++ b/script/inat_reflection_report.rb
@@ -27,13 +27,18 @@
 #    #4585: the import link if present, else the highest iNat id.
 
 require "csv"
+require "fileutils"
 require "optparse"
 
 class InatReflectionReport
+  # Generated report/data files live under reports/ (git-ignored), not
+  # the repo root or a developer's home directory.
+  DEFAULT_OUT = "reports/inat_reflection_report.csv"
+
   def initialize(opts)
     @limit = opts[:limit] || 200
     @seed = opts[:seed]
-    @out = opts[:out] || "inat_reflection_report.csv"
+    @out = opts[:out] || DEFAULT_OUT
     @stats = Hash.new(0)
     @field = Hash.new(0)
     @started_at = Time.current
@@ -47,11 +52,16 @@ class InatReflectionReport
       warn("  #{i + 1}/#{ids.length}") if ((i + 1) % 25).zero?
       compare_one(id)
     end
-    CSV.open(@out, "w") { |csv| write_csv(csv, rows) }
+    write_report(rows)
     summarize(rows)
   end
 
   private
+
+  def write_report(rows)
+    FileUtils.mkdir_p(File.dirname(@out))
+    CSV.open(@out, "w") { |csv| write_csv(csv, rows) }
+  end
 
   def inat_site_id
     @inat_site_id ||= ExternalSite.inaturalist.id

--- a/script/inat_reflection_report.rb
+++ b/script/inat_reflection_report.rb
@@ -31,7 +31,7 @@ require "fileutils"
 require "optparse"
 
 class InatReflectionReport
-  # Scratch/output for the iNat-sync effort lives under
+  # Scratch/output for the iNat-sync effort (#4208) lives under
   # projects/inat-sync/ (git-ignored, via the /projects/ folder), not the
   # repo root or a home directory.
   DEFAULT_OUT = "projects/inat-sync/inat_reflection_report.csv"

--- a/script/inat_reflection_report.rb
+++ b/script/inat_reflection_report.rb
@@ -100,20 +100,14 @@ class InatReflectionReport
     obs.images.map { |img| img.dhash || safe_hash { img.compute_dhash! } }
   end
 
+  # Each photo hashes to its four rotation dHashes (downloaded once), so an
+  # MO image that is a rotated copy still matches. The single-column
+  # InatPhotoHash cache can't hold a rotation set, so these are computed
+  # fresh per run (the download — the costly part — happens once either way).
   def inat_hashes(extract)
     Array(extract.photos).map do |photo|
-      record = InatPhotoHash.find_by(inat_photo_id: photo["id"])
-      next record.dhash if record
-
-      safe_hash { hash_inat_photo(photo) }
+      safe_hash { Image::Dhash.rotations_from_url(photo["url"]) }
     end
-  end
-
-  def hash_inat_photo(photo)
-    dhash = Image::Dhash.from_url(photo["url"])
-    InatPhotoHash.create!(inat_photo_id: photo["id"], dhash: dhash,
-                          fetched_at: Time.current)
-    dhash
   end
 
   def safe_hash

--- a/script/inat_reflection_report.rb
+++ b/script/inat_reflection_report.rb
@@ -80,12 +80,12 @@ class InatReflectionReport
   end
 
   def compare_one(obs_id)
-    obs = Observation.includes(:images).find(obs_id)
+    obs = Observation.includes(:images, :location).find(obs_id)
     extract = InatObsExtract.find_by(inat_id: @extract_for[obs_id])
     return nil unless extract
 
     result = Inat::ReflectionComparator.new(
-      mo_obs: obs, extract: extract,
+      mo_obs: obs, extract: extract, mo_box: obs.location,
       mo_hashes: mo_hashes(obs), inat_hashes: inat_hashes(extract)
     ).compare
     tally(result)

--- a/script/inat_reflection_report.rb
+++ b/script/inat_reflection_report.rb
@@ -31,9 +31,9 @@ require "fileutils"
 require "optparse"
 
 class InatReflectionReport
-  # Generated report/data files live under reports/ (git-ignored), not
-  # the repo root or a developer's home directory.
-  DEFAULT_OUT = "reports/inat_reflection_report.csv"
+  # Generated report/data files live under projects/ (git-ignored, the
+  # existing dev-projects folder), not the repo root or a home directory.
+  DEFAULT_OUT = "projects/inat_reflection_report.csv"
 
   def initialize(opts)
     @limit = opts[:limit] || 200

--- a/script/inat_reflection_report.rb
+++ b/script/inat_reflection_report.rb
@@ -31,9 +31,10 @@ require "fileutils"
 require "optparse"
 
 class InatReflectionReport
-  # Generated report/data files live under projects/ (git-ignored, the
-  # existing dev-projects folder), not the repo root or a home directory.
-  DEFAULT_OUT = "projects/inat_reflection_report.csv"
+  # Scratch/output for the iNat-sync effort lives under
+  # projects/inat-sync/ (git-ignored, via the /projects/ folder), not the
+  # repo root or a home directory.
+  DEFAULT_OUT = "projects/inat-sync/inat_reflection_report.csv"
 
   def initialize(opts)
     @limit = opts[:limit] || 200

--- a/script/inat_reflection_report.rb
+++ b/script/inat_reflection_report.rb
@@ -80,13 +80,15 @@ class InatReflectionReport
   end
 
   def compare_one(obs_id)
-    obs = Observation.includes(:images, :location).find(obs_id)
+    obs = Observation.includes(:images, :location, :user, :collector_user).
+          find(obs_id)
     extract = InatObsExtract.find_by(inat_id: @extract_for[obs_id])
     return nil unless extract
 
     result = Inat::ReflectionComparator.new(
-      mo_obs: obs, extract: extract, mo_box: obs.location,
-      mo_hashes: mo_hashes(obs), inat_hashes: inat_hashes(extract)
+      mo_obs: obs, extract: extract,
+      mo_hashes: mo_hashes(obs), inat_hashes: inat_hashes(extract),
+      mo_context: { box: obs.location, logins: mo_inat_logins(obs) }
     ).compare
     tally(result)
     row(obs_id, extract, result)
@@ -94,6 +96,11 @@ class InatReflectionReport
     @stats[:error] += 1
     warn("  obs #{obs_id}: #{e.class}: #{e.message}")
     nil
+  end
+
+  # The MO side's iNat login(s): the owner's, plus the collector's when set.
+  def mo_inat_logins(obs)
+    [obs.user&.inat_username, obs.collector_user&.inat_username].compact
   end
 
   def mo_hashes(obs)
@@ -120,7 +127,7 @@ class InatReflectionReport
 
   def tally(result)
     @stats[result.image_relation] += 1
-    [:date, :location, :taxon].each do |f|
+    [:date, :location, :taxon, :collector].each do |f|
       @field[:"#{f}_#{result[:"#{f}_status"]}"] += 1
     end
   end
@@ -133,7 +140,8 @@ class InatReflectionReport
       location_status: result.location_status,
       location_meters: result.location_meters,
       mo_coord_source: result.mo_coord_source,
-      taxon_status: result.taxon_status }
+      taxon_status: result.taxon_status,
+      collector_status: result.collector_status }
   end
 
   def write_csv(csv, rows)

--- a/test/classes/inat/reflection_comparator_test.rb
+++ b/test/classes/inat/reflection_comparator_test.rb
@@ -98,7 +98,50 @@ class Inat::ReflectionComparatorTest < UnitTestCase
     assert_equal(:differ, build(obs, extract, [], []).compare.location_status)
   end
 
+  def test_centroid_source_tolerates_the_whole_named_area
+    # No obs point; a large named Location whose centroid is ~70 km from the
+    # iNat point, but the point is well within the box. Without the radius
+    # tolerance this coarse centroid would read as a location edit.
+    obs = fake_obs(location_lat: 34.0, location_lng: -109.5)
+    box = fake_box(north: 34.6, south: 33.4, east: -108.8, west: -110.2)
+    extract = InatObsExtract.new(lat: 33.5, lng: -109.0, obscured: false)
+    result = build(obs, extract, [], [], box: box).compare
+
+    assert_equal(:location, result.mo_coord_source)
+    assert_operator(result.location_meters, :>, 50_000)
+    assert_equal(:match, result.location_status)
+  end
+
+  def test_point_outside_its_own_location_is_gps_suspect
+    # MO point near the South Pole, but the named Location and the iNat
+    # point are both in Pennsylvania: the point is corrupt, not an edit.
+    obs = fake_obs(lat: -79.2372, lng: 113.71,
+                   location_lat: 41.139, location_lng: -77.444)
+    box = fake_box(north: 41.154, south: 41.124, east: -77.414, west: -77.475)
+    extract = InatObsExtract.new(lat: 41.1388, lng: -77.4443, obscured: false)
+
+    result = build(obs, extract, [], [], box: box).compare
+    assert_equal(:mo_gps_suspect, result.location_status)
+  end
+
+  def test_corrupt_point_with_inat_also_elsewhere_is_plain_differ
+    # MO point is outside its box, but iNat's point is nowhere near the
+    # named Location either — no basis to blame the MO point specifically.
+    obs = fake_obs(lat: -79.2372, lng: 113.71,
+                   location_lat: 41.139, location_lng: -77.444)
+    box = fake_box(north: 41.154, south: 41.124, east: -77.414, west: -77.475)
+    extract = InatObsExtract.new(lat: 10.0, lng: 10.0, obscured: false)
+
+    result = build(obs, extract, [], [], box: box).compare
+    assert_equal(:differ, result.location_status)
+  end
+
   private
+
+  def fake_box(north:, south:, east:, west:)
+    Struct.new(:north, :south, :east, :west, keyword_init: true).
+      new(north: north, south: south, east: east, west: west)
+  end
 
   # `when` is a reserved word; the label form (`when:`) is fine as a kwarg
   # key, and Struct members with that name read back via `obj.when`.
@@ -107,10 +150,10 @@ class Inat::ReflectionComparatorTest < UnitTestCase
                keyword_init: true).new(**attrs)
   end
 
-  def build(obs, extract, mo_hashes, inat_hashes)
+  def build(obs, extract, mo_hashes, inat_hashes, box: nil)
     Inat::ReflectionComparator.new(mo_obs: obs, extract: extract,
                                    mo_hashes: mo_hashes,
-                                   inat_hashes: inat_hashes)
+                                   inat_hashes: inat_hashes, mo_box: box)
   end
 
   def relation(mo_hashes, inat_hashes)

--- a/test/classes/inat/reflection_comparator_test.rb
+++ b/test/classes/inat/reflection_comparator_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Inat::ReflectionComparatorTest < UnitTestCase
+  # dHashes with known Hamming distances from 0. SAME_PHOTO_MAX_DISTANCE is
+  # 8, so NEAR (4 bits) matches 0 and FAR/FAR2 (>8 bits, and 64 bits apart
+  # from each other) do not match anything.
+  ZERO = 0
+  NEAR = 0b1111                       # distance 4 from ZERO -> match
+  FAR  = 0xFFFFFFFF00000000           # distance 32 from ZERO
+  FAR2 = 0x00000000FFFFFFFF           # distance 32 from ZERO, 64 from FAR
+
+  def test_image_relations
+    assert_equal(:no_images, relation([], []))
+    assert_equal(:identical, relation([ZERO], [NEAR]))
+    assert_equal(:mo_subset_of_inat, relation([ZERO], [NEAR, FAR]))
+    assert_equal(:inat_subset_of_mo, relation([ZERO, FAR], [NEAR]))
+    assert_equal(:overlapping, relation([ZERO, FAR], [NEAR, FAR2]))
+    assert_equal(:disjoint, relation([ZERO], [FAR]))
+    # Empty MO images but iNat has some: MO's (empty) set is a subset.
+    assert_equal(:mo_subset_of_inat, relation([], [ZERO]))
+  end
+
+  def test_case_numbers
+    assert_equal(1, compare([ZERO], [NEAR]).case_number)          # identical
+    assert_equal(1, compare([ZERO], [NEAR, FAR]).case_number)     # mo subset
+    assert_equal(2, compare([ZERO, FAR], [NEAR]).case_number)     # inat subset
+    assert_equal(3, compare([ZERO], [FAR]).case_number)           # disjoint
+    assert_equal(4, compare([ZERO, FAR], [NEAR, FAR2]).case_number) # overlap
+  end
+
+  def test_matched_count_is_one_to_one
+    # Two identical MO images against one iNat photo: only one can match.
+    result = compare([ZERO, ZERO], [ZERO])
+
+    assert_equal(1, result.matched_image_count)
+    assert_equal(:inat_subset_of_mo, result.image_relation)
+  end
+
+  def test_field_matches
+    obs = fake_obs(when: Date.new(2023, 8, 25), lat: 35.2279, lng: -82.5433,
+                   text_name: "Aureoboletus betula")
+    extract = InatObsExtract.new(observed_on: Date.new(2023, 8, 25),
+                                 lat: 35.2279, lng: -82.5433, obscured: false,
+                                 taxon_name: "aureoboletus betula")
+    result = build(obs, extract, [], []).compare
+
+    assert_equal(:match, result.date_status)
+    assert_equal(:match, result.location_status)
+    assert_equal(0, result.location_meters)
+    assert_equal(:match, result.taxon_status) # case-insensitive
+  end
+
+  def test_field_statuses_are_na_without_data
+    result = build(fake_obs, InatObsExtract.new, [], []).compare
+
+    assert_equal(:na, result.date_status)
+    assert_equal(:na, result.location_status)
+    assert_nil(result.location_meters)
+    assert_equal(:na, result.taxon_status)
+  end
+
+  def test_obscured_coordinates_are_not_a_location_edit
+    obs = fake_obs(lat: 35.2279, lng: -82.5433)
+    # iNat public point ~7km away, but obscured with 28.7km accuracy.
+    extract = InatObsExtract.new(lat: 35.2899, lng: -82.4103,
+                                 obscured: true, public_accuracy: 28_706)
+
+    assert_equal(:match, build(obs, extract, [], []).compare.location_status)
+  end
+
+  def test_falls_back_to_location_centroid_when_no_point
+    # No obs point, but a Location centroid that matches the iNat point.
+    obs = fake_obs(location_lat: 35.2279, location_lng: -82.5433)
+    extract = InatObsExtract.new(lat: 35.2279, lng: -82.5433, obscured: false)
+    result = build(obs, extract, [], []).compare
+
+    assert_equal(:location, result.mo_coord_source)
+    assert_equal(:match, result.location_status)
+    assert_equal(0, result.location_meters)
+  end
+
+  def test_unobscured_distant_coordinates_do_not_match
+    obs = fake_obs(lat: 35.2279, lng: -82.5433)
+    extract = InatObsExtract.new(lat: 40.0, lng: -80.0, obscured: false)
+
+    assert_equal(:differ, build(obs, extract, [], []).compare.location_status)
+  end
+
+  private
+
+  # `when` is a reserved word; the label form (`when:`) is fine as a kwarg
+  # key, and Struct members with that name read back via `obj.when`.
+  def fake_obs(**attrs)
+    Struct.new(:when, :lat, :lng, :location_lat, :location_lng, :text_name,
+               keyword_init: true).new(**attrs)
+  end
+
+  def build(obs, extract, mo_hashes, inat_hashes)
+    Inat::ReflectionComparator.new(mo_obs: obs, extract: extract,
+                                   mo_hashes: mo_hashes,
+                                   inat_hashes: inat_hashes)
+  end
+
+  def relation(mo_hashes, inat_hashes)
+    # image_relation reads only the hash lists, not obs/extract.
+    build(nil, nil, mo_hashes, inat_hashes).image_relation
+  end
+
+  def compare(mo_hashes, inat_hashes)
+    build(fake_obs, InatObsExtract.new, mo_hashes, inat_hashes).compare
+  end
+end

--- a/test/classes/inat/reflection_comparator_test.rb
+++ b/test/classes/inat/reflection_comparator_test.rb
@@ -38,6 +38,16 @@ class Inat::ReflectionComparatorTest < UnitTestCase
     assert_equal(:inat_subset_of_mo, result.image_relation)
   end
 
+  def test_matches_rotated_inat_photo
+    # The MO image matches only a rotated version of the iNat photo — the
+    # iNat entry is that photo's set of rotation hashes, and one (NEAR) is
+    # within threshold. Without rotation-awareness this would be disjoint.
+    result = compare([ZERO], [[FAR, FAR2, NEAR, FAR]])
+
+    assert_equal(:identical, result.image_relation)
+    assert_equal(1, result.matched_image_count)
+  end
+
   def test_field_matches
     obs = fake_obs(when: Date.new(2023, 8, 25), lat: 35.2279, lng: -82.5433,
                    text_name: "Aureoboletus betula")

--- a/test/classes/inat/reflection_comparator_test.rb
+++ b/test/classes/inat/reflection_comparator_test.rb
@@ -136,6 +136,30 @@ class Inat::ReflectionComparatorTest < UnitTestCase
     assert_equal(:differ, result.location_status)
   end
 
+  def test_collector_matches_inat_login_case_insensitively
+    extract = InatObsExtract.new(inat_login: "FungusFan")
+    result = build(fake_obs, extract, [], [], logins: ["fungusfan"]).compare
+
+    assert_equal(:match, result.collector_status)
+  end
+
+  def test_collector_differs_when_no_mo_login_matches
+    extract = InatObsExtract.new(inat_login: "someone_else")
+    result = build(fake_obs, extract, [], [], logins: ["fungusfan"]).compare
+
+    assert_equal(:differ, result.collector_status)
+  end
+
+  def test_collector_is_na_without_logins_on_either_side
+    with_login = InatObsExtract.new(inat_login: "fungusfan")
+    no_login = InatObsExtract.new
+
+    assert_equal(:na, build(fake_obs, with_login, [], []).compare.
+                        collector_status)
+    assert_equal(:na, build(fake_obs, no_login, [], [], logins: ["x"]).compare.
+                        collector_status)
+  end
+
   private
 
   def fake_box(north:, south:, east:, west:)
@@ -150,10 +174,11 @@ class Inat::ReflectionComparatorTest < UnitTestCase
                keyword_init: true).new(**attrs)
   end
 
-  def build(obs, extract, mo_hashes, inat_hashes, box: nil)
+  def build(obs, extract, mo_hashes, inat_hashes, **context)
     Inat::ReflectionComparator.new(mo_obs: obs, extract: extract,
                                    mo_hashes: mo_hashes,
-                                   inat_hashes: inat_hashes, mo_box: box)
+                                   inat_hashes: inat_hashes,
+                                   mo_context: context)
   end
 
   def relation(mo_hashes, inat_hashes)

--- a/test/models/image/dhash_test.rb
+++ b/test/models/image/dhash_test.rb
@@ -45,6 +45,28 @@ class Image::DhashTest < UnitTestCase
     assert_equal(64, Image::Dhash.distance(0, (2**64) - 1))
   end
 
+  def test_min_distance
+    assert_equal(0, Image::Dhash.min_distance(0b1010, [0b0000, 0b1010]))
+    assert_equal(1, Image::Dhash.min_distance(0b1010, [0b1110, 0b0000]))
+    # A bare hash is treated as a one-element candidate set.
+    assert_equal(2, Image::Dhash.min_distance(0b1010, 0b0110))
+  end
+
+  def test_rotation_invariant_matching
+    # A 90-degree-rotated copy does not match the original directly...
+    original = Image::Dhash.from_file(FIXTURE)
+    rotated = Image::Dhash.from_file(FIXTURE, rotate: 90)
+
+    assert_operator(Image::Dhash.distance(original, rotated), :>, 5)
+
+    # ...but matches the original's four-rotation set (rotating back).
+    set = Image::Dhash::ROTATIONS.map do |deg|
+      Image::Dhash.from_file(FIXTURE, rotate: deg)
+    end
+
+    assert_equal(0, Image::Dhash.min_distance(rotated, set))
+  end
+
   def test_from_file_error
     assert_raises(Image::Dhash::Error) do
       Image::Dhash.from_file("no_such_file.jpg")

--- a/test/models/inat_obs_extract_test.rb
+++ b/test/models/inat_obs_extract_test.rb
@@ -38,6 +38,20 @@ class InatObsExtractTest < UnitTestCase
     assert_not_includes(photo["url"], "square")
   end
 
+  # Unidentified iNat observations have no :taxon. The importer never sees
+  # these, but the extract builder walks every linked obs, so from_raw must
+  # not raise on a nil/absent taxon.
+  def test_from_raw_handles_missing_taxon
+    raw = raw_obs("somion_unicolor").merge(taxon: nil)
+
+    extract = InatObsExtract.from_raw(raw, fetched_at: Time.current)
+
+    assert_nil(extract.taxon_name)
+    assert_nil(extract.taxon_rank)
+    # Other fields still populate.
+    assert_equal(Date.new(2023, 3, 23), extract.observed_on)
+  end
+
   def test_upsert_is_idempotent_and_updates
     raw = raw_obs("somion_unicolor")
     first = InatObsExtract.upsert_from_raw(raw, fetched_at: Time.current)


### PR DESCRIPTION
## Summary

**Draft — the analysis/comparison foundation for reflection resolution (#4585), not the read-only-reflection implementation itself.** This is the engine that classifies how each MO observation relates to its iNat counterpart, and the tooling that ran it over the whole linked corpus to produce the distribution the reflection design is now being specified from (posted on #4585).

### What's here

- **`Inat::ReflectionComparator`** — classifies a single MO observation against its cached iNat counterpart: the image-set relation (identical / subset / overlapping / disjoint) computed on perceptual-hash (dHash) identity so it survives the MO-original vs iNat-rendition resolution gap, plus tri-state field diffs (date / location / taxon / collector) reported for distribution analysis. Pure and testable — hashes and reference data are passed in.
- **`script/inat_reflection_report.rb`** — runs the comparator over linked MO observations that have a cached `InatObsExtract`, writes one CSV row per observation, and prints the distribution summary. Reads the pre-computed `images.dhash` and `InatPhotoHash` caches, so a full-corpus run is a pure DB compare (166,328 obs in ~8 min).
- **`Image::Dhash`** — rotation-invariant matching helpers (`rotations_from_url`, `min_distance`). The report itself does single-rotation matching by decision (#4585 comment); the rotation infra stays for the later targeted pass on the non-match residual (also serves #4673).
- **`InatObsExtract.from_raw`** — nil-taxon fix for unidentified iNat observations.
- **`script/claim_inat_username.rb`** — manual iNat-username claim runner (identity work, #4585/#4217).

### Results

The full run over all 166,328 linked observations is summarized on #4585: ~84% already-clean reflections (identical images), ~11% needing occurrence-splitting resolution, and taxon drift as the dominant field signal at ~24%.

### Not here (forthcoming, separate slices)

The read-only reflection model, the origin markers on satellite objects, occurrence-based editing, the notes hash-merge, and sync — those are the implementation slices being designed on #4585 and #4208. This PR is only the comparison/classification groundwork they build on.

## Test plan

- [x] `bin/rails test test/classes/inat/reflection_comparator_test.rb test/models/inat_obs_extract_test.rb test/models/image/dhash_test.rb` — 28 tests, 0 failures
- [x] Full report run over 166,328 linked observations — 0 errors, distribution posted to #4585
- [x] `bundle exec rubocop` clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
