### PR TITLE
Fix 3 flaky/stale system test assertions

### DIFF
--- a/test/system/image_show_system_test.rb
+++ b/test/system/image_show_system_test.rb
@@ -18,9 +18,10 @@ class ImageShowSystemTest < ApplicationSystemTestCase
 
     visit("/images/#{image.id}")
     assert_selector("body.images__show")
-    # Let external assets (Maps JS, license badge) finish loading so
-    # they don't count as pending connections against the next action.
-    sleep(1)
+    # Wait for external assets (Maps JS, license badge) to finish
+    # loading so they don't register as pending connections against
+    # the next Ferrum action (#4854 follow-up flakiness).
+    page.driver.browser.network.wait_for_idle
 
     page.execute_script("window.moTestMarker = true")
 

--- a/test/system/image_show_system_test.rb
+++ b/test/system/image_show_system_test.rb
@@ -18,6 +18,9 @@ class ImageShowSystemTest < ApplicationSystemTestCase
 
     visit("/images/#{image.id}")
     assert_selector("body.images__show")
+    # Let external assets (Maps JS, license badge) finish loading so
+    # they don't count as pending connections against the next action.
+    sleep(1)
 
     page.execute_script("window.moTestMarker = true")
 

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1326,9 +1326,9 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
       assert_text(:show_observation_seen_at.l)
     end
     if new_obs.specimen
-      assert_text(/Fungarium records/)
+      assert_text(:herbarium_records.ti)
     else
-      assert_text(/No specimen/)
+      assert_text(:show_observation_specimen_not_available.l)
     end
     assert_text(new_obs.notes_show_formatted)
     # assert_text(new_img.notes) # nope, in the caption on carousel

--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -293,6 +293,8 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
       click_button(class: "btn-danger")
     end
     assert_no_selector("#mo_confirm", visible: true)
-    assert_no_link(text: /MyCoPortal/)
+    within("#observation_external_links") do
+      assert_no_link(text: /MyCoPortal/)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes three flaky/stale system test assertions found while running the suite after unrelated en.txt tag-consolidation work landed:

- **`observation_form_system_test.rb`**: `test_post_edit_and_destroy_with_details_and_location` was failing on `main` with `expected to find text matching /Fungarium records/`. The specimen-panel heading renders title-cased ("Fungarium Records:", via `:herbarium_records.ti`), but the test's hardcoded regex required a lowercase `r`. Replaced both hardcoded literals in `assert_show_observation_page_has_important_info` with the real translation tags (`:herbarium_records.ti` / `:show_observation_specimen_not_available.l`), matching the two assertions immediately above it in the same method.
- **`image_show_system_test.rb`**: `test_rotate_does_not_reload_page` intermittently hit `Ferrum::PendingConnectionsError` (Maps JS / license badge still loading when the next action fired). Added a short settle delay after `visit` before proceeding.
- **`observation_show_system_test.rb`**: `test_add_and_edit_external_links`'s post-destroy `assert_no_link(text: /MyCoPortal/)` was matching an unrelated "Find in MyCoPortal" research-link tab elsewhere on the page, not a timing issue. Scoped the assertion to `#observation_external_links`, matching the pattern the rest of the test already uses.

## Test plan

- [x] `bundle exec rubocop` on all three changed test files — clean.
- [x] Each fix verified individually against its specific failing test, then the full file it lives in, all green.
