### PR TITLE
Silence `SolidCache::Entry` query logging

### DIFF
--- a/config/initializers/silence_solid_cache_logs.rb
+++ b/config/initializers/silence_solid_cache_logs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# SolidCache::Record has its own DB connection (the `cache:` role) and
+# its own logger, independent of ActiveRecord::Base.logger -- every
+# cache read/write otherwise logs a full "SolidCache::Entry Load" SQL
+# line, drowning out the rest of the request's log output.
+ActiveSupport.on_load(:solid_cache) do
+  self.logger = nil
+end

--- a/test/initializers/silence_solid_cache_logs_test.rb
+++ b/test/initializers/silence_solid_cache_logs_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class SilenceSolidCacheLogsTest < UnitTestCase
+  def test_solid_cache_record_logger_is_silenced
+    assert_nil(SolidCache::Record.logger,
+               "SolidCache::Record.logger should be nil (config/" \
+               "initializers/silence_solid_cache_logs.rb) so every " \
+               "cache read/write doesn't log a SolidCache::Entry Load " \
+               "SQL line -- the app's own ActiveRecord::Base.logger is " \
+               "unaffected, since each AR subclass can override its own")
+  end
+
+  def test_other_active_record_logging_is_unaffected
+    assert_not_nil(ActiveRecord::Base.logger,
+                   "Silencing SolidCache::Record must not silence the " \
+                   "app's shared query logger")
+  end
+end


### PR DESCRIPTION
## Summary

Every `Rails.cache` read/write against Solid Cache logs a full `SolidCache::Entry Load` SQL line at debug level. Verified against real dev-log samples: this accounts for ~29% of total log lines on a typical request (280 of ~960 lines in two separate captured logs).

Confirmed this is pre-existing on `main` today, unrelated to #4811 -- diffed a log captured on `main` against one captured on the #4811 branch and they contain byte-for-byte identical `SolidCache::Entry Load` sequences (same key hashes, same order). So this fix stands alone and benefits both.

## Fix

`SolidCache::Record` (the base class for `SolidCache::Entry`) establishes its own DB connection (the `cache:` role) and, like any `ActiveRecord::Base` subclass, can override its own `logger` independently of the shared `ActiveRecord::Base.logger` -- silencing it doesn't touch logging for any other model. Wired up via the gem's own documented `:solid_cache` load hook (`ActiveSupport.run_load_hooks :solid_cache, SolidCache::Record`), not a monkey patch.

- `config/initializers/silence_solid_cache_logs.rb`
- `test/initializers/silence_solid_cache_logs_test.rb`

## Test plan

- [x] `bundle exec rubocop` clean on both files
- [x] New tests: `SolidCache::Record.logger` is `nil`, `ActiveRecord::Base.logger` is unaffected
- [x] Manually verified end-to-end in development: hit `/observations` through a real request cycle before and after -- `SolidCache::Entry` lines gone, other query logging (e.g. `User Load`) unaffected
