### PR TITLE
Address Copilot review comments on #4881

### DIFF
--- a/app/views/controllers/observations/show/details.rb
+++ b/app/views/controllers/observations/show/details.rb
@@ -210,12 +210,11 @@ class Views::Controllers::Observations::Show::Details < Views::Base
     links? || (@user && @sites.present?)
   end
 
-  # Own/sibling links to show as badges -- rendered above when/where/
-  # who. With nothing to show yet (only an eligible site to add one
-  # to), the section instead renders below when/where/who, as the
-  # last item, so the page doesn't lead with an empty-looking "+".
+  # Own/sibling links to show as badges. Called 3x per render.
   def links?
-    @obs.external_links.any? || sibling_has?(:external_links)
+    return @links if defined?(@links)
+
+    @links = @obs.external_links.any? || sibling_has?(:external_links)
   end
 
   def with_external_links_body(panel)

--- a/test/views/controllers/observations/show/details/external_links_test.rb
+++ b/test/views/controllers/observations/show/details/external_links_test.rb
@@ -136,7 +136,7 @@ class Views::Controllers::Observations::Show::Details::ExternalLinksTest <
     # No flex/justify-content-between shell with no badges to space
     # against -- the add link sits right after the caption inline,
     # matching the "No fungarium records [ + ]" pattern.
-    assert_no_html(html, ".d-flex.justify-content-between")
+    assert_no_html(html, ".obs-links.d-flex.justify-content-between")
   end
 
   # With both badges AND an addable site, the row DOES use the flex
@@ -149,7 +149,7 @@ class Views::Controllers::Observations::Show::Details::ExternalLinksTest <
 
     html = render(panel_with(obs, sites: sites))
 
-    assert_html(html, "div.d-flex.justify-content-between")
+    assert_html(html, "div.obs-links.d-flex.justify-content-between")
     assert_html(html, "a.badge.badge-id", text: "iNat")
     assert_html(html, "a[data-modal='modal_external_link']")
   end


### PR DESCRIPTION
## Summary

Addresses Copilot's two review comments on `#4881` (already merged):

- `Details#links?` is called 3 times per render (once via `show_external_links?`, twice directly in `view_template`) -- memoized.
- `test/views/controllers/observations/show/details/external_links_test.rb`'s two `d-flex.justify-content-between` assertions weren't scoped to `.obs-links`, so they could pass/fail for the wrong reason if unrelated nested markup used the same classes.

## Test plan

- [x] `bin/rails test test/views/controllers/observations/show/details_test.rb test/views/controllers/observations/show/details/external_links_test.rb` -- 24 tests, 0 failures
- [x] `bundle exec rubocop` clean on both touched files
