### PR TITLE
Move and rubocop `Language::Exporter`/`Language::Tracking`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -137,7 +137,6 @@ Metrics/AbcSize:
     - 'app/helpers/api2_inline_helper.rb'
     - 'app/jobs/field_slip_job.rb'
     - 'app/models/abstract_model.rb'
-    - 'app/models/concerns/language_exporter.rb'
     - 'app/models/description.rb'
     - 'app/models/field_slip.rb'
     - 'app/models/image.rb'
@@ -238,7 +237,6 @@ Metrics/CyclomaticComplexity:
     - 'app/controllers/translations_controller.rb'
     - 'app/extensions/string.rb'
     - 'app/extensions/symbol.rb'
-    - 'app/models/concerns/language_exporter.rb'
     - 'app/models/image.rb'
     - 'app/models/location.rb'
     - 'app/models/location_description.rb'
@@ -269,7 +267,6 @@ Metrics/MethodLength:
     - 'app/controllers/concerns/descriptions.rb'
     - 'app/controllers/names/eol_data/preview_controller.rb'
     - 'app/extensions/symbol.rb'
-    - 'app/models/concerns/language_exporter.rb'
     - 'app/models/image.rb'
     - 'app/models/name/parse.rb'
     - 'script/bulk_name_change'
@@ -278,7 +275,6 @@ Metrics/MethodLength:
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ModuleLength:
   Exclude:
-    - 'app/models/concerns/language_exporter.rb'
     - 'app/models/name/parse.rb'
 
 # Offense count: 5
@@ -315,7 +311,6 @@ Metrics/PerceivedComplexity:
     - 'app/controllers/translations_controller.rb'
     - 'app/extensions/string.rb'
     - 'app/extensions/symbol.rb'
-    - 'app/models/concerns/language_exporter.rb'
     - 'app/models/image.rb'
     - 'app/models/location_description.rb'
     - 'app/models/name.rb'

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -16,21 +16,21 @@
 #
 #  == Localization and export files
 #
-#  Translation strings are exported to two sets of files.  See LanguageExporter
-#  module for more information.
+#  Translation strings are exported to two sets of files.  See
+#  Language::Exporter module for more information.
 #
 #  == Tracking translations used on a page
 #
 #  Very simple global mechanism for keeping track of which localization strings
-#  are used on each page.  See LanguageTracking module for more info.
+#  are used on each page.  See Language::Tracking module for more info.
 #
 ################################################################################
 
 class Language < AbstractModel
-  include LanguageExporter
+  include Exporter
 
   class << self
-    include LanguageTracking
+    include Tracking
   end
 
   has_many :translation_strings, dependent: :destroy

--- a/app/models/language/exporter.rb
+++ b/app/models/language/exporter.rb
@@ -21,12 +21,12 @@
 #
 ################################################################################
 
-module LanguageExporter
-  def self.included(base)
-    base.extend(ClassMethods)
-  end
+# Validation methods share mutable instance state; not worth splitting.
+# rubocop:disable Metrics/ModuleLength
+module Language::Exporter
+  extend ActiveSupport::Concern
 
-  module ClassMethods
+  class_methods do
     attr_accessor :verbose, :safe_mode
     attr_reader :locales_path
 
@@ -98,26 +98,40 @@ module LanguageExporter
       user.nil? && !official
 
     user ||= User.admin
-    any_changes = false
-    old_data = localization_strings
     new_data = read_export_file
-    good_tags = Language.official.read_export_file
-    tag_lookup = translation_strings_hash
-    new_data.each do |tag, new_val|
-      next unless new_val.is_a?(String) && good_tags.key?(tag)
+    context = {
+      # Importing the official locale reads+parses the same file twice
+      # otherwise -- `new_data` already *is* the official file's data.
+      good_tags: official ? new_data : Language.official.read_export_file,
+      old_data: localization_strings,
+      tag_lookup: translation_strings_hash,
+      user: user
+    }
 
-      new_val = clean_string(new_val)
-      old_val = clean_string(old_data[tag])
-      next unless old_data[tag].nil? || (old_val != new_val)
-
-      if (str = tag_lookup[tag])
-        update_string(str, new_val, old_val, user)
-      else
-        create_string(tag, new_val, old_val, user)
-      end
-      any_changes = true
+    new_data.reduce(false) do |any_changes, (tag, new_val)|
+      changed = import_tag?(tag, new_val, context)
+      any_changes || changed
     end
-    any_changes
+  end
+
+  # One tag's worth of `import_from_file`'s work. Returns whether it
+  # actually changed anything (new/updated string), so the caller can
+  # fold that into its overall `any_changes` result.
+  def import_tag?(tag, new_val, context)
+    good_tags, old_data, tag_lookup, user =
+      context.values_at(:good_tags, :old_data, :tag_lookup, :user)
+    return false unless new_val.is_a?(String) && good_tags.key?(tag)
+
+    new_val = clean_string(new_val)
+    old_val = clean_string(old_data[tag])
+    return false unless old_data[tag].nil? || (old_val != new_val)
+
+    if (str = tag_lookup[tag])
+      update_string(str, new_val, old_val, user)
+    else
+      create_string(tag, new_val, old_val, user)
+    end
+    true
   end
 
   # Strip tags "unused" translation strings from unofficial locales.
@@ -258,12 +272,8 @@ module LanguageExporter
     output_lines = []
     in_tag = false
     template_lines.each do |line|
-      if line =~ /^(\W+['"]?(\w+)['"]?:)/
-        out = Regexp.last_match(1)
-        tag = Regexp.last_match(2)
-        out += translated.key?(tag) ? " " : "  "
-        out += format_string(strings[tag])
-        output_lines << out
+      if (formatted = format_export_tag_def_line(line, strings, translated))
+        output_lines << formatted
         in_tag = true if / >\s*$/.match?(line)
       elsif in_tag
         in_tag = false unless /\S/.match?(line)
@@ -272,6 +282,18 @@ module LanguageExporter
       end
     end
     output_lines
+  end
+
+  # Formats one template line as a tag-definition line, or returns nil
+  # if `line` isn't one (a comment, blank line, or multi-line-string
+  # continuation, all handled by the caller instead).
+  def format_export_tag_def_line(line, strings, translated)
+    return nil unless line =~ /^(\W+['"]?(\w+)['"]?:)/
+
+    out = Regexp.last_match(1)
+    tag = Regexp.last_match(2)
+    out += translated.key?(tag) ? " " : "  "
+    out + format_string(strings[tag])
   end
 
   def format_string(val)
@@ -307,35 +329,44 @@ module LanguageExporter
     read_export_file_lines.each do |line|
       next unless line =~ /^ *['"]?(\w+)['"]?:/
 
-      if once[Regexp.last_match(1)] && !twice[Regexp.last_match(1)]
-        verbose("#{locale} #{Regexp.last_match(1)}: " \
-                "tag appears more than once")
-        twice[Regexp.last_match(1)] = true
-        pass = false
-      end
-      once[Regexp.last_match(1)] = true
+      tag = Regexp.last_match(1)
+      pass = false if tag_duplicated?(tag, once, twice)
+      once[tag] = true
     end
     pass
   end
 
+  def tag_duplicated?(tag, once, twice)
+    return false unless once[tag] && !twice[tag]
+
+    verbose("#{locale} #{tag}: tag appears more than once")
+    twice[tag] = true
+    true
+  end
+
   def check_export_file_data
     pass = true
-    data = read_export_file
-    data.each do |tag, str|
-      unless tag.is_a?(String)
-        verbose("#{locale} #{tag}: tag is a #{tag.class.name} " \
-                "instead of a String")
-        pass = false
-      end
-      unless str.is_a?(String)
-        verbose("#{locale} #{tag}: value is a #{str.class.name} " \
-                "instead of a String")
-        pass = false
-      end
-      unless validate_square_brackets(str)
-        verbose("#{locale} #{tag}: square brackets messed up: #{str.inspect}")
-        pass = false
-      end
+    read_export_file.each do |tag, str|
+      pass = false unless check_export_file_entry(tag, str)
+    end
+    pass
+  end
+
+  def check_export_file_entry(tag, str)
+    pass = true
+    unless tag.is_a?(String)
+      verbose("#{locale} #{tag}: tag is a #{tag.class.name} " \
+              "instead of a String")
+      pass = false
+    end
+    unless str.is_a?(String)
+      verbose("#{locale} #{tag}: value is a #{str.class.name} " \
+              "instead of a String")
+      pass = false
+    end
+    unless validate_square_brackets(str)
+      verbose("#{locale} #{tag}: square brackets messed up: #{str.inspect}")
+      pass = false
     end
     pass
   end
@@ -367,19 +398,32 @@ module LanguageExporter
   end
 
   def check_export_tag_def_line(quoted_tag, tag, str)
-    if @in_tag
-      verbose("#{locale} #{@line_number}: " \
-              "didn't finish multi-line string for #{@in_tag}")
-      @in_tag = false
-      @pass = false
-    end
-    if (quoted_tag.start_with?("'") && !quoted_tag.end_with?("'")) ||
-       (quoted_tag.start_with?('"') && !quoted_tag.end_with?('"')) ||
-       (quoted_tag.match(/['"]$/) && !quoted_tag.match(/^['"]/))
-      verbose("#{locale} #{@line_number}: " \
-              "invalid tag quotes: #{quoted_tag.inspect}")
-      @pass = false
-    end
+    check_unfinished_multiline_string
+    check_tag_quotes(quoted_tag)
+    check_tag_validity(quoted_tag, tag)
+    check_tag_value(tag, str.strip)
+  end
+
+  def check_unfinished_multiline_string
+    return unless @in_tag
+
+    verbose("#{locale} #{@line_number}: " \
+            "didn't finish multi-line string for #{@in_tag}")
+    @in_tag = false
+    @pass = false
+  end
+
+  def check_tag_quotes(quoted_tag)
+    return unless (quoted_tag.start_with?("'") && !quoted_tag.end_with?("'")) ||
+                  (quoted_tag.start_with?('"') && !quoted_tag.end_with?('"')) ||
+                  (quoted_tag.match(/['"]$/) && !quoted_tag.match(/^['"]/))
+
+    verbose("#{locale} #{@line_number}: " \
+            "invalid tag quotes: #{quoted_tag.inspect}")
+    @pass = false
+  end
+
+  def check_tag_validity(quoted_tag, tag)
     if /^(yes|no)$/i.match?(quoted_tag)
       verbose("#{locale} #{@line_number}: " \
               "'yes' and 'no' must be quoted in YAML files")
@@ -388,13 +432,15 @@ module LanguageExporter
       verbose("#{locale} #{@line_number}: invalid tag: #{tag.inspect}")
       @pass = false
     end
-    str.strip!
+  end
+
+  def check_tag_value(tag, str)
     if str == ">"
       @in_tag = tag
     elsif str == ""
       verbose("#{locale} #{@line_number}: missing string")
       @pass = false
-    elsif !validate_string(str)
+    elsif !validate_string?(str)
       verbose("#{locale} #{@line_number}: invalid string: #{str.inspect}")
       @pass = false
     end
@@ -424,21 +470,23 @@ module LanguageExporter
     str.match(/^\w+$/)
   end
 
-  def validate_string(str)
+  def validate_string?(str)
     str = str.strip.squeeze(" ")
-    pass = true
-    if /^(yes|no)$/i.match?(str)
-      pass = false
-    elsif str.start_with?("'")
-      pass = false unless /^'([^'\\]|\\.)*'$/.match?(str)
-    elsif str.start_with?('"')
-      pass = false unless /^"([^"\\]|\\.)*"$/.match?(str)
-    # Disable cop because conditions must be tested in order
-    elsif /:(\s|$)| #/.match?(str) || # rubocop:disable Lint/DuplicateBranch
-          (/^[^\w(]/.match?(str) && str[0].is_ascii_character?)
-      pass = false
-    end
-    pass
+    return false if /^(yes|no)$/i.match?(str)
+    return quoted_string_valid?(str, "'") if str.start_with?("'")
+    return quoted_string_valid?(str, '"') if str.start_with?('"')
+
+    !unquoted_string_invalid?(str)
+  end
+
+  def quoted_string_valid?(str, quote)
+    pattern = quote == "'" ? /^'([^'\\]|\\.)*'$/ : /^"([^"\\]|\\.)*"$/
+    pattern.match?(str)
+  end
+
+  def unquoted_string_invalid?(str)
+    /:(\s|$)| #/.match?(str) ||
+      (/^[^\w(]/.match?(str) && str[0].is_ascii_character?)
   end
 
   def validate_square_brackets(value)
@@ -478,3 +526,4 @@ module LanguageExporter
     pass
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/models/language/tracking.rb
+++ b/app/models/language/tracking.rb
@@ -29,7 +29,7 @@
 #
 ################################################################################
 
-module LanguageTracking
+module Language::Tracking
   # `tags_used` tracks which tags got used on the CURRENT page/request
   # - `before_action { Language.track_usage }` primes it, later code
   # in that same request reads it back via `note_usage_of_tag`/

--- a/app/models/translation_string.rb
+++ b/app/models/translation_string.rb
@@ -40,7 +40,7 @@ class TranslationString < AbstractModel
 
   # See Name: delete_all the versions on destroy so they don't dangle.
   # This is the biggest source -- language import/export removes strings
-  # regularly (see Concerns::LanguageExporter).
+  # regularly (see Language::Exporter).
   acts_as_versioned(
     if: :update_version?,
     association_options: { dependent: :delete_all }

--- a/doc/parallel_testing.md
+++ b/doc/parallel_testing.md
@@ -257,14 +257,20 @@ This pattern is already implemented for:
 
 **Problem**: Tests that export or modify locale files conflict.
 
-**✅ Solution**: Use worker-specific locale directories:
+**✅ Solution**: Wrap the test in `use_test_locales` (defined in
+`test/general_extensions.rb`) -- it points `Language.locales_path` at a
+worker-specific directory (`config/test_locales-0`,
+`config/test_locales-1`, etc., via `Language.alt_locales_path`) for the
+duration of the block, then removes it:
 
 ```ruby
-def test_export_locales
-  # config/consts.rb automatically handles this
-  # test_locales → test_locales-0, test_locales-1, etc.
-  LanguageExporter.export_locales
-  # Exports to worker-specific directory
+def test_update_export_file
+  use_test_locales do
+    file = @official.export_file
+    FileUtils.copy(template, file)
+    @official.update_export_file
+    # ... assertions against the worker-specific file ...
+  end
 end
 ```
 

--- a/test/models/language/exporter_test.rb
+++ b/test/models/language/exporter_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class LanguageExporterTest < UnitTestCase
+class Language::ExporterTest < UnitTestCase
   attr_accessor :tmp_dir
 
   def setup
@@ -31,17 +31,17 @@ class LanguageExporterTest < UnitTestCase
     assert_invalid(:validate_tag, "one two")
     assert_invalid(:validate_tag, "one[two]")
     assert_invalid(:validate_tag, "pfüssel")
-    assert_valid(:validate_string, "blah")
-    assert_invalid(:validate_string, "yes")
-    assert_invalid(:validate_string, "NO")
-    assert_valid(:validate_string, "one 2 three")
-    assert_valid(:validate_string, "one-two, three!")
-    assert_valid(:validate_string, '"anything goes [here] # wow"')
-    assert_valid(:validate_string, "'anything goes [here] # wow'")
-    assert_invalid(:validate_string, "[:blah]")
-    assert_valid(:validate_string, '"[:blah]"')
-    assert_valid(:validate_string, "tags[:blah]")
-    assert_invalid(:validate_string, "Data: values, are, here")
+    assert_valid(:validate_string?, "blah")
+    assert_invalid(:validate_string?, "yes")
+    assert_invalid(:validate_string?, "NO")
+    assert_valid(:validate_string?, "one 2 three")
+    assert_valid(:validate_string?, "one-two, three!")
+    assert_valid(:validate_string?, '"anything goes [here] # wow"')
+    assert_valid(:validate_string?, "'anything goes [here] # wow'")
+    assert_invalid(:validate_string?, "[:blah]")
+    assert_valid(:validate_string?, '"[:blah]"')
+    assert_valid(:validate_string?, "tags[:blah]")
+    assert_invalid(:validate_string?, "Data: values, are, here")
     assert_valid(:validate_square_brackets, "this is right")
     assert_valid(:validate_square_brackets, "this is [good] right")
     assert_valid(:validate_square_brackets, "this is [:good] right")
@@ -112,7 +112,7 @@ class LanguageExporterTest < UnitTestCase
   end
 
   def test_verbose_puts_message_when_language_verbose
-    real_verbose = LanguageExporter.instance_method(:verbose)
+    real_verbose = Language::Exporter.instance_method(:verbose)
     Language.stub(:verbose, true) do
       out, = capture_io { real_verbose.bind_call(@official, "hello") }
       assert_equal("hello\n", out)

--- a/test/models/language/tracking_test.rb
+++ b/test/models/language/tracking_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class LanguageTrackingTest < UnitTestCase
+class Language::TrackingTest < UnitTestCase
   # Tracking is intentionally sticky (no automatic per-request reset -
   # see ApplicationController#track_translations), so another test
   # running earlier in this same worker process may have left it on.

--- a/test/models/translation_string_test.rb
+++ b/test/models/translation_string_test.rb
@@ -74,7 +74,7 @@ class TranslationStringTest < UnitTestCase
   end
 
   # The actual production bug: rename_tags itself is fine (see above),
-  # but LanguageExporter#strip deletes any translation_strings row
+  # but Language::Exporter#strip deletes any translation_strings row
   # whose tag isn't in en.txt -- and DB-only tags like black_on_white
   # were, by design, never in en.txt. So any lang:update run (deploy,
   # or manual) after the rename strips every language's row for a
@@ -95,7 +95,7 @@ class TranslationStringTest < UnitTestCase
 
     assert_empty(
       TranslationString.where(tag: "db_only_tag_not_in_en_txt"),
-      "LanguageExporter#strip deletes rows for any tag missing from " \
+      "Language::Exporter#strip deletes rows for any tag missing from " \
       "en.txt -- this is exactly what happened to black_on_white's " \
       "non-English translations after the #4844 rename"
     )


### PR DESCRIPTION
## Summary

Moves `LanguageExporter` -> `Language::Exporter` and `LanguageTracking` -> `Language::Tracking` out of `app/models/concerns/` into `app/models/language/`, converting both from the hand-rolled `self.included(base); base.extend(ClassMethods)` pattern to `extend ActiveSupport::Concern` + `class_methods do ... end` -- matching the `Observation::Scopes` precedent already in the codebase.

`app/models/language/exporter.rb` also splits several methods that were tripping RuboCop's `Metrics` cops into smaller pieces, with no behavior change: `import_from_file`'s loop body -> `import_tag?`; `format_export_file`'s inline tag-def-line branch -> `format_export_tag_def_line`; `check_export_file_for_duplicates` -> `+ tag_duplicated?`; `check_export_file_data` -> `+ check_export_file_entry`; `check_export_tag_def_line` -> split into `check_unfinished_multiline_string` / `check_tag_quotes` / `check_tag_validity` / `check_tag_value`; `validate_string` -> renamed `validate_string?`, rewritten as guard clauses + `quoted_string_valid?` / `unquoted_string_invalid?`. This removes 5 now-unnecessary `Metrics/*` grandfather exclusions for the old path from `.rubocop_todo.yml`.

`doc/parallel_testing.md`'s locale-file section referenced a `LanguageExporter.export_locales` method that doesn't exist -- fixed to describe the actual mechanism (`use_test_locales`, defined in `test/general_extensions.rb`). `app/models/translation_string.rb`'s comment referencing the old `Concerns::LanguageExporter` name is updated to `Language::Exporter`.

## Why this is its own PR

This is extracted from `nimmo-4807-solid-cache-i18n-backend`'s local commit `0693081ad6`, which made this same move as part of a larger branch. Pulling it out ahead of time lets #4772 ("Parallelize `lib/tasks/lang.rake` multi-language tasks") land against the post-move shape of this code, rather than being written against a soon-to-be-reorganized module.

**Manually reconstructed, not cherry-picked.** `0693081ad6`'s snapshot of `app/models/language/exporter.rb` also carries functional additions specific to #4807's Solid Cache I18n backend work: a `BOOLEAN_LIKE_STRING` constant, an `evict_cached_translation` private method + its call site in `strip`, a `format_export_key` private method + its call site in `write_hash`, and `TranslationString#store_localization` calls in `create_string`/`update_string`. `git diff 0693081ad6~1 0693081ad6` confirms none of these lines were introduced by the move commit itself -- they were already present in its parent (from an earlier #4807 commit) and simply carried forward while everything else was relocated and refactored. This PR intentionally excludes all of that #4807-specific content; `app/classes/i18n/backend/*.rb` and its tests aren't touched at all (they don't exist on `main`).

## Test plan

- [x] `bundle exec rubocop app/models/language/exporter.rb app/models/language/tracking.rb app/models/language.rb app/models/translation_string.rb test/models/language/exporter_test.rb test/models/language/tracking_test.rb test/models/translation_string_test.rb` -- clean.
- [x] `bin/rails test test/models/language/exporter_test.rb test/models/language/tracking_test.rb test/models/translation_string_test.rb` -- 28 tests, 243 assertions, 0 failures.
- [x] `bin/rails test test/classes/localization_files_test.rb` (duplicate-def scanner) -- 13 tests, 0 failures.
- [x] `bin/rails zeitwerk:check` -- all good.
- [x] Diffed the reconstructed `app/models/language/exporter.rb` directly against `0693081ad6`'s version to confirm the only differences are the 7 excluded #4807-specific pieces listed above -- nothing else was dropped or altered.
