### PR TITLE
Scrub invalid UTF-8 from incoming requests via `Rack::UTF8Sanitizer`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,11 @@ end
 # See https://github.com/trilogy-libraries/trilogy/tree/main/contrib/ruby
 gem("trilogy")
 
+# Scrubs invalid UTF-8 bytes out of incoming request params/headers at
+# the Rack layer, so a scanner's malformed bytes can't reach a String
+# op deep in the app and raise `invalid byte sequence in UTF-8` (a 500).
+gem("rack-utf8_sanitizer", require: "rack/utf8_sanitizer")
+
 # solid_cache for cache store db
 gem("solid_cache")
 # add locale to cache key

--- a/Gemfile
+++ b/Gemfile
@@ -38,9 +38,7 @@ end
 # See https://github.com/trilogy-libraries/trilogy/tree/main/contrib/ruby
 gem("trilogy")
 
-# Scrubs invalid UTF-8 bytes out of incoming request params/headers at
-# the Rack layer, so a scanner's malformed bytes can't reach a String
-# op deep in the app and raise `invalid byte sequence in UTF-8` (a 500).
+# Scrubs invalid UTF-8 from incoming requests; wired in config/application.rb.
 gem("rack-utf8_sanitizer", require: "rack/utf8_sanitizer")
 
 # solid_cache for cache store db

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,6 +400,8 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
+    rack-utf8_sanitizer (1.11.1)
+      rack (>= 1.0, < 4.0)
     rackup (2.3.1)
       rack (>= 3)
     rails-controller-testing (1.0.5)
@@ -671,6 +673,7 @@ DEPENDENCIES
   prawn-manual_builder
   prawn-svg
   puma
+  rack-utf8_sanitizer
   rails-controller-testing
   railties (~> 7.0)
   requestjs-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,11 +52,9 @@ module MushroomObserver
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
-    # Scrub invalid UTF-8 out of every incoming request before anything
-    # (including Rails' own param-filtering for the logs) touches it.
-    # Automated scanners POST malformed bytes; without this they reach a
-    # String op deep in the app and raise `invalid byte sequence in
-    # UTF-8` (a 500). Inserted at the front of the stack so it runs first.
+    # Scrub invalid UTF-8 out of every request at the front of the stack,
+    # before anything (including Rails' log param-filtering) touches it --
+    # else a scanner's malformed bytes reach a String op and 500.
     config.middleware.insert_before(0, Rack::UTF8Sanitizer)
 
     # Tells rails not to generate controller-specific css and js stubs.

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,13 @@ module MushroomObserver
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
+    # Scrub invalid UTF-8 out of every incoming request before anything
+    # (including Rails' own param-filtering for the logs) touches it.
+    # Automated scanners POST malformed bytes; without this they reach a
+    # String op deep in the app and raise `invalid byte sequence in
+    # UTF-8` (a 500). Inserted at the front of the stack so it runs first.
+    config.middleware.insert_before(0, Rack::UTF8Sanitizer)
+
     # Tells rails not to generate controller-specific css and js stubs.
     config.generators.assets = false
 

--- a/test/integration/rails-dom-testing/utf8_sanitizer_integration_test.rb
+++ b/test/integration/rails-dom-testing/utf8_sanitizer_integration_test.rb
@@ -2,12 +2,10 @@
 
 require("test_helper")
 
-# Rack::UTF8Sanitizer (wired in config/application.rb) scrubs invalid
-# UTF-8 bytes out of every incoming request, so a scanner's malformed
-# bytes in a form POST can't reach a String op deep in the app and raise
-# `invalid byte sequence in UTF-8` (a 500). These reproduce the shapes
-# seen in the wild: POST /account/login and POST /support/confirm with
-# an invalid byte (0xFF / 0xFE, URL-encoded) in a form value.
+# Regression for Rack::UTF8Sanitizer (see config/application.rb): a POST
+# with an invalid UTF-8 byte in a form value should be served, not 500.
+# Reproduces the shapes seen in the wild -- POST /account/login and
+# /support/confirm with a 0xFF / 0xFE byte URL-encoded in a form value.
 #
 # Subclasses ActionDispatch::IntegrationTest directly (not
 # IntegrationTestCase, which turns CSRF protection on) so the tokenless

--- a/test/integration/rails-dom-testing/utf8_sanitizer_integration_test.rb
+++ b/test/integration/rails-dom-testing/utf8_sanitizer_integration_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Rack::UTF8Sanitizer (wired in config/application.rb) scrubs invalid
+# UTF-8 bytes out of every incoming request, so a scanner's malformed
+# bytes in a form POST can't reach a String op deep in the app and raise
+# `invalid byte sequence in UTF-8` (a 500). These reproduce the shapes
+# seen in the wild: POST /account/login and POST /support/confirm with
+# an invalid byte (0xFF / 0xFE, URL-encoded) in a form value.
+#
+# Subclasses ActionDispatch::IntegrationTest directly (not
+# IntegrationTestCase, which turns CSRF protection on) so the tokenless
+# POST reaches the action -- CSRF is orthogonal to the byte-sanitizing
+# this covers, and the 500 it guards against happens during param
+# parsing/logging, before the controller's CSRF check.
+class Utf8SanitizerIntegrationTest < ActionDispatch::IntegrationTest
+  FORM = { "CONTENT_TYPE" => "application/x-www-form-urlencoded" }.freeze
+
+  def test_invalid_utf8_in_login_post_does_not_500
+    post("/account/login",
+         params: "user[login]=%FFabc&user[password]=x", headers: FORM)
+    assert(response.status < 500,
+           "login POST with invalid UTF-8 should not 500, " \
+           "got #{response.status}")
+  end
+
+  def test_invalid_utf8_in_support_confirm_post_does_not_500
+    post("/support/confirm",
+         params: "donation[amount]=5&donation[who]=%FFbad&" \
+                 "donation[email]=a%FEb&donation[anonymous]=0",
+         headers: FORM)
+    assert(response.status < 500,
+           "confirm POST with invalid UTF-8 should not 500, " \
+           "got #{response.status}")
+  end
+end


### PR DESCRIPTION
## Summary

Automated scanners POST malformed bytes (an invalid UTF-8 byte like `0xFF` in a form value). When those bytes reach a String operation deep in the app they raise `ArgumentError: invalid byte sequence in UTF-8` — a 500, and an `#alerts` notification. Seen recently on `POST /account/login` (`login#create`) and `POST /support/confirm` (`support#confirm`).

The scanner never injects anything — this is a robustness/noise problem, the encoding analog of #4846 (which coerced hash-shaped scalar params). Rails already catches *some* invalid-byte params itself and returns a 400 (`ActionController::BadRequest: Invalid encoding for parameter`), but others slip past that check into a raw String op and 500.

## Change

Adds the `rack-utf8_sanitizer` gem and inserts `Rack::UTF8Sanitizer` at the front of the middleware stack (`config.middleware.insert_before(0, …)`). It scrubs invalid UTF-8 out of every request's params and headers — the default `:replace` strategy swaps bad bytes for the Unicode replacement character — before any Rails or app code touches them. The garbage request is then processed normally (a junk login just fails auth) instead of erroring.

One boundary fix covering every endpoint, rather than patching `login#create` / `support#confirm` individually — the next scanner would otherwise just find a different action. The gem's default `SANITIZABLE_CONTENT_TYPES` covers `application/x-www-form-urlencoded` (the form POSTs in the alerts) plus JSON and query strings/headers.

## Test plan

All MO devs have a prod-data dev DB. Against a running instance, reproduce the probes with `curl` (the `%FF` is an invalid UTF-8 byte in a form value):

```
curl -i --data 'user[login]=%FFabc&user[password]=x' https://<host>/account/login
curl -i --data 'donation[amount]=5&donation[who]=%FFbad&donation[email]=a%FEb' https://<host>/support/confirm
```

- **Before** this change: a 500 (or a bare `ActionController::BadRequest`) and an alert.
- **After**: the request is served normally — the login page re-renders / the donation flow proceeds with the bad bytes replaced by `�`, no 500.

A valid request is unaffected — normal logins and donations behave exactly as before, since well-formed UTF-8 passes through untouched.

_Automated coverage: `test/integration/rails-dom-testing/utf8_sanitizer_integration_test.rb` POSTs invalid-byte form bodies to both endpoints and asserts a non-5xx response. (Verified it fails without the middleware — the requests raise on the bad encoding — and passes with it.)_
