### PR TITLE
Fix GPS-leak race between image file rewrites (`strip_gps!`, rotate) and `TransferImagesJob`

### DIFF
--- a/app/jobs/rotate_image_job.rb
+++ b/app/jobs/rotate_image_job.rb
@@ -9,6 +9,10 @@
 class RotateImageJob < ApplicationJob
   queue_as(:default)
 
+  # See TransferImagesJob -- a rotate can block on the same row lock
+  # behind an in-flight transfer or an earlier rotate of the same image.
+  retry_on ActiveRecord::LockWaitTimeout, wait: 30.seconds, attempts: 5
+
   def perform(image_id, ext, orientation)
     image = Image.find_by(id: image_id)
     return unless image

--- a/app/jobs/transfer_images_job.rb
+++ b/app/jobs/transfer_images_job.rb
@@ -9,6 +9,13 @@
 class TransferImagesJob < ApplicationJob
   queue_as(:default)
 
+  # Each image's transfer serializes on its row lock with the writers
+  # that rewrite its files in place (Image#strip_gps!,
+  # Image::Processor#rotate -- see Verifier#transfer_image). A slow
+  # re-render can hold the lock past MySQL's wait timeout; requeue
+  # instead of failing the transfer permanently.
+  retry_on ActiveRecord::LockWaitTimeout, wait: 30.seconds, attempts: 5
+
   def perform(image_ids:)
     result = Image::Processor.transfer_images(image_ids) { |msg| log(msg) }
     log("Uploaded #{result[:uploaded].size}, " \

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -965,17 +965,35 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
 
   # Attempt to strip GPS data from original image. Returns error message as
   # string if it fails.
+  #
+  # Runs under the image's row lock, serialized with
+  # Image::Processor::Verifier#transfer_image -- see the GPS-leak
+  # rationale there. Under the lock, `transferred` is the transfer's
+  # settled state: still local means the strip rewrote files the
+  # in-flight/pending upload predates, so re-enqueue TransferImagesJob
+  # (idempotent) to push the stripped set.
   def strip_gps!
     return nil if gps_stripped
 
+    error = nil
+    with_lock do
+      break if gps_stripped # may have flipped while waiting for the lock
+
+      error = run_strip_exif_script
+      unless error
+        update_attribute(:gps_stripped, true)
+        TransferImagesJob.perform_later(image_ids: [id]) unless transferred
+      end
+    end
+    error
+  end
+
+  def run_strip_exif_script
     # Pass the worker-specific image root for parallel testing
     env = { "MO_IMAGE_ROOT" => MO.local_image_files }
     output, status = Open3.capture2e(env, "script/strip_exif", id.to_s,
                                      transferred ? "1" : "0")
-    return output unless status.success?
-
-    update_attribute(:gps_stripped, true)
-    nil
+    status.success? ? nil : output
   end
 
   # Get exif data from image by reading the header straight off the file,

--- a/app/models/image/processor.rb
+++ b/app/models/image/processor.rb
@@ -85,12 +85,21 @@ class Image
       compute_dhash
     end
 
+    # Holds the image's row lock for the whole fetch/transform/re-render:
+    # rotation rewrites every local file in place, the same shape as the
+    # GPS strip -- see Verifier#transfer_image for the interleavings this
+    # serialization prevents (here it's the server silently keeping the
+    # pre-rotate renditions while the rotated local set is deleted).
+    # RotateImageJob re-enqueues TransferImagesJob afterward, so the
+    # stranded interleaving self-heals just like strip_gps!'s.
     def rotate(orientation)
-      make_sure_we_have_full_size_locally
-      reset_file_orientation
-      transform_full_size_file(orientation)
-      update_image_record_width_height_and_transferred
-      process
+      @image.with_lock do
+        make_sure_we_have_full_size_locally
+        reset_file_orientation
+        transform_full_size_file(orientation)
+        update_image_record_width_height_and_transferred
+        process
+      end
     end
 
     # Fetches the original back from whichever configured server has it,

--- a/app/models/image/processor/verifier.rb
+++ b/app/models/image/processor/verifier.rb
@@ -50,7 +50,22 @@ class Image
 
       private
 
+      # The whole stat/upload/confirm/delete sequence holds the image's
+      # row lock, serialized with Image#strip_gps! (and any concurrent
+      # transfer of the same image). strip_gps! rewrites orig/<id>.* in
+      # place; unserialized, it can interleave here so the confirm
+      # compares pre-strip sizes on both ends, deletes the just-stripped
+      # local set, and leaves the server holding the pre-strip original
+      # -- real GPS the user asked to hide, with nothing left on disk for
+      # StaleImageFilesJob to flag. Locking only the confirm/delete step
+      # wouldn't close it: a second transfer that statted the files
+      # pre-strip could still push the pre-strip original after the
+      # stripped one was confirmed and the local copies deleted.
       def transfer_image(image)
+        image.with_lock { locked_transfer_image(image) }
+      end
+
+      def locked_transfer_image(image)
         paths = paths_for(image)
         local_sizes = paths.index_with { |path| local_size(path) }
         # Still mid-#process (a size hasn't been generated locally yet) --

--- a/script/strip_exif
+++ b/script/strip_exif
@@ -27,8 +27,9 @@ DESCRIPTION
   This attempts to strip the GPS data from the EXIF header of the original
   image. If it is stored locally, easy-peasy. If it has already been
   transferred, then it runs the strip command remotely on the image server.
-  If it has been moved to Digital Ocean object store, then we return an
-  error message and tell the user to re-upload the image.
+  Copies archived to Google Cloud Storage (mo-image-archive-bucket) are
+  NOT touched -- once an original only exists there, this script can't
+  strip it.
 
 END
 

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -179,6 +179,72 @@ class ImageTest < UnitTestCase
     end
   end
 
+  # A local strip rewrites files that any in-flight/pending upload
+  # predates (see Image::Processor::Verifier#transfer_image for the
+  # race), so it must re-enqueue the transfer to push the stripped set.
+  def test_strip_gps_local_image_strips_and_reenqueues_transfer
+    img = images(:in_situ_image)
+    captured = nil
+    fake_capture2e = lambda do |_env, *args|
+      captured = args
+      ["", stub_status(true)]
+    end
+
+    Open3.stub(:capture2e, fake_capture2e) do
+      assert_enqueued_with(job: TransferImagesJob,
+                           args: [{ image_ids: [img.id] }]) do
+        assert_nil(img.strip_gps!)
+      end
+    end
+
+    assert_equal(["script/strip_exif", img.id.to_s, "0"], captured)
+    assert_true(img.reload.gps_stripped)
+  end
+
+  # An already-transferred image is stripped server-side -- nothing
+  # local to push, so no transfer job.
+  def test_strip_gps_transferred_image_strips_remotely_without_enqueue
+    img = images(:in_situ_image)
+    img.update_columns(transferred: true)
+    captured = nil
+    fake_capture2e = lambda do |_env, *args|
+      captured = args
+      ["", stub_status(true)]
+    end
+
+    Open3.stub(:capture2e, fake_capture2e) do
+      assert_no_enqueued_jobs { assert_nil(img.strip_gps!) }
+    end
+
+    assert_equal(["script/strip_exif", img.id.to_s, "1"], captured)
+    assert_true(img.reload.gps_stripped)
+  end
+
+  def test_strip_gps_failure_marks_nothing_and_enqueues_nothing
+    img = images(:in_situ_image)
+
+    Open3.stub(:capture2e, ["boom", stub_status(false)]) do
+      assert_no_enqueued_jobs { assert_equal("boom", img.strip_gps!) }
+    end
+
+    assert_false(img.reload.gps_stripped)
+  end
+
+  def test_strip_gps_noop_when_already_stripped
+    img = images(:in_situ_image)
+    img.update_columns(gps_stripped: true)
+
+    Open3.stub(:capture2e, ->(*) { raise("must not shell out") }) do
+      assert_no_enqueued_jobs { assert_nil(img.strip_gps!) }
+    end
+  end
+
+  def stub_status(success)
+    status = Object.new
+    status.define_singleton_method(:success?) { success }
+    status
+  end
+
   # dHash is computed from the small local rendition — never the full-size
   # original, whose ImageMagick decode can exhaust the host (#4796).
   def test_compute_dhash_uses_small_local_rendition


### PR DESCRIPTION
## Summary

`Image#strip_gps!` rewrites `orig/<id>.*` in place (via `script/strip_exif`) during observation create/update when `gps_hidden` is set. The image's `TransferImagesJob` — enqueued when the async upload finished, seconds earlier — can be mid-transfer for the same image at that moment. The two interleavings of that race:

- **Strand (observed, benign):** rsync reads the orig *after* the strip, so the post-upload verify sees a size that no longer matches the pre-strip local snapshot — `Image::Processor::Verifier` returns without deleting or marking, nothing retries, and `StaleImageFilesJob` flags the leftovers an hour later. This is exactly what happened to image 2043471 on 2026-07-20 (`job.log`: `Uploaded 6, deleted 0, completed 0, failed 0`; the observation POST with `gps_hidden=1` ran 01:24:44.87–47.05 UTC, overlapping the transfer's 01:24:46–52 upload window).
- **Leak (silent, the dangerous one):** rsync reads the orig *before* the strip. Both sides of the verify then hold pre-strip sizes, so the Verifier confirms, deletes the just-stripped local set, and marks the image transferred — leaving the image server permanently holding the **unstripped** original with the real coordinates the user asked to hide, with nothing left on disk for `StaleImageFilesJob` to notice.

## Fix

Serialize the two writers on the image's DB row lock (`with_lock`):

- `Verifier#transfer_image` holds the lock across the whole stat/upload/confirm/delete sequence (locking only the confirm step would still let a second transfer that statted pre-strip push the pre-strip original afterward).
- `strip_gps!` takes the same lock, so it sees the transfer's settled state: already `transferred` → strips the server copy remotely (existing `strip_exif` path); still local → strips locally and **re-enqueues `TransferImagesJob`** (idempotent), so the stranded case now self-heals instead of waiting on the hourly alert.
- `Image::Processor#rotate` rewrites every local file in place — the same race shape (here the leak-shaped interleaving silently keeps the pre-rotate renditions on the server while the rotated local set is deleted). It now holds the same lock across the whole fetch/transform/re-render; `RotateImageJob`'s existing trailing `TransferImagesJob` heals the stranded interleaving the same way `strip_gps!`'s re-enqueue does.
- A slow re-render can hold the lock past MySQL's wait timeout, so `TransferImagesJob` and `RotateImageJob` `retry_on ActiveRecord::LockWaitTimeout` instead of failing permanently.

Worst-case cost: an obs create with `gps_hidden` blocks on the lock for the duration of one in-flight image transfer (~6s observed) — only when the form is submitted within seconds of the upload finishing. A transfer behind a long rotate re-render requeues rather than blocking a worker thread past the DB timeout.

## Test plan

- On a branch deploy (or dev with a writable image server configured), upload a photo on the observation form and submit the form with "hide coordinates" checked immediately, before the transfer job finishes. Check `log/job.log`: the first `TransferImagesJob` should complete or strand, and if it stranded, a second `TransferImagesJob` (enqueued by the strip) should finish with `completed 1`. Run `exiftool` on the image server's `orig/<id>.jpg` — no GPS tags — and confirm no `StaleImageFilesJob` alert follows on the next hour.
- Rotate an image on the image show page immediately after uploading it (while its transfer is still in flight): the rotation should stick (image server ends up with the rotated renditions after the rotate's own `TransferImagesJob` runs), with no stale-file alert afterward.

## Follow-up (not in this PR)

- One-time audit: `gps_hidden` observations whose images are `transferred` + `gps_stripped` — verify server-side originals actually carry no GPS tags (detects any past occurrences of the leak interleaving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
