### PR TITLE
Warn on dev server/console boot when Solid Cache caching is off

### DIFF
--- a/app/classes/dev_cache_warning.rb
+++ b/app/classes/dev_cache_warning.rb
@@ -20,7 +20,7 @@ class DevCacheWarning
   # in their output.
   def self.applicable?(
     env: Rails.env,
-    server_or_console: defined?(Rails::Server) || defined?(Rails::Console),
+    server_or_console: !!(defined?(Rails::Server) || defined?(Rails::Console)),
     cache_file_exists: Rails.root.join("tmp/caching-dev.txt").exist?
   )
     env.development? && server_or_console && !cache_file_exists

--- a/app/classes/dev_cache_warning.rb
+++ b/app/classes/dev_cache_warning.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Local caching defaults to off (config/environments/development.rb),
+# unlike production -- so a real N+1-cache-round-trip bug (#4865) can
+# go unnoticed locally for a long time. Printed once at server/console
+# boot by config/initializers/warn_if_dev_cache_disabled.rb.
+class DevCacheWarning
+  MESSAGE = "\n*** Caching is OFF -- this doesn't match production. Run " \
+            "`bin/rails dev:cache` to toggle it on (creates " \
+            "tmp/caching-dev.txt) and catch cache-related bugs locally; " \
+            "run it again to toggle back off if you're editing views/" \
+            "components and want to see changes to cached HTML " \
+            "immediately. If you want caching on AND to see an updated " \
+            "fragment, run `Rails.cache.clear` from `bin/rails console` " \
+            "instead of toggling. ***\n"
+
+  # Only a server/console boot gets the reminder -- rake tasks
+  # (migrations, asset precompile, etc.) also load initializers under
+  # RAILS_ENV=development and shouldn't get an unrelated warning line
+  # in their output.
+  def self.applicable?(
+    env: Rails.env,
+    server_or_console: defined?(Rails::Server) || defined?(Rails::Console),
+    cache_file_exists: Rails.root.join("tmp/caching-dev.txt").exist?
+  )
+    env.development? && server_or_console && !cache_file_exists
+  end
+
+  def self.warn_if_applicable
+    warn(MESSAGE) if applicable?
+  end
+end

--- a/config/initializers/warn_if_dev_cache_disabled.rb
+++ b/config/initializers/warn_if_dev_cache_disabled.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  DevCacheWarning.warn_if_applicable
+end

--- a/test/classes/dev_cache_warning_test.rb
+++ b/test/classes/dev_cache_warning_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class DevCacheWarningTest < UnitTestCase
+  def test_applicable_when_dev_server_boot_and_caching_off
+    assert(
+      DevCacheWarning.applicable?(
+        env: ActiveSupport::StringInquirer.new("development"),
+        server_or_console: true, cache_file_exists: false
+      )
+    )
+  end
+
+  def test_not_applicable_when_caching_already_on
+    assert_not(
+      DevCacheWarning.applicable?(
+        env: ActiveSupport::StringInquirer.new("development"),
+        server_or_console: true, cache_file_exists: true
+      )
+    )
+  end
+
+  def test_not_applicable_outside_server_or_console_boot
+    assert_not(
+      DevCacheWarning.applicable?(
+        env: ActiveSupport::StringInquirer.new("development"),
+        server_or_console: false, cache_file_exists: false
+      )
+    )
+  end
+
+  def test_not_applicable_outside_development
+    assert_not(
+      DevCacheWarning.applicable?(
+        env: ActiveSupport::StringInquirer.new("test"),
+        server_or_console: true, cache_file_exists: false
+      )
+    )
+  end
+
+  def test_warn_if_applicable_prints_the_message_when_applicable
+    DevCacheWarning.stub(:applicable?, true) do
+      assert_output(nil, DevCacheWarning::MESSAGE) do
+        DevCacheWarning.warn_if_applicable
+      end
+    end
+  end
+
+  def test_warn_if_applicable_silent_when_not_applicable
+    DevCacheWarning.stub(:applicable?, false) do
+      assert_output(nil, "") do
+        DevCacheWarning.warn_if_applicable
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`config.action_controller.perform_caching` defaults to off locally (`config/environments/development.rb`), unlike production, so a real N+1-cache-round-trip bug like #4865 can go unnoticed on a dev machine for a long time.

`DevCacheWarning` prints a one-line reminder at `bin/rails server`/`bin/rails console` boot (not at rake-task boot, since those also load initializers under `RAILS_ENV=development` and shouldn't get an unrelated warning line in their output) when caching is off, pointing at:

- `bin/rails dev:cache` to toggle it on/off (creates/removes `tmp/caching-dev.txt`)
- turning it back off if you're actively editing views/components and want to see changes to cached HTML immediately
- `Rails.cache.clear` from `bin/rails console` if you want caching on AND to see an updated fragment, instead of toggling

Fixes #4869.

## Implementation note

The check/message logic lives in `app/classes/dev_cache_warning.rb` (testable, injectable env/file-state args) rather than inline in the initializer, because Rails' Zeitwerk autoloader isn't fully set up until *after* `config/initializers/*` load — referencing an autoloaded `app/` constant directly at an initializer's top level raises `uninitialized constant`. The initializer just calls it inside `Rails.application.config.after_initialize`.

## Test plan

- [x] `bundle exec rubocop` — clean on all 3 files.
- [x] `bin/rails test test/classes/dev_cache_warning_test.rb` — 6 tests, 100% line coverage on the new class.
- [x] `bin/rails runner 'puts "boot ok"'` — confirms the initializer no longer breaks app boot.
