### PR TITLE
Add weekly `GpsLeakDetectorJob` tripwire + re-archiving `rclone_originals.sh`

### DIFF
--- a/app/jobs/gps_leak_detector_job.rb
+++ b/app/jobs/gps_leak_detector_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Weekly tripwire (#4859): directly checks recently-uploaded gps_hidden
+# originals on the image server(s) for GPS tags that survived the strip
+# pipeline. Alert-only -- a hit means a #4858-class mechanism is back and
+# needs investigating, not silent auto-fixing. The 14-day window with a
+# weekly schedule scans every image at least once after its transfer has
+# settled (untransferred images are skipped here; their originals are
+# still local, a window the transfer/stale-files pipeline owns, and they
+# land in next week's run).
+class GpsLeakDetectorJob < ApplicationJob
+  queue_as(:maintenance)
+
+  WINDOW = 14.days
+
+  def perform
+    images = candidates
+    return log("No recent gps_hidden images to check") if images.empty?
+
+    hit_ids = Image::Processor.detect_gps_leaks(images) { |msg| log(msg) }
+    if hit_ids.empty?
+      log("Checked #{images.size} recent gps_hidden image(s): clean")
+    else
+      alert("#{hit_ids.size} gps_hidden image(s) still carry GPS on the " \
+            "image server (see issue #4859 for the known mechanisms and " \
+            "remediation tooling): ids #{hit_ids}")
+    end
+  end
+
+  private
+
+  def candidates
+    Image.joins(observation_images: :observation).
+      where(observations: { gps_hidden: true }).
+      where(transferred: true).
+      where(created_at: WINDOW.ago..).
+      distinct.to_a
+  end
+end

--- a/app/models/image/processor.rb
+++ b/app/models/image/processor.rb
@@ -141,6 +141,13 @@ class Image
       GapDetector.new(&log).run
     end
 
+    # Tripwire scan of the given images' originals on the image
+    # server(s) for GPS tags that survived stripping -- see GpsLeakScan
+    # and GpsLeakDetectorJob (#4859).
+    def self.detect_gps_leaks(images, &log)
+      GpsLeakScan.new(&log).scan(images)
+    end
+
     # Strips GPS/geotag data from an image's original file synchronously,
     # before the image is exposed anywhere -- this can't wait on the
     # deferred resize/transfer pipeline in #process, which may run much

--- a/app/models/image/processor/gps_leak_scan.rb
+++ b/app/models/image/processor/gps_leak_scan.rb
@@ -23,6 +23,10 @@ class Image
       GPS_CONDITION = "$GPS:GPSLatitude or $GPS:GPSLongitude or " \
                       "$XMP:GPSLatitude or $XMP:GPSLongitude"
       CHUNK = 400
+      # BatchMode fails fast instead of hanging on a password/host-key
+      # prompt; without these a single dead host could wedge the
+      # recurring job's worker indefinitely.
+      SSH_OPTIONS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10"].freeze
 
       def initialize(&log)
         @log = log
@@ -68,7 +72,8 @@ class Image
       def remote_gps_hits(server, host, full_paths)
         command = "exiftool -q -q -m -fast2 -if '#{GPS_CONDITION}' " \
                   "-p '$directory/$filename' #{full_paths.join(" ")}"
-        output, error, _status = Open3.capture3("ssh", host, command)
+        output, error, _status =
+          Open3.capture3("ssh", *SSH_OPTIONS, host, command)
         report_real_errors(server, host, error)
         output.lines.filter_map { |line| line[%r{/(\d+)\.\w+\s*\z}, 1]&.to_i }
       end

--- a/app/models/image/processor/gps_leak_scan.rb
+++ b/app/models/image/processor/gps_leak_scan.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require("open3")
+
+class Image
+  class Processor
+    # Tripwire scan for GPS tags that survived the strip pipeline
+    # (GitHub issue #4859): checks the given images' original files ON
+    # the ssh-type image server(s), where the served copies live, via
+    # one remote exiftool call per chunk of paths. Header-only reads
+    # (-fast2, EXIF/XMP sit at the front of a JPEG), so scanning a
+    # couple of weeks of gps_hidden uploads costs seconds.
+    #
+    # Why this exists: three separate mechanisms (the pre-#4791
+    # verify_images 4am "repair", the pre-#4858 strip/transfer race,
+    # and the strip-vs-first-archival race) each silently restored or
+    # preserved GPS on files every DB flag said were clean, for years.
+    # Only a periodic check of the actual served bytes catches the
+    # class rather than a known instance.
+    class GpsLeakScan
+      # Truthiness, not `defined` -- with -m an absent tag interpolates
+      # to "" (which IS defined), so `defined $tag` matches every file.
+      GPS_CONDITION = "$GPS:GPSLatitude or $GPS:GPSLongitude or " \
+                      "$XMP:GPSLatitude or $XMP:GPSLongitude"
+      CHUNK = 400
+
+      def initialize(&log)
+        @log = log
+        @image_server_data = Processor.image_server_data
+      end
+
+      # Returns ids of images whose orig file still carries GPS lat/lng
+      # on any ssh image server.
+      def scan(images)
+        paths = images.flat_map { |image| paths_for(image) }
+        return [] if paths.empty?
+
+        ssh_servers.flat_map { |server| hits_on(server, paths) }.uniq.sort
+      end
+
+      private
+
+      def ssh_servers
+        @image_server_data.select do |_server, data|
+          data[:type] == "ssh" && data[:subdirs].include?("orig")
+        end.keys
+      end
+
+      def paths_for(image)
+        paths = ["orig/#{image.id}.jpg"]
+        ext = image.original_extension
+        paths << "orig/#{image.id}.#{ext}" if ext != "jpg"
+        paths
+      end
+
+      def hits_on(server, paths)
+        host, root = @image_server_data[server][:path].split(":", 2)
+        paths.each_slice(CHUNK).flat_map do |chunk|
+          remote_gps_hits(server, host, chunk.map { |p| "#{root}/#{p}" })
+        end
+      end
+
+      # Hits come back one path per line. A missing file is routine
+      # (files can be re-uploaded/renamed between candidate query and
+      # scan) -- exiftool reports it on stderr and exits non-zero, the
+      # same as when no file matches the -if, so the exit status is
+      # ignored and only non-"File not found" stderr is worth logging.
+      def remote_gps_hits(server, host, full_paths)
+        command = "exiftool -q -q -m -fast2 -if '#{GPS_CONDITION}' " \
+                  "-p '$directory/$filename' #{full_paths.join(" ")}"
+        output, error, _status = Open3.capture3("ssh", host, command)
+        report_real_errors(server, host, error)
+        output.lines.filter_map { |line| line[%r{/(\d+)\.\w+\s*\z}, 1]&.to_i }
+      end
+
+      def report_real_errors(server, host, error)
+        real = error.lines.reject { |line| line.include?("File not found") }
+        return if real.empty?
+
+        log("Errors checking #{host} for #{server}: #{real.join}")
+      end
+
+      def log(msg)
+        @log&.call(msg)
+      end
+    end
+  end
+end

--- a/config/etc/README.md
+++ b/config/etc/README.md
@@ -1,0 +1,40 @@
+# config/etc — deployed-infrastructure copies of record
+
+Files in this directory are **not** executed or loaded from the repo
+checkout. Each one is the checked-in copy of record for a piece of
+system configuration that is deployed by hand to its real location on
+one of MO's machines. They live here so that infrastructure changes get
+the same review, history, and searchability as application code — and
+so audits can read what production is (supposed to be) running without
+logging into a server (see issue #4859 for a case where a server-only
+script's behavior took an afternoon of forensics to reconstruct).
+
+Two rules:
+
+1. **When you change a file here, deploy it; when you change the
+   deployed copy, backport it here.** Nothing syncs these
+   automatically, and a divergent repo copy is worse than none — it
+   reads as authoritative and isn't.
+2. **New server-side config belongs here, not only on the server.**
+   `rclone_originals.sh` lived solely on the images server for years;
+   its once-only-archival design flaw stayed invisible until #4859.
+
+## Where each file goes
+
+| File | Machine | Deployed location / how |
+|---|---|---|
+| `crontab` | web server | `mo`'s crontab (`crontab config/etc/crontab` as `mo`) |
+| `nginx.conf` | web server | `/etc/nginx/nginx.conf` |
+| `nginx_dev.conf` | local dev | nginx config for a dev setup |
+| `puma.service` | web server | `/etc/systemd/system/puma.service` |
+| `solidqueue.service` | web server | `/etc/systemd/system/solidqueue.service` |
+| `rclone_originals.sh` | images server | `/data/images/mo/rclone/rclone_originals.sh`, run by `mo`'s crontab there (`15 1 * * *`) — nightly originals→GCS archive sync |
+| `bash_aliases.sh` | web server | sourced from `mo`'s shell profile |
+| `no-reply.forward` | web server | `~no-reply/.forward` — pipes mail to the autoreply |
+| `no-reply.autoreply` | web server | autoreply body sent for mail to no-reply@ |
+| `no-reply.muttrc` | web server | `~no-reply/.muttrc` for the autoreply pipeline |
+| `indexmaker` | web server | MRTG 2.17.4 index generator (traffic-graph pages) |
+| `unicorn` | — | obsolete init script from the pre-puma era; kept for history |
+
+If a location above is wrong or has drifted, fix the table — it is only
+as useful as it is accurate.

--- a/config/etc/rclone_originals.sh
+++ b/config/etc/rclone_originals.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Nightly originals -> Google Cloud Storage archive sync. Deployed on
+# the IMAGES server (images.mushroomobserver.org) at
+# /data/images/mo/rclone/rclone_originals.sh, run by mo's crontab:
+#   15 1 * * * /data/images/mo/rclone/rclone_originals.sh
+#
+# `rclone copy` compares size+modtime for every local orig against the
+# bucket and uploads what's new OR modified. This replaces the original
+# once-only orig.done-ledger version (kept in ~mo's rclone dir until
+# 2026-07), whose one-shot design meant post-archival modifications --
+# remote GPS strips, rotations pushed by TransferImagesJob -- never
+# reached the archive; issue #4859 documents the ~9,700-image cleanup
+# that followed. The ledger files (orig.done etc.) are now unused.
+#
+# NEVER change `copy` to `sync`: the bucket holds pre-cutover originals
+# (id < next_image_id_to_go_to_cloud) whose server copies are deliberately
+# deleted -- sync would delete them from the archive too.
+#
+# Cost: the nightly listing of the bucket (~2M objects) is ~2000 list
+# calls, pennies; uploads are free ingress.
+
+root=/data/images/mo
+bucket=mo-image-archive-bucket
+log=$root/rclone/rclone_originals.log
+
+# fresh log each night -- INFO logs one line per uploaded file
+rm -f "$log"
+rclone --config /home/mo/.config/rclone/rclone.conf \
+  copy "$root/orig" "google:$bucket/orig" \
+  --log-file "$log" --log-level INFO
+
+exit 0

--- a/config/etc/rclone_originals.sh
+++ b/config/etc/rclone_originals.sh
@@ -26,8 +26,8 @@ log=$root/rclone/rclone_originals.log
 
 # fresh log each night -- INFO logs one line per uploaded file
 rm -f "$log"
+# rclone is the last command so its exit status is the script's --
+# cron/operators can detect a failed sync instead of a masking exit 0.
 rclone --config /home/mo/.config/rclone/rclone.conf \
   copy "$root/orig" "google:$bucket/orig" \
   --log-file "$log" --log-level INFO
-
-exit 0

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -54,6 +54,16 @@ production:
   image_gap_detector:
     class: ImageGapDetectorJob
     schedule: every day at 7:33am
+  # Weekly GPS-leak tripwire (#4859): scans the last two weeks'
+  # gps_hidden originals on the image server for GPS tags that survived
+  # stripping. History -- three separate mechanisms silently re-leaked
+  # ~9,700 images over 2019-2026 while every DB flag read clean -- says
+  # only a periodic check of the actual served bytes catches the class.
+  # Staggered off the other maintenance slots and the every-3-minutes
+  # marks, same reasoning as above.
+  gps_leak_detector:
+    class: GpsLeakDetectorJob
+    schedule: every monday at 4:43am
   check_for_broken_references:
     class: CheckForBrokenReferencesJob
     schedule: every sunday at 7:13am

--- a/test/jobs/gps_leak_detector_job_test.rb
+++ b/test/jobs/gps_leak_detector_job_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class GpsLeakDetectorJobTest < ActiveJob::TestCase
+  def setup
+    super
+    @image = images(:in_situ_image)
+    # in_situ_image belongs to minimal_unknown, which isn't gps_hidden;
+    # make it a candidate: hidden obs, transferred, uploaded this week.
+    @image.observations.first.update_columns(gps_hidden: true)
+    @image.update_columns(transferred: true, created_at: 2.days.ago)
+  end
+
+  def test_alerts_with_ids_when_gps_found
+    scanned = nil
+    fake_scan = lambda do |images, &_log|
+      scanned = images
+      [@image.id]
+    end
+
+    alerts = Image::Processor.stub(:detect_gps_leaks, fake_scan) do
+      capture_alerts { GpsLeakDetectorJob.perform_now }
+    end
+
+    assert_equal(1, alerts.size)
+    assert_includes(alerts.first.message, "1 gps_hidden image(s)")
+    assert_includes(alerts.first.message, "[#{@image.id}]")
+    assert_includes(alerts.first.message, "#4859")
+    assert_includes(scanned, @image)
+  end
+
+  def test_no_alert_when_scan_is_clean
+    alerts = Image::Processor.stub(:detect_gps_leaks, ->(_i, &_l) { [] }) do
+      capture_alerts { GpsLeakDetectorJob.perform_now }
+    end
+
+    assert_empty(alerts)
+  end
+
+  def test_candidate_scoping
+    old = images(:turned_over_image)
+    old.observations.first.update_columns(gps_hidden: true)
+    old.update_columns(transferred: true, created_at: 3.months.ago)
+    untransferred = images(:commercial_inquiry_image)
+    untransferred.update_columns(transferred: false, created_at: 1.day.ago)
+
+    scanned = nil
+    Image::Processor.stub(:detect_gps_leaks, lambda { |images, &_log|
+      scanned = images
+      []
+    }) do
+      capture_alerts { GpsLeakDetectorJob.perform_now }
+    end
+
+    assert_includes(scanned, @image)
+    assert_not_includes(scanned, old,
+                        "images older than the window must be excluded")
+    assert_not_includes(scanned, untransferred,
+                        "untransferred images have no server copy yet")
+  end
+
+  private
+
+  # See StaleImageFilesJobTest -- records exceptions handed to the
+  # #alerts pipeline while alerting is forced active.
+  def capture_alerts(&block)
+    alerts = []
+    ExceptionNotifier.stub(:notifiers, [:slack]) do
+      ExceptionNotifier.stub(:notify_exception,
+                             lambda { |exception, **_o|
+                               alerts << exception
+                             }, &block)
+    end
+    alerts
+  end
+end

--- a/test/models/image/processor/gps_leak_scan_test.rb
+++ b/test/models/image/processor/gps_leak_scan_test.rb
@@ -30,19 +30,21 @@ class Image::Processor::GpsLeakScanTest < UnitTestCase
 
     assert_equal([image.id], hits)
     assert_equal("ssh", captured[0])
-    assert_equal("mo@example.test", captured[1],
+    assert_includes(captured, "BatchMode=yes",
+                    "ssh must fail fast, never hang on a prompt")
+    assert_equal("mo@example.test", captured[-2],
                  "only the ssh server with an orig subdir should be " \
                  "scanned -- never thumbs_only or the file-type local")
-    assert_includes(captured[2], "$GPS:GPSLatitude or $GPS:GPSLongitude")
-    assert_includes(captured[2], "-fast2")
-    assert_includes(captured[2], "/data/mo/orig/#{image.id}.jpg")
+    assert_includes(captured[-1], "$GPS:GPSLatitude or $GPS:GPSLongitude")
+    assert_includes(captured[-1], "-fast2")
+    assert_includes(captured[-1], "/data/mo/orig/#{image.id}.jpg")
   end
 
   def test_includes_raw_original_path_for_non_jpg_images
     image = images(:in_situ_image)
     commands = []
     fake_capture3 = lambda do |*args|
-      commands << args[2]
+      commands << args[-1]
       ["", "", nil]
     end
 

--- a/test/models/image/processor/gps_leak_scan_test.rb
+++ b/test/models/image/processor/gps_leak_scan_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# See GpsLeakDetectorJob for the recurring job that drives this, and
+# GitHub issue #4859 for the leak mechanisms the tripwire exists to
+# catch.
+class Image::Processor::GpsLeakScanTest < UnitTestCase
+  SERVER_DATA = {
+    local: { type: "file", path: "/local", subdirs: %w[orig] },
+    sshbox: { type: "ssh", path: "mo@example.test:/data/mo",
+              subdirs: %w[thumb 320 640 960 1280 orig] },
+    thumbs_only: { type: "ssh", path: "mo@thumbs.test:/data/thumbs",
+                   subdirs: %w[thumb 320] }
+  }.freeze
+
+  def test_scans_ssh_servers_with_orig_and_parses_hit_ids
+    image = images(:in_situ_image)
+    captured = nil
+    fake_capture3 = lambda do |*args|
+      captured = args
+      ["/data/mo/orig/#{image.id}.jpg\n", "", nil]
+    end
+
+    hits = Image::Processor.stub(:image_server_data, SERVER_DATA) do
+      Open3.stub(:capture3, fake_capture3) do
+        Image::Processor.detect_gps_leaks([image])
+      end
+    end
+
+    assert_equal([image.id], hits)
+    assert_equal("ssh", captured[0])
+    assert_equal("mo@example.test", captured[1],
+                 "only the ssh server with an orig subdir should be " \
+                 "scanned -- never thumbs_only or the file-type local")
+    assert_includes(captured[2], "$GPS:GPSLatitude or $GPS:GPSLongitude")
+    assert_includes(captured[2], "-fast2")
+    assert_includes(captured[2], "/data/mo/orig/#{image.id}.jpg")
+  end
+
+  def test_includes_raw_original_path_for_non_jpg_images
+    image = images(:in_situ_image)
+    commands = []
+    fake_capture3 = lambda do |*args|
+      commands << args[2]
+      ["", "", nil]
+    end
+
+    image.stub(:original_extension, "tiff") do
+      Image::Processor.stub(:image_server_data, SERVER_DATA) do
+        Open3.stub(:capture3, fake_capture3) do
+          assert_empty(Image::Processor.detect_gps_leaks([image]))
+        end
+      end
+    end
+
+    assert_includes(commands.first, "/data/mo/orig/#{image.id}.jpg")
+    assert_includes(commands.first, "/data/mo/orig/#{image.id}.tiff")
+  end
+
+  def test_missing_file_stderr_is_silent_but_real_errors_are_logged
+    image = images(:in_situ_image)
+    messages = []
+    stderr = "Error: File not found - /data/mo/orig/#{image.id}.jpg\n"
+
+    Image::Processor.stub(:image_server_data, SERVER_DATA) do
+      Open3.stub(:capture3, ["", stderr, nil]) do
+        Image::Processor.detect_gps_leaks([image]) { |msg| messages << msg }
+      end
+    end
+    assert_empty(messages, "missing files are routine, not loggable errors")
+
+    ssh_error = "ssh: Could not resolve hostname example.test\n"
+    Image::Processor.stub(:image_server_data, SERVER_DATA) do
+      Open3.stub(:capture3, ["", ssh_error, nil]) do
+        Image::Processor.detect_gps_leaks([image]) { |msg| messages << msg }
+      end
+    end
+    assert(messages.any? do |msg|
+      msg.start_with?("Errors checking mo@example.test") &&
+        msg.include?(ssh_error.strip)
+    end)
+  end
+
+  def test_returns_empty_for_no_images_without_shelling_out
+    Image::Processor.stub(:image_server_data, SERVER_DATA) do
+      Open3.stub(:capture3, ->(*) { raise("must not shell out") }) do
+        assert_empty(Image::Processor.detect_gps_leaks([]))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes out the two deferred follow-ups from #4859 (see that issue for the full history: the strip/transfer race, the `verify_images` 4am re-infection mechanism, and the ~9,700-image remediation).

## `GpsLeakDetectorJob` — weekly tripwire

Every Monday at 4:43am, scans every image uploaded in the last 14 days that's attached to a `gps_hidden` observation and already `transferred`, by running exiftool directly against the originals on the ssh image server(s) (header-only `-fast2` reads, one ssh call per 400 paths via the new `Image::Processor::GpsLeakScan`). If any file still carries GPS latitude/longitude (EXIF or XMP), it alerts to #alerts with the image ids and a pointer to #4859's mechanisms and tooling.

Rationale: three separate mechanisms each silently restored or preserved GPS on files whose `gps_stripped`/`transferred` flags all read clean, for years. Every flag-based check was blind to all of them. A periodic direct check of the actual served bytes is the only detector that catches the *class* rather than a known instance. Its first production run also doubles as the planned post-#4858 escapee re-check.

Alert-only by design — a hit means a new mechanism is at work and needs investigation, not silent auto-fixing.

## `config/etc/rclone_originals.sh` — re-archiving nightly sync

The images server's nightly archive cron script now lives in the repo. It's rewritten from the once-only `orig.done`-ledger design to a plain `rclone copy` of the whole orig dir, which compares size+modtime and uploads what's new **or modified** — so post-archival modifications (remote GPS strips, rotations pushed by `TransferImagesJob`) reach the GCS archive on the next nightly run instead of never. That once-only design is why 2,490 stale archive copies needed manual re-copying in #4859. The header documents the deploy location and warns against ever switching `copy` to `sync` (the bucket holds pre-cutover originals whose server copies are deliberately deleted).

**Deploy note (manual):** the script must be copied to `/data/images/mo/rclone/rclone_originals.sh` on the images server; the crontab entry (`15 1 * * *`) is unchanged. Nightly listing cost is ~2000 list calls (pennies); uploads are free ingress.

## Test plan

- On a branch deploy, run `GpsLeakDetectorJob.perform_now` from the console: `log/job.log` should show `Checked N recent gps_hidden image(s): clean` (or an ids alert in #alerts if it ever finds something — which today would be news).
- On the images server, run the new `rclone_originals.sh` by hand once and check its log: it should upload only files newer than / modified since last night's ledger run, and never delete anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
