### PR TITLE
Fix dangling-reference leaks at their sources; report every broken-references cleanup

### DIFF
--- a/app/jobs/check_for_broken_references_job.rb
+++ b/app/jobs/check_for_broken_references_job.rb
@@ -104,7 +104,14 @@ class CheckForBrokenReferencesJob < ApplicationJob
     ids = query.pluck(:id)
     return if ids.empty?
 
-    apply_action(model, column, query, ids, action)
+    # :alert is dispatched here, where ref_model is in scope, so its
+    # human-facing message can name the referenced model; the mutating
+    # actions don't need it.
+    if action == :alert
+      alert_broken(model, column, query, ids, ref_model)
+    else
+      apply_action(model, column, query, ids, action)
+    end
   end
 
   # A Checks::MONOMORPHIC/POLYMORPHIC entry naming an association that no
@@ -138,7 +145,6 @@ class CheckForBrokenReferencesJob < ApplicationJob
 
   def apply_action(model, column, query, ids, action)
     case action
-    when :alert then alert_broken(model, column, query, ids)
     when :delete then delete_broken(model, column, query, ids)
     when :nil then nullify_broken(model, column, query, ids)
     when :zero then zero_broken(model, column, query, ids)
@@ -146,18 +152,26 @@ class CheckForBrokenReferencesJob < ApplicationJob
     end
   end
 
-  # Logs a count + a bounded [id, column] sample rather than the full list.
-  # Each pair is an offending row's primary key and its dangling #{column}
-  # value, so the sample can't be misread as a list of FK values. :alert
-  # rows should be rare (something's wrong upstream), but an unbounded pluck
-  # would blow up log/job.log if that ever stops holding (e.g. after a bad
-  # data migration).
-  def alert_broken(model, column, query, ids)
-    sample = query.limit(10).pluck(:id, column)
-    log("ALERT!! #{ids.size} #{model.table_name} row(s) with a dangling " \
-        "#{column} - [id, #{column}]: #{sample.inspect}")
-    note_for_review("#{ids.size} #{model.table_name}.#{column} dangling " \
-                    "(e.g. #{sample.first(3).inspect})")
+  # Logs a count + a bounded sample rather than the full list, each row
+  # rendered as "<Model> <id> -> missing <RefModel> <fk>" so the message
+  # reads as a sentence and can't be misread as a list of FK values.
+  # :alert rows should be rare (something's wrong upstream), but an
+  # unbounded pluck would blow up log/job.log if that ever stops holding
+  # (e.g. after a bad data migration).
+  def alert_broken(model, column, query, ids, ref_model)
+    pairs = broken_pairs(model, column, query, ref_model)
+    log("ALERT!! #{ids.size} #{model.name} row(s) point to a missing " \
+        "#{ref_model.name} via #{column}: #{pairs.first(10).join("; ")}")
+    note_for_review(
+      "#{ids.size} #{model.name} rows point to a #{ref_model.name} that " \
+      "no longer exists (via #{column}) -- e.g. #{pairs.first(3).join("; ")}"
+    )
+  end
+
+  def broken_pairs(model, column, query, ref_model)
+    query.limit(10).pluck(:id, column).map do |id, fk|
+      "#{model.name} #{id} -> missing #{ref_model.name} #{fk}"
+    end
   end
 
   def delete_broken(model, column, query, ids)

--- a/app/jobs/check_for_broken_references_job.rb
+++ b/app/jobs/check_for_broken_references_job.rb
@@ -19,6 +19,11 @@
 class CheckForBrokenReferencesJob < ApplicationJob
   queue_as :maintenance
 
+  # One dangling-reference finding: the referencing model + column, the
+  # referenced model, and the offending rows. Bundled so every action can
+  # name the referenced model in its report without a long param list.
+  Finding = Data.define(:model, :column, :ref_model, :query, :ids)
+
   def perform(dry_run: false, verbose: false)
     @dry_run = dry_run
     @verbose = verbose
@@ -104,14 +109,11 @@ class CheckForBrokenReferencesJob < ApplicationJob
     ids = query.pluck(:id)
     return if ids.empty?
 
-    # :alert is dispatched here, where ref_model is in scope, so its
-    # human-facing message can name the referenced model; the mutating
-    # actions don't need it.
-    if action == :alert
-      alert_broken(model, column, query, ids, ref_model)
-    else
-      apply_action(model, column, query, ids, action)
-    end
+    apply_action(
+      Finding.new(model: model, column: column, ref_model: ref_model,
+                  query: query, ids: ids),
+      action
+    )
   end
 
   # A Checks::MONOMORPHIC/POLYMORPHIC entry naming an association that no
@@ -143,53 +145,66 @@ class CheckForBrokenReferencesJob < ApplicationJob
     @reflections[key] = :done
   end
 
-  def apply_action(model, column, query, ids, action)
+  # Every action -- the mutating :delete/:nil/:zero cleanups as well as
+  # :alert -- reports to the #alerts summary, so a dangling reference is
+  # always visible: a cleanup you didn't expect is itself the signal that
+  # some deletion path isn't cleaning up at its source. The sample is
+  # captured up front, before the mutation removes/changes those rows.
+  def apply_action(finding, action)
+    pairs = broken_pairs(finding)
     case action
-    when :delete then delete_broken(model, column, query, ids)
-    when :nil then nullify_broken(model, column, query, ids)
-    when :zero then zero_broken(model, column, query, ids)
-    else raise_invalid_action(model, action)
+    when :alert then alert_broken(finding, pairs)
+    when :delete then delete_broken(finding, pairs)
+    when :nil then nullify_broken(finding, pairs)
+    when :zero then zero_broken(finding, pairs)
+    else raise_invalid_action(finding.model, action)
     end
   end
 
-  # Logs a count + a bounded sample rather than the full list, each row
-  # rendered as "<Model> <id> -> missing <RefModel> <fk>" so the message
-  # reads as a sentence and can't be misread as a list of FK values.
-  # :alert rows should be rare (something's wrong upstream), but an
-  # unbounded pluck would blow up log/job.log if that ever stops holding
-  # (e.g. after a bad data migration).
-  def alert_broken(model, column, query, ids, ref_model)
-    pairs = broken_pairs(model, column, query, ref_model)
-    log("ALERT!! #{ids.size} #{model.name} row(s) point to a missing " \
-        "#{ref_model.name} via #{column}: #{pairs.first(10).join("; ")}")
-    note_for_review(
-      "#{ids.size} #{model.name} rows point to a #{ref_model.name} that " \
-      "no longer exists (via #{column}) -- e.g. #{pairs.first(3).join("; ")}"
-    )
-  end
-
-  def broken_pairs(model, column, query, ref_model)
-    query.limit(10).pluck(:id, column).map do |id, fk|
-      "#{model.name} #{id} -> missing #{ref_model.name} #{fk}"
+  # A bounded sample, each row rendered as "<Model> <id> -> missing
+  # <RefModel> <fk>" so the message reads as a sentence and can't be
+  # misread as a list of FK values. Bounded because an unbounded pluck
+  # would blow up log/job.log after e.g. a bad data migration.
+  def broken_pairs(finding)
+    finding.query.limit(10).pluck(:id, finding.column).map do |id, fk|
+      "#{finding.model.name} #{id} -> missing #{finding.ref_model.name} #{fk}"
     end
   end
 
-  def delete_broken(model, column, query, ids)
-    query.delete_all unless @dry_run
-    log("DELETING #{ids.count} #{model.name.pluralize(ids.count)} " \
-        "whose #{column} doesn't exist#{dry_run_note}")
+  def alert_broken(finding, pairs)
+    summary = "#{finding.ids.size} #{finding.model.name} rows point to a " \
+              "#{finding.ref_model.name} that no longer exists " \
+              "(via #{finding.column})"
+    log("ALERT!! #{summary}: #{pairs.first(10).join("; ")}")
+    review_note(pairs, summary)
   end
 
-  def nullify_broken(model, column, query, ids)
-    query.update_all(column => nil) unless @dry_run
-    log("SETTING #{ids.count} nonexistent #{model.table_name}.#{column} " \
-        "TO NIL#{dry_run_note}")
+  def delete_broken(finding, pairs)
+    finding.query.delete_all unless @dry_run
+    report_cleanup(finding, pairs, "Deleted")
   end
 
-  def zero_broken(model, column, query, ids)
-    query.update_all(column => 0) unless @dry_run
-    log("SETTING #{ids.count} nonexistent #{model.table_name}.#{column} " \
-        "TO ZERO#{dry_run_note}")
+  def nullify_broken(finding, pairs)
+    finding.query.update_all(finding.column => nil) unless @dry_run
+    report_cleanup(finding, pairs, "Nulled")
+  end
+
+  def zero_broken(finding, pairs)
+    finding.query.update_all(finding.column => 0) unless @dry_run
+    report_cleanup(finding, pairs, "Zeroed")
+  end
+
+  # Log + #alerts summary for a mutating cleanup (:delete/:nil/:zero).
+  def report_cleanup(finding, pairs, verb)
+    summary = "#{verb} #{finding.ids.size} #{finding.model.name} rows " \
+              "referencing a missing #{finding.ref_model.name} " \
+              "(via #{finding.column})#{dry_run_note}"
+    log(summary)
+    review_note(pairs, summary)
+  end
+
+  def review_note(pairs, summary)
+    note_for_review("#{summary} -- e.g. #{pairs.first(3).join("; ")}")
   end
 
   # Appended to mutation log lines so a dry run doesn't read as if it
@@ -218,9 +233,14 @@ class CheckForBrokenReferencesJob < ApplicationJob
   end
 
   def delete_broken_polymorphic(model, ref_model, query, ids)
+    finding = Finding.new(model: model, column: :target_id,
+                          ref_model: ref_model, query: query, ids: ids)
+    pairs = broken_pairs(finding)
     query.delete_all unless @dry_run
-    log("DELETING #{ids.count} #{model.name.pluralize(ids.count)} " \
-        "whose target #{ref_model.name} doesn't exist#{dry_run_note}")
+    summary = "Deleted #{ids.size} #{model.name} rows whose target " \
+              "#{ref_model.name} no longer exists#{dry_run_note}"
+    log(summary)
+    review_note(pairs, summary)
   end
 
   def polymorphic_target?(model)

--- a/app/jobs/check_for_broken_references_job/checks.rb
+++ b/app/jobs/check_for_broken_references_job/checks.rb
@@ -189,7 +189,11 @@ class CheckForBrokenReferencesJob
       [User,                         :location,             :nil],
       [UserGroupUser,                :user,                 :delete],
       [UserGroupUser,                :user_group,           :delete],
-      [UserStats,                    :user,                 :alert],
+      # Derived per-user stats (rebuilt by refresh_all_user_stats) --
+      # meaningless without their user, so safe to delete. erase_user now
+      # removes them up front (User::OWN_RECORDS); this cleans up the
+      # ~26k that erase_user leaked before that fix, and stays a net.
+      [UserStats,                    :user,                 :delete],
       [VisualGroup,                  :visual_model,         :alert],
       [VisualGroupImage,             :image,                :delete],
       [VisualGroupImage,             :visual_group,         :delete],

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -122,7 +122,9 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     center_lng
   ].freeze
 
-  acts_as_versioned(if_changed: VERSIONED_COLUMNS)
+  # See Name: delete_all the versions on destroy so they don't dangle.
+  acts_as_versioned(if_changed: VERSIONED_COLUMNS,
+                    association_options: { dependent: :delete_all })
   non_versioned_columns.push(
     "created_at",
     "updated_at",

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -356,7 +356,12 @@ class Name < AbstractModel
     icn_id
   ].freeze
 
-  acts_as_versioned(if_changed: VERSIONED_COLUMNS)
+  # delete_all the versions when a name is destroyed (e.g. merged away),
+  # else they're left with a dangling name_id (swept by
+  # CheckForBrokenReferencesJob). The description/glossary versioned
+  # models use :nullify instead -- an unresolved inconsistency.
+  acts_as_versioned(if_changed: VERSIONED_COLUMNS,
+                    association_options: { dependent: :delete_all })
   non_versioned_columns.push(
     "created_at",
     "updated_at",

--- a/app/models/translation_string.rb
+++ b/app/models/translation_string.rb
@@ -38,8 +38,12 @@ class TranslationString < AbstractModel
   belongs_to :language
   belongs_to :user
 
+  # See Name: delete_all the versions on destroy so they don't dangle.
+  # This is the biggest source -- language import/export removes strings
+  # regularly (see Concerns::LanguageExporter).
   acts_as_versioned(
-    if: :update_version?
+    if: :update_version?,
+    association_options: { dependent: :delete_all }
   )
   non_versioned_columns.push("tag")
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -860,6 +860,9 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     [:sequences,                      :user_id],
     [:species_lists,                  :user_id],
     [:user_group_users,               :user_id],
+    # Deleted here because erase_user removes the user row via delete_all,
+    # which bypasses `User has_one :user_stats, dependent: :destroy`.
+    [:user_stats,                     :user_id],
     [:users,                          :id]
   ].freeze
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -860,8 +860,12 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     [:sequences,                      :user_id],
     [:species_lists,                  :user_id],
     [:user_group_users,               :user_id],
-    # Deleted here because erase_user removes the user row via delete_all,
-    # which bypasses `User has_one :user_stats, dependent: :destroy`.
+    # These are removed here because erase_user deletes the user row via
+    # delete_all, which bypasses the User's has_one/has_many
+    # `dependent: :destroy` callbacks -- so they'd otherwise be orphaned
+    # (and swept later by CheckForBrokenReferencesJob).
+    [:observation_views,              :user_id],
+    [:project_members,                :user_id],
     [:user_stats,                     :user_id],
     [:users,                          :id]
   ].freeze

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -733,6 +733,9 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
         UserGroup.one_user(id)&.destroy
       end
       UserGroupUser.where(user_id: ids).delete_all
+      # delete_all below bypasses `has_many :api_keys, dependent: :destroy`,
+      # so clean them here too (erase_user handles this via OWN_RECORDS).
+      APIKey.where(user_id: ids).delete_all
       User.where(id: ids).delete_all
     end
 

--- a/test/jobs/check_for_broken_references_job_test.rb
+++ b/test/jobs/check_for_broken_references_job_test.rb
@@ -32,6 +32,19 @@ class CheckForBrokenReferencesJobTest < ActiveJob::TestCase
     assert_equal(0, article.reload.user_id)
   end
 
+  # UserStats.user flipped from :alert to :delete -- an orphaned stats
+  # row (derived data) is meaningless without its user, so the job now
+  # cleans it up.
+  def test_delete_action_removes_dangling_user_stats
+    stats = user_stats(:rolf)
+    stats.update_column(:user_id, DANGLING_ID)
+
+    CheckForBrokenReferencesJob.perform_now
+
+    assert_not(UserStats.exists?(stats.id),
+               "user_stats whose user_id is dangling should be deleted")
+  end
+
   def test_alert_action_only_reports_does_not_modify
     coll_num = collection_numbers(:minimal_unknown_coll_num)
     coll_num.update_column(:user_id, DANGLING_ID)
@@ -100,7 +113,8 @@ class CheckForBrokenReferencesJobTest < ActiveJob::TestCase
   end
 
   # A dangling :alert reference produces exactly one summary alert for the
-  # whole run, naming the offending table.column.
+  # whole run, naming the offending model, the referenced model, the
+  # foreign key, and the dangling id in a readable sentence.
   def test_emits_one_review_alert_for_dangling_alert_reference
     coll_num = collection_numbers(:minimal_unknown_coll_num)
     coll_num.update_column(:user_id, DANGLING_ID)
@@ -109,7 +123,10 @@ class CheckForBrokenReferencesJobTest < ActiveJob::TestCase
 
     assert_equal(1, alerts.size, "expected exactly one summary alert per run")
     assert_instance_of(JobAlert, alerts.first)
-    assert_includes(alerts.first.message, "collection_numbers.user_id")
+    message = alerts.first.message
+    assert_includes(message, "CollectionNumber rows point to a User")
+    assert_includes(message, "via user_id")
+    assert_includes(message, "missing User #{DANGLING_ID}")
   end
 
   # emit_review_summary is the "at most one alert per run" choke point:

--- a/test/jobs/check_for_broken_references_job_test.rb
+++ b/test/jobs/check_for_broken_references_job_test.rb
@@ -5,31 +5,40 @@ require("test_helper")
 class CheckForBrokenReferencesJobTest < ActiveJob::TestCase
   DANGLING_ID = 999_999_999
 
-  def test_delete_action_removes_dangling_row
+  def test_delete_action_removes_dangling_row_and_reports
     key = api_keys(:rolfs_api_key)
     key.update_column(:user_id, DANGLING_ID)
 
-    CheckForBrokenReferencesJob.perform_now
+    alerts = capture_alerts { CheckForBrokenReferencesJob.perform_now }
 
     assert_not(APIKey.exists?(key.id))
+    # :delete now reports to the #alerts summary, not just job.log.
+    assert_includes(alerts.first.message, "Deleted")
+    assert_includes(alerts.first.message, "APIKey")
   end
 
-  def test_nil_action_nulls_dangling_column
+  def test_nil_action_nulls_dangling_column_and_reports
     list = species_lists(:first_species_list)
     list.update_column(:location_id, DANGLING_ID)
 
-    CheckForBrokenReferencesJob.perform_now
+    alerts = capture_alerts { CheckForBrokenReferencesJob.perform_now }
 
     assert_nil(list.reload.location_id)
+    msg = alerts.first.message
+    assert_includes(msg, "Nulled")
+    assert_includes(msg, "via location_id")
   end
 
-  def test_zero_action_zeroes_dangling_column
+  def test_zero_action_zeroes_dangling_column_and_reports
     article = articles(:premier_article)
     article.update_column(:user_id, DANGLING_ID)
 
-    CheckForBrokenReferencesJob.perform_now
+    alerts = capture_alerts { CheckForBrokenReferencesJob.perform_now }
 
     assert_equal(0, article.reload.user_id)
+    msg = alerts.first.message
+    assert_includes(msg, "Zeroed")
+    assert_includes(msg, "via user_id")
   end
 
   # UserStats.user flipped from :alert to :delete -- an orphaned stats
@@ -95,10 +104,13 @@ class CheckForBrokenReferencesJobTest < ActiveJob::TestCase
   def test_invalid_action_raises
     job = CheckForBrokenReferencesJob.new
     job.instance_variable_set(:@dry_run, true)
+    finding = CheckForBrokenReferencesJob::Finding.new(
+      model: APIKey, column: :user_id, ref_model: User,
+      query: APIKey.none, ids: [1]
+    )
 
     assert_raises(RuntimeError) do
-      job.send(:apply_action, APIKey, :user_id, APIKey.none, [1],
-               :bogus_action)
+      job.send(:apply_action, finding, :bogus_action)
     end
   end
 

--- a/test/models/translation_string_test.rb
+++ b/test/models/translation_string_test.rb
@@ -3,6 +3,28 @@
 require("test_helper")
 
 class TranslationStringTest < UnitTestCase
+  # Destroying a versioned record must delete its versions, else they're
+  # left with a dangling FK (swept by CheckForBrokenReferencesJob).
+  def test_destroy_cascades_to_versions
+    str = translation_strings(:greek_one)
+    version_ids = TranslationString::Version.
+                  where(translation_string_id: str.id).pluck(:id)
+    assert(version_ids.any?, "fixture should have versions")
+
+    str.destroy!
+
+    assert_empty(TranslationString::Version.where(id: version_ids),
+                 "destroying a translation_string should delete its versions")
+    # Name and Location share the same cascade config.
+    [Name, Location, TranslationString].each do |model|
+      assert_equal(
+        :delete_all,
+        model.reflect_on_association(:versions).options[:dependent],
+        "#{model} versions should cascade-delete on destroy"
+      )
+    end
+  end
+
   def test_rename_tags_upcase
     str = TranslationString.create(
       { tag: "JOHN", text: "Harding",

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -227,6 +227,20 @@ class UserTest < UnitTestCase
     assert_raises(ActiveRecord::RecordNotFound) { Publication.find(pub_id) }
   end
 
+  # erase_user deletes the user row via delete_all, which bypasses the
+  # `has_one :user_stats, dependent: :destroy` callback, so user_stats
+  # must be erased explicitly (else it's left dangling -- see #26085).
+  def test_erase_user_removes_user_stats
+    user = users(:spammer)
+    UserStats.find_or_create_by!(user_id: user.id)
+    assert(UserStats.exists?(user_id: user.id))
+
+    User.erase_user(user.id)
+
+    assert_not(UserStats.exists?(user_id: user.id),
+               "erase_user should delete the user's user_stats")
+  end
+
   def test_erase_user_with_comment_and_name_descriptions
     user = dick
     num_comments = Comment.count

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -228,17 +228,24 @@ class UserTest < UnitTestCase
   end
 
   # erase_user deletes the user row via delete_all, which bypasses the
-  # `has_one :user_stats, dependent: :destroy` callback, so user_stats
-  # must be erased explicitly (else it's left dangling -- see #26085).
-  def test_erase_user_removes_user_stats
+  # User's `dependent: :destroy` callbacks, so these user-owned records
+  # must be erased explicitly (else they're left dangling -- see #26085).
+  def test_erase_user_removes_own_leaked_records
     user = users(:spammer)
     UserStats.find_or_create_by!(user_id: user.id)
-    assert(UserStats.exists?(user_id: user.id))
+    ObservationView.find_or_create_by!(
+      observation: observations(:minimal_unknown_obs), user: user
+    )
+    ProjectMember.create!(project: projects(:bolete_project), user: user)
 
     User.erase_user(user.id)
 
     assert_not(UserStats.exists?(user_id: user.id),
                "erase_user should delete the user's user_stats")
+    assert_not(ObservationView.exists?(user_id: user.id),
+               "erase_user should delete the user's observation_views")
+    assert_not(ProjectMember.exists?(user_id: user.id),
+               "erase_user should delete the user's project_members")
   end
 
   def test_erase_user_with_comment_and_name_descriptions

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -525,11 +525,15 @@ class UserTest < UnitTestCase
 
   def test_culling_unverified_users
     unverified = users(:unverified)
+    key = APIKey.create!(user: unverified, notes: "cull test")
     msgs = User.cull_unverified_users(dry_run: true)
     assert_equal("Deleted 1 unverified user(s).", msgs.first)
+    assert(APIKey.exists?(key.id), "dry run should not delete the api_key")
     msgs = User.cull_unverified_users(dry_run: false)
     assert_equal("Deleted 1 unverified user(s).", msgs.first)
     assert_nil(User.find_by(id: unverified.id))
+    assert_not(APIKey.exists?(key.id),
+               "culling should delete the unverified user's api_key")
   end
 
   def test_lookup_unique_text_name


### PR DESCRIPTION
## Summary

`CheckForBrokenReferencesJob` (the weekly maintenance job — `every sunday at 7:13am`) alerted on ~26,000 dangling `user_stats.user_id` references. Investigating that surfaced a family of the same problem: several deletion paths orphan child rows because they use `delete_all` (bypassing `dependent: :destroy`) or rely on `acts_as_versioned`, which doesn't cascade. The job had been *silently* sweeping all of those every week (`:delete`/`:nil`/`:zero` only logged to `job.log`, never to `#alerts`), so nobody knew.

This fixes each leak at its source, and changes the job so every cleanup is reported — turning it into a real signal: once the sources are fixed and the backlog is cleared, the weekly summary goes quiet, and a non-empty report means "some deletion path regressed."

The full current-prod picture that drove this (from a checkpoint + the last run's `job.log`): `UserStats` 25,845, `TranslationString::Version` 251, `ObservationView` 23, `APIKey` 6, `ProjectMember` 2, `Name::Version` 2 — all `:delete`, no `:nil`/`:zero` danglers.

## Commits (each a distinct fix)

1. **`user_stats`** — add `[:user_stats, :user_id]` to `User::OWN_RECORDS` (erase_user was leaking it), and flip the check to `:delete` so the backlog is cleared.
2. **`observation_views` + `project_members`** — same erase_user leak (a member-only user's memberships, a user's view rows); added to `OWN_RECORDS`.
3. **`api_keys`** — `cull_unverified_users` (`User...delete_all`) bypassed `has_many :api_keys, dependent: :destroy`; clean them there too.
4. **version cascade** — `Name`, `Location`, `TranslationString` used `acts_as_versioned`'s default (no cascade), so destroying one — a name merge, or a translation string removed during language import/export (the ~251/week source) — left its version rows dangling. Set `association_options: { dependent: :delete_all }` on the three. (`NameDescription`/`LocationDescription`/`GlossaryTerm` already use `:nullify` — a pre-existing inconsistency, flagged in a code comment but not changed here since they don't dangle.)
5. **report every cleanup** — `:delete`/`:nil`/`:zero` now report to the `#alerts` summary alongside `:alert`, each as a readable sentence, instead of vanishing into `job.log`.

## Behavior / ops notes

- **`:alert` is unchanged** — the ~48 ownership/attribution references ("never silently touch ownership") still report-only.
- After deploy, the next weekly run clears the prod backlog via `:delete` **and reports it** — so expect one larger `#alerts` summary on the first run (the 26k `user_stats` cleanup, etc.), then it quiets down as the source fixes hold. No separate cleanup script needed. `perform_now(dry_run: true, verbose: true)` previews counts to `job.log` without mutating.
- One item deliberately left as-is: `ObservationView` is intentionally not a blocker for erasure elsewhere; here we just stop *leaking* it from erase_user.

## Test plan

- **The real signal** is the weekly `#alerts` summary itself: after this deploys and runs once, the recurring `user_stats` / version / api_key / membership lines should disappear (backlog cleared, sources fixed), and future runs stay quiet unless a path regresses.
- **On a dev DB**, exercise each source fix:
  - `UserStats.find_or_create_by!(user_id: u.id)` + an `ObservationView`/`ProjectMember` for `u`, then `User.erase_user(u.id)` → all gone.
  - Give an unverified user an `APIKey`, `User.cull_unverified_users(dry_run: false)` → the key is gone.
  - `translation_strings(:greek_one).destroy!` → its `TranslationString::Version` rows are gone (same for a `Name` merge).
- **See the new report**: point any reference at a missing target (e.g. `api_keys(:rolfs_api_key).update_column(:user_id, 999_999_999)`), run the job, and the `#alerts` summary reads `Deleted N APIKey rows referencing a missing User (via user_id) -- e.g. ...` rather than staying silent.

_Automated coverage added across `test/models/user_test.rb`, `test/models/translation_string_test.rb`, and `test/jobs/check_for_broken_references_job_test.rb`; full suite green._
