### PR TITLE
Add empty-state caption + inline add-link to the observation external-links row

### DIFF
--- a/app/views/controllers/observations/show/details.rb
+++ b/app/views/controllers/observations/show/details.rb
@@ -18,14 +18,9 @@ class Views::Controllers::Observations::Show::Details < Views::Base
     Panel(panel_id: "observation_details") do |panel|
       panel.with_heading { :show_observation_details.l }
       panel.with_heading_links { print_labels_button } if @user
-      if show_external_links?
-        panel.with_body(classes: "p-0", id: "observation_external_links",
-                        data: { controller: "section-update",
-                                section_update_user_value: @user&.id }) do
-          render_external_links_section
-        end
-      end
+      with_external_links_body(panel) if show_external_links? && links?
       panel.with_body { render_body }
+      with_external_links_body(panel) if show_external_links? && !links?
     end
   end
 
@@ -208,9 +203,27 @@ class Views::Controllers::Observations::Show::Details < Views::Base
 
   # ---- external links ---------------------------------------------
 
+  # Matches ExternalLinks' own "hides silently" condition -- a
+  # logged-out viewer (or one with no eligible site) gets nothing
+  # rendered at all, not an empty .p-0 wrapper with no content.
   def show_external_links?
-    @obs.external_links.any? || @sites.present? ||
-      sibling_has?(:external_links)
+    links? || (@user && @sites.present?)
+  end
+
+  # Own/sibling links to show as badges -- rendered above when/where/
+  # who. With nothing to show yet (only an eligible site to add one
+  # to), the section instead renders below when/where/who, as the
+  # last item, so the page doesn't lead with an empty-looking "+".
+  def links?
+    @obs.external_links.any? || sibling_has?(:external_links)
+  end
+
+  def with_external_links_body(panel)
+    panel.with_body(classes: "p-0", id: "observation_external_links",
+                    data: { controller: "section-update",
+                            section_update_user_value: @user&.id }) do
+      render_external_links_section
+    end
   end
 
   def render_external_links_section

--- a/app/views/controllers/observations/show/details/external_links.rb
+++ b/app/views/controllers/observations/show/details/external_links.rb
@@ -11,7 +11,9 @@
 # own + sibling `ExternalLink` for that site. Only one pane is ever
 # open (native Bootstrap collapse accordion via `data-parent`). Hides
 # silently when there's nothing to show and no eligible site to add a
-# link to. `Details` renders this inside a `.panel-body.p-0` (own id +
+# link to; when there's an eligible site but no badges yet, shows a
+# "No external links" caption alongside the add link instead of an
+# unlabeled "+". `Details` renders this inside a `.panel-body.p-0` (own id +
 # section-update wiring live on that panel-body, not here) so the
 # badge row and the accordion below it can each supply their own
 # padding and be genuinely full-width against the panel edge -- see
@@ -32,7 +34,11 @@ class Views::Controllers::Observations::Show::Details::ExternalLinks < Views::Ba
     return if visible_sites.empty? && !show_new_link?
 
     div(class: class_names(wrapper_class, "p-3 border-bottom")) do
-      render_badges
+      if visible_sites.any?
+        render_badges
+      else
+        plain(:no_objects.t(type: :external_link))
+      end
       render_new_link if show_new_link?
     end
     render_accordion
@@ -52,8 +58,6 @@ class Views::Controllers::Observations::Show::Details::ExternalLinks < Views::Ba
   end
 
   def render_badges
-    return unless visible_sites.any?
-
     div do
       plain("#{:shared_with.ti}: ")
       visible_sites.each { |site_name, link| render_badge(site_name, link) }

--- a/app/views/controllers/observations/show/details/external_links.rb
+++ b/app/views/controllers/observations/show/details/external_links.rb
@@ -46,15 +46,19 @@ class Views::Controllers::Observations::Show::Details::ExternalLinks < Views::Ba
 
   private
 
-  # Only add the flex/justify-content-between shell when there's a
-  # right-side item (the add link) to space against -- an empty right
-  # side would otherwise leave a wasted flex wrapper around one item.
+  # Only add the flex/justify-content-between shell when there's both
+  # a left side (badges) AND a right side (the add link) to space
+  # apart -- with no badges yet, the add link instead sits right after
+  # the "No external links" caption inline, matching the "No
+  # fungarium records [ + ]" pattern used elsewhere (RecordListSection)
+  # rather than getting shoved to the far right of an empty row.
   # Kept on its own inner div (not the outer #observation_external_links
   # container) so the accordion pane below it isn't itself a flex item
   # trying to sit beside the badges/add-link row.
   def wrapper_class
     class_names("obs-links",
-                show_new_link? && "d-flex justify-content-between")
+                visible_sites.any? && show_new_link? &&
+                  "d-flex justify-content-between")
   end
 
   def render_badges

--- a/test/views/controllers/observations/show/details/external_links_test.rb
+++ b/test/views/controllers/observations/show/details/external_links_test.rb
@@ -119,6 +119,22 @@ class Views::Controllers::Observations::Show::Details::ExternalLinksTest <
     assert_html(html, "a[data-modal='modal_external_link']")
   end
 
+  # No badges yet, but an eligible site to add one to: shows a "No
+  # external links" caption instead of a bare, unlabeled "+".
+  def test_renders_no_links_caption_when_empty_but_addable
+    obs = observations(:detailed_unknown_obs)
+    assert_empty(obs.external_links)
+    sites = ::ExternalSite.all.to_a
+    skip("Need at least one ExternalSite fixture") if sites.empty?
+
+    html = render(panel_with(obs, sites: sites))
+
+    assert_html(html, "div.p-3.border-bottom",
+                text: :no_objects.t(type: :external_link).as_displayed)
+    assert_no_html(html, "a.badge.badge-id")
+    assert_html(html, "a[data-modal='modal_external_link']")
+  end
+
   def test_hides_new_link_when_no_sites
     link = external_links(:coprinus_comatus_obs_inaturalist_link)
     obs = link.observation

--- a/test/views/controllers/observations/show/details/external_links_test.rb
+++ b/test/views/controllers/observations/show/details/external_links_test.rb
@@ -133,6 +133,25 @@ class Views::Controllers::Observations::Show::Details::ExternalLinksTest <
                 text: :no_objects.t(type: :external_link).as_displayed)
     assert_no_html(html, "a.badge.badge-id")
     assert_html(html, "a[data-modal='modal_external_link']")
+    # No flex/justify-content-between shell with no badges to space
+    # against -- the add link sits right after the caption inline,
+    # matching the "No fungarium records [ + ]" pattern.
+    assert_no_html(html, ".d-flex.justify-content-between")
+  end
+
+  # With both badges AND an addable site, the row DOES use the flex
+  # shell to push the add link to the far right, away from the badges.
+  def test_wraps_badges_and_add_link_in_flex_row_when_both_present
+    link = external_links(:imported_inat_obs_inat_link)
+    obs = link.observation
+    sites = ::ExternalSite.all.to_a
+    skip("Need at least one ExternalSite fixture") if sites.empty?
+
+    html = render(panel_with(obs, sites: sites))
+
+    assert_html(html, "div.d-flex.justify-content-between")
+    assert_html(html, "a.badge.badge-id", text: "iNat")
+    assert_html(html, "a[data-modal='modal_external_link']")
   end
 
   def test_hides_new_link_when_no_sites

--- a/test/views/controllers/observations/show/details_test.rb
+++ b/test/views/controllers/observations/show/details_test.rb
@@ -53,6 +53,42 @@ class Views::Controllers::Observations::Show::DetailsTest <
     assert_no_html(html, "#observation_external_links")
   end
 
+  # A logged-out viewer can't add a link, so an eligible site with no
+  # existing links renders nothing at all -- not an empty .p-0 wrapper
+  # with a "No external links" caption nobody who's reading it can
+  # act on.
+  def test_does_not_render_external_links_body_for_logged_out_viewer_with_sites
+    obs = observations(:detailed_unknown_obs)
+    assert_empty(obs.external_links)
+    sites = ::ExternalSite.all.to_a
+    skip("Need at least one ExternalSite fixture") if sites.empty?
+
+    html = render(Views::Controllers::Observations::Show::Details.new(
+                    obs: obs, user: nil, sites: sites, siblings: []
+                  ))
+
+    assert_no_html(html, "#observation_external_links")
+  end
+
+  # With nothing to show yet (only an eligible site to add one to),
+  # the external-links body renders AFTER when/where/who, as the last
+  # panel-body -- not leading the panel with an empty-looking "+".
+  def test_renders_external_links_body_last_when_no_links_yet
+    obs = observations(:detailed_unknown_obs)
+    assert_empty(obs.external_links)
+    sites = ::ExternalSite.all.to_a
+    skip("Need at least one ExternalSite fixture") if sites.empty?
+
+    html = render(Views::Controllers::Observations::Show::Details.new(
+                    obs: obs, user: @user, sites: sites, siblings: []
+                  ))
+
+    bodies = Nokogiri::HTML5.fragment(html).css(
+      "#observation_details > .panel-body"
+    )
+    assert_equal("observation_external_links", bodies.last["id"])
+  end
+
   # --- Collector / Entered by (#4211) ---
 
   def test_who_collector_is_creator_no_entered_by


### PR DESCRIPTION
## Summary

Two commits that were part of `#4821`'s work but got left un-pushed when that PR merged (my mistake — `gh pr merge` only picked up the last-pushed state of the branch). Landing them now as a small follow-up:

- When an observation has no external links yet but an eligible site to add one to, the badge row now renders below when/where/who (last item), captioned "No external links" via the existing `no_objects` translation tag, instead of leading the panel with a bare, unlabeled "+". A logged-out viewer (or one with no eligible site) gets nothing rendered at all, matching `ExternalLinks`' own "hide silently" condition.
- With no badges to space against, the add link now sits right after the caption inline (matching the "No fungarium records `[ + ]`" pattern used by `RecordListSection`) instead of being pushed to the far right of an otherwise-empty flex row.

## Test plan

- [x] `bin/rails test test/views/controllers/observations/show/details_test.rb test/views/controllers/observations/show/details/external_links_test.rb` — 24 tests, 0 failures
- [x] `bundle exec rubocop` clean on every touched file
- [x] `bin/rails zeitwerk:check` clean
