### PR TITLE
Bulk-delete obsolete translation strings in `Language#strip`

### DIFF
--- a/app/models/concerns/language_exporter.rb
+++ b/app/models/concerns/language_exporter.rb
@@ -124,12 +124,12 @@ module LanguageExporter
   # That is, remove any strings from unofficial locales which are not also
   # in the official locale.
   def strip
-    any_changes = false
     good_tags = Language.official.read_export_file
-    translation_strings.reject { |str| good_tags.key?(str.tag) }.each do |str|
-      verbose("  deleting :#{str.tag}")
-      translation_strings.delete(str) unless safe_mode
-      any_changes = true
+    obsolete = translation_strings.reject { |str| good_tags.key?(str.tag) }
+    any_changes = obsolete.any?
+    if any_changes
+      obsolete.each { |str| verbose("  deleting :#{str.tag}") }
+      delete_translation_strings(obsolete) unless safe_mode
     end
     any_changes
   end
@@ -206,6 +206,16 @@ module LanguageExporter
   ##############################################################################
 
   private
+
+  # Bulk, not one .destroy per record -- each individual destroy also
+  # ran its own separate DELETE for that record's versions, so a
+  # `strip` removing hundreds of tags across many locales was doing
+  # thousands of round trips.
+  def delete_translation_strings(strs)
+    ids = strs.map(&:id)
+    TranslationString::Version.where(translation_string_id: ids).delete_all
+    TranslationString.where(id: ids).delete_all
+  end
 
   def merge_localization_strings_into(data)
     translation_strings.includes([:user, :versions]).find_each do |str|


### PR DESCRIPTION
## Summary

`Language#strip` (`app/models/concerns/language_exporter.rb`) deletes any translation tag no longer present in `en.txt` -- run per-locale as part of the language update task. It was deleting each obsolete row individually via `translation_strings.delete(str)`, and `Language has_many :translation_strings, dependent: :destroy` means each one is a full `.destroy`: its own SQL DELETE for the row, plus its own separate SQL DELETE for that record's `acts_as_versioned` version rows (`translation_string_versions`).

Deploying #4861 (which dropped 330 twin-pair ALL-CAPS tags from `en.txt`) made this cost thousands of individual round trips across all locales -- confirmed live during that deploy ("holy cow the deletions take a long time").

## Fix

Replaced the per-record `.destroy` loop with two bulk `delete_all` calls -- one for the obsolete tags' version rows, one for the tags themselves. Verbose per-tag logging is preserved.

- `app/models/concerns/language_exporter.rb`

## Test plan

- [x] `bundle exec rubocop` clean
- [x] `bin/rails test test/classes/language_exporter_test.rb` -- 17 tests, 0 failures (existing coverage already exercises both new bulk-delete lines at 100%, confirmed via SimpleCov)
