### PR TITLE
Extract `Components::ApplicationForm::FieldWrapperRendering`

### DIFF
--- a/app/components/application_form/field_wrapper_rendering.rb
+++ b/app/components/application_form/field_wrapper_rendering.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class Components::ApplicationForm < Superform::Rails::Form
+  # Shared field-wrapper skeleton: the form-group div, its Bootstrap
+  # classes, and the label -> prepend -> [field content] -> help ->
+  # append rendering order. Every simple field type (TextField,
+  # TextareaField, ...) wants this same skeleton; only the field
+  # content itself (an <input>, a <textarea>, ...) differs.
+  #
+  # `prepend`/`append` are optional per field type -- declare
+  # `slot :prepend` (via Phlex::Slotable) only on the types that need
+  # it. Guarded with `respond_to?`, the same pattern FieldLabelRow
+  # already uses for `label_end_slot`.
+  module FieldWrapperRendering
+    attr_reader :wrapper_options
+
+    def show_label?
+      wrapper_options[:label] != false
+    end
+
+    def inline?
+      wrapper_options[:inline] || false
+    end
+
+    def wrapper_class
+      form_group_class("form-group", inline?, wrapper_options[:wrap_class])
+    end
+
+    def form_group_class(base, inline, wrap_class)
+      classes = base
+      classes += " form-inline" if inline && base == "form-group"
+      classes += " #{wrap_class}" if wrap_class.present?
+      classes
+    end
+
+    def prepend_present?
+      respond_to?(:prepend_slot) && prepend_slot
+    end
+
+    def append_present?
+      respond_to?(:append_slot) && append_slot
+    end
+
+    def render_with_wrapper
+      div(class: wrapper_class, data: wrapper_options[:wrap_data]) do
+        render_label_row(label_text, inline?) if show_label?
+        render(prepend_slot) if prepend_present?
+        yield
+        render_help_after_field
+        render(append_slot) if append_present?
+      end
+    end
+  end
+end

--- a/app/components/application_form/field_wrapper_rendering.rb
+++ b/app/components/application_form/field_wrapper_rendering.rb
@@ -14,6 +14,8 @@ class Components::ApplicationForm < Superform::Rails::Form
   module FieldWrapperRendering
     attr_reader :wrapper_options
 
+    private
+
     def show_label?
       wrapper_options[:label] != false
     end

--- a/app/components/application_form/text_field.rb
+++ b/app/components/application_form/text_field.rb
@@ -6,6 +6,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     include Phlex::Slotable
     include FieldWithHelp
     include FieldLabelRow
+    include FieldWrapperRendering
     include InputGroupAddon
 
     slot :between
@@ -15,8 +16,6 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     # Make slot accessors public (Phlex::Slotable makes them private by default)
     public :between_slot, :label_end_slot, :append_slot, :help_slot
-
-    attr_reader :wrapper_options
 
     def initialize(field, wrapper_options: {}, **attributes)
       super(field, **attributes)
@@ -29,38 +28,19 @@ class Components::ApplicationForm < Superform::Rails::Form
                                                "form-control"))
       else
         render_with_wrapper do
-          input(**attributes, class: class_names(attributes[:class],
-                                                 "form-control"))
+          render_field_input do
+            input(**attributes, class: class_names(attributes[:class],
+                                                   "form-control"))
+          end
         end
       end
     end
 
     private
 
-    def render_with_wrapper(&field_input)
-      div(class: wrapper_class, data: wrapper_options[:wrap_data]) do
-        render_label_row(label_text, inline?) if show_label?
-        render_field_input(&field_input)
-        render_help_after_field
-        render(append_slot) if append_slot
-      end
-    end
-
     def bare_input?
       attributes[:type] == "hidden" ||
         (wrapper_options[:label] == false && !help_slot)
-    end
-
-    def show_label?
-      wrapper_options[:label] != false
-    end
-
-    def inline?
-      wrapper_options[:inline] || false
-    end
-
-    def wrapper_class
-      form_group_class("form-group", inline?, wrapper_options[:wrap_class])
     end
 
     def render_field_input(&block)
@@ -71,13 +51,6 @@ class Components::ApplicationForm < Superform::Rails::Form
       else
         yield
       end
-    end
-
-    def form_group_class(base, inline, wrap_class)
-      classes = base
-      classes += " form-inline" if inline && base == "form-group"
-      classes += " #{wrap_class}" if wrap_class.present?
-      classes
     end
   end
 end

--- a/app/components/application_form/textarea_field.rb
+++ b/app/components/application_form/textarea_field.rb
@@ -6,6 +6,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     include Phlex::Slotable
     include FieldWithHelp
     include FieldLabelRow
+    include FieldWrapperRendering
 
     slot :between
     slot :label_end
@@ -16,8 +17,6 @@ class Components::ApplicationForm < Superform::Rails::Form
     # Make slot accessors public (Phlex::Slotable makes them private by default)
     public :between_slot, :label_end_slot, :prepend_slot, :append_slot,
            :help_slot
-
-    attr_reader :wrapper_options
 
     def initialize(field, wrapper_options: {}, **attributes)
       super(field, **attributes)
@@ -42,38 +41,6 @@ class Components::ApplicationForm < Superform::Rails::Form
     def textarea_class
       mono = "text-monospace" if wrapper_options[:monospace]
       class_names(attributes[:class], "form-control", mono)
-    end
-
-    def render_with_wrapper
-      div(class: wrapper_class, data: wrapper_options[:wrap_data]) do
-        render_label_row(label_text, inline?) if show_label?
-        # `prepend` renders between the label row and the field itself
-        # (symmetric with `append`, which renders after the field) --
-        # e.g. a full-width control that drives the field.
-        render(prepend_slot) if prepend_slot
-        yield
-        render_help_after_field
-        render(append_slot) if append_slot
-      end
-    end
-
-    def show_label?
-      wrapper_options[:label] != false
-    end
-
-    def inline?
-      wrapper_options[:inline] || false
-    end
-
-    def wrapper_class
-      form_group_class("form-group", inline?, wrapper_options[:wrap_class])
-    end
-
-    def form_group_class(base, inline, wrap_class)
-      classes = base
-      classes += " form-inline" if inline && base == "form-group"
-      classes += " #{wrap_class}" if wrap_class.present?
-      classes
     end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up flagged in [PR #4842's discussion](https://github.com/MushroomObserver/mushroom-observer/pull/4842#issuecomment-5014819805): `TextField` and `TextareaField` had byte-for-byte identical `show_label?`, `inline?`, `wrapper_class`, and `form_group_class` methods, plus a near-identical `render_with_wrapper` (`label -> [prepend] -> field content -> help -> append`). #4842 added a `:prepend` slot to `TextareaField` only, since that PR's scope didn't touch `TextField` — the same duplication would recur the next time a text field needed the same slot.

## What changed

- New `Components::ApplicationForm::FieldWrapperRendering` module (`app/components/application_form/field_wrapper_rendering.rb`), sibling to `FieldLabelRow`/`FieldWithHelp` — owns the shared wrapper skeleton.
- `prepend`/`append` presence is guarded via `respond_to?`, the same pattern `FieldLabelRow` already uses for `label_end_slot` — a field type that doesn't declare `slot :prepend` just no-ops instead of needing its own override.
- `TextField` and `TextareaField` both `include FieldWrapperRendering` and drop their now-duplicate methods.

No behavior change — this is a pure extraction.

## Test plan

- [x] `bundle exec rubocop` clean on all 3 touched files
- [x] `bin/rails test test/components/application_form_test.rb test/components/application_form_helper_parity_test.rb test/components/form/search_test.rb test/components/form/notes_test.rb test/components/application_form/ test/components/autocompleter_field_test.rb` — 208 tests, 0 failures (covers both field types directly, plus `AutocompleterField`, which composes `TextField`/`TextareaField` and forwards slots into them)
