### PR TITLE
Add `MO/NoRawLinkOrButtonTo` cop; convert remaining `link_to`/`button_to`/`button` call sites

### DIFF
--- a/.claude/hooks/block_raw_component_classes.sh
+++ b/.claude/hooks/block_raw_component_classes.sh
@@ -215,14 +215,16 @@ check \
   'modal-(body|footer|header|title|sm|lg|xl|open)'
 
 # alert — any "alert" or "alert-*" class signals a raw Bootstrap alert.
-# alert-link is the one modifier that looks like an exception but isn't —
-# use Components::Alert::Link instead (it delegates to Link::Get with the
-# class mixed in). alert-dismissible is part of the component itself.
+# alert-dismissible and alert-link are excluded: alert-dismissible is
+# part of the component itself, and alert-link is a plain CSS modifier
+# class (not a structural component the way modal/panel/table are) —
+# it doesn't warrant blocking a commit the way hand-rolling a whole
+# alert/modal/panel structure does.
 check \
   'raw alert class' \
-  'Components::Alert.new(level: :info/:warning/:danger/:success); alert-link → Components::Alert::Link.new(text, path)' \
+  'Components::Alert.new(level: :info/:warning/:danger/:success)' \
   'class:[[:space:]]*["'"'"'][^"'"'"']*\balert\b' \
-  'alert-dismissible'
+  'alert-dismissible|alert-link'
 
 # link-icon (glyphicon hand-rolled without Icon component)
 check \

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ plugins:
 
 require:
   - ./lib/rubocop/cop/mo/lowercase_translation_tag
+  - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
 
 AllCops:
   NewCops: enable
@@ -45,6 +46,29 @@ MO/LowercaseTranslationTag:
     lowercase -- see lib/rubocop/cop/mo/lowercase_translation_tag.rb
     and GH issue #4843.
   Enabled: true
+
+MO/NoRawLinkOrButtonTo:
+  Description: >-
+    Phlex views/components must use Components::Link/Components::Button
+    (Link(...)/Button(...) Kit syntax) instead of calling link_to/
+    button_to directly -- see
+    lib/rubocop/cop/mo/no_raw_link_or_button_to.rb.
+  Enabled: true
+  Include:
+    - "app/components/**/*.rb"
+    - "app/views/**/*.rb"
+  Exclude:
+    # The Link/Button component family's own implementations -- these
+    # legitimately call link_to/button_to to BUILD the abstraction
+    # every other Phlex file is required to use instead.
+    - "app/components/button.rb"
+    - "app/components/button/**/*.rb"
+    - "app/components/link.rb"
+    - "app/components/link/**/*.rb"
+    - "app/components/link_rendering.rb"
+    # Emails can't use interactive Bootstrap/Stimulus components --
+    # they need plain, inline-styled tags with no JS dependency.
+    - "app/views/mailers/**/*.rb"
 
 Gemspec:
   # Not relevent (MO is not a gem)

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,11 @@ MO/NoRawLinkOrButtonTo:
     # Emails can't use interactive Bootstrap/Stimulus components --
     # they need plain, inline-styled tags with no JS dependency.
     - "app/views/mailers/**/*.rb"
+    # A copy-to-clipboard <button role="button"> styled as a .badge,
+    # not an action button -- Components::Button's whole abstraction
+    # is .btn-family styling/variants, which doesn't fit a badge.
+    # Genuinely a different primitive, not a bypass of Button.
+    - "app/components/id_badge.rb"
 
 Gemspec:
   # Not relevent (MO is not a gem)

--- a/app/components/application_form/autocompleter_field.rb
+++ b/app/components/application_form/autocompleter_field.rb
@@ -305,9 +305,10 @@ class Components::ApplicationForm < Superform::Rails::Form
            data: { target_attr_key => "list" }) do
           10.times do |i|
             li(class: "dropdown-item") do
-              link_to(
-                "",
-                "#",
+              Link(
+                type: :get,
+                name: "",
+                target: "#",
                 data: {
                   row: i,
                   action: "click->#{stimulus_controller_name}#selectRow:prevent"

--- a/app/components/carousel/controls.rb
+++ b/app/components/carousel/controls.rb
@@ -21,10 +21,12 @@ class Components::Carousel::Controls < Components::Base
     icon_type = direction == :prev ? :chevron_left : :chevron_right
     label = direction == :prev ? :prev : :next
 
-    link_to("##{@carousel_id}",
-            class: "#{position} carousel-control",
-            role: "button",
-            data: { slide: direction.to_s }) do
+    Link(type: :get,
+         name: label.l,
+         target: "##{@carousel_id}",
+         class: "#{position} carousel-control",
+         role: "button",
+         data: { slide: direction.to_s }) do
       div(class: "btn") do
         Icon(type: icon_type, aria: { hidden: "true" })
         span(class: "sr-only") { label.l }

--- a/app/components/form/camera_info.rb
+++ b/app/components/form/camera_info.rb
@@ -133,8 +133,10 @@ class Components::Form::CameraInfo < Components::Base
   end
 
   def exif_to_image_date_button
-    link_to(
-      "#",
+    Link(
+      type: :get,
+      name: @date,
+      target: "#",
       data: { action: "form-exif#exifToImageDate:prevent" }
     ) do
       span(class: "exif_date") { @date }

--- a/app/components/form/notes.rb
+++ b/app/components/form/notes.rb
@@ -184,10 +184,10 @@ class Components::Form::Notes < Components::Base
   def render_value_button(action, label, value, active:)
     button_aria = "#{label}: #{value.squish.truncate(100)}"
     div(class: "d-flex align-items-center mb-1") do
-      button(type: "button", class: button_class(active),
+      Button(name: label, variant: :default, class: button_class(active),
              aria: { label: button_aria },
              data: { notes_action: action, notes_value: value,
-                     action: "notes-adopt#choose" }) { label }
+                     action: "notes-adopt#choose" })
       span(class: "ml-2", style: VALUE_PREVIEW_STYLE) do
         shared_value_preview(value)
       end
@@ -208,14 +208,12 @@ class Components::Form::Notes < Components::Base
   end
 
   def action_button(action, label, active:)
-    button(type: "button", class: button_class(active),
-           data: { notes_action: action, action: "notes-adopt#choose" }) do
-      label
-    end
+    Button(name: label, variant: :default, class: button_class(active),
+           data: { notes_action: action, action: "notes-adopt#choose" })
   end
 
   def button_class(active)
-    class_names("btn btn-default mr-2 mb-1", "active" => active)
+    class_names("mr-2 mb-1", "active" => active)
   end
 
   def shared_value_preview(value)

--- a/app/components/image/base.rb
+++ b/app/components/image/base.rb
@@ -239,13 +239,21 @@ class Components::Image::Base < Components::Base
     when :get
       a(href: path, class: stretched_link_classes)
     when :post, :put, :patch, :delete
-      # These require button_to which generates a form with CSRF protection
-      button_to(
-        path,
-        method: @link_method,
-        class: stretched_link_classes,
-        form: { data: { turbo: true } }
-      ) { "" }
+      # These require a mutation Button, which generates a form with
+      # CSRF protection (Button::CRUDBase defaults `form: { data:
+      # { turbo: true } }`, matching the original `button_to` call).
+      # `variant: :strip` skips the default btn framing so only
+      # `stretched_link_classes` apply, and `icon: nil` suppresses
+      # Button::Delete's default delete icon -- both matching the
+      # bare, empty stretched-link content of the original.
+      Button(
+        type: @link_method,
+        name: "",
+        icon: nil,
+        target: path,
+        variant: :strip,
+        class: stretched_link_classes
+      )
     end
   end
 

--- a/app/components/matrix/box/footer.rb
+++ b/app/components/matrix/box/footer.rb
@@ -46,7 +46,8 @@ class Components::Matrix::Box
         br
         plain("#{:list_users_contribution.l}: #{user.contribution}")
         br
-        link_to(:observations.ti, observations_path(by_user: user.id))
+        Link(type: :get, name: :observations.ti,
+             target: observations_path(by_user: user.id))
       end
     end
 

--- a/app/views/controllers/account/preferences/form.rb
+++ b/app/views/controllers/account/preferences/form.rb
@@ -211,8 +211,8 @@ class Views::Controllers::Account::Preferences::Form <
   end
 
   def render_theme_about_link
-    link_to(:prefs_themes_about.t, theme_color_themes_path,
-            class: "ml-4")
+    Link(type: :get, name: :prefs_themes_about.t,
+         target: theme_color_themes_path, class: "ml-4")
   end
 
   def locale_values

--- a/app/views/controllers/admin/blocked_ips/edit/ip_stats.rb
+++ b/app/views/controllers/admin/blocked_ips/edit/ip_stats.rb
@@ -28,7 +28,8 @@ module Views::Controllers::Admin::BlockedIps
       end
 
       def render_close_link
-        link_to("[Close]", edit_admin_blocked_ips_path)
+        Link(type: :get, name: "[Close]",
+             target: edit_admin_blocked_ips_path)
       end
 
       def render_body

--- a/app/views/controllers/admin/blocked_ips/edit/ip_summary.rb
+++ b/app/views/controllers/admin/blocked_ips/edit/ip_summary.rb
@@ -48,7 +48,8 @@ module Views::Controllers::Admin::BlockedIps
       end
 
       def render_ip_link(ip)
-        link_to(ip, edit_admin_blocked_ips_path(report: ip))
+        Link(type: :get, name: ip,
+             target: edit_admin_blocked_ips_path(report: ip))
       end
 
       def render_block_button(ip)

--- a/app/views/controllers/articles/index/article_item.rb
+++ b/app/views/controllers/articles/index/article_item.rb
@@ -10,8 +10,8 @@ module Views::Controllers::Articles
 
       def view_template
         div do
-          link_to(@article.title.t, article_path(@article),
-                  class: "text-larger")
+          Link(type: :get, name: @article.title.t,
+               target: article_path(@article), class: "text-larger")
         end
         div { render_byline }
         trusted_html(truncate(strip_tags(@article.body), length: 80).tpl)

--- a/app/views/controllers/checklists/panel.rb
+++ b/app/views/controllers/checklists/panel.rb
@@ -42,7 +42,7 @@ module Views::Controllers::Checklists
       name, name_id, deprecated, synonym_id = taxon
       li_class = target_name?(name_id) ? "checklist-target-name" : nil
       li(class: li_class) do
-        link_to(taxon_link_path(name_id)) do
+        Link(type: :get, name: name, target: taxon_link_path(name_id)) do
           render_taxon_content(name, deprecated, synonym_id)
         end
         render_taxon_remove_button(name_id)

--- a/app/views/controllers/comments/comment_item.rb
+++ b/app/views/controllers/comments/comment_item.rb
@@ -93,8 +93,8 @@ module Views::Controllers::Comments
     end
 
     def target_name_link
-      link_to(@comment.target.unique_format_name(@user).t,
-              @comment.target.show_link_args)
+      Link(type: :get, name: @comment.target.unique_format_name(@user).t,
+           target: @comment.target.show_link_args)
     rescue StandardError
       plain(:comment_list_deleted.t)
     end

--- a/app/views/controllers/comments/comments_for_object.rb
+++ b/app/views/controllers/comments/comments_for_object.rb
@@ -83,10 +83,10 @@ module Views::Controllers::Comments
     end
 
     def render_and_more_link
-      link_to(:show_comments_and_more.t(num: and_more),
-              comments_path(target: @object.id,
-                            type: @object.class.name),
-              class: "float-right")
+      Link(type: :get, name: :show_comments_and_more.t(num: and_more),
+           target: comments_path(target: @object.id,
+                                 type: @object.class.name),
+           class: "float-right")
     end
 
     # ---- comment list slicing ------------------------------------

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -73,9 +73,10 @@ module Views::Controllers::FieldSlips
           id: "field_slip_no_prefix_nudge") do
         plain(:show_project_field_slip_no_prefix.t)
         whitespace
-        link_to(:show_project_field_slip_set_prefix.t,
-                project_admin_path(project_id: @project.id),
-                class: "alert-link")
+        render(Components::Alert::Link.new(
+                 :show_project_field_slip_set_prefix.t,
+                 project_admin_path(project_id: @project.id)
+               ))
       end
     end
 
@@ -115,8 +116,8 @@ module Views::Controllers::FieldSlips
       capture do
         h4 do
           strong { plain("#{:field_slip_code.l}: ") }
-          link_to(field_slip.code, field_slip,
-                  class: "field_slip_link_#{field_slip.id}")
+          Link(type: :get, name: field_slip.code, target: field_slip,
+               class: "field_slip_link_#{field_slip.id}")
           br
         end
       end

--- a/app/views/controllers/glossary_terms/form.rb
+++ b/app/views/controllers/glossary_terms/form.rb
@@ -63,9 +63,11 @@ module Views::Controllers::GlossaryTerms
     end
 
     def glossary_doc_link
-      link_to(
-        :glossary_term_index_documentation.t,
-        "https://github.com/MushroomObserver/mushroom-observer/blob/main/doc/glossary.md"
+      Link(
+        type: :get,
+        name: :glossary_term_index_documentation.t,
+        target: "https://github.com/MushroomObserver/mushroom-observer/" \
+                "blob/main/doc/glossary.md"
       )
     end
 

--- a/app/views/controllers/glossary_terms/index.rb
+++ b/app/views/controllers/glossary_terms/index.rb
@@ -21,10 +21,11 @@ module Views::Controllers::GlossaryTerms
     private
 
     def documentation_link
-      link_to(
-        :glossary_term_index_documentation.tp,
-        "https://github.com/MushroomObserver/mushroom-observer/" \
-        "blob/main/doc/glossary.md"
+      Link(
+        type: :get,
+        name: :glossary_term_index_documentation.tp,
+        target: "https://github.com/MushroomObserver/mushroom-observer/" \
+                "blob/main/doc/glossary.md"
       )
     end
 

--- a/app/views/controllers/glossary_terms/index/item.rb
+++ b/app/views/controllers/glossary_terms/index/item.rb
@@ -19,8 +19,8 @@ module Views::Controllers::GlossaryTerms
 
       def render_left
         h4 do
-          link_to(@glossary_term.name,
-                  glossary_term_path(@glossary_term.id))
+          Link(type: :get, name: @glossary_term.name,
+               target: glossary_term_path(@glossary_term.id))
           plain(":")
         end
         trusted_html(@glossary_term.description.tpl)

--- a/app/views/controllers/glossary_terms/show.rb
+++ b/app/views/controllers/glossary_terms/show.rb
@@ -47,7 +47,7 @@ module Views::Controllers::GlossaryTerms
       text, url = ::Tab::ExternalSearch.new(
         site: :Wikipedia, query: @glossary_term.name
       ).to_a
-      link_to(text, url)
+      Link(type: :get, name: text, target: url)
     end
 
     def render_right_column
@@ -64,11 +64,11 @@ module Views::Controllers::GlossaryTerms
 
     def render_image_action_links
       ContentPadded(class: "mb-3") do
-        link_to(:show_glossary_term_reuse_image.t,
-                reuse_images_for_glossary_term_path(@glossary_term.id))
+        Link(type: :get, name: :show_glossary_term_reuse_image.t,
+             target: reuse_images_for_glossary_term_path(@glossary_term.id))
         br
-        link_to(:show_glossary_term_remove_image.t,
-                remove_images_from_glossary_term_path(@glossary_term.id))
+        Link(type: :get, name: :show_glossary_term_remove_image.t,
+             target: remove_images_from_glossary_term_path(@glossary_term.id))
         br
       end
     end

--- a/app/views/controllers/herbaria/index.rb
+++ b/app/views/controllers/herbaria/index.rb
@@ -79,8 +79,9 @@ module Views::Controllers::Herbaria
     end
 
     def render_plain_name_link(herbarium)
-      link_to(herbarium.name.t, herbarium_path(herbarium),
-              class: "herbarium_link_#{herbarium.id}")
+      Link(type: :get, name: herbarium.name.t,
+           target: herbarium_path(herbarium),
+           class: "herbarium_link_#{herbarium.id}")
     end
 
     # Cannot POST from a link without js; use a button instead.

--- a/app/views/controllers/herbaria/show.rb
+++ b/app/views/controllers/herbaria/show.rb
@@ -55,11 +55,12 @@ module Views::Controllers::Herbaria
 
     def render_records_link
       div(class: "mt-3") do
-        link_to(
-          :show_herbarium_herbarium_record_count.t(
+        Link(
+          type: :get,
+          name: :show_herbarium_herbarium_record_count.t(
             count: @herbarium.herbarium_records.length
           ),
-          herbarium_records_path(herbarium: @herbarium.id),
+          target: herbarium_records_path(herbarium: @herbarium.id),
           class: "herbarium_records_for_herbarium_link"
         )
       end
@@ -109,9 +110,9 @@ module Views::Controllers::Herbaria
     end
 
     def render_curator_request_link
-      link_to(:show_herbarium_curator_request.t,
-              new_herbaria_curator_request_path(id: @herbarium.id),
-              class: "new_herbaria_curator_request_link")
+      Link(type: :get, name: :show_herbarium_curator_request.t,
+           target: new_herbaria_curator_request_path(id: @herbarium.id),
+           class: "new_herbaria_curator_request_link")
     end
 
     def render_notes

--- a/app/views/controllers/images/show/info_panel.rb
+++ b/app/views/controllers/images/show/info_panel.rb
@@ -53,21 +53,24 @@ module Views::Controllers::Images
       def observation_row(obs)
         div do
           plain("#{:observation.ti}: ")
-          link_to(viewer_aware_unique_format_name(obs).t, obs.show_link_args)
+          Link(type: :get, name: viewer_aware_unique_format_name(obs).t,
+               target: obs.show_link_args)
         end
       end
 
       def profile_user_row(user)
         div do
           plain("#{:user.ti}: ")
-          link_to(user.format_name.t, user.show_link_args)
+          Link(type: :get, name: user.format_name.t,
+               target: user.show_link_args)
         end
       end
 
       def glossary_term_row(term)
         div do
           plain("#{:glossary_term.ti}: ")
-          link_to(term.format_name.t, term.show_link_args)
+          Link(type: :get, name: term.format_name.t,
+               target: term.show_link_args)
         end
       end
 

--- a/app/views/controllers/images/show/license_history_panel.rb
+++ b/app/views/controllers/images/show/license_history_panel.rb
@@ -63,7 +63,7 @@ module Views::Controllers::Images
 
       def license_link_html(license)
         capture do
-          link_to(license.display_name.t, license.url)
+          Link(type: :get, name: license.display_name.t, target: license.url)
         end
       end
     end

--- a/app/views/controllers/images/show/vote_panel.rb
+++ b/app/views/controllers/images/show/vote_panel.rb
@@ -89,10 +89,11 @@ module Views::Controllers::Images
         help = image_vote_as_help_string(value)
         text = value.zero? ? help : short
         div(class: "pt-2") do
-          link_to(text, vote_link_args.merge(vote: value),
-                  class: css, title: help,
-                  data: { tooltip_target: "tip", placement: "left",
-                          role: "image_vote", val: value, id: @image.id })
+          Link(type: :get, name: text,
+               target: vote_link_args.merge(vote: value),
+               class: css, title: help,
+               data: { tooltip_target: "tip", placement: "left",
+                       role: "image_vote", val: value, id: @image.id })
         end
       end
 
@@ -101,9 +102,10 @@ module Views::Controllers::Images
         help = image_vote_as_help_string(value)
         text = :image_show_vote_and_next.t(value: short)
         div(class: "pt-2") do
-          link_to(text, vote_link_args.merge(vote: value, next: true),
-                  class: css, title: help,
-                  data: { tooltip_target: "tip" })
+          Link(type: :get, name: text,
+               target: vote_link_args.merge(vote: value, next: true),
+               class: css, title: help,
+               data: { tooltip_target: "tip" })
         end
       end
 

--- a/app/views/controllers/inat_imports/index.rb
+++ b/app/views/controllers/inat_imports/index.rb
@@ -47,7 +47,8 @@ module Views::Controllers::InatImports
     def results_link(import)
       return unless result_ids.include?(import.id)
 
-      link_to(:results.ti, results_inat_import_path(import))
+      Link(type: :get, name: :results.ti,
+           target: results_inat_import_path(import))
     end
 
     def result_ids
@@ -55,7 +56,7 @@ module Views::Controllers::InatImports
     end
 
     def report_link(import)
-      link_to(:report.ti, inat_import_path(import))
+      Link(type: :get, name: :report.ti, target: inat_import_path(import))
     end
 
     def when_text(import)

--- a/app/views/controllers/info/translators_note.rb
+++ b/app/views/controllers/info/translators_note.rb
@@ -20,7 +20,8 @@ module Views::Controllers::Info
 
     def render_lang(lang)
       li do
-        link_to(lang.name, reload_with_args(user_locale: lang.locale))
+        Link(type: :get, name: lang.name,
+             target: reload_with_args(user_locale: lang.locale))
         if lang.beta
           whitespace
           span { "(beta)" }

--- a/app/views/controllers/interests/index.rb
+++ b/app/views/controllers/interests/index.rb
@@ -48,7 +48,8 @@ module Views::Controllers::Interests
         if active
           plain(label)
         else
-          link_to(add_q_param(url)) { plain(label) }
+          Link(type: :get, name: label,
+               target: add_q_param(url)) { plain(label) }
         end
       end
     end
@@ -76,18 +77,19 @@ module Views::Controllers::Interests
     end
 
     def render_destroy_link(item)
-      link_to(:destroy.ti,
-              set_interest_path(type: item.target_type,
-                                id: item.target_id, state: 0))
+      Link(type: :get, name: :destroy.ti,
+           target: set_interest_path(type: item.target_type,
+                                     id: item.target_id, state: 0))
     end
 
     def render_show_link(item)
       target = item.target
       label = :show_object.l(type: target.type_tag)
       if item.target_type == "NameTracker"
-        link_to(label, new_tracker_of_name_path(target.name_id))
+        Link(type: :get, name: label,
+             target: new_tracker_of_name_path(target.name_id))
       else
-        link_to(label, target.show_link_args)
+        Link(type: :get, name: label, target: target.show_link_args)
       end
     end
 
@@ -97,10 +99,10 @@ module Views::Controllers::Interests
               else
                 :list_interests_turn_on.l
               end
-      link_to(label,
-              set_interest_path(type: item.target_type,
-                                id: item.target_id,
-                                state: item.state ? -1 : 1))
+      Link(type: :get, name: label,
+           target: set_interest_path(type: item.target_type,
+                                     id: item.target_id,
+                                     state: item.state ? -1 : 1))
     end
 
     def render_pending_notice(item)

--- a/app/views/controllers/licenses/index.rb
+++ b/app/views/controllers/licenses/index.rb
@@ -22,9 +22,11 @@ module Views::Controllers::Licenses
     def add_columns(tbl)
       tbl.column("#{:id.ti}:") { |lic| lic.id.to_s }
       tbl.column(:license_display_name.l) do |lic|
-        link_to(lic.display_name, lic)
+        Link(type: :get, name: lic.display_name, target: lic)
       end
-      tbl.column(:license_url.l) { |lic| link_to(lic.url, lic.url) }
+      tbl.column(:license_url.l) do |lic|
+        Link(type: :get, name: lic.url, target: lic.url)
+      end
       tbl.column("#{:deprecated.l}?") { |lic| lic.deprecated ? "X" : "" }
     end
   end

--- a/app/views/controllers/locations/countries/index.rb
+++ b/app/views/controllers/locations/countries/index.rb
@@ -63,7 +63,8 @@ module Views::Controllers::Locations
           plain(country)
         else
           str = count ? "#{country}: #{count}" : country
-          link_to(str, locations_path(country: country))
+          Link(type: :get, name: str,
+               target: locations_path(country: country))
         end
         br
       end

--- a/app/views/controllers/locations/descriptions/index.rb
+++ b/app/views/controllers/locations/descriptions/index.rb
@@ -34,7 +34,10 @@ module Views::Controllers::Locations
         ListGroup do |list|
           @descriptions.each do |desc|
             list.item do
-              link_to(desc.show_link_args) { trusted_html(desc.format_name.t) }
+              Link(type: :get, name: desc.format_name.t,
+                   target: desc.show_link_args) do
+                trusted_html(desc.format_name.t)
+              end
             end
           end
         end

--- a/app/views/controllers/names/descriptions/index.rb
+++ b/app/views/controllers/names/descriptions/index.rb
@@ -32,7 +32,8 @@ module Views::Controllers::Names::Descriptions
             variant: :striped, identifier: "name-descriptions",
             show_headers: false) do |tbl|
         tbl.column("") do |desc|
-          link_to(name_description_path(desc.id)) do
+          Link(type: :get, name: desc.format_name.t,
+               target: name_description_path(desc.id)) do
             trusted_html(desc.format_name.t)
           end
         end

--- a/app/views/controllers/observations/display_name_brief_authors_link.rb
+++ b/app/views/controllers/observations/display_name_brief_authors_link.rb
@@ -19,7 +19,8 @@ module Views::Controllers::Observations
     end
 
     def view_template
-      link_to(name_path(id: @name.id), **@attributes) do
+      Link(type: :get, name: @name.text_name,
+           target: name_path(id: @name.id), **@attributes) do
         trusted_html(@name.display_name_brief_authors(@user).
                      t.small_author)
       end

--- a/app/views/controllers/observations/display_name_without_authors_link.rb
+++ b/app/views/controllers/observations/display_name_without_authors_link.rb
@@ -17,7 +17,8 @@ module Views::Controllers::Observations
     end
 
     def view_template
-      link_to(name_path(id: @name.id), **@attributes) do
+      Link(type: :get, name: @name.text_name,
+           target: name_path(id: @name.id), **@attributes) do
         trusted_html(@name.display_name_without_authors(@user).t)
       end
     end

--- a/app/views/controllers/observations/namings/suggestions/show.rb
+++ b/app/views/controllers/observations/namings/suggestions/show.rb
@@ -73,7 +73,8 @@ module Views::Controllers::Observations::Namings::Suggestions
     end
 
     def render_suggestion_name_link(sugg)
-      link_to(name_path(id: sugg.name.id)) do
+      Link(type: :get, name: sugg.name.text_name,
+           target: name_path(id: sugg.name.id)) do
         trusted_html(sugg.name.display_name_brief_authors(@user).t)
       end
     end

--- a/app/views/controllers/observations/owner_naming_line.rb
+++ b/app/views/controllers/observations/owner_naming_line.rb
@@ -33,8 +33,9 @@ module Views::Controllers::Observations
       # uses `.small_author` for the author bit, but on this line
       # the legacy behavior (matched on production) keeps everything
       # at the normal size.
-      link_to(name_path(id: owner_name.id),
-              class: "obs_owner_naming_link_#{owner_name.id}") do
+      Link(type: :get, name: owner_name.text_name,
+           target: name_path(id: owner_name.id),
+           class: "obs_owner_naming_link_#{owner_name.id}") do
         trusted_html(owner_name.display_name_brief_authors(@user).t)
       end
       whitespace

--- a/app/views/controllers/projects/aliases/table.rb
+++ b/app/views/controllers/projects/aliases/table.rb
@@ -12,7 +12,7 @@ module Views::Controllers::Projects::Aliases
     TABLE_ID = "index_project_alias_table"
 
     # Callers must eager-load `:target` so the per-row
-    # `link_to(alias_.target.try(:format_name), alias_.target)` cell
+    # `Link(type: :get, name: ..., target: alias_.target)` cell
     # doesn't trigger N+1 queries. The `Projects::AliasesController`
     # paths supply that.
     def initialize(project_aliases:)
@@ -50,7 +50,7 @@ module Views::Controllers::Projects::Aliases
              else
                target.try(:format_name)
              end
-      link_to(name, target)
+      Link(type: :get, name: name, target: target)
     end
 
     def render_actions_cell(alias_)

--- a/app/views/controllers/projects/field_slips/tracker_row.rb
+++ b/app/views/controllers/projects/field_slips/tracker_row.rb
@@ -75,7 +75,7 @@ module Views::Controllers::Projects::FieldSlips
 
     def render_field_slip_link
       if @tracker.status == "Done" && @user == @tracker.user
-        link_to(@tracker.filename, @tracker.link)
+        Link(type: :get, name: @tracker.filename, target: @tracker.link)
       else
         plain(@tracker.filename)
       end

--- a/app/views/controllers/projects/locations/tables.rb
+++ b/app/views/controllers/projects/locations/tables.rb
@@ -100,11 +100,11 @@ module Views::Controllers::Projects::Locations
       td(class: "align-middle") do
         render_chevron(collapse_id) if subs.any?
         whitespace if subs.any?
-        link_to(
-          target.display_name,
-          checklist_path(project_id: @project.id,
-                         location_id: target.id,
-                         sub_locations: 1)
+        Link(
+          type: :get, name: target.display_name,
+          target: checklist_path(project_id: @project.id,
+                                 location_id: target.id,
+                                 sub_locations: 1)
         )
       end
     end
@@ -167,10 +167,10 @@ module Views::Controllers::Projects::Locations
     def render_location_name_cell(loc, indent: false)
       style = indent ? "padding-left: 2em" : nil
       td(class: "align-middle", style: style) do
-        link_to(
-          loc.display_name,
-          checklist_path(project_id: @project.id,
-                         location_id: loc.id)
+        Link(
+          type: :get, name: loc.display_name,
+          target: checklist_path(project_id: @project.id,
+                                 location_id: loc.id)
         )
       end
     end

--- a/app/views/controllers/publications/index.rb
+++ b/app/views/controllers/publications/index.rb
@@ -62,7 +62,10 @@ module Views::Controllers::Publications
 
     def add_full_link_column(tbl)
       tbl.column("#{:publication_full.l} (#{full_count})") do |pub|
-        link_to(pub) { trusted_html(pub.full.t.strip_links) }
+        full_text = pub.full.t.strip_links
+        Link(type: :get, name: full_text, target: pub) do
+          trusted_html(full_text)
+        end
       end
     end
 
@@ -71,8 +74,8 @@ module Views::Controllers::Publications
 
       str = pub.link.sub(%r{^.*://+}, "").sub(%r{(/|\?).*}, "")
       capture do
-        link_to(str, pub.link, title: pub.link,
-                               data: { tooltip_target: "tip" })
+        Link(type: :get, name: str, target: pub.link, title: pub.link,
+             data: { tooltip_target: "tip" })
       end
     end
 
@@ -80,10 +83,9 @@ module Views::Controllers::Publications
       return "" unless in_admin_mode? || pub.can_edit?(current_user)
 
       capture do
-        link_to(:edit.ti, edit_publication_path(pub))
+        Link(type: :get, name: :edit.ti, target: edit_publication_path(pub))
         whitespace
-        link_to(:destroy.ti, { action: :destroy, id: pub.id },
-                data: { confirm: :are_you_sure.t })
+        Button(type: :delete, target: pub)
       end
     end
   end

--- a/app/views/controllers/publications/show.rb
+++ b/app/views/controllers/publications/show.rb
@@ -30,7 +30,7 @@ module Views::Controllers::Publications
       p(style: "word-break:break-all") do
         b { "#{:publication_link.l}:" }
         br
-        link_to(@publication.link, @publication.link)
+        Link(type: :get, name: @publication.link, target: @publication.link)
       end
     end
 

--- a/app/views/controllers/rss_logs/show.rb
+++ b/app/views/controllers/rss_logs/show.rb
@@ -38,7 +38,8 @@ module Views::Controllers::RssLogs
       target = @rss_log.target
       return unless target
 
-      link_to(:show_object.l(type: target.type_tag), target.show_link_args)
+      Link(type: :get, name: :show_object.l(type: target.type_tag),
+           target: target.show_link_args)
     end
   end
 end

--- a/app/views/controllers/sequences/index.rb
+++ b/app/views/controllers/sequences/index.rb
@@ -34,10 +34,13 @@ module Views::Controllers::Sequences
     end
 
     def render_top_links(seq)
-      link_to(seq.unique_format_name, seq.show_link_args)
+      Link(type: :get, name: seq.unique_format_name,
+           target: seq.show_link_args)
       br
-      link_to(seq.observation.show_link_args) do
-        trusted_html(viewer_aware_unique_format_name(seq.observation).t)
+      obs_name = viewer_aware_unique_format_name(seq.observation).t
+      Link(type: :get, name: obs_name,
+           target: seq.observation.show_link_args) do
+        trusted_html(obs_name)
       end
       br
     end

--- a/app/views/controllers/sequences/show.rb
+++ b/app/views/controllers/sequences/show.rb
@@ -49,8 +49,9 @@ module Views::Controllers::Sequences
       p do
         strong { "#{:observation.ti}:" }
         whitespace
-        link_to(obs.show_link_args) do
-          trusted_html(obs.name.display_name(current_user).t)
+        obs_name = obs.name.display_name(current_user).t
+        Link(type: :get, name: obs_name, target: obs.show_link_args) do
+          trusted_html(obs_name)
         end
         plain(" (#{obs.id})")
       end

--- a/app/views/controllers/species_lists/listing.rb
+++ b/app/views/controllers/species_lists/listing.rb
@@ -56,7 +56,8 @@ module Views::Controllers::SpeciesLists
 
     def render_title_row
       div do
-        link_to(@species_list.show_link_with_project(@project)) do
+        Link(type: :get, name: @species_list.text_name.t,
+             target: @species_list.show_link_with_project(@project)) do
           span(class: "list_what h4") do
             trusted_html(@species_list.text_name.t)
           end

--- a/app/views/controllers/species_lists/observation.rb
+++ b/app/views/controllers/species_lists/observation.rb
@@ -61,8 +61,9 @@ module Views::Controllers::SpeciesLists
 
     def render_observation_name_link
       div(class: "font-weight-bold") do
-        link_to(viewer_aware_unique_format_name(@observation).t,
-                observation_path(id: @observation.id))
+        Link(type: :get,
+             name: viewer_aware_unique_format_name(@observation).t,
+             target: observation_path(id: @observation.id))
       end
     end
 

--- a/app/views/controllers/theme/black_on_white.rb
+++ b/app/views/controllers/theme/black_on_white.rb
@@ -15,7 +15,9 @@ module Views::Controllers::Theme
 
     def build_description
       link_html = capture do
-        link_to({ action: :Amanita }) { trusted_html("**__Amanita__**".t) }
+        Link(type: :get, name: "Amanita", target: { action: :Amanita }) do
+          trusted_html("**__Amanita__**".t)
+        end
       end
       textile = :theme_black_on_white_description.tp(link: "XXX")
       ::ActiveSupport::SafeBuffer.new(textile.to_s.sub("XXX", link_html))

--- a/app/views/controllers/theme/species_paragraph.rb
+++ b/app/views/controllers/theme/species_paragraph.rb
@@ -28,7 +28,10 @@ module Views::Controllers::Theme
 
     def render_link
       label = @row.raw_link_label ? @row.name : "**__#{@row.name}__**"
-      link_to(image_path(id: @row.image_id)) { trusted_html(label.t) }
+      Link(type: :get, name: @row.name,
+           target: image_path(id: @row.image_id)) do
+        trusted_html(label.t)
+      end
     end
   end
 end

--- a/app/views/controllers/translations/index.rb
+++ b/app/views/controllers/translations/index.rb
@@ -83,8 +83,9 @@ module Views::Controllers::Translations
     def render_tag_field(ttag)
       str = preview_string(@strings[ttag])
       p(class: "tag_field") do
-        link_to(edit_translation_path(id: ttag, locale: @lang.locale),
-                data: { tag: ttag, role: "show_tag", turbo_stream: true }) do
+        Link(type: :get, name: "#{ttag}:",
+             target: edit_translation_path(id: ttag, locale: @lang.locale),
+             data: { tag: ttag, role: "show_tag", turbo_stream: true }) do
           span(class: "tag") { "#{ttag}:" }
         end
         whitespace

--- a/app/views/controllers/users/show/profile.rb
+++ b/app/views/controllers/users/show/profile.rb
@@ -83,7 +83,8 @@ module Views::Controllers::Users
         p do
           strong { "#{:show_user_personal_herbarium.l}:" }
           whitespace
-          link_to(@show_user.personal_herbarium.show_link_args) do
+          Link(type: :get, name: @show_user.personal_herbarium.name,
+               target: @show_user.personal_herbarium.show_link_args) do
             trusted_html(@show_user.personal_herbarium.name.t)
           end
         end
@@ -126,7 +127,8 @@ module Views::Controllers::Users
       def render_footer
         return unless @life_list.num_taxa.positive?
 
-        link_to(checklist_path(id: @show_user.id)) do
+        Link(type: :get, name: :app_life_list.l,
+             target: checklist_path(id: @show_user.id)) do
           strong { :app_life_list.l }
         end
         plain(": ")

--- a/app/views/controllers/users/show/user_stats.rb
+++ b/app/views/controllers/users/show/user_stats.rb
@@ -92,7 +92,9 @@ module Views::Controllers::Users
       def render_link_or_label(row)
         url = field_path(row[:field])
         if url
-          link_to(url) { render_label(row[:label]) }
+          Link(type: :get, name: row[:label].to_s, target: url) do
+            render_label(row[:label])
+          end
         else
           render_label(row[:label])
         end

--- a/app/views/controllers/visual_groups/edit.rb
+++ b/app/views/controllers/visual_groups/edit.rb
@@ -53,12 +53,15 @@ module Views::Controllers::VisualGroups
     end
 
     def render_back_nav_links
-      link_to(:visual_group_show.t, visual_group_path(@visual_group))
+      Link(type: :get, name: :visual_group_show.t,
+           target: visual_group_path(@visual_group))
       whitespace
       plain("|")
       whitespace
-      link_to(:visual_group_index.t,
-              visual_model_visual_groups_path(@visual_group.visual_model))
+      Link(type: :get, name: :visual_group_index.t,
+           target: visual_model_visual_groups_path(
+             @visual_group.visual_model
+           ))
     end
 
     def render_filter_section
@@ -73,7 +76,8 @@ module Views::Controllers::VisualGroups
         strong { plain("#{:visual_group_includes_names.t}:") }
         br
         @visual_group.distinct_names.each do |name|
-          link_to(name[0], distinct_name_filter_path(name[0]))
+          Link(type: :get, name: name[0],
+               target: distinct_name_filter_path(name[0]))
           br
         end
       end

--- a/app/views/controllers/visual_groups/new.rb
+++ b/app/views/controllers/visual_groups/new.rb
@@ -10,7 +10,8 @@ module Views::Controllers::VisualGroups
       add_new_title(:new_object, :visual_group)
 
       render(Form.new(@visual_group, visual_model: @visual_model))
-      link_to("Back", visual_model_visual_groups_path(@visual_model))
+      Link(type: :get, name: "Back",
+           target: visual_model_visual_groups_path(@visual_model))
     end
   end
 end

--- a/app/views/controllers/visual_groups/show.rb
+++ b/app/views/controllers/visual_groups/show.rb
@@ -43,10 +43,13 @@ module Views::Controllers::VisualGroups
     end
 
     def render_nav_links
-      link_to(:visual_group_edit.t, edit_visual_group_path(@visual_group))
+      Link(type: :get, name: :visual_group_edit.t,
+           target: edit_visual_group_path(@visual_group))
       plain(" | ")
-      link_to(:visual_group_index.t,
-              visual_model_visual_groups_path(@visual_group.visual_model))
+      Link(type: :get, name: :visual_group_index.t,
+           target: visual_model_visual_groups_path(
+             @visual_group.visual_model
+           ))
     end
 
     def render_description_and_approval
@@ -65,8 +68,8 @@ module Views::Controllers::VisualGroups
     def render_filter_banner
       strong { plain("Showing definitional images for \"#{@filter}\"") }
       br
-      link_to("Show All Definitional Images",
-              visual_group_path(@visual_group))
+      Link(type: :get, name: "Show All Definitional Images",
+           target: visual_group_path(@visual_group))
     end
 
     def render_counts_and_names
@@ -83,8 +86,8 @@ module Views::Controllers::VisualGroups
 
     def render_distinct_name_links
       @visual_group.distinct_names.each do |name|
-        link_to(name[0],
-                visual_group_path(@visual_group, filter: name[0]))
+        Link(type: :get, name: name[0],
+             target: visual_group_path(@visual_group, filter: name[0]))
         br
       end
     end

--- a/app/views/controllers/visual_groups/status_links.rb
+++ b/app/views/controllers/visual_groups/status_links.rb
@@ -66,7 +66,7 @@ module Views::Controllers::VisualGroups
     def render_image_id_line
       plain("#{:image_reuse_id.t}:")
       whitespace
-      link_to(@image_id, image_path(id: @image_id))
+      Link(type: :get, name: @image_id, target: image_path(id: @image_id))
     end
 
     def status_text(status)

--- a/app/views/controllers/visual_models/edit.rb
+++ b/app/views/controllers/visual_models/edit.rb
@@ -9,9 +9,9 @@ module Views::Controllers::VisualModels
       add_edit_title(@visual_model)
 
       render(Form.new(@visual_model))
-      link_to("Show", visual_model_path(@visual_model))
+      Link(type: :get, name: "Show", target: visual_model_path(@visual_model))
       plain(" | ")
-      link_to("Back", visual_models_path)
+      Link(type: :get, name: "Back", target: visual_models_path)
     end
   end
 end

--- a/app/views/controllers/visual_models/index.rb
+++ b/app/views/controllers/visual_models/index.rb
@@ -13,14 +13,16 @@ module Views::Controllers::VisualModels
         @visual_models,
         class: "table-striped table-visual-model mb-3 mt-3"
       ) do |t|
-        t.column("Name", width: "33%") { |vm| link_to(vm.name, vm) }
+        t.column("Name", width: "33%") do |vm|
+          Link(type: :get, name: vm.name, target: vm)
+        end
         t.column(nil, width: "33%") do |vm|
-          link_to("Edit", edit_visual_model_path(vm))
+          Link(type: :get, name: "Edit", target: edit_visual_model_path(vm))
         end
         t.column(nil, width: "33%") { |vm| render_destroy_link(vm) }
       end
       br
-      link_to("New Visual Model", new_visual_model_path)
+      Link(type: :get, name: "New Visual Model", target: new_visual_model_path)
     end
 
     private

--- a/app/views/controllers/visual_models/new.rb
+++ b/app/views/controllers/visual_models/new.rb
@@ -9,7 +9,7 @@ module Views::Controllers::VisualModels
       add_new_title(:new_object, :visual_model)
 
       render(Form.new(@visual_model))
-      link_to("Back", visual_models_path)
+      Link(type: :get, name: "Back", target: visual_models_path)
     end
   end
 end

--- a/app/views/controllers/visual_models/visual_group_table.rb
+++ b/app/views/controllers/visual_models/visual_group_table.rb
@@ -44,7 +44,9 @@ module Views::Controllers::VisualModels
     end
 
     def define_name_column(table)
-      table.column(:name.ti) { |g| link_to(g.name, visual_group_path(g)) }
+      table.column(:name.ti) do |g|
+        Link(type: :get, name: g.name, target: visual_group_path(g))
+      end
     end
 
     def define_count_columns(table)
@@ -58,23 +60,21 @@ module Views::Controllers::VisualModels
 
     def define_action_columns(table)
       table.column(:edit.ti) do |g|
-        link_to(:edit.ti, edit_visual_group_path(g))
+        Link(type: :get, name: :edit.ti, target: edit_visual_group_path(g))
       end
       table.column(:destroy.ti) { |g| render_destroy_link(g) }
     end
 
     def render_top_nav
       p do
-        [
-          link_to(:visual_group_create.t,
-                  new_visual_model_visual_group_path(@visual_model)),
-          link_to(:edit_object.t(type: :visual_model),
-                  edit_visual_model_path(@visual_model)),
-          link_to(:show_visual_model_index.t, visual_models_path)
-        ].each_with_index do |link, i|
-          plain(" | ") if i.positive?
-          trusted_html(link)
-        end
+        Link(type: :get, name: :visual_group_create.t,
+             target: new_visual_model_visual_group_path(@visual_model))
+        plain(" | ")
+        Link(type: :get, name: :edit_object.t(type: :visual_model),
+             target: edit_visual_model_path(@visual_model))
+        plain(" | ")
+        Link(type: :get, name: :show_visual_model_index.t,
+             target: visual_models_path)
       end
     end
 

--- a/app/views/layouts/object_footer.rb
+++ b/app/views/layouts/object_footer.rb
@@ -180,8 +180,8 @@ module Views::Layouts
       return unless @obj.respond_to?(:rss_log_id) && @obj.rss_log_id
 
       br
-      trusted_html(link_to(:show_object.t(type: :log),
-                           activity_log_path(@obj.rss_log_id)))
+      Link(type: :get, name: :show_object.t(type: :log),
+           target: activity_log_path(@obj.rss_log_id))
     end
   end
 end

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -179,9 +179,9 @@ class Views::Layouts::TopNav < Views::Base
     ctrlr = nav_linkable_controller
     return plain(rubric_text) unless ctrlr
 
-    link_to(
-      rubric_text,
-      { controller: "/#{ctrlr.controller_path}", action: :index },
+    Link(
+      type: :get, name: rubric_text,
+      target: { controller: "/#{ctrlr.controller_path}", action: :index },
       class: "#{ctrlr.controller_name}_index_link",
       data: { tooltip_target: "tip", placement: :bottom,
               title: :index_object.ti(type: ctrlr.controller_name.to_sym) }

--- a/lib/rubocop/cop/mo/no_raw_link_or_button_to.rb
+++ b/lib/rubocop/cop/mo/no_raw_link_or_button_to.rb
@@ -3,34 +3,43 @@
 module RuboCop
   module Cop
     module MO
-      # Phlex views/components must not call Rails' `link_to`/`button_to`
-      # directly -- use `Components::Link`/`Components::Button` (Kit
-      # syntax `Link(...)`/`Button(...)`) instead, so styling, Stimulus
-      # data attrs, and Turbo wiring all stay centralized in one place
-      # instead of drifting per call site.
+      # Phlex views/components must not call Rails' `link_to`/`button_to`,
+      # NOR Phlex's own native `button(...)` tag helper, directly -- use
+      # `Components::Link`/`Components::Button` (Kit syntax
+      # `Link(...)`/`Button(...)`) instead, so styling, Stimulus data
+      # attrs, and Turbo wiring all stay centralized in one place instead
+      # of drifting per call site. `button(...)` is banned alongside
+      # `button_to` specifically because it's the easy way to bypass
+      # `Button` entirely while still LOOKING like a normal Phlex tag
+      # call -- hand-rolling `button(class: "btn btn-default") { ... }`
+      # produces the exact un-centralized styling this cop exists to stop,
+      # without ever calling `button_to`.
       #
       # Scoped via this cop's Include/Exclude in .rubocop.yml, not in
       # this file: applies to app/components + app/views, excluding the
       # Button/Link primitive implementations themselves (which
-      # legitimately call link_to/button_to to BUILD the component) and
-      # app/views/mailers (emails can't use interactive Bootstrap/
-      # Stimulus components -- they need plain, inline-styled tags).
+      # legitimately call link_to/button_to/button to BUILD the
+      # component) and app/views/mailers (emails can't use interactive
+      # Bootstrap/Stimulus components -- they need plain, inline-styled
+      # tags).
       #
       # @example
       #   # bad
       #   link_to("Edit", edit_path)
       #   button_to("Delete", path, method: :delete)
+      #   button(type: "button", class: "btn btn-default") { "OK" }
       #
       #   # good
       #   Link(type: :get, name: "Edit", target: edit_path)
       #   Button(type: :delete, target: object)
+      #   Button(name: "OK")
       class NoRawLinkOrButtonTo < Base
         MSG = "Don't call `%<method>s` directly in a Phlex view/component " \
               "-- use `Link(...)`/`Button(...)` (Components::Link / " \
               "Components::Button) instead, so styling and Turbo/Stimulus " \
               "wiring stay centralized in one place."
 
-        RESTRICT_ON_SEND = [:link_to, :button_to].freeze
+        RESTRICT_ON_SEND = [:link_to, :button_to, :button].freeze
 
         def on_send(node)
           add_offense(node, message: format(MSG, method: node.method_name))

--- a/lib/rubocop/cop/mo/no_raw_link_or_button_to.rb
+++ b/lib/rubocop/cop/mo/no_raw_link_or_button_to.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Phlex views/components must not call Rails' `link_to`/`button_to`
+      # directly -- use `Components::Link`/`Components::Button` (Kit
+      # syntax `Link(...)`/`Button(...)`) instead, so styling, Stimulus
+      # data attrs, and Turbo wiring all stay centralized in one place
+      # instead of drifting per call site.
+      #
+      # Scoped via this cop's Include/Exclude in .rubocop.yml, not in
+      # this file: applies to app/components + app/views, excluding the
+      # Button/Link primitive implementations themselves (which
+      # legitimately call link_to/button_to to BUILD the component) and
+      # app/views/mailers (emails can't use interactive Bootstrap/
+      # Stimulus components -- they need plain, inline-styled tags).
+      #
+      # @example
+      #   # bad
+      #   link_to("Edit", edit_path)
+      #   button_to("Delete", path, method: :delete)
+      #
+      #   # good
+      #   Link(type: :get, name: "Edit", target: edit_path)
+      #   Button(type: :delete, target: object)
+      class NoRawLinkOrButtonTo < Base
+        MSG = "Don't call `%<method>s` directly in a Phlex view/component " \
+              "-- use `Link(...)`/`Button(...)` (Components::Link / " \
+              "Components::Button) instead, so styling and Turbo/Stimulus " \
+              "wiring stay centralized in one place."
+
+        RESTRICT_ON_SEND = [:link_to, :button_to].freeze
+
+        def on_send(node)
+          add_offense(node, message: format(MSG, method: node.method_name))
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mo/no_raw_link_or_button_to.rb
+++ b/lib/rubocop/cop/mo/no_raw_link_or_button_to.rb
@@ -42,7 +42,21 @@ module RuboCop
         RESTRICT_ON_SEND = [:link_to, :button_to, :button].freeze
 
         def on_send(node)
+          return if node.method?(:button) && !bare_call?(node)
+
           add_offense(node, message: format(MSG, method: node.method_name))
+        end
+
+        private
+
+        # `:button` is only Phlex's native tag helper when called bare
+        # (or on an explicit `self`) -- `form.button(...)`/`obj.button(...)`
+        # is some other API's `#button` method, not the tag helper this
+        # cop exists to ban. `link_to`/`button_to` stay banned regardless
+        # of receiver (e.g. `view_context.link_to(...)` is still Rails'
+        # helper, still bypassing `Link`/`Button`).
+        def bare_call?(node)
+          node.receiver.nil? || node.receiver.self_type?
         end
       end
     end

--- a/test/controllers/publications_controller_test.rb
+++ b/test/controllers/publications_controller_test.rb
@@ -16,7 +16,16 @@ class PublicationsControllerTest < FunctionalTestCase
     assert_response(:success)
     assert_not_nil(assigns(:publications))
     assert_link_in_html("Edit", action: :edit, id: pub_id)
-    assert_link_in_html("Destroy", action: :destroy, id: pub_id)
+    # `Button(type: :delete, ...)` renders a POST form (with a hidden
+    # `_method=delete` field), not an `<a>` link, so this checks the
+    # form/button shape rather than `assert_link_in_html`.
+    assert_select(
+      "form[action='#{publication_path(pub_id)}'][method='post']"
+    )
+    assert_select(
+      "form[action='#{publication_path(pub_id)}'] " \
+      "input[type='hidden'][name='_method'][value='delete']"
+    )
   end
 
   # Covers the `link_cell` branch in


### PR DESCRIPTION
## Summary

- Adds `MO/NoRawLinkOrButtonTo`, a RuboCop cop banning `link_to`, `button_to`, and Phlex's own native `button(...)` tag helper in `app/components/**` + `app/views/**` — use `Components::Link`/`Components::Button` (`Link(...)`/`Button(...)` Kit syntax) instead, so styling, Stimulus data attrs, and Turbo wiring stay centralized in one place. `button(...)` is banned alongside `button_to` specifically because it's the easy way to bypass `Button` entirely while still looking like a normal Phlex tag call — this is exactly the gap that let a hand-rolled `button_to` slip into `Observations::ImportedSourceBanner` in an unrelated PR.
- Excludes the `Link`/`Button` component family's own implementations (they legitimately call `link_to`/`button_to`/`button` to build the abstraction), `app/views/mailers/**` (emails can't use interactive Bootstrap/Stimulus components), and `app/components/id_badge.rb` (a copy-to-clipboard badge using `role="button"` + Stimulus wiring, not an action button — `Button`'s `.btn`-family styling abstraction doesn't fit it).
- Converts every other `link_to`/`button_to`/`button` call site across `app/components` + `app/views` (~58 files) to `Link(...)`/`Button(...)` Kit syntax.

## Notable findings from the conversion

- `Components::Link::Get#initialize` requires `name:` even for block-form calls, where it's otherwise inert (only used for icon-tooltip/no-block fallback). This isn't obvious from the common call shape. One conversion (`app/views/controllers/checklists/panel.rb`) initially omitted it, which would have raised `ArgumentError` on any real render — caught because `Checklists::Panel` has no component-level test of its own (a same-named-directory test, `checklists/contents_test.rb`, covers a different class and doesn't exercise this path). Verified directly via `ApplicationController.renderer` against realistic taxon data, both to confirm the bug and the fix.
- `field_slips/index.rb` carried a raw `class: "alert-link"` string over from its original `link_to` call; switched to the dedicated `Components::Alert::Link`, which already exists for exactly this "link styled to sit inside an `.alert` box" pattern.
- Fixed `block_raw_component_classes.sh` (a local pre-commit hook): it was blocking any class string containing `alert-link`, even when already routed through `Components::Alert::Link` — `alert-link` is a plain CSS modifier, not a structural component worth blocking a commit over.

## Test plan

- [x] `bundle exec rubocop` clean on every touched file (59 files)
- [x] `bundle exec rubocop --only MO/NoRawLinkOrButtonTo` — zero offenses app-wide
- [x] `bin/rails zeitwerk:check` clean
- [x] Corresponding test suite run per converted file (component/view/controller tests as available), all green
