### PR TITLE
Log rsync exit code + stderr on image transfer failure

### DIFF
--- a/app/models/image/processor/file_transfer.rb
+++ b/app/models/image/processor/file_transfer.rb
@@ -8,6 +8,14 @@ class Image
     # server. No per-image state -- shared by Image::Processor (per-upload
     # transfers) and Image::Processor::Verifier (bulk local/remote sync).
     module FileTransfer
+      # Raised when rsync exits non-zero, carrying its exit code and
+      # stderr. Without these, a failed upload logs only "Failed to upload
+      # X to Y" -- a transient ssh/network blip (exit 30/255/12) then reads
+      # identically to a full disk (11) or a permissions problem (23), and
+      # only the exit code and stderr tell them apart. See
+      # Verifier#upload_one_file, whose rescue logs this message.
+      class RsyncError < StandardError; end
+
       def self.copy_file_to_server(server, local_file, remote_file = local_file)
         case Processor.image_server_data[server][:type]
         when "file"
@@ -44,14 +52,20 @@ class Image
         true
       end
 
-      # Rsync is used to copy files to remote image server(s).
+      # Rsync is used to copy files to remote image server(s). Raises
+      # RsyncError (exit code + stderr) rather than returning false on
+      # failure, so the caller's log records why the upload failed instead
+      # of a bare boolean.
       def self.copy_file_to_remote_server(server, local_file, remote_file)
         return unless (remote_path = Processor.image_server_data[server][:path])
 
         result = nil
         Rsync.run("#{Processor.local_images_path}/#{local_file}",
                   "#{remote_path}/#{remote_file}") { |r| result = r }
-        result.success?
+        return true if result.success?
+
+        raise(RsyncError.new("rsync exited #{result.exitcode}: " \
+                          "#{result.error.to_s.strip}"))
       end
 
       def self.copy_file_from_local_server(server, remote_file, local_file)

--- a/app/models/image/processor/verifier.rb
+++ b/app/models/image/processor/verifier.rb
@@ -125,10 +125,12 @@ class Image
         attempted
       end
 
-      # One file's transfer failing (returned false, or raised -- e.g.
-      # a missing rsync binary or Errno::ENOENT) must not abort the rest
-      # of the run: every other mismatched file still needs its chance
-      # to upload.
+      # One file's transfer failing must not abort the rest of the run:
+      # every other mismatched file still needs its chance to upload. A
+      # failure surfaces either as a falsy return (a server configured
+      # with no path) or a raise -- FileTransfer::RsyncError (exit code +
+      # stderr), a missing rsync binary, Errno::ENOENT -- and the rescue
+      # logs the raised message so the reason lands in the job log.
       def upload_one_file(image, server, path)
         log("Uploading #{path} to #{server}")
         if FileTransfer.copy_file_to_server(server, path)

--- a/test/models/image/processor/file_transfer_test.rb
+++ b/test/models/image/processor/file_transfer_test.rb
@@ -48,6 +48,23 @@ class Image::Processor::FileTransferTest < UnitTestCase
     )
   end
 
+  def test_copy_file_to_server_ssh_type_raises_rsync_error_with_detail
+    # No local source file exists, so the real rsync exits non-zero; the
+    # failure must raise RsyncError carrying the exit code and stderr,
+    # never swallow it as a bare false.
+    fake_data = { ssh_server: { type: "ssh", path: remote_server_path(1) } }
+
+    error = Image::Processor.stub(:image_server_data, fake_data) do
+      assert_raises(Image::Processor::FileTransfer::RsyncError) do
+        Image::Processor::FileTransfer.copy_file_to_server(
+          :ssh_server, "thumb/does-not-exist.jpg"
+        )
+      end
+    end
+
+    assert_match(/rsync exited \d+:/, error.message)
+  end
+
   def test_copy_file_to_server_unknown_type_raises
     fake_data = { weird: { type: "ftp", path: "/tmp" } }
 


### PR DESCRIPTION
## Background

On 2026-07-22 two `#alerts` fired for image 2045503: `TransferImagesJob` reported "Transfer failed for 2 file(s)" at 15:27, and `StaleImageFilesJob` re-flagged it at 17:00. A manual `TransferImagesJob.perform_now(image_ids: [2045503])` at 17:47 uploaded the same two files (`1280`, `960`) verbatim and completed cleanly.

The incident was almost certainly a transient ssh/network blip to `mycolab` — the two failures were consecutive, instant, bracketed by successful transfers to the same server in the same second, and cleared on retry. But that could only be inferred, not confirmed, because the failure log discarded the one datum that would have named the cause.

## What this changes

`Image::Processor::FileTransfer.copy_file_to_remote_server` returned a bare `false` when `rsync` exited non-zero, so `Verifier#upload_one_file` logged only `Failed to upload 1280/2045503.jpg to mycolab` — no exit code, no stderr. A transient blip (rsync exit 30/255/12), a full disk (11), and a permissions problem (23) all look identical in that line.

It now raises `FileTransfer::RsyncError` carrying the exit code and rsync's stderr. `Verifier#upload_one_file` already rescues raised upload failures and logs the message, so the reason now lands in `log/job.log` with no other change to the failure flow (a mismatched file still gets recorded in `result[:failed]`, and the rest of the run still proceeds). The next occurrence will read like `Failed to upload 1280/2045503.jpg to mycolab: rsync exited 30: <stderr>` and be diagnosable on sight.

## Proposed follow-up (not in this PR — wants a design decision)

A transient rsync failure currently goes straight to the `#alerts` post and sits stranded until the hourly `StaleImageFilesJob` sweep or a manual `perform_now`. `TransferImagesJob` only `retry_on ActiveRecord::LockWaitTimeout`, so a network blip gets no automatic retry.

A bounded auto-retry on transfer failure (raise a `TransferIncomplete` and `retry_on ... attempts: N` with backoff, alerting only in the exhausted-retries block) would have healed 2045503 on its own — no manual command, no ~1.5h stranded-files window. The tradeoff is that a *genuinely* persistent failure would then alert later (after the retries) rather than immediately, though the stale-files sweep still backstops it hourly. I left it out here because it changes production alert timing and reshapes `test_alerts_with_retry_command_when_a_file_fails`; happy to open it as its own PR if you want it.

## Test plan

- [x] `bin/rails test test/models/image/processor/file_transfer_test.rb test/models/image/processor/verifier_test.rb test/jobs/transfer_images_job_test.rb`
- [x] `bundle exec rubocop` clean on the three touched files
- New `test_copy_file_to_server_ssh_type_raises_rsync_error_with_detail` drives a real failing `rsync` (no local source file) and asserts it raises `RsyncError` with `rsync exited <n>:` in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
