### PR TITLE
Enforce image upload size limit client-side; block over-limit submits (#4872)

### DIFF
--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -64,7 +64,13 @@ export default class extends Controller {
     this.form = this.element;
     this.drop_zone = this.formTarget;
     this.submit_buttons = this.element.querySelectorAll('input[type="submit"]');
-    this.max_image_size = this.element.dataset.upload_max_size;
+    // Phlex renders `data: { upload_max_size: ... }` as the DOM attribute
+    // `data-upload-max-size`, which reads back as `dataset.uploadMaxSize`
+    // (camelCase) -- NOT `dataset.upload_max_size`. The old underscore key
+    // was always undefined, so every `file_size > this.max_image_size`
+    // check silently passed and no size limit was ever enforced client-side
+    // (issue #4872). Number() so the comparisons are numeric, not string.
+    this.max_image_size = Number(this.element.dataset.uploadMaxSize);
 
     this.fileStore = { items: [], index: {} }
 
@@ -184,6 +190,18 @@ export default class extends Controller {
   }
 
   uploadAll() {
+    // Block submission entirely if any pending image is over the size
+    // limit, rather than silently dropping it and stalling the upload
+    // queue on a failed empty POST (issue #4872). Report every offending
+    // file by name so the user knows exactly what to fix.
+    const _oversized = this.fileStore.items.filter(
+      (item) => item.file_size > this.max_image_size
+    );
+    if (_oversized.length > 0) {
+      this.reportOversizedItems(_oversized);
+      return false;
+    }
+
     // disable submit and remove image buttons during upload process.
     this.submit_buttons.forEach(
       (element) => { element.disabled = true }
@@ -204,6 +222,15 @@ export default class extends Controller {
     }
 
     return false;
+  }
+
+  // Show a prominent, blocking message naming each file that exceeds the
+  // upload size limit, so an over-limit photo can never be mistaken for a
+  // successful upload (issue #4872). The message text carries the limit;
+  // we append the offending file names.
+  reportOversizedItems(items) {
+    const _names = items.map((item) => item.file_name).join("\n");
+    alert(`${this.localized_text.image_too_big_text}\n\n${_names}`);
   }
 
   onUploadedCallback() {
@@ -505,6 +532,14 @@ export default class extends Controller {
     });
 
     const _formData = this.asFormData(item);
+    // asFormData returns null for an over-limit file. uploadAll blocks
+    // these up front (issue #4872), so this is a belt-and-suspenders guard:
+    // skip the pointless empty POST and keep the queue moving instead of
+    // stalling on a failed request.
+    if (_formData === null) {
+      this.onUploadedCallback();
+      return;
+    }
     const response = await post(this.upload_image_uri,
       { body: _formData, responseKind: "json" });
 

--- a/test/system/observation_form_carousel_system_test.rb
+++ b/test/system/observation_form_carousel_system_test.rb
@@ -87,4 +87,30 @@ class ObservationFormCarouselSystemTest < ApplicationSystemTestCase
              "Thumbnail #{i + 1} src should be base64, got: #{src[0..50]}")
     end
   end
+
+  # An image over the upload size limit must block submission with a
+  # visible, blocking message naming the file -- never be silently
+  # dropped (issue #4872). Stub the limit tiny so a normal test image
+  # exceeds it, rather than fabricating a 20+ MB file.
+  def test_oversized_image_blocks_submission_with_alert
+    setup_image_dirs
+    login!(rolf)
+
+    MO.stub(:image_upload_max_size, 1000) do
+      visit(new_observation_path)
+      click_attach_file("Coprinus_comatus.jpg")
+      assert_selector(".carousel-item[data-image-status='upload']", wait: 10)
+
+      assert_no_difference(["Image.count", "Observation.count"]) do
+        alert_text = accept_alert do
+          within("#observation_form") { click_commit }
+        end
+        assert_includes(alert_text, "Coprinus_comatus.jpg",
+                        "alert must name the over-limit file")
+      end
+
+      # Submission was blocked client-side: still on the new-obs form.
+      assert_selector("body.observations__new")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #4872.

## Root cause (deeper than the issue described)

The issue was filed as "oversized image is silently dropped." The real cause is that the client-side size limit was **never enforced at all**.

`form-images_controller.js` read the limit with `this.element.dataset.upload_max_size`. But the value is set in the Phlex view as `data: { upload_max_size: MO.image_upload_max_size.to_s }`, and Phlex renders that as the DOM attribute `data-upload-max-size` — which reads back as `dataset.uploadMaxSize` (camelCase), **not** `dataset.upload_max_size`. So `this.max_image_size` was always `undefined`, and every `item.file_size > this.max_image_size` guard compared against `undefined` (always false). No size check ever fired.

The consequence chain that produced "nothing happens":

1. An over-limit photo passes the (dead) client check and is POSTed to the server.
2. `Image#validate_image_length` rejects it (the 20 MB cap).
3. The failed upload response isn't `ok`, so `uploadItem` only `console.log`s it and never calls `onUploadedCallback()`.
4. The upload queue stalls — the observation form never submits and the submit buttons stay disabled. To the user (issue #4872, reported by a real observer whose two photos vanished from observation 656392) it looks like the Edit form does nothing.

## Changes

- Read the limit from `dataset.uploadMaxSize` and `Number()` it, so the existing size checks actually work.
- On submit, `uploadAll` now blocks the whole submission up front if any pending image is over the limit, showing a prominent `alert` that names each offending file — instead of the silent drop / empty POST that stalled the queue. Nothing is silently lost; the user is told exactly which file to fix.
- `uploadItem` guards against a `null` FormData (the `asFormData` over-limit return) as defense in depth, so an over-limit item can never fire a pointless empty POST.

## Test plan

- [x] New `test_oversized_image_blocks_submission_with_alert` in `observation_form_carousel_system_test.rb`: stubs `MO.image_upload_max_size` tiny so a normal test image exceeds it (rather than fabricating a 20+ MB file), attaches it, and asserts the submit is blocked with an alert naming the file and that no `Image`/`Observation` is created. This test **fails without the `dataset.uploadMaxSize` fix** (the image reaches the server), confirming it guards the real bug.
- [x] `bin/rails test test/system/observation_form_carousel_system_test.rb` — all 3 pass (normal single- and multi-image upload paths unaffected).
- [x] `bin/rails test test/system/image_upload_system_test.rb test/system/observation_form_system_test.rb` — green except one **pre-existing** failure unrelated to this PR: `test_post_edit_and_destroy_with_details_and_location` expects `/Fungarium records/` but the page now renders "Fungarium Records" (a leftover from the `.ti` title-case sweep). It fails identically on `main` without this change.

## Note

`Image#validate_image_length` remains a correct server-side backstop and is unchanged. This PR restores the client-side guard that was silently broken, so users get an immediate, clear message instead of a wedged form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
