### PR TITLE
Make tooltip activation properly reactive by using a Stimulus target

### DIFF
--- a/app/components/button/clipboard.rb
+++ b/app/components/button/clipboard.rb
@@ -28,7 +28,7 @@ class Components::Button::Clipboard < Components::Button
   private
 
   def tooltip_data(name)
-    { tooltip_target: "trigger", placement: "bottom", title: name }
+    { tooltip_target: "tip", placement: "bottom", title: name }
   end
 
   def clipboard_data

--- a/app/components/button/clipboard.rb
+++ b/app/components/button/clipboard.rb
@@ -28,7 +28,7 @@ class Components::Button::Clipboard < Components::Button
   private
 
   def tooltip_data(name)
-    { toggle: "tooltip", placement: "bottom", title: name }
+    { tooltip_target: "trigger", placement: "bottom", title: name }
   end
 
   def clipboard_data

--- a/app/components/button/crud_base.rb
+++ b/app/components/button/crud_base.rb
@@ -59,7 +59,7 @@ class Components::Button::CRUDBase < Components::Button
     form_data = { turbo: true }
     form_data[:turbo_confirm] = @confirm if @confirm
 
-    button_data = { toggle: "tooltip", placement: "top", title: @name }
+    button_data = { tooltip_target: "trigger", placement: "top", title: @name }
     if @confirm
       button_data[:turbo_confirm_title] = @confirm
       button_data[:turbo_confirm_button] = @name

--- a/app/components/button/crud_base.rb
+++ b/app/components/button/crud_base.rb
@@ -59,7 +59,7 @@ class Components::Button::CRUDBase < Components::Button
     form_data = { turbo: true }
     form_data[:turbo_confirm] = @confirm if @confirm
 
-    button_data = { tooltip_target: "trigger", placement: "top", title: @name }
+    button_data = { tooltip_target: "tip", placement: "top", title: @name }
     if @confirm
       button_data[:turbo_confirm_title] = @confirm
       button_data[:turbo_confirm_button] = @name

--- a/app/components/dropdown.rb
+++ b/app/components/dropdown.rb
@@ -156,9 +156,9 @@ class Components::Dropdown < Components::Base
   # interfere with dropdown click handling.
   def strip_tooltip_data(kwargs)
     data = kwargs[:data]
-    return kwargs unless data.is_a?(Hash) && data[:toggle] == "tooltip"
+    return kwargs unless data.is_a?(Hash) && data[:tooltip_target] == "trigger"
 
-    stripped = data.except(:toggle, :title, :placement)
+    stripped = data.except(:tooltip_target, :title, :placement)
     stripped.empty? ? kwargs.except(:data) : kwargs.merge(data: stripped)
   end
 

--- a/app/components/dropdown.rb
+++ b/app/components/dropdown.rb
@@ -156,7 +156,7 @@ class Components::Dropdown < Components::Base
   # interfere with dropdown click handling.
   def strip_tooltip_data(kwargs)
     data = kwargs[:data]
-    return kwargs unless data.is_a?(Hash) && data[:tooltip_target] == "trigger"
+    return kwargs unless data.is_a?(Hash) && data[:tooltip_target] == "tip"
 
     stripped = data.except(:tooltip_target, :title, :placement)
     stripped.empty? ? kwargs.except(:data) : kwargs.merge(data: stripped)

--- a/app/components/help/tooltip.rb
+++ b/app/components/help/tooltip.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 # `<span>` with a context-help tooltip — `data-tooltip-target="tip"`
-# (the tooltip Stimulus controller's target) displays the `title=`
-# attribute on hover. Used for inline label-decorating glyphs (the `?`
-# next to a filter header, etc.).
+# marks the element as the tooltip Stimulus controller's target, which
+# activates Bootstrap's tooltip plugin; that plugin then displays the
+# `title=` attribute on hover. Used for inline label-decorating glyphs
+# (the `?` next to a filter header, etc.).
 #
 # @example
 #   render(Components::Help::Tooltip.new(label: "(?)",

--- a/app/components/help/tooltip.rb
+++ b/app/components/help/tooltip.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# `<span>` with a context-help tooltip — `data-tooltip-target="trigger"`
+# `<span>` with a context-help tooltip — `data-tooltip-target="tip"`
 # (the tooltip Stimulus controller's target) displays the `title=`
 # attribute on hover. Used for inline label-decorating glyphs (the `?`
 # next to a filter header, etc.).
@@ -17,7 +17,7 @@ class Components::Help::Tooltip < Components::Base
   def view_template
     span(class: class_names("context-help", @extra_class),
          title: @title,
-         data: { tooltip_target: "trigger" }.merge(@data)) do
+         data: { tooltip_target: "tip" }.merge(@data)) do
       plain(@label)
     end
   end

--- a/app/components/help/tooltip.rb
+++ b/app/components/help/tooltip.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# `<span>` with a context-help tooltip — Bootstrap's
-# `data-toggle="tooltip"` displays the `title=` attribute on hover.
-# Used for inline label-decorating glyphs (the `?` next to a filter
-# header, etc.).
+# `<span>` with a context-help tooltip — `data-tooltip-target="trigger"`
+# (the tooltip Stimulus controller's target) displays the `title=`
+# attribute on hover. Used for inline label-decorating glyphs (the `?`
+# next to a filter header, etc.).
 #
 # @example
 #   render(Components::Help::Tooltip.new(label: "(?)",
@@ -17,7 +17,7 @@ class Components::Help::Tooltip < Components::Base
   def view_template
     span(class: class_names("context-help", @extra_class),
          title: @title,
-         data: { toggle: "tooltip" }.merge(@data)) do
+         data: { tooltip_target: "trigger" }.merge(@data)) do
       plain(@label)
     end
   end

--- a/app/components/icon.rb
+++ b/app/components/icon.rb
@@ -10,7 +10,7 @@
 # @example With tooltip + screen-reader title + extra CSS
 #   Icon(type: :edit, title: :edit.ti, class: "text-primary")
 #   # => <span class="glyphicon glyphicon-edit link-icon text-primary"
-#   #          title="Edit" data-toggle="tooltip">
+#   #          title="Edit" data-tooltip-target="trigger">
 #   #      <span class="sr-only">Edit</span>
 #   #    </span>
 class Components::Icon < Components::Base
@@ -116,6 +116,6 @@ class Components::Icon < Components::Base
 
   def span_data
     data = @attributes[:data] || {}
-    @title.present? ? { toggle: "tooltip" }.merge(data) : data
+    @title.present? ? { tooltip_target: "trigger" }.merge(data) : data
   end
 end

--- a/app/components/icon.rb
+++ b/app/components/icon.rb
@@ -10,7 +10,7 @@
 # @example With tooltip + screen-reader title + extra CSS
 #   Icon(type: :edit, title: :edit.ti, class: "text-primary")
 #   # => <span class="glyphicon glyphicon-edit link-icon text-primary"
-#   #          title="Edit" data-tooltip-target="trigger">
+#   #          title="Edit" data-tooltip-target="tip">
 #   #      <span class="sr-only">Edit</span>
 #   #    </span>
 class Components::Icon < Components::Base
@@ -116,6 +116,6 @@ class Components::Icon < Components::Base
 
   def span_data
     data = @attributes[:data] || {}
-    @title.present? ? { tooltip_target: "trigger" }.merge(data) : data
+    @title.present? ? { tooltip_target: "tip" }.merge(data) : data
   end
 end

--- a/app/components/id_badge.rb
+++ b/app/components/id_badge.rb
@@ -14,7 +14,7 @@ class Components::IDBadge < Components::Base
       class: class_names("badge badge-id", @extra_class),
       role: "button",
       data: {
-        toggle: "tooltip", placement: "bottom",
+        tooltip_target: "trigger", placement: "bottom",
         title: :copy_this_id.ti,
         controller: "clipboard", clipboard_target: "source",
         action: "clipboard#copy",

--- a/app/components/id_badge.rb
+++ b/app/components/id_badge.rb
@@ -14,7 +14,7 @@ class Components::IDBadge < Components::Base
       class: class_names("badge badge-id", @extra_class),
       role: "button",
       data: {
-        tooltip_target: "trigger", placement: "bottom",
+        tooltip_target: "tip", placement: "bottom",
         title: :copy_this_id.ti,
         controller: "clipboard", clipboard_target: "source",
         action: "clipboard#copy",

--- a/app/components/link/get.rb
+++ b/app/components/link/get.rb
@@ -67,6 +67,6 @@ class Components::Link::Get < Components::Link
 
   def tooltip_data
     { title: @name,
-      data: { toggle: "tooltip", placement: "top", title: @name } }
+      data: { tooltip_target: "trigger", placement: "top", title: @name } }
   end
 end

--- a/app/components/link/get.rb
+++ b/app/components/link/get.rb
@@ -67,6 +67,6 @@ class Components::Link::Get < Components::Link
 
   def tooltip_data
     { title: @name,
-      data: { tooltip_target: "trigger", placement: "top", title: @name } }
+      data: { tooltip_target: "tip", placement: "top", title: @name } }
   end
 end

--- a/app/components/link/icon.rb
+++ b/app/components/link/icon.rb
@@ -114,7 +114,7 @@ class Components::Link::Icon < Components::Base
     base = {
       title: @content,
       class: class_names("icon-link", button_classes, @opts[:class]),
-      data: { tooltip_target: "trigger", title: @content,
+      data: { tooltip_target: "tip", title: @content,
               active_title: @opts[:active_content] }
     }
     base[:data][:turbo_confirm] = @opts[:confirm] if @opts[:confirm]

--- a/app/components/link/icon.rb
+++ b/app/components/link/icon.rb
@@ -114,7 +114,7 @@ class Components::Link::Icon < Components::Base
     base = {
       title: @content,
       class: class_names("icon-link", button_classes, @opts[:class]),
-      data: { toggle: "tooltip", title: @content,
+      data: { tooltip_target: "trigger", title: @content,
               active_title: @opts[:active_content] }
     }
     base[:data][:turbo_confirm] = @opts[:confirm] if @opts[:confirm]

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,22 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="tooltip", once, on <body> -- every
-// tooltip trigger on the page is a `trigger` TARGET of this one
-// instance, not its own controller. BS3 tooltips are "opt-in" and
+// tooltip trigger element on the page carries a `tip` TARGET of this
+// one instance, not its own controller. BS3 tooltips are "opt-in" and
 // need per-element activation; Stimulus's own target tracking (a
-// MutationObserver scoped to this.element) calls triggerTargetConnected
+// MutationObserver scoped to this.element) calls tipTargetConnected
 // for every matching element automatically, whether it's present at
 // initial page load or added later by any means (a turbo-frame fetch,
 // a Turbo Stream, raw JS) -- no manual sweep or extra event listener
 // needed for the dynamic case.
 export default class extends Controller {
-  static targets = ["trigger"]
+  static targets = ["tip"]
 
   connect() {
     this.element.dataset.tooltip = "connected";
   }
 
-  triggerTargetConnected(element) {
+  tipTargetConnected(element) {
     $(element).tooltip()
   }
 }

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,15 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="tooltip"
-// BS3 tooltips are "opt-in", so they require on-page activation
+// Connects to data-controller="tooltip", once, on <body> -- every
+// tooltip trigger on the page is a `trigger` TARGET of this one
+// instance, not its own controller. BS3 tooltips are "opt-in" and
+// need per-element activation; Stimulus's own target tracking (a
+// MutationObserver scoped to this.element) calls triggerTargetConnected
+// for every matching element automatically, whether it's present at
+// initial page load or added later by any means (a turbo-frame fetch,
+// a Turbo Stream, raw JS) -- no manual sweep or extra event listener
+// needed for the dynamic case.
 export default class extends Controller {
+  static targets = ["trigger"]
 
   connect() {
     this.element.dataset.tooltip = "connected";
-    this.activateTooltips();
   }
 
-  activateTooltips() {
-    $('[data-toggle="tooltip"]').tooltip()
+  triggerTargetConnected(element) {
+    $(element).tooltip()
   }
 }

--- a/app/views/controllers/images/show/vote_panel.rb
+++ b/app/views/controllers/images/show/vote_panel.rb
@@ -91,7 +91,7 @@ module Views::Controllers::Images
         div(class: "pt-2") do
           link_to(text, vote_link_args.merge(vote: value),
                   class: css, title: help,
-                  data: { tooltip_target: "trigger", placement: "left",
+                  data: { tooltip_target: "tip", placement: "left",
                           role: "image_vote", val: value, id: @image.id })
         end
       end
@@ -103,7 +103,7 @@ module Views::Controllers::Images
         div(class: "pt-2") do
           link_to(text, vote_link_args.merge(vote: value, next: true),
                   class: css, title: help,
-                  data: { tooltip_target: "trigger" })
+                  data: { tooltip_target: "tip" })
         end
       end
 

--- a/app/views/controllers/images/show/vote_panel.rb
+++ b/app/views/controllers/images/show/vote_panel.rb
@@ -91,7 +91,7 @@ module Views::Controllers::Images
         div(class: "pt-2") do
           link_to(text, vote_link_args.merge(vote: value),
                   class: css, title: help,
-                  data: { toggle: "tooltip", placement: "left",
+                  data: { tooltip_target: "trigger", placement: "left",
                           role: "image_vote", val: value, id: @image.id })
         end
       end
@@ -103,7 +103,7 @@ module Views::Controllers::Images
         div(class: "pt-2") do
           link_to(text, vote_link_args.merge(vote: value, next: true),
                   class: css, title: help,
-                  data: { toggle: "tooltip" })
+                  data: { tooltip_target: "trigger" })
         end
       end
 

--- a/app/views/controllers/names/index/row.rb
+++ b/app/views/controllers/names/index/row.rb
@@ -59,7 +59,7 @@ class Views::Controllers::Names::Index::Row < Views::Base
       variant: :link,
       class: "py-0 link-normal opacity-75",
       role: "button",
-      data: { toggle: "tooltip", placement: "bottom",
+      data: { tooltip_target: "trigger", placement: "bottom",
               title: :copy_this_name.ti,
               action: "clipboard#copy" }
     ) { Icon(type: :copy) }

--- a/app/views/controllers/names/index/row.rb
+++ b/app/views/controllers/names/index/row.rb
@@ -59,7 +59,7 @@ class Views::Controllers::Names::Index::Row < Views::Base
       variant: :link,
       class: "py-0 link-normal opacity-75",
       role: "button",
-      data: { tooltip_target: "trigger", placement: "bottom",
+      data: { tooltip_target: "tip", placement: "bottom",
               title: :copy_this_name.ti,
               action: "clipboard#copy" }
     ) { Icon(type: :copy) }

--- a/app/views/controllers/publications/index.rb
+++ b/app/views/controllers/publications/index.rb
@@ -71,7 +71,8 @@ module Views::Controllers::Publications
 
       str = pub.link.sub(%r{^.*://+}, "").sub(%r{(/|\?).*}, "")
       capture do
-        link_to(str, pub.link, title: pub.link, data: { toggle: "tooltip" })
+        link_to(str, pub.link, title: pub.link,
+                               data: { tooltip_target: "trigger" })
       end
     end
 

--- a/app/views/controllers/publications/index.rb
+++ b/app/views/controllers/publications/index.rb
@@ -72,7 +72,7 @@ module Views::Controllers::Publications
       str = pub.link.sub(%r{^.*://+}, "").sub(%r{(/|\?).*}, "")
       capture do
         link_to(str, pub.link, title: pub.link,
-                               data: { tooltip_target: "trigger" })
+                               data: { tooltip_target: "tip" })
       end
     end
 

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -89,7 +89,7 @@ module Views::Layouts
                end,
         data: { filter_caption_target: action,
                 action: "filter-caption##{action}",
-                tooltip_target: "trigger" }
+                tooltip_target: "tip" }
       ) do
         # aria-hidden as a string — Phlex 2 renders boolean `true`
         # as an empty-string attr, not "true".

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -89,7 +89,7 @@ module Views::Layouts
                end,
         data: { filter_caption_target: action,
                 action: "filter-caption##{action}",
-                toggle: "tooltip" }
+                tooltip_target: "trigger" }
       ) do
         # aria-hidden as a string — Phlex 2 renders boolean `true`
         # as an empty-string attr, not "true".

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -183,7 +183,7 @@ class Views::Layouts::TopNav < Views::Base
       rubric_text,
       { controller: "/#{ctrlr.controller_path}", action: :index },
       class: "#{ctrlr.controller_name}_index_link",
-      data: { tooltip_target: "trigger", placement: :bottom,
+      data: { tooltip_target: "tip", placement: :bottom,
               title: :index_object.ti(type: ctrlr.controller_name.to_sym) }
     )
   end
@@ -238,7 +238,7 @@ class Views::Layouts::TopNav < Views::Base
       class: "ml-1 mr-0 mx-sm-3 top_nav_button",
       title: full_label,
       aria: { label: full_label },
-      data: { tooltip_target: "trigger" } }
+      data: { tooltip_target: "tip" } }
   end
 
   def nav_create_label

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -183,7 +183,7 @@ class Views::Layouts::TopNav < Views::Base
       rubric_text,
       { controller: "/#{ctrlr.controller_path}", action: :index },
       class: "#{ctrlr.controller_name}_index_link",
-      data: { toggle: "tooltip", placement: :bottom,
+      data: { tooltip_target: "trigger", placement: :bottom,
               title: :index_object.ti(type: ctrlr.controller_name.to_sym) }
     )
   end
@@ -238,7 +238,7 @@ class Views::Layouts::TopNav < Views::Base
       class: "ml-1 mr-0 mx-sm-3 top_nav_button",
       title: full_label,
       aria: { label: full_label },
-      data: { toggle: "tooltip" } }
+      data: { tooltip_target: "trigger" } }
   end
 
   def nav_create_label

--- a/test/components/button/crud_base_test.rb
+++ b/test/components/button/crud_base_test.rb
@@ -239,7 +239,7 @@ class ButtonSubclassesTest < ComponentTestCase
     assert_html(html, "a span.glyphicon-edit")
     assert_html(html, "a span.sr-only",
                 text: :edit_object.t(type: :herbarium))
-    assert_html(html, "a[data-tooltip-target='trigger']")
+    assert_html(html, "a[data-tooltip-target='tip']")
   end
 
   # `icon: nil` opt-out for text-only edit links.
@@ -254,7 +254,7 @@ class ButtonSubclassesTest < ComponentTestCase
                 text: :edit_object.t(type: :herbarium))
     assert_no_html(html, "a span.glyphicon")
     assert_no_html(html, "a span.sr-only")
-    assert_no_html(html, "a[data-tooltip-target='trigger']")
+    assert_no_html(html, "a[data-tooltip-target='tip']")
   end
 
   # Default renders the standard btn-default frame.
@@ -328,7 +328,7 @@ class ButtonSubclassesTest < ComponentTestCase
     assert_html(html, "a span.glyphicon-plus")
     assert_html(html, "a span.sr-only",
                 text: :new_object.t(type: :herbarium))
-    assert_html(html, "a[data-tooltip-target='trigger']")
+    assert_html(html, "a[data-tooltip-target='tip']")
   end
 
   # `icon: nil` opt-out: text-only new links.
@@ -343,7 +343,7 @@ class ButtonSubclassesTest < ComponentTestCase
     assert_html(html, "a[href='#{path}']", text: "New Herbarium")
     assert_no_html(html, "a span.glyphicon")
     assert_no_html(html, "a span.sr-only")
-    assert_no_html(html, "a[data-tooltip-target='trigger']")
+    assert_no_html(html, "a[data-tooltip-target='tip']")
   end
 
   # Default renders the standard btn-default frame.

--- a/test/components/button/crud_base_test.rb
+++ b/test/components/button/crud_base_test.rb
@@ -239,7 +239,7 @@ class ButtonSubclassesTest < ComponentTestCase
     assert_html(html, "a span.glyphicon-edit")
     assert_html(html, "a span.sr-only",
                 text: :edit_object.t(type: :herbarium))
-    assert_html(html, "a[data-toggle='tooltip']")
+    assert_html(html, "a[data-tooltip-target='trigger']")
   end
 
   # `icon: nil` opt-out for text-only edit links.
@@ -254,7 +254,7 @@ class ButtonSubclassesTest < ComponentTestCase
                 text: :edit_object.t(type: :herbarium))
     assert_no_html(html, "a span.glyphicon")
     assert_no_html(html, "a span.sr-only")
-    assert_no_html(html, "a[data-toggle='tooltip']")
+    assert_no_html(html, "a[data-tooltip-target='trigger']")
   end
 
   # Default renders the standard btn-default frame.
@@ -328,7 +328,7 @@ class ButtonSubclassesTest < ComponentTestCase
     assert_html(html, "a span.glyphicon-plus")
     assert_html(html, "a span.sr-only",
                 text: :new_object.t(type: :herbarium))
-    assert_html(html, "a[data-toggle='tooltip']")
+    assert_html(html, "a[data-tooltip-target='trigger']")
   end
 
   # `icon: nil` opt-out: text-only new links.
@@ -343,7 +343,7 @@ class ButtonSubclassesTest < ComponentTestCase
     assert_html(html, "a[href='#{path}']", text: "New Herbarium")
     assert_no_html(html, "a span.glyphicon")
     assert_no_html(html, "a span.sr-only")
-    assert_no_html(html, "a[data-toggle='tooltip']")
+    assert_no_html(html, "a[data-tooltip-target='trigger']")
   end
 
   # Default renders the standard btn-default frame.

--- a/test/components/dropdown_test.rb
+++ b/test/components/dropdown_test.rb
@@ -69,7 +69,7 @@ class DropdownTest < ComponentTestCase
     assert_no_html(html, "button.btn")
   end
 
-  # Tooltip data attrs (`data-toggle="tooltip"`, `data-title`,
+  # Tooltip data attrs (`data-tooltip-target="trigger"`, `data-title`,
   # `data-placement`) are stripped from dropdown items. They're
   # redundant inside a menu (the label is already visible) and
   # Bootstrap's tooltip JS can interfere with dropdown click handling.
@@ -80,13 +80,13 @@ class DropdownTest < ComponentTestCase
                     label: "Menu"
                   )) do |menu|
       menu.section([["Edit", "/edit",
-                     { data: { toggle: "tooltip",
+                     { data: { tooltip_target: "trigger",
                                title: "Edit this",
                                placement: "top" } }]])
     end
 
     assert_html(html, "li a[href='/edit']")
-    assert_no_html(html, "[data-toggle='tooltip']")
+    assert_no_html(html, "[data-tooltip-target='trigger']")
     assert_no_html(html, "[data-title]")
     assert_no_html(html, "[data-placement]")
   end

--- a/test/components/dropdown_test.rb
+++ b/test/components/dropdown_test.rb
@@ -69,7 +69,7 @@ class DropdownTest < ComponentTestCase
     assert_no_html(html, "button.btn")
   end
 
-  # Tooltip data attrs (`data-tooltip-target="trigger"`, `data-title`,
+  # Tooltip data attrs (`data-tooltip-target="tip"`, `data-title`,
   # `data-placement`) are stripped from dropdown items. They're
   # redundant inside a menu (the label is already visible) and
   # Bootstrap's tooltip JS can interfere with dropdown click handling.
@@ -80,13 +80,13 @@ class DropdownTest < ComponentTestCase
                     label: "Menu"
                   )) do |menu|
       menu.section([["Edit", "/edit",
-                     { data: { tooltip_target: "trigger",
+                     { data: { tooltip_target: "tip",
                                title: "Edit this",
                                placement: "top" } }]])
     end
 
     assert_html(html, "li a[href='/edit']")
-    assert_no_html(html, "[data-tooltip-target='trigger']")
+    assert_no_html(html, "[data-tooltip-target='tip']")
     assert_no_html(html, "[data-title]")
     assert_no_html(html, "[data-placement]")
   end

--- a/test/components/help/tooltip_test.rb
+++ b/test/components/help/tooltip_test.rb
@@ -10,10 +10,10 @@ class HelpTooltipTest < ComponentTestCase
 
     assert_html(html, "span.context-help", text: "(?)")
     # Tooltip wiring: the tooltip Stimulus controller reads
-    # `data-tooltip-target="trigger"` to find triggers and `title=`
+    # `data-tooltip-target="tip"` to find triggers and `title=`
     # for the popup text.
     assert_html(html, "span[title='Click for explanation']")
-    assert_html(html, "span[data-tooltip-target='trigger']")
+    assert_html(html, "span[data-tooltip-target='tip']")
   end
 
   def test_extra_class_appends_to_context_help
@@ -31,7 +31,7 @@ class HelpTooltipTest < ComponentTestCase
 
     # Caller's custom data attrs deep-merge with the tooltip
     # wiring — both end up on the span.
-    assert_html(html, "span[data-tooltip-target='trigger']")
+    assert_html(html, "span[data-tooltip-target='tip']")
     assert_html(html, "span[data-other='v']")
   end
 end

--- a/test/components/help/tooltip_test.rb
+++ b/test/components/help/tooltip_test.rb
@@ -9,10 +9,11 @@ class HelpTooltipTest < ComponentTestCase
                   ))
 
     assert_html(html, "span.context-help", text: "(?)")
-    # Tooltip wiring: Bootstrap's tooltip JS reads `data-toggle` to
-    # find triggers and `title=` for the popup text.
+    # Tooltip wiring: the tooltip Stimulus controller reads
+    # `data-tooltip-target="trigger"` to find triggers and `title=`
+    # for the popup text.
     assert_html(html, "span[title='Click for explanation']")
-    assert_html(html, "span[data-toggle='tooltip']")
+    assert_html(html, "span[data-tooltip-target='trigger']")
   end
 
   def test_extra_class_appends_to_context_help
@@ -30,7 +31,7 @@ class HelpTooltipTest < ComponentTestCase
 
     # Caller's custom data attrs deep-merge with the tooltip
     # wiring — both end up on the span.
-    assert_html(html, "span[data-toggle='tooltip']")
+    assert_html(html, "span[data-tooltip-target='trigger']")
     assert_html(html, "span[data-other='v']")
   end
 end

--- a/test/components/help/tooltip_test.rb
+++ b/test/components/help/tooltip_test.rb
@@ -10,8 +10,9 @@ class HelpTooltipTest < ComponentTestCase
 
     assert_html(html, "span.context-help", text: "(?)")
     # Tooltip wiring: the tooltip Stimulus controller reads
-    # `data-tooltip-target="tip"` to find triggers and `title=`
-    # for the popup text.
+    # `data-tooltip-target="tip"` to find triggers and activate
+    # Bootstrap's tooltip plugin, which reads `title=` for the popup
+    # text.
     assert_html(html, "span[title='Click for explanation']")
     assert_html(html, "span[data-tooltip-target='tip']")
   end

--- a/test/components/icon_test.rb
+++ b/test/components/icon_test.rb
@@ -27,7 +27,7 @@ class LinkIconTest < ComponentTestCase
 
     assert_html(html,
                 "span.glyphicon-edit.link-icon.text-primary" \
-                "[title='#{:edit.ti}'][data-tooltip-target='trigger']")
+                "[title='#{:edit.ti}'][data-tooltip-target='tip']")
     # Screen-reader label so the icon-only link has an accessible name.
     assert_html(html, "span.sr-only", text: :edit.ti)
   end
@@ -39,7 +39,7 @@ class LinkIconTest < ComponentTestCase
                   ))
 
     # Tooltip target still present alongside caller's custom data attr.
-    assert_html(html, "span[data-tooltip-target='trigger'][data-other='v']")
+    assert_html(html, "span[data-tooltip-target='tip'][data-other='v']")
   end
 
   def test_extra_attrs_passed_through

--- a/test/components/icon_test.rb
+++ b/test/components/icon_test.rb
@@ -27,7 +27,7 @@ class LinkIconTest < ComponentTestCase
 
     assert_html(html,
                 "span.glyphicon-edit.link-icon.text-primary" \
-                "[title='#{:edit.ti}'][data-toggle='tooltip']")
+                "[title='#{:edit.ti}'][data-tooltip-target='trigger']")
     # Screen-reader label so the icon-only link has an accessible name.
     assert_html(html, "span.sr-only", text: :edit.ti)
   end
@@ -38,8 +38,8 @@ class LinkIconTest < ComponentTestCase
                     data: { other: "v" }
                   ))
 
-    # Tooltip toggle still present alongside caller's custom data attr.
-    assert_html(html, "span[data-toggle='tooltip'][data-other='v']")
+    # Tooltip target still present alongside caller's custom data attr.
+    assert_html(html, "span[data-tooltip-target='trigger'][data-other='v']")
   end
 
   def test_extra_attrs_passed_through

--- a/test/components/link/icon_test.rb
+++ b/test/components/link/icon_test.rb
@@ -12,7 +12,7 @@ class IconLinkTest < ComponentTestCase
     # data-tooltip-target/data-title pair the tooltip Stimulus
     # controller reads.
     assert_html(html, "a[href='/foo'][title='Edit'].icon-link" \
-                      "[data-tooltip-target='trigger'][data-title='Edit']")
+                      "[data-tooltip-target='tip'][data-title='Edit']")
     # Icon glyph + screen-reader-only label inside the anchor.
     assert_html(html, "a span.glyphicon-edit")
     assert_html(html, "a span.sr-only", text: "Edit")
@@ -94,7 +94,7 @@ class IconLinkTest < ComponentTestCase
     # `data: { ... }` from the caller deep_merges with the tooltip
     # data attrs, so both the tooltip wiring AND the caller's custom
     # attrs end up on the anchor.
-    assert_html(html, "a[data-my-attr='v'][data-tooltip-target='trigger']")
+    assert_html(html, "a[data-my-attr='v'][data-tooltip-target='tip']")
   end
 
   # `tab:` shortcut — derive content / path / opts from a Tab PORO so

--- a/test/components/link/icon_test.rb
+++ b/test/components/link/icon_test.rb
@@ -9,9 +9,10 @@ class IconLinkTest < ComponentTestCase
                   ))
 
     # Outer anchor: href, tooltip title, icon-link class, and the
-    # data-toggle/data-title pair the bootstrap tooltip plugin reads.
+    # data-tooltip-target/data-title pair the tooltip Stimulus
+    # controller reads.
     assert_html(html, "a[href='/foo'][title='Edit'].icon-link" \
-                      "[data-toggle='tooltip'][data-title='Edit']")
+                      "[data-tooltip-target='trigger'][data-title='Edit']")
     # Icon glyph + screen-reader-only label inside the anchor.
     assert_html(html, "a span.glyphicon-edit")
     assert_html(html, "a span.sr-only", text: "Edit")
@@ -93,7 +94,7 @@ class IconLinkTest < ComponentTestCase
     # `data: { ... }` from the caller deep_merges with the tooltip
     # data attrs, so both the tooltip wiring AND the caller's custom
     # attrs end up on the anchor.
-    assert_html(html, "a[data-my-attr='v'][data-toggle='tooltip']")
+    assert_html(html, "a[data-my-attr='v'][data-tooltip-target='trigger']")
   end
 
   # `tab:` shortcut — derive content / path / opts from a Tab PORO so

--- a/test/components/link/icon_test.rb
+++ b/test/components/link/icon_test.rb
@@ -8,9 +8,10 @@ class IconLinkTest < ComponentTestCase
                     content: "Edit", path: "/foo", icon: :edit
                   ))
 
-    # Outer anchor: href, tooltip title, icon-link class, and the
-    # data-tooltip-target/data-title pair the tooltip Stimulus
-    # controller reads.
+    # Outer anchor: href, tooltip title, icon-link class, the
+    # data-tooltip-target pair the tooltip Stimulus controller reads
+    # to activate Bootstrap's tooltip plugin, and the data-title
+    # Bootstrap's own plugin reads for the popup text.
     assert_html(html, "a[href='/foo'][title='Edit'].icon-link" \
                       "[data-tooltip-target='tip'][data-title='Edit']")
     # Icon glyph + screen-reader-only label inside the anchor.

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -208,7 +208,7 @@ module Views::Layouts
                     ))
 
       # All links should have tooltip data attributes
-      assert_includes(html, 'data-toggle="tooltip"')
+      assert_html(html, "a[data-tooltip-target='trigger']")
     end
 
     def test_link_nesting_structure

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -208,7 +208,9 @@ module Views::Layouts
                     ))
 
       # All links should have tooltip data attributes
-      assert_html(html, "a[data-tooltip-target='tip']")
+      assert_html(html, "a.prev_object_link[data-tooltip-target='tip']")
+      assert_html(html, "a.index_object_link[data-tooltip-target='tip']")
+      assert_html(html, "a.next_object_link[data-tooltip-target='tip']")
     end
 
     def test_link_nesting_structure

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -208,7 +208,7 @@ module Views::Layouts
                     ))
 
       # All links should have tooltip data attributes
-      assert_html(html, "a[data-tooltip-target='trigger']")
+      assert_html(html, "a[data-tooltip-target='tip']")
     end
 
     def test_link_nesting_structure

--- a/test/views/layouts/top_nav_test.rb
+++ b/test/views/layouts/top_nav_test.rb
@@ -43,7 +43,7 @@ class Views::Layouts::TopNavTest < ComponentTestCase
     full_label = "#{:new.ti} #{:observation.ti}"
     assert_html(html, "a.btn-success[aria-label='#{full_label}']")
     assert_html(html, "a.btn-success[title='#{full_label}']")
-    assert_html(html, "a.btn-success[data-toggle='tooltip']")
+    assert_html(html, "a.btn-success[data-tooltip-target='trigger']")
     # Responsive content: the word "Add" appears in a span hidden at
     # xs width and shown at sm and up.
     assert_html(html, "a.btn-success span.d-none.d-sm-inline",

--- a/test/views/layouts/top_nav_test.rb
+++ b/test/views/layouts/top_nav_test.rb
@@ -43,7 +43,7 @@ class Views::Layouts::TopNavTest < ComponentTestCase
     full_label = "#{:new.ti} #{:observation.ti}"
     assert_html(html, "a.btn-success[aria-label='#{full_label}']")
     assert_html(html, "a.btn-success[title='#{full_label}']")
-    assert_html(html, "a.btn-success[data-tooltip-target='trigger']")
+    assert_html(html, "a.btn-success[data-tooltip-target='tip']")
     # Responsive content: the word "Add" appears in a span hidden at
     # xs width and shown at sm and up.
     assert_html(html, "a.btn-success span.d-none.d-sm-inline",


### PR DESCRIPTION
## Summary

Bootstrap 3 tooltips are opt-in and need per-element JS activation. `tooltip_controller.js` did this via a one-time bulk `$('[data-toggle="tooltip"]').tooltip()` sweep, run from `connect()` on the single controller instance (attached to `<body>`). That only ever found elements present at the moment `connect()` fired — content added later by any means (a turbo-frame fetch, a Turbo Stream render, dynamic JS) never got swept, so its tooltip silently never activated. This surfaced concretely while building the external-links accordion (#4821): a copy-to-clipboard badge inside a lazily-fetched accordion pane never got its tooltip wired up.

`data-toggle="tooltip"` was also never a real Stimulus target — just a plain attribute the controller queried manually via jQuery, so Stimulus's own dynamic-content tracking never applied to it.

## What changed

- `app/javascript/controllers/tooltip_controller.js` now declares `static targets = ["tip"]` and implements `tipTargetConnected(element)` instead of a manual `connect()`-time sweep. Stimulus's own MutationObserver (scoped to the controller's element) calls this for every matching element automatically, however and whenever it enters the DOM — initial page load or dynamically added later, no distinction, no manual sweep or extra event listener required.
- Every `data-toggle="tooltip"` call site (14 production files) renamed to `data-tooltip-target="tip"`.
- One controller instance still lives on `<body>` (not one per trigger element) — deliberate, since a page can have many tooltippable elements and Stimulus targets don't require a controller per target.
- `Components::Dropdown#strip_tooltip_data` keyed off the literal `data[:toggle] == "tooltip"` value to strip tooltip wiring from menu items (redundant inside a dropdown, where the label is already visible) — updated to match the new key.
- 7 test files updated to assert on `data-tooltip-target='tip'` instead of `data-toggle='tooltip'`.

## Test plan

- [x] `bundle exec rubocop` clean on all 21 touched files.
- [x] `bin/rails test test/components/ test/views/layouts/` — 1153 tests, 0 failures.
- [x] `bin/rails zeitwerk:check` — clean.
