### PR TITLE
Batch `MatrixBox`'s per-object cache reads/writes

### DIFF
--- a/README_MACOSX_NOTES.md
+++ b/README_MACOSX_NOTES.md
@@ -431,6 +431,25 @@ Hopefully this is not necessary on a fresh clean system, but
   rails t
 ```
 
+## Fragment caching in development
+
+Rails' fragment/low-level caching is off by default in development
+(`config.action_controller.perform_caching = false`) so that editing
+a view always shows your latest change instead of a stale cached
+fragment. Run `bin/rails dev:cache` to toggle it on (creates
+`tmp/caching-dev.txt`); run it again to toggle back off.
+
+When it's on, the cache store is Solid Cache (the `cache_development`
+database), matching production — not an in-process memory store — so
+a cache read/write costs a real query locally too, same as prod.
+
+MO's fragment-caching call site, `Components::Matrix::Table` (the
+observations/images grid), keys its fragments on a hand-maintained
+`CACHE_VERSION` string (see `app/components/matrix/table.rb`), not
+automatic template-digest busting. If you're editing `Matrix::Box`'s
+rendering with caching toggled on, remember to bump `CACHE_VERSION`
+or you'll see stale HTML for previously-cached rows.
+
 ## Other
 
 You probably need to generate a new development master key (see below)

--- a/README_MACOSX_NOTES.md
+++ b/README_MACOSX_NOTES.md
@@ -450,6 +450,13 @@ automatic template-digest busting. If you're editing `Matrix::Box`'s
 rendering with caching toggled on, remember to bump `CACHE_VERSION`
 or you'll see stale HTML for previously-cached rows.
 
+Because the store is a real database table now, neither restarting
+the server nor toggling `bin/rails dev:cache` off and back on clears
+it (`dev:cache`'s only side effect is `tmp:clear`, which doesn't touch
+`cache_development`). If you need a clean slate -- e.g. you forgot to
+bump `CACHE_VERSION` and want to confirm that's really the cause --
+run `Rails.cache.clear` from `bin/rails console`.
+
 ## Other
 
 You probably need to generate a new development master key (see below)

--- a/README_UBUNTU_NOTES.md
+++ b/README_UBUNTU_NOTES.md
@@ -71,3 +71,29 @@ doing that.
 
 at the end of this script it runs the entire test suite which should
 pass with no errors or failures.
+
+# Fragment caching in development
+
+Rails' fragment/low-level caching is off by default in development
+(`config.action_controller.perform_caching = false`) so that editing
+a view always shows your latest change instead of a stale cached
+fragment. Run `bin/rails dev:cache` to toggle it on (creates
+`tmp/caching-dev.txt`); run it again to toggle back off.
+
+When it's on, the cache store is Solid Cache (the `cache_development`
+database), matching production — not an in-process memory store — so
+a cache read/write costs a real query locally too, same as prod.
+
+MO's fragment-caching call site, `Components::Matrix::Table` (the
+observations/images grid), keys its fragments on a hand-maintained
+`CACHE_VERSION` string (see `app/components/matrix/table.rb`), not
+automatic template-digest busting. If you're editing `Matrix::Box`'s
+rendering with caching toggled on, remember to bump `CACHE_VERSION`
+or you'll see stale HTML for previously-cached rows.
+
+Because the store is a real database table now, neither restarting
+the server nor toggling `bin/rails dev:cache` off and back on clears
+it (`dev:cache`'s only side effect is `tmp:clear`, which doesn't touch
+`cache_development`). If you need a clean slate -- e.g. you forgot to
+bump `CACHE_VERSION` and want to confirm that's really the cause --
+run `Rails.cache.clear` from `bin/rails console`.

--- a/app/components/matrix/table.rb
+++ b/app/components/matrix/table.rb
@@ -120,7 +120,7 @@ class Components::Matrix::Table < Components::Base
   private
 
   def render_cached_boxes
-    @batched_store = BatchedCacheStore.new(Rails.cache, cacheable_keys)
+    @batched_store = build_batched_store
 
     @objects.each do |object|
       if cacheable_render?(object)
@@ -146,6 +146,16 @@ class Components::Matrix::Table < Components::Base
     # of a stale, already-flushed wrapper.
     @batched_store&.flush_writes!
     @batched_store = nil
+  end
+
+  # Skip the batched store (and its upfront read_multi) entirely when
+  # caching is off -- `low_level_cache` (phlex-rails) already yields
+  # unconditionally in that case and never touches `cache_store`, so
+  # building it here would be a pure-waste DB round trip.
+  def build_batched_store
+    return unless Rails.application.config.action_controller.perform_caching
+
+    BatchedCacheStore.new(Rails.cache, cacheable_keys)
   end
 
   def cacheable_keys

--- a/app/components/matrix/table.rb
+++ b/app/components/matrix/table.rb
@@ -33,7 +33,7 @@ class Components::Matrix::Table < Components::Base
   # observable behavior the cached fragment captures). This is the
   # invalidation lever for cached `MatrixBox` fragments — both the
   # write site (`render_cached_boxes`) and the controller's
-  # pre-check (`ApplicationController::Indexes#object_fragment_exist?`)
+  # pre-check (`ApplicationController::Indexes#uncached_object_ids`)
   # read this through `cache_key_for`. Phlex's automatic class +
   # method + line digest doesn't survive into the controller's
   # check, so we encode the version explicitly.
@@ -42,10 +42,10 @@ class Components::Matrix::Table < Components::Base
   # tokenless URLs and must be regenerated.
   CACHE_VERSION = "v2"
 
-  # The cache key MatrixBox fragments are stored under, used by
-  # both the Phlex `low_level_cache` write inside this component and
-  # the controller's `Rails.cache.exist?` pre-check in
-  # `ApplicationController::Indexes#object_fragment_exist?`. Keeping
+  # The cache key MatrixBox fragments are stored under, used by both
+  # the write inside this component and the controller's batched
+  # `read_multi` pre-check in
+  # `ApplicationController::Indexes#uncached_object_ids`. Keeping
   # both ends on one method ensures they agree on the key shape.
   #
   # Folds in the thumb image record itself so the expanded key tracks
@@ -67,7 +67,7 @@ class Components::Matrix::Table < Components::Base
   # Per-object predicate the render path uses to decide whether to
   # write the fragment cache (`render_cached_boxes`) AND the
   # controller's pre-check uses to decide whether to consult it
-  # (`ApplicationController::Indexes#object_fragment_exist?`).
+  # (`ApplicationController::Indexes#uncached_object_ids`).
   # Objects with an untransferred thumb_image are skipped — the
   # rendered HTML embeds the image URL, which would be wrong (and
   # wrongly cached) until the transfer completes. An `Image` object
@@ -111,13 +111,23 @@ class Components::Matrix::Table < Components::Base
     div(class: "clearfix")
   end
 
+  # Overrides Components::Base#cache_store for the duration of a
+  # #render_cached_boxes call -- see BatchedCacheStore.
+  def cache_store
+    @batched_store || super
+  end
+
   private
 
   def render_cached_boxes
+    @batched_store = BatchedCacheStore.new(Rails.cache, cacheable_keys)
+
     @objects.each do |object|
       if cacheable_render?(object)
         # `low_level_cache` with the deterministic key from
         # `cache_key_for` — same key the controller pre-check uses.
+        # Talks to `cache_store` (overridden above), unaware it's the
+        # batched wrapper rather than Rails.cache directly.
         low_level_cache(
           self.class.cache_key_for(object, I18n.locale)
         ) { render(Components::Matrix::Box.new(user: @user, object: object)) }
@@ -128,6 +138,13 @@ class Components::Matrix::Table < Components::Base
                ))
       end
     end
+
+    @batched_store.flush_writes!
+  end
+
+  def cacheable_keys
+    @objects.select { |object| cacheable_render?(object) }.
+      map { |object| self.class.cache_key_for(object, I18n.locale) }
   end
 
   # Mirrors the controller's `matrix_caches_in_this_request?` AND

--- a/app/components/matrix/table.rb
+++ b/app/components/matrix/table.rb
@@ -138,8 +138,14 @@ class Components::Matrix::Table < Components::Base
                ))
       end
     end
-
-    @batched_store.flush_writes!
+  ensure
+    # Runs even if a box raised partway through -- flushes whatever
+    # was already computed instead of silently discarding it. Cleared
+    # afterward so a stray later #cache_store call (component reuse,
+    # an unrelated caching need) falls through to Rails.cache instead
+    # of a stale, already-flushed wrapper.
+    @batched_store&.flush_writes!
+    @batched_store = nil
   end
 
   def cacheable_keys

--- a/app/components/matrix/table/batched_cache_store.rb
+++ b/app/components/matrix/table/batched_cache_store.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Cache-store wrapper for one Matrix::Table#render_cached_boxes call.
+# Phlex's `low_level_cache` calls `cache_store.fetch(key) { block }`
+# once per object -- against the real store, that's one round trip
+# per object (Solid Cache is DB-backed, so N objects means N SQL
+# queries just to check cache status). This wrapper answers `fetch`
+# from a single upfront `read_multi` instead, and batches every miss's
+# write into one `write_multi` -- `low_level_cache` itself is
+# unmodified, it just talks to this instead of the real store.
+class Components::Matrix::Table::BatchedCacheStore
+  def initialize(real_store, keys)
+    @real_store = real_store
+    @prefetched = keys.empty? ? {} : real_store.read_multi(*keys)
+    @pending_writes = {}
+  end
+
+  def fetch(key, **_options)
+    return @prefetched[key] if @prefetched.key?(key)
+
+    value = yield
+    @pending_writes[key] = value
+    value
+  end
+
+  def flush_writes!
+    return if @pending_writes.empty?
+
+    @real_store.write_multi(@pending_writes)
+  end
+end

--- a/app/components/matrix/table/batched_cache_store.rb
+++ b/app/components/matrix/table/batched_cache_store.rb
@@ -9,9 +9,17 @@
 # write into one `write_multi` -- `low_level_cache` itself is
 # unmodified, it just talks to this instead of the real store.
 class Components::Matrix::Table::BatchedCacheStore
-  def initialize(real_store, keys)
+  # `options` (e.g. `expires_in:`) apply to the whole batch, read and
+  # write alike -- captured here because the batched read happens
+  # once, upfront, before any individual `fetch` call exists to carry
+  # its own. `render_cached_boxes` has exactly one `low_level_cache`
+  # call site today, so there's only one options value in play; a
+  # `fetch(key, **options)` call still accepts (but doesn't use) its
+  # own `options` to match Phlex's real cache_store interface.
+  def initialize(real_store, keys, **options)
     @real_store = real_store
-    @prefetched = keys.empty? ? {} : real_store.read_multi(*keys)
+    @options = options
+    @prefetched = keys.empty? ? {} : real_store.read_multi(*keys, **options)
     @pending_writes = {}
   end
 
@@ -26,6 +34,7 @@ class Components::Matrix::Table::BatchedCacheStore
   def flush_writes!
     return if @pending_writes.empty?
 
-    @real_store.write_multi(@pending_writes)
+    @real_store.write_multi(@pending_writes, **@options)
+    @pending_writes = {}
   end
 end

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -441,40 +441,45 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     # If temporarily disabling cached matrix boxes: eager load everything
     # ids_to_eager_load = objects_simple
 
-    ids_to_eager_load = objects_simple.reject do |obj|
-      object_fragment_exist?(obj, locale)
-    end.pluck(:id)
+    ids_to_eager_load = uncached_object_ids(objects_simple, locale)
     # now get the heavy loaded instances:
     objects_eager = query.model.where(id: ids_to_eager_load).includes(include)
     # our Array extension: collates new instances with old, in original order
     objects_simple.collate_new_instances(objects_eager)
   end
 
-  # Check if a cached partial exists for this object.
-  # Pre-check: does the `MatrixBox` fragment for this object+locale
-  # already exist in the cache? If yes, the row doesn't need eager-
-  # loaded associations (it'll be served from cache as-is); if no,
-  # the row needs eager-loading.
+  # Which of `objects` need eager-loading because their `MatrixBox`
+  # fragment isn't already cached. One `read_multi` round trip covers
+  # every object's cache-key check, instead of one `Rails.cache.exist?`
+  # query per object (Solid Cache is DB-backed, so that was one SQL
+  # query per row on the index).
   #
-  # Two-stage gate. Both have to be true for the row to be served
-  # from cache:
-  #   1. `matrix_caches_in_this_request?` (per-request) — false
-  #      when `Components::Matrix::Table#render_cached_boxes` would
-  #      bypass the cache for this whole render (identify mode,
-  #      project-admin view). Controllers override.
-  #   2. `MatrixTable.should_cache_object?` (per-object) — false
-  #      when the object itself isn't cacheable (e.g. an
-  #      Observation with an untransferred thumb image).
+  # Gate: `matrix_caches_in_this_request?` is already guaranteed true
+  # by this method's only caller (`objects_with_only_needed_eager_loads`
+  # returns early otherwise); `MatrixTable.should_cache_object?`
+  # (per-object) is false when the object itself isn't cacheable (e.g.
+  # an Observation with an untransferred thumb image) -- those always
+  # need eager-loading, no cache lookup necessary.
   #
-  # Then `Rails.cache.exist?` confirms the fragment is actually in
-  # the store. Uses the shared key from `MatrixTable.cache_key_for`
-  # so the read matches what `MatrixTable#render_cached_boxes`
-  # writes.
-  def object_fragment_exist?(obj, locale)
-    return false unless matrix_caches_in_this_request?
-    return false unless ::Components::Matrix::Table.should_cache_object?(obj)
+  # Uses the shared key from `MatrixTable.cache_key_for` so the read
+  # matches what `MatrixTable#render_cached_boxes` writes.
+  def uncached_object_ids(objects, locale)
+    cacheable, uncacheable = objects.partition do |obj|
+      ::Components::Matrix::Table.should_cache_object?(obj)
+    end
+    keys_by_object = cacheable.index_by do |obj|
+      ::Components::Matrix::Table.cache_key_for(obj, locale)
+    end
+    cached_keys = if keys_by_object.empty?
+                    []
+                  else
+                    Rails.cache.read_multi(
+                      *keys_by_object.keys
+                    ).keys
+                  end
 
-    Rails.cache.exist?(::Components::Matrix::Table.cache_key_for(obj, locale))
+    uncached = keys_by_object.except(*cached_keys)
+    (uncached.values + uncacheable).pluck(:id)
   end
 
   # Associations the per-object cache pre-check needs to consult

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -23,10 +23,10 @@ module Observations
 
     # `MatrixTable` always renders in `identify: true` mode here, which
     # bypasses the fragment cache — the per-user vote selector and
-    # footer chrome can't be cached. The pre-check on
-    # `object_fragment_exist?` must agree, otherwise the controller
-    # would skip eager-loading rows it thinks are cache hits and then
-    # render uncached boxes → N+1.
+    # footer chrome can't be cached. The pre-check in
+    # `Indexes#objects_with_only_needed_eager_loads` must agree,
+    # otherwise the controller would skip eager-loading rows it
+    # thinks are cache hits and then render uncached boxes → N+1.
     def matrix_caches_in_this_request?
       false
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -89,7 +89,13 @@ MushroomObserver::Application.configure do
     # (it will show [cache hit] even if set to false)
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store # :mem_cache_store via application.rb
+    # Match production's store (config/application.rb) rather than
+    # :memory_store -- Solid Cache is DB-backed, so a per-item cache
+    # loop costs one query per item here too, the same as prod. A
+    # local :memory_store hides that cost entirely (in-process hash
+    # lookups are free), which let the N+1-cache-round-trip bug behind
+    # #4865 go unnoticed locally for a long time.
+    config.cache_store = :solid_cache_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/test/components/matrix/table/batched_cache_store_test.rb
+++ b/test/components/matrix/table/batched_cache_store_test.rb
@@ -26,13 +26,13 @@ class Components::Matrix::Table::BatchedCacheStoreTest < UnitTestCase
     def read_multi(*keys, **options)
       @read_multi_calls += 1
       @read_multi_options = options
-      @real_store.read_multi(*keys)
+      @real_store.read_multi(*keys, **options)
     end
 
     def write_multi(hash, **options)
       @write_multi_calls += 1
       @write_multi_options = options
-      @real_store.write_multi(hash)
+      @real_store.write_multi(hash, **options)
     end
 
     delegate :read, to: :@real_store

--- a/test/components/matrix/table/batched_cache_store_test.rb
+++ b/test/components/matrix/table/batched_cache_store_test.rb
@@ -14,7 +14,8 @@ class Components::Matrix::Table::BatchedCacheStoreTest < UnitTestCase
   # store issues exactly one read_multi/write_multi regardless of how
   # many individual keys are involved -- the whole point of this class.
   class CallCountingStore
-    attr_reader :read_multi_calls, :write_multi_calls
+    attr_reader :read_multi_calls, :write_multi_calls,
+                :read_multi_options, :write_multi_options
 
     def initialize(real_store)
       @real_store = real_store
@@ -22,13 +23,15 @@ class Components::Matrix::Table::BatchedCacheStoreTest < UnitTestCase
       @write_multi_calls = 0
     end
 
-    def read_multi(*keys)
+    def read_multi(*keys, **options)
       @read_multi_calls += 1
+      @read_multi_options = options
       @real_store.read_multi(*keys)
     end
 
-    def write_multi(hash)
+    def write_multi(hash, **options)
       @write_multi_calls += 1
+      @write_multi_options = options
       @real_store.write_multi(hash)
     end
 
@@ -136,6 +139,30 @@ class Components::Matrix::Table::BatchedCacheStoreTest < UnitTestCase
 
     assert_equal("computed", result)
     assert_equal(0, spy.read_multi_calls)
+  end
+
+  def test_options_are_forwarded_to_both_read_multi_and_write_multi
+    spy = CallCountingStore.new(@store)
+    batched = Components::Matrix::Table::BatchedCacheStore.new(
+      spy, ["a"], expires_in: 5.minutes
+    )
+    batched.fetch("a") { "fresh_a" }
+    batched.flush_writes!
+
+    assert_equal({ expires_in: 5.minutes }, spy.read_multi_options)
+    assert_equal({ expires_in: 5.minutes }, spy.write_multi_options)
+  end
+
+  def test_flush_writes_clears_pending_writes_so_a_second_call_is_a_noop
+    spy = CallCountingStore.new(@store)
+    batched = Components::Matrix::Table::BatchedCacheStore.new(spy, ["a"])
+    batched.fetch("a") { "fresh_a" }
+
+    batched.flush_writes!
+    batched.flush_writes!
+
+    assert_equal(1, spy.write_multi_calls,
+                 "a second flush must not re-write already-flushed entries")
   end
 end
 # rubocop:enable Style/RedundantFetchBlock

--- a/test/components/matrix/table/batched_cache_store_test.rb
+++ b/test/components/matrix/table/batched_cache_store_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# BatchedCacheStore#fetch is a custom cache-store method (matching
+# Rails.cache's fetch(key) { block } interface), not Hash/Array#fetch
+# -- Style/RedundantFetchBlock doesn't know that and "corrects" these
+# calls into fetch(key, value), which doesn't even match this class's
+# signature (raises ArgumentError). Disabled for the whole file since
+# nearly every test calls #fetch.
+# rubocop:disable Style/RedundantFetchBlock
+class Components::Matrix::Table::BatchedCacheStoreTest < UnitTestCase
+  # Wraps a real store, counting calls so tests can assert the batched
+  # store issues exactly one read_multi/write_multi regardless of how
+  # many individual keys are involved -- the whole point of this class.
+  class CallCountingStore
+    attr_reader :read_multi_calls, :write_multi_calls
+
+    def initialize(real_store)
+      @real_store = real_store
+      @read_multi_calls = 0
+      @write_multi_calls = 0
+    end
+
+    def read_multi(*keys)
+      @read_multi_calls += 1
+      @real_store.read_multi(*keys)
+    end
+
+    def write_multi(hash)
+      @write_multi_calls += 1
+      @real_store.write_multi(hash)
+    end
+
+    delegate :read, to: :@real_store
+  end
+
+  def setup
+    super
+    @store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  def test_fetch_serves_a_prefetched_hit_without_calling_the_block
+    @store.write("a", "cached_a")
+    batched = Components::Matrix::Table::BatchedCacheStore.new(@store, ["a"])
+
+    computed = false
+    result = batched.fetch("a") do
+      computed = true
+      "fresh_a"
+    end
+
+    assert_equal("cached_a", result)
+    assert_not(computed, "block must not run for a prefetched hit")
+  end
+
+  def test_fetch_computes_and_returns_the_value_for_a_miss
+    batched = Components::Matrix::Table::BatchedCacheStore.new(@store, ["a"])
+
+    result = batched.fetch("a") { "fresh_a" }
+
+    assert_equal("fresh_a", result)
+  end
+
+  def test_a_miss_is_not_written_until_flush_writes
+    batched = Components::Matrix::Table::BatchedCacheStore.new(@store, ["a"])
+    batched.fetch("a") { "fresh_a" }
+
+    assert_nil(@store.read("a"))
+  end
+
+  def test_flush_writes_persists_every_pending_miss
+    batched = Components::Matrix::Table::BatchedCacheStore.new(
+      @store, %w[a b]
+    )
+    batched.fetch("a") { "fresh_a" }
+    batched.fetch("b") { "fresh_b" }
+    batched.flush_writes!
+
+    assert_equal("fresh_a", @store.read("a"))
+    assert_equal("fresh_b", @store.read("b"))
+  end
+
+  def test_flush_writes_does_not_touch_the_store_when_nothing_is_pending
+    spy = CallCountingStore.new(@store)
+    @store.write("a", "cached_a")
+    batched = Components::Matrix::Table::BatchedCacheStore.new(spy, ["a"])
+    batched.fetch("a") { "unused" } # hit, nothing queued
+    batched.flush_writes!
+
+    assert_equal(0, spy.write_multi_calls)
+  end
+
+  def test_a_mix_of_hits_and_misses_resolves_each_correctly
+    @store.write("a", "cached_a")
+    batched = Components::Matrix::Table::BatchedCacheStore.new(
+      @store, %w[a b]
+    )
+
+    a_computed = false
+    b_computed = false
+    a_result = batched.fetch("a") do
+      a_computed = true
+      "fresh_a"
+    end
+    b_result = batched.fetch("b") do
+      b_computed = true
+      "fresh_b"
+    end
+
+    assert_equal("cached_a", a_result)
+    assert_not(a_computed, "a was prefetched, block must not run")
+    assert_equal("fresh_b", b_result)
+    assert(b_computed, "b was a genuine miss, block must run")
+  end
+
+  def test_read_multi_and_write_multi_are_each_called_exactly_once
+    spy = CallCountingStore.new(@store)
+    batched = Components::Matrix::Table::BatchedCacheStore.new(
+      spy, %w[a b c]
+    )
+    batched.fetch("a") { "x" }
+    batched.fetch("b") { "y" }
+    batched.fetch("c") { "z" }
+    batched.flush_writes!
+
+    assert_equal(1, spy.read_multi_calls)
+    assert_equal(1, spy.write_multi_calls)
+  end
+
+  def test_empty_keys_skips_read_multi_entirely
+    spy = CallCountingStore.new(@store)
+    batched = Components::Matrix::Table::BatchedCacheStore.new(spy, [])
+
+    result = batched.fetch("a") { "computed" }
+
+    assert_equal("computed", result)
+    assert_equal(0, spy.read_multi_calls)
+  end
+end
+# rubocop:enable Style/RedundantFetchBlock

--- a/test/components/matrix/table_test.rb
+++ b/test/components/matrix/table_test.rb
@@ -420,12 +420,17 @@ class MatrixTableTest < ComponentTestCase
     original_cache = Rails.cache
     original_perform_caching =
       Rails.application.config.action_controller.perform_caching
-    Rails.cache = spy
-    Rails.application.config.action_controller.perform_caching = true
-    html = render(component)
-    Rails.cache = original_cache
-    Rails.application.config.action_controller.perform_caching =
-      original_perform_caching
+    html = begin
+             Rails.cache = spy
+             Rails.application.config.action_controller.perform_caching = true
+             render(component)
+           ensure
+             # Must run even if render raises, or a broken spy cache store
+             # leaks into every other test in this worker process.
+             Rails.cache = original_cache
+             Rails.application.config.action_controller.perform_caching =
+               original_perform_caching
+           end
 
     assert_equal(1, spy.read_multi_calls,
                  "expected one batched read regardless of object count")
@@ -445,5 +450,29 @@ class MatrixTableTest < ComponentTestCase
     cached_buffer, = real_store.read(second_key)
     assert_includes(cached_buffer, "box_#{observations.second.id}",
                     "the miss must be written to the store")
+  end
+
+  def test_batched_store_is_cleared_after_render_completes
+    obs = observations(:coprinus_comatus_obs)
+    obs.thumb_image.update_column(:transferred, true)
+    component = Components::Matrix::Table.new(
+      objects: [obs], user: @user, cached: true
+    )
+
+    original_perform_caching =
+      Rails.application.config.action_controller.perform_caching
+    begin
+      Rails.application.config.action_controller.perform_caching = true
+      render(component)
+    ensure
+      Rails.application.config.action_controller.perform_caching =
+        original_perform_caching
+    end
+
+    assert_nil(
+      component.instance_variable_get(:@batched_store),
+      "a stale batched wrapper must not survive past its own render, " \
+      "or a later #cache_store call would incorrectly reuse it"
+    )
   end
 end

--- a/test/components/matrix/table_test.rb
+++ b/test/components/matrix/table_test.rb
@@ -475,4 +475,34 @@ class MatrixTableTest < ComponentTestCase
       "or a later #cache_store call would incorrectly reuse it"
     )
   end
+
+  def test_render_cached_boxes_skips_the_batched_read_when_caching_is_off
+    obs = observations(:coprinus_comatus_obs)
+    obs.thumb_image.update_column(:transferred, true)
+    component = Components::Matrix::Table.new(
+      objects: [obs], user: @user, cached: true
+    )
+    spy = CountingCacheStore.new(ActiveSupport::Cache::MemoryStore.new)
+
+    original_cache = Rails.cache
+    original_perform_caching =
+      Rails.application.config.action_controller.perform_caching
+    begin
+      Rails.cache = spy
+      Rails.application.config.action_controller.perform_caching = false
+      render(component)
+    ensure
+      Rails.cache = original_cache
+      Rails.application.config.action_controller.perform_caching =
+        original_perform_caching
+    end
+
+    assert_equal(
+      0, spy.read_multi_calls,
+      "perform_caching = false means low_level_cache never touches " \
+      "cache_store -- building the batched store anyway would be a " \
+      "wasted read_multi on every render"
+    )
+    assert_equal(0, spy.write_multi_calls)
+  end
 end

--- a/test/components/matrix/table_test.rb
+++ b/test/components/matrix/table_test.rb
@@ -366,4 +366,84 @@ class MatrixTableTest < ComponentTestCase
                                          "different cache keys")
     end
   end
+
+  # Counts read_multi/write_multi calls so the batching tests below can
+  # assert exactly one round trip regardless of object count.
+  class CountingCacheStore
+    attr_reader :read_multi_calls, :write_multi_calls
+
+    def initialize(real_store)
+      @real_store = real_store
+      @read_multi_calls = 0
+      @write_multi_calls = 0
+    end
+
+    def read_multi(*keys)
+      @read_multi_calls += 1
+      @real_store.read_multi(*keys)
+    end
+
+    def write_multi(hash)
+      @write_multi_calls += 1
+      @real_store.write_multi(hash)
+    end
+
+    delegate :read, :write, to: :@real_store
+  end
+
+  def test_render_cached_boxes_resolves_a_hit_and_a_miss_in_one_round_trip
+    observations = [
+      observations(:coprinus_comatus_obs),
+      observations(:agaricus_campestris_obs)
+    ]
+    observations.each do |obs|
+      obs.thumb_image.update_column(:transferred, true)
+    end
+
+    real_store = ActiveSupport::Cache::MemoryStore.new
+    first_key = Components::Matrix::Table.cache_key_for(
+      observations.first, I18n.locale
+    )
+    # Pre-warm only the first object's fragment -- proves a genuine
+    # mix of hit + miss both resolve correctly in one batched pass,
+    # not just an all-hit or all-miss case.
+    real_store.write(first_key, ["<li>already cached</li>", {}])
+    spy = CountingCacheStore.new(real_store)
+
+    component = Components::Matrix::Table.new(
+      objects: observations, user: @user, cached: true
+    )
+
+    # Phlex-rails' low_level_cache gates on perform_caching (unset,
+    # so falsy, in the test env by default) -- without this, it always
+    # `yield`s and never touches cache_store at all.
+    original_cache = Rails.cache
+    original_perform_caching =
+      Rails.application.config.action_controller.perform_caching
+    Rails.cache = spy
+    Rails.application.config.action_controller.perform_caching = true
+    html = render(component)
+    Rails.cache = original_cache
+    Rails.application.config.action_controller.perform_caching =
+      original_perform_caching
+
+    assert_equal(1, spy.read_multi_calls,
+                 "expected one batched read regardless of object count")
+    assert_equal(1, spy.write_multi_calls,
+                 "expected one batched write regardless of miss count")
+
+    assert_includes(html, "already cached",
+                    "first object should be served from the prefetched " \
+                    "hit, not recomputed")
+    assert_not_includes(html, "box_#{observations.first.id}")
+    assert_includes(html, "box_#{observations.second.id}",
+                    "second object was a genuine miss and must render")
+
+    second_key = Components::Matrix::Table.cache_key_for(
+      observations.second, I18n.locale
+    )
+    cached_buffer, = real_store.read(second_key)
+    assert_includes(cached_buffer, "box_#{observations.second.id}",
+                    "the miss must be written to the store")
+  end
 end

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -755,6 +755,58 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_nil(session["return-to"])
   end
 
+  # `uncached_object_ids` batches the MatrixBox cache-key pre-check
+  # into one `read_multi` instead of one `Rails.cache.exist?` per
+  # object -- verify it still resolves each object correctly (one
+  # already cached, one not, one uncacheable) with a single round trip.
+  def test_uncached_object_ids_batches_the_cache_precheck
+    login
+    cached_obs = observations(:coprinus_comatus_obs)
+    uncached_obs = observations(:agaricus_campestris_obs)
+    cached_obs.thumb_image.update_column(:transferred, true)
+    uncached_obs.thumb_image.update_column(:transferred, true)
+    untransferred_obs = observations(:detailed_unknown_obs)
+    untransferred_obs.thumb_image&.update_column(:transferred, false)
+
+    locale = I18n.locale
+    cached_key = Components::Matrix::Table.cache_key_for(cached_obs, locale)
+
+    real_store = ActiveSupport::Cache::MemoryStore.new
+    real_store.write(cached_key, ["<li>already cached</li>", {}])
+    spy = CountingCacheStoreForIndexes.new(real_store)
+
+    original_cache = Rails.cache
+    Rails.cache = spy
+    ids = @controller.send(
+      :uncached_object_ids,
+      [cached_obs, uncached_obs, untransferred_obs], locale
+    )
+    Rails.cache = original_cache
+
+    assert_equal(1, spy.read_multi_calls,
+                 "expected one batched read regardless of object count")
+    assert_equal([uncached_obs.id, untransferred_obs.id].sort, ids.sort,
+                 "the cached object should be excluded; the genuine " \
+                 "miss and the uncacheable object should both need " \
+                 "eager-loading")
+  end
+
+  # Counts read_multi calls so the test above can assert one round
+  # trip regardless of object count.
+  class CountingCacheStoreForIndexes
+    attr_reader :read_multi_calls
+
+    def initialize(real_store)
+      @real_store = real_store
+      @read_multi_calls = 0
+    end
+
+    def read_multi(*keys)
+      @read_multi_calls += 1
+      @real_store.read_multi(*keys)
+    end
+  end
+
   PARAMS_UNDER_LIMIT =
     { names: {
         lookup: ["Agaricus campestris"],

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -776,12 +776,17 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     spy = CountingCacheStoreForIndexes.new(real_store)
 
     original_cache = Rails.cache
-    Rails.cache = spy
-    ids = @controller.send(
-      :uncached_object_ids,
-      [cached_obs, uncached_obs, untransferred_obs], locale
-    )
-    Rails.cache = original_cache
+    ids = begin
+            Rails.cache = spy
+            @controller.send(
+              :uncached_object_ids,
+              [cached_obs, uncached_obs, untransferred_obs], locale
+            )
+          ensure
+            # Must run even if the call above raises, or a broken spy cache
+            # store leaks into every other test in this worker process.
+            Rails.cache = original_cache
+          end
 
     assert_equal(1, spy.read_multi_calls,
                  "expected one batched read regardless of object count")


### PR DESCRIPTION
## Summary

Nathan reported observations-index query counts jumping from ~40 to ~170 -- confirmed in real production logs (5 consecutive homepage loads across 3 different Puma worker PIDs, all landing at ~163-164 queries, no improvement between loads).

Traced it to two call sites, both doing one `Rails.cache` round trip per object in a loop over the page's items (144 on a full-width index page):

- `Components::Matrix::Table#render_cached_boxes` -- Phlex's `low_level_cache` (`cache_store.fetch(key) { ... }`), called once per object.
- `ApplicationController::Indexes#object_fragment_exist?` -- a `Rails.cache.exist?` pre-check (decides which objects need eager-loading), also called once per object.

Since Solid Cache is DB-backed, N objects meant N SQL queries just to check cache status, at *each* of the two sites -- confirmed via a synthetic query-count harness (matched Nathan's real numbers once I accounted for a stale personal `tmp/caching-dev.txt` toggle masking it locally) and via `SolidCache::Entry Load` lines in real dev-log captures.

## Fix

Both sites now batch via `read_multi`/`write_multi` instead of one round trip per object:

- **`ApplicationController::Indexes#uncached_object_ids`** (replaces `object_fragment_exist?`) -- one `read_multi` covering every candidate object's cache key, instead of one `exist?` per object.
- **`Components::Matrix::Table::BatchedCacheStore`** -- wraps `Rails.cache` for the duration of one `render_cached_boxes` call. Answers Phlex's `low_level_cache` `fetch` from a single upfront `read_multi` instead of one query per object, and batches every miss's write into one `write_multi`. `low_level_cache` itself is unmodified -- this only swaps what `Components::Matrix::Table#cache_store` resolves to (an existing, documented Phlex extension seam: `cache_store` returning an object with a `fetch(key, &block)` interface), rather than reaching into Phlex's internal fragment-caching machinery, which would be a much more fragile fix tied to the exact installed Phlex version.

Both fixes preserve granular per-object hit/miss resolution -- if 120 of 144 objects are already cached, those 120 are served from the single batched read with zero recomputation; only the genuine misses get computed and included in the single batched write.

## Self-review + Copilot follow-up

A deliberate antagonistic self-review, plus Copilot's automated pass, surfaced and fixed:

- `flush_writes!` now clears `@pending_writes` after a successful write, so a second call can't re-write the same entries (Copilot).
- `@batched_store` is reset to `nil` after `render_cached_boxes` completes, so a stray later `#cache_store` call can't reuse a stale, already-flushed wrapper (Copilot).
- `render_cached_boxes` flushes pending writes in an `ensure` block, so a mid-loop render failure doesn't silently discard already-computed fragments for earlier objects in the same pass (self-review).
- `BatchedCacheStore` now threads `**options` through to both `read_multi` and `write_multi` instead of silently dropping them (self-review).
- Both integration tests now restore `Rails.cache` / `perform_caching` via `begin`/`ensure`, so a raise mid-test can't leak a broken spy cache store into later tests in the same worker (self-review + Copilot, same finding on both test files).

## Local dev cache-store parity (bundled in this PR)

While verifying the fix, found why this went unnoticed locally for so long: `config/environments/development.rb` overrode `config.cache_store` to `:memory_store` whenever `tmp/caching-dev.txt` enabled local caching, diverging from production's `:solid_cache_store` (`config/application.rb`). An in-process `:memory_store` makes N individual cache round trips free, so the per-object query cost this PR fixes was invisible in local dev regardless of how many objects were on the page.

Switched local dev to `:solid_cache_store` too (`cache_development` is already a real, migrated database) -- toggling `bin/rails dev:cache` on locally now reproduces production's caching behavior, including its query cost, instead of a cheaper stand-in. Also added a short note to `README_MACOSX_NOTES.md` documenting the `perform_caching` gate, why it exists (avoid stale fragments while editing views), and the `CACHE_VERSION` gotcha for anyone toggling caching on to work on `Matrix::Table`/`Matrix::Box`.

## Test plan

- [x] `bundle exec rubocop` clean on all touched files
- [x] All existing `test/components/matrix/table_test.rb` tests still pass unmodified -- the batching is transparent to callers
- [x] `test/components/matrix/table/batched_cache_store_test.rb` -- unit coverage for `BatchedCacheStore`: hits served without calling the block, misses computed and queued, `flush_writes!` batches every pending miss in one `write_multi` and is a no-op on a second call, a genuine mix of hits/misses resolves each correctly, `read_multi`/`write_multi` are each called exactly once regardless of key count, options forwarded to both
- [x] `MatrixTableTest#test_render_cached_boxes_resolves_a_hit_and_a_miss_in_one_round_trip` -- real end-to-end integration test (not stubbed) proving one batched read + one batched write against a real cache store, with correct HTML content for both the cache hit (served from the prefetched value, not recomputed) and the cache miss (computed fresh and written)
- [x] `MatrixTableTest#test_batched_store_is_cleared_after_render_completes` -- proves `@batched_store` doesn't leak into a later render
- [x] `ObservationsControllerIndexTest#test_uncached_object_ids_batches_the_cache_precheck` -- same batching proof at the controller pre-check layer (one `read_multi`, correct object-id resolution across a cached object, a genuine miss, and an uncacheable object)
