### PR TITLE
Read-only reflections: stamp new iNat imports `reflected_at` and block their edits (#4214)

### DIFF
--- a/app/classes/api2/error/observation_is_read_only.rb
+++ b/app/classes/api2/error/observation_is_read_only.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class API2
+  # Attempted to edit a read-only reflection of an imported observation
+  # (#4214). Change it at the source and resync instead.
+  class ObservationIsReadOnly < ObjectError
+  end
+end

--- a/app/classes/api2/observation_api.rb
+++ b/app/classes/api2/observation_api.rb
@@ -123,6 +123,10 @@ class API2
     def build_setter(params)
       lambda do |obs|
         must_have_edit_permission!(obs)
+        # A read-only reflection is kept in sync from its source (#4214);
+        # block scalar-core edits here as the web edit form does.
+        raise(ObservationIsReadOnly.new(obs)) if obs.reflection?
+
         update_notes_fields(obs)
         obs.update!(params)
         update_images(obs)

--- a/app/classes/inat/mo_observation_builder.rb
+++ b/app/classes/inat/mo_observation_builder.rb
@@ -65,7 +65,10 @@ class Inat
         specimen: inat_obs.specimen?,
         text_name: lead_name.text_name,
         notes: inat_obs.notes,
-        inat_import_id: @inat_import&.id }.merge(collector_attrs)
+        inat_import_id: @inat_import&.id,
+        # A fresh import is a clean reflection by construction, so mark it
+        # read-only now (#4214). The #4585 engine stamps the backlog later.
+        reflected_at: Time.zone.now }.merge(collector_attrs)
     end
 
     # Link the collector to an MO user when the iNat collector (a custom

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -25,12 +25,7 @@ module ObservationsController::EditAndUpdate
   #   @good_images                      list of images already attached
   #
   def edit
-    return unless find_observation!
-
-    # Make sure user owns this observation!
-    unless permission!(@observation)
-      redirect_to(action: :show, id: @observation.id) and return
-    end
+    return unless editable_or_redirect?
 
     init_license_var
     init_new_image_var(@observation.when)
@@ -51,6 +46,30 @@ module ObservationsController::EditAndUpdate
   def find_observation!
     @observation = Observation.edit_includes.safe_find(params[:id]) ||
                    flash_error_and_goto_index(Observation, params[:id])
+  end
+
+  # Both edit and update bail early on a missing obs, a read-only
+  # reflection (#4214 — change it at the source and resync), or a
+  # permission failure. Returns true only when the request may proceed;
+  # each guard performs its own redirect when it stops the request.
+  def editable_or_redirect?
+    return false unless find_observation!
+    return false if redirect_if_reflection!
+    return true if permission!(@observation)
+
+    redirect_to(action: :show, id: @observation.id)
+    false
+  end
+
+  # A read-only reflection can't have its scalar core edited on MO.
+  # Adding namings/comments/images is still allowed, so the guard is on
+  # the edit form itself, not a blanket record lock. Returns the redirect
+  # (truthy) when it stops the request, nil otherwise.
+  def redirect_if_reflection!
+    return unless @observation.reflection?
+
+    flash_warning(:edit_observation_is_reflection.t)
+    redirect_to(action: :show, id: @observation.id)
   end
 
   # Edit-mode: just build the union of projects to display. The
@@ -75,9 +94,7 @@ module ObservationsController::EditAndUpdate
   public
 
   def update
-    return unless find_observation!
-    return redirect_to(action: :show, id: @observation.id) \
-      unless permission!(@observation)
+    return unless editable_or_redirect?
 
     init_update
     apply_observation_changes

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1126,6 +1126,16 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
+  # True when this observation is a read-only reflection of an imported
+  # source (#4214): its scalar core (date/location/notes/name) mirrors
+  # the source and is kept current by resync (#4215), so MO-side edits to
+  # those fields are blocked. `reflected_at` is stamped at import time for
+  # new imports (clean by construction) and by the #4585 resolution engine
+  # for the verified backlog; NULL means editable (not a reflection).
+  def reflection?
+    reflected_at.present?
+  end
+
   # Structured form of source_credit for external imports — returns
   # { text:, url: } so renderers can build the link element with
   # whatever attributes they need (e.g. target="_blank" for off-site).

--- a/app/views/controllers/observations/external_links/info_frame.rb
+++ b/app/views/controllers/observations/external_links/info_frame.rb
@@ -5,8 +5,11 @@
 # `Turbo-Frame` request header. Renders a bold "On iNaturalist:" label
 # followed by the site's own + sibling `ExternalLink` rows inside the
 # frame the clicked badge targets. Own rows get an inline edit/destroy
-# `InlineCRUDLinks` (self-gated on `link.can_edit?(user)`); sibling
-# rows never do. Otherwise purely informational, not a form.
+# `InlineCRUDLinks` (self-gated on `link.can_edit?(user)`), EXCEPT when
+# `@obs` is a read-only reflection (#4214) -- its own external link is
+# the sync source, so no edit/destroy affordance at all, just a note
+# pointing at the source. Sibling rows never get InlineCRUDLinks
+# either way. Otherwise purely informational, not a form.
 module Views::Controllers::Observations::ExternalLinks
   class InfoFrame < Views::Base
     # A sibling observation's link to the same site, paired with the
@@ -40,12 +43,26 @@ module Views::Controllers::Observations::ExternalLinks
 
     # Edit/destroy affordance for the current obs's own links only --
     # a sibling's link (below) isn't this page's to manage, even if
-    # the viewer happens to have edit permission on it too.
+    # the viewer happens to have edit permission on it too. A
+    # read-only reflection gets a note instead -- its own link can't
+    # be edited or destroyed on MO at all (#4214).
     def render_own_row(link)
       li(class: "hanging-indent") do
         Link(type: :external, link: link)
-        whitespace
-        InlineCRUDLinks(target: link, observation: @obs, user: @user)
+        if @obs.reflection?
+          render_read_only_note
+        else
+          whitespace
+          InlineCRUDLinks(target: link, observation: @obs, user: @user)
+        end
+      end
+    end
+
+    # Read-only reflections (#4214) can't be edited on MO; the note tells
+    # the user to change the record at its source and resync.
+    def render_read_only_note
+      div(class: "reflection-read-only-note text-muted small mt-1") do
+        plain(:observation_reflection_read_only_note.l)
       end
     end
 

--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -20,7 +20,7 @@ module Views::Layouts
     def view_template
       ul(class: "nav d-flex align-items-center " \
                 "justify-content-end mt-0 h4 object_edit") do
-        li { render_edit_button } if can_edit_object?
+        li { render_edit_button } if can_edit_object? && !read_only_reflection?
         li { render_delete_button } if can_destroy_object?
       end
     end
@@ -41,6 +41,13 @@ module Views::Layouts
 
     def can_edit_object?
       in_admin_mode? || @object.can_edit?(@user)
+    end
+
+    # A read-only reflection (#4214) can't have its scalar core edited on
+    # MO, so no edit icon -- change it at the source and resync. Delete is
+    # a separate lifecycle concern and stays available.
+    def read_only_reflection?
+      @object.respond_to?(:reflection?) && @object.reflection?
     end
 
     def can_destroy_object?

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1127,6 +1127,7 @@
   source_credit_external: '"Imported from [name]":[url]'
   source_credit_external_text: Imported from [name]
   source_credit_help_link: About imported observations
+  observation_reflection_read_only_note: Read-only reflection of its imported source. To change it, edit it at the source and resync.
 
   ##############################################################################
 
@@ -1464,6 +1465,7 @@
   form_observations_field_code: for field slip
   form_observations_field_slip_code: Field Slip Code
   edit_observation_field_slip_invalid: 'Invalid field slip code "[code]".'
+  edit_observation_is_reflection: This observation is a read-only reflection of its imported source. To change it, edit it at the source and resync.
   create_observation_field_slip_invalid: 'Observation created, but the field slip code "[code]" was invalid and was not attached.'
   form_observations_specimen_available: Specimen Available
   form_observations_is_collection_location: Is this location where it was collected?
@@ -4108,6 +4110,7 @@
   api_must_be_owner: You must be the owner of the [type] "[name]" to do this.
   api_must_be_site_admin: This action requires a site administrator's API key.
   api_must_have_edit_permission: You do not have permission to edit [type] "[name]".
+  api_observation_is_read_only: '[type] "[name]" is a read-only reflection of an imported source. Edit it at the source and resync instead.'
   api_must_have_view_permission: You do not have permission to view [type] "[name]".
   api_must_not_have_any_herbaria: You can't edit this [:location] because there is an [:herbarium] there.
   api_must_own_all_descriptions: You can only edit [types] if you own all the [:descriptions].

--- a/test/classes/api2/observations_test.rb
+++ b/test/classes/api2/observations_test.rb
@@ -556,6 +556,26 @@ class API2::ObservationsTest < UnitTestCase
     assert_obj_arrays_equal([obs], spec.observations)
   end
 
+  # A read-only reflection (#4214) can't be edited through the API
+  # either, even by its owner — the setter raises before any update.
+  def test_patching_a_reflection_is_blocked
+    obs = observations(:coprinus_comatus_obs)
+    assert(obs.can_edit?(rolf), "owner would otherwise be able to edit")
+    obs.update_column(:reflected_at, Time.zone.now)
+    params = {
+      method: :patch,
+      action: :observation,
+      api_key: @api_key.key,
+      id: obs.id,
+      set_date: "2012-12-12"
+    }
+    assert_api_fail(params)
+    assert(@api.errors.any?(API2::ObservationIsReadOnly),
+           "editing a reflection should raise ObservationIsReadOnly")
+    assert_not_equal(Date.parse("2012-12-12"), obs.reload.when,
+                     "a reflection's date must not change via the API")
+  end
+
   def test_patching_observations
     rolfs_obs = observations(:coprinus_comatus_obs)
     marys_obs = observations(:detailed_unknown_obs)

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -168,6 +168,39 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     assert_response(:redirect)
   end
 
+  # A read-only reflection (#4214) can't be edited on MO even by its
+  # owner — the edit form redirects with a warning. The guard sits ahead
+  # of the permission check, so the owner (who would otherwise pass) is
+  # still blocked.
+  def test_edit_reflection_redirects_with_warning
+    obs = observations(:imported_inat_obs)
+    obs.update_column(:reflected_at, Time.zone.now)
+    login(obs.user.login)
+
+    get(:edit, params: { id: obs.id })
+
+    assert_redirected_to(action: :show, id: obs.id)
+    assert_flash_warning
+  end
+
+  def test_update_reflection_is_blocked
+    obs = observations(:imported_inat_obs)
+    original_notes = obs.notes
+    obs.update_column(:reflected_at, Time.zone.now)
+    login(obs.user.login)
+
+    put(:update, params: {
+          id: obs.id,
+          observation: { place_name: "Somewhere Else, Japan",
+                         notes: { other: "changed on MO" } }
+        })
+
+    assert_redirected_to(action: :show, id: obs.id)
+    assert_flash_warning
+    assert_equal(original_notes, obs.reload.notes,
+                 "a reflection's notes must not change through update")
+  end
+
   def test_update_observation
     obs = observations(:detailed_unknown_obs)
     updated_at = obs.rss_log.updated_at

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -86,6 +86,12 @@ class InatImportJobTest < ActiveJob::TestCase
     assert_equal(@user.unique_text_name, obs.collector)
     assert_equal(@user.id, obs.collector_user_id)
 
+    # New imports are read-only reflections (#4214): reflected_at is
+    # stamped at creation, so scalar-core edits are blocked until the
+    # value is changed at the source and resynced (#4215).
+    assert_not_nil(obs.reflected_at, "Import should stamp reflected_at")
+    assert(obs.reflection?, "A new import should be a read-only reflection")
+
     assert_equal(before_total_imported_count + 1,
                  @inat_import.reload.total_imported_count,
                  "Failed to update user's inat_import count")

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -2110,6 +2110,21 @@ class ObservationTest < UnitTestCase
     assert(obs.source_noteworthy?)
   end
 
+  # reflection? is driven solely by reflected_at (#4214) — an import
+  # link alone doesn't lock an obs, so the existing editable backlog
+  # stays editable until the resolution engine stamps it.
+  def test_reflection_predicate
+    obs = observations(:imported_inat_obs)
+    assert_not(obs.reflection?,
+               "an import without reflected_at is still editable")
+
+    obs.update_column(:reflected_at, Time.zone.now)
+    assert(obs.reflection?, "reflected_at present marks a read-only reflection")
+
+    obs.update_column(:reflected_at, nil)
+    assert_not(obs.reflection?)
+  end
+
   # ----- Coverage gap tests for app/models/observation.rb -----
 
   # field_slip= is a no-op when the slip arg is nil — the early

--- a/test/views/controllers/observations/external_links/info_frame_test.rb
+++ b/test/views/controllers/observations/external_links/info_frame_test.rb
@@ -67,6 +67,27 @@ module Views::Controllers::Observations::ExternalLinks
       assert_no_html(html, "button.destroy_external_link_link_#{link.id}")
     end
 
+    # A read-only reflection's own link can't be edited or destroyed on
+    # MO at all (#4214) -- no InlineCRUDLinks, just a note pointing at
+    # the source, even for a viewer who'd otherwise have permission.
+    def test_reflection_shows_read_only_note_not_mod_links
+      link = external_links(:coprinus_comatus_obs_inaturalist_link)
+      obs = link.observation
+      user = users(:rolf)
+      assert(link.can_edit?(user),
+             "Need a user fixture with edit permission on this link")
+      obs.update_column(:reflected_at, Time.zone.now)
+
+      html = render(frame_with(obs: obs, site_links: [link], user: user))
+
+      assert_html(html, ".reflection-read-only-note",
+                  text: :observation_reflection_read_only_note.l)
+      assert_no_html(html, "button.destroy_external_link_link_#{link.id}")
+      assert_no_html(
+        html, "a[data-modal='modal_#{link.type_tag}_#{link.id}']"
+      )
+    end
+
     private
 
     def sibling_link(link, observation)

--- a/test/views/layouts/header/edit_delete_icons_test.rb
+++ b/test/views/layouts/header/edit_delete_icons_test.rb
@@ -37,5 +37,16 @@ module Views::Layouts
 
       assert_html(html, "ul.object_edit li", count: 2)
     end
+
+    # A read-only reflection (#4214) drops the edit icon (its scalar core
+    # can't be edited on MO) but keeps delete — a separate lifecycle.
+    def test_reflection_suppresses_edit_icon_but_keeps_delete
+      @obs.update_column(:reflected_at, Time.zone.now)
+      html = render(Header::EditDeleteIcons.new(object: @obs, user: @owner))
+
+      assert_html(html, "ul.object_edit li", count: 1)
+      assert_no_html(html, "a[href$='/edit']",
+                     "a reflection should have no edit-form link")
+    end
   end
 end


### PR DESCRIPTION
Part of #4214 / #4208. **Slice 1** of the read-only-reflection work — the first half of the "read-only reflections + resync" pair. This ships together with the resync PR (slice 2): read-only only makes sense once "edit it at the source and resync" is a real path, so **this must not deploy on its own.**

## What this does

A newly imported iNat observation is a clean reflection of its source by construction. The importer now stamps `reflected_at` at creation (`Inat::MoObservationBuilder#new_obs_params`), and `Observation#reflection?` reports it.

Reflection status keys on `reflected_at`, **not** on merely having an import link — so the existing ~50k editable import backlog is untouched, and nothing is retroactively locked. The #4585 resolution engine stamps the verified backlog later; new imports are stamped up front because they're clean by definition.

Read-only is enforced only on the observation's own scalar-core edit, at both entry points a user can reach:

- web `edit` / `update` (`observations_controller/edit_and_update.rb`) redirect to the show page with a warning flash;
- API2's observation update setter (`API2::ObservationAPI#build_setter`) raises a new `API2::ObservationIsReadOnly`.

It is deliberately **not** a blanket `ActiveRecord#readonly?`. Adding namings/votes/comments/images is still allowed on a reflection, and those operations write cached state back onto the observations row (`vote_cache`, `name_id`, `thumb_image_id`, `updated_at`) — a record-level lock would wrongly block them. The guard sits on the scalar-core edit action only.

UI: the imported-source banner gains a read-only note, and the show-page edit icon is suppressed for reflections (delete is a separate lifecycle concern and stays).

## Test plan

On a dev DB with production data:

1. **New imports are read-only.** Import one of your own iNat observations through the normal iNat-import flow. On the resulting MO observation's show page, confirm the imported-source banner now shows the "Read-only reflection…" note, and there is **no edit (pencil) icon** in the title bar (the delete icon remains).
2. **Editing is blocked (web).** Visit `/observations/<that id>/edit` directly. You should be redirected to the show page with a warning flash ("…read-only reflection of its imported source…"), even though you own it.
3. **Editing is blocked (API2).** `PATCH` that observation via API2 (`/api2/observations?...&set_date=2012-12-12&api_key=<yours>`). It should fail with an `ObservationIsReadOnly` error and leave the record unchanged.
4. **The backlog is untouched.** Any pre-existing imported observation (one whose `reflected_at` is still `NULL`) edits exactly as before — banner shows no read-only note, edit icon present, edit form works.
5. **Satellite adds still work on a reflection.** On a read-only reflection, propose a naming / add a comment / add an image — all should succeed (only the observation's own fields are locked).

To exercise (2)–(5) without running an import, take any imported observation and set `reflected_at` (e.g. `Observation.find(<id>).update_column(:reflected_at, Time.current)`), then try the above.
