### PR TITLE
Exempt `db/schema.rb` from the rubocop-on-save hook

### DIFF
--- a/.claude/hooks/rubocop_on_save.sh
+++ b/.claude/hooks/rubocop_on_save.sh
@@ -32,6 +32,21 @@ case "$FILE" in
   *) exit 0 ;;
 esac
 
+# Skip db/schema.rb -- it's auto-generated (no style discipline
+# applied to it) and .rubocop.yml already excludes "db/**/*", but
+# RuboCop's Exclude only applies to auto-discovered targets, not
+# files passed explicitly on the command line, so this hook has to
+# honor the same exclusion itself for schema.rb specifically.
+# Without this, invoking rubocop directly on it triggers a full-file
+# autocorrect (adds frozen_string_literal, reflows every create_table
+# line, etc.) on top of whatever one-line hand-edit prompted the save
+# -- a huge, unreviewable diff unrelated to the actual change.
+# Migrations (db/migrate/*) are NOT excluded here -- they're
+# hand-written code and still expected to pass rubocop normally.
+case "$FILE" in
+  */db/schema.rb) exit 0 ;;
+esac
+
 # Skip files that don't exist (the tool may have failed to write).
 [ -f "$FILE" ] || exit 0
 


### PR DESCRIPTION
## Summary

Exempts `db/schema.rb` from the `rubocop_on_save.sh` PostToolUse hook's autocorrect step.

## Why

`.rubocop.yml` already excludes `db/**/*` via `AllCops: Exclude`, but that config only applies to auto-discovered targets — not files passed explicitly on the command line. The hook invokes `bundle exec rubocop --autocorrect-all` directly on whatever file was just saved, so it bypasses that exclusion. Hand-editing a single line of `schema.rb` (an auto-generated file with no style discipline applied to it) triggered a full-file autocorrect — `frozen_string_literal` added, every `create_table` line reflowed — burying the real one-line change in ~1200 lines of unrelated noise.

Migrations (`db/migrate/*`) are untouched by this change — they're hand-written code and still expected to pass rubocop normally on save.

## Test plan

- [x] Confirmed the hook now exits early for `db/schema.rb` (skip case matches before the file-existence/rubocop-invocation steps).
- [x] Confirmed migrations are unaffected — the new skip is scoped to `*/db/schema.rb` only.
