### PR TITLE
Fix dead lightbox caption links behind invisible `.vote-section` overlay; extract `Components::ObservationWho`

### DIFF
--- a/app/assets/stylesheets/mo/_lightgallery.scss
+++ b/app/assets/stylesheets/mo/_lightgallery.scss
@@ -7,4 +7,15 @@
   margin-left: auto;
   margin-right: auto;
   max-width: $screen-md-min;
+
+  // The global .vote-section is a thumbnail hover-overlay (absolute,
+  // bottom-pinned, opacity 0 until .image-sizer:hover). There's no
+  // .image-sizer in the lightbox caption, so without this override it
+  // stays an invisible strip covering the caption's bottom row and
+  // swallowing clicks on the original-image/EXIF links (issue #4884).
+  .vote-section {
+    position: static;
+    opacity: 1;
+    background: transparent;
+  }
 }

--- a/app/assets/stylesheets/mo/_lightgallery.scss
+++ b/app/assets/stylesheets/mo/_lightgallery.scss
@@ -7,15 +7,4 @@
   margin-left: auto;
   margin-right: auto;
   max-width: $screen-md-min;
-
-  // The global .vote-section is a thumbnail hover-overlay (absolute,
-  // bottom-pinned, opacity 0 until .image-sizer:hover). There's no
-  // .image-sizer in the lightbox caption, so without this override it
-  // stays an invisible strip covering the caption's bottom row and
-  // swallowing clicks on the original-image/EXIF links (issue #4884).
-  .vote-section {
-    position: static;
-    opacity: 1;
-    background: transparent;
-  }
 }

--- a/app/components/image/base.rb
+++ b/app/components/image/base.rb
@@ -197,8 +197,7 @@ class Components::Image::Base < Components::Base
                image_id: lightbox_data[:image_id],
                obs: lightbox_data[:obs],
                identify: lightbox_data[:identify],
-               observation_view: lightbox_data[:observation_view],
-               votes: @votes
+               observation_view: lightbox_data[:observation_view]
              ))
     end
   end

--- a/app/components/image/lightbox/caption.rb
+++ b/app/components/image/lightbox/caption.rb
@@ -184,41 +184,9 @@ class Components::Image::Lightbox::Caption < Components::Base
   end
 
   def render_obs_who
-    obs_user = @obs.user
-
     p(class: "obs-who", id: "observation_who") do
-      plain("#{:who.ti}: ")
-      render_obs_user(obs_user)
-      render_contact_link(obs_user) if show_contact_link?(obs_user)
+      ObservationWho(obs: @obs, user: @user)
     end
-  end
-
-  def render_obs_user(obs_user)
-    if @user
-      Link(type: :user, user: obs_user)
-    else
-      plain(obs_user.unique_text_name)
-    end
-  end
-
-  def show_contact_link?(obs_user)
-    @user && obs_user != @user && !obs_user&.no_emails &&
-      obs_user&.email_general_question
-  end
-
-  def render_contact_link(_obs_user)
-    InlineLinkBlock(items: [contact_button])
-  end
-
-  def contact_button
-    Components::Button.new(
-      type: :modal,
-      name: :show_observation_send_question.l,
-      target: new_question_for_observation_path(@obs.id),
-      modal_id: "observation_email",
-      variant: :strip, icon: :email,
-      class: Components::InlineLinkBlock.item_class
-    )
   end
 
   def render_truncated_notes

--- a/app/components/image/lightbox/caption.rb
+++ b/app/components/image/lightbox/caption.rb
@@ -39,13 +39,6 @@ class Components::Image::Lightbox::Caption < Components::Base
   prop :obs, _Union(Observation, Hash), default: -> { {} }
   prop :identify, _Boolean, default: false
   prop :observation_view, _Nilable(ObservationView), default: nil
-  # Propagated from the parent `BaseImage` (carousel /
-  # interactive-image). When the parent disables votes — e.g. the
-  # profile-images reuse page passes `votes: false` because it
-  # doesn't pre-load `:image_votes` — the lightbox caption must
-  # also skip the vote section. Otherwise `ImageVoteInterface`
-  # calls `Image#users_vote(@user)` and triggers a Bullet N+1.
-  prop :votes, _Boolean, default: true
 
   def view_template
     if @obs.is_a?(Observation)
@@ -54,7 +47,6 @@ class Components::Image::Lightbox::Caption < Components::Base
       render_image_caption
     end
 
-    render_vote_section
     render_image_links
   end
 
@@ -216,24 +208,6 @@ class Components::Image::Lightbox::Caption < Components::Base
 
   def render_image_caption
     div(class: "image-notes") { @image.notes.tl.truncate_html(300) }
-  end
-
-  # Vote interface inside the lightbox overlay — same component that
-  # renders below carousel/interactive images. Gated on `@user` to match
-  # `images/show/_image_panel.html.erb`'s "login required to vote" rule;
-  # anonymous viewers see no vote UI. Also skipped when `@votes` is
-  # false (parent opted out — see prop doc above) or no image is in
-  # scope (obs-only pre-render contexts).
-  def render_vote_section
-    return unless @votes && @user && @image
-
-    div(class: "mt-3 text-center") do
-      render(Components::Image::VoteInterface.new(
-               user: @user,
-               image: @image,
-               votes: true
-             ))
-    end
   end
 
   def render_image_links

--- a/app/components/observation_who.rb
+++ b/app/components/observation_who.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# The "Collector:" / "Entered by:" identity line(s) for an observation
+# (#4211 semantics). Renders the line *contents* only — callers supply
+# their own wrapper element (the obs show page's Details panel uses an
+# `li.obs-who`; the lightbox caption uses a `p.obs-who`).
+class Components::ObservationWho < Components::Base
+  prop :obs, ::Observation
+  prop :user, _Nilable(::User), default: nil
+
+  # A field-slip obs with no recorded collector shows only
+  # "Entered by:" — we don't claim the entering recorder as the
+  # collector.
+  def view_template
+    if @obs.collector_unrecorded?
+      render_entered_by
+    else
+      render_collector
+      if @obs.collector_differs_from_creator?
+        br
+        render_entered_by
+      end
+    end
+  end
+
+  private
+
+  # The send-question link rides the "Collector:" line only when the
+  # collector is the entering user; when they differ it moves to the
+  # "Entered by:" line (you email the MO account, not a free-text name).
+  def render_collector
+    plain("#{:collector.ti}: ")
+    render_collector_identity
+    return if @obs.collector_differs_from_creator?
+
+    render_send_question_link if show_send_question?
+  end
+
+  def render_entered_by
+    plain("#{:entered_by.ti}: ")
+    render_user_link(@obs.user)
+    render_send_question_link if show_send_question?
+  end
+
+  # Linked MO user when known, else the free-text collector string, else
+  # the entering user.
+  def render_collector_identity
+    if @obs.collector_user
+      render_user_link(@obs.collector_user)
+    elsif @obs.collector.present?
+      plain(@obs.collector)
+    else
+      render_user_link(@obs.user)
+    end
+  end
+
+  def render_user_link(target)
+    if @user
+      Link(type: :user, user: target)
+    else
+      plain(target.unique_text_name)
+    end
+  end
+
+  def show_send_question?
+    @user && @obs.user != @user &&
+      !@obs.user&.no_emails && @obs.user&.email_general_question
+  end
+
+  def render_send_question_link
+    InlineLinkBlock(items: [send_question_button])
+  end
+
+  def send_question_button
+    Components::Button.new(
+      type: :modal,
+      name: :show_observation_send_question.l,
+      target: new_question_for_observation_path(@obs.id),
+      modal_id: "observation_email",
+      variant: :strip, icon: :email,
+      class: Components::InlineLinkBlock.item_class
+    )
+  end
+end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -271,7 +271,8 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
 
   # Eager-load tree every `Components::Matrix::Box` render of an
   # observation reaches into — image with vote/license/project/user
-  # for `can_edit?`, location, name, namings (+ votes for
+  # for `can_edit?`, collector_user (lightbox caption's who line),
+  # location, name, namings (+ votes for
   # `Observation::NamingConsensus`), occurrence (+ observations for
   # the multi-obs occurrence link), projects, rss_log, user.
   # Shared by observations#index, field_slips show/index,
@@ -286,6 +287,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     [{ thumb_image: [:image_votes, :license, :projects, :user] },
      # for matrix_box_carousels:
      # { images: [:image_votes, :license, :projects, :user] },
+     :collector_user,
      { external_links: :external_site }, :location, :name,
      { namings: :votes },
      { occurrence: :observations }, :projects, :rss_log, :user]

--- a/app/views/controllers/observations/show/details.rb
+++ b/app/views/controllers/observations/show/details.rb
@@ -118,78 +118,10 @@ class Views::Controllers::Observations::Show::Details < Views::Base
     )
   end
 
-  # "Collector:" and (when they differ) "Entered by:" lines. A field-slip
-  # obs with no recorded collector shows only "Entered by:" — we don't
-  # claim the entering recorder as the collector. See #4211.
   def render_who
     li(class: "obs-who hanging-indent", id: "observation_who") do
-      if @obs.collector_unrecorded?
-        render_entered_by
-      else
-        render_collector
-        if @obs.collector_differs_from_creator?
-          br
-          render_entered_by
-        end
-      end
+      ObservationWho(obs: @obs, user: @user)
     end
-  end
-
-  # The send-question link rides the "Collector:" line only when the
-  # collector is the entering user; when they differ it moves to the
-  # "Entered by:" line (you email the MO account, not a free-text name).
-  def render_collector
-    plain("#{:collector.ti}: ")
-    render_collector_identity
-    return if @obs.collector_differs_from_creator?
-
-    render_send_question_link if show_send_question?
-  end
-
-  def render_entered_by
-    plain("#{:entered_by.ti}: ")
-    render_user_link(@obs.user)
-    render_send_question_link if show_send_question?
-  end
-
-  # Linked MO user when known, else the free-text collector string, else
-  # the entering user.
-  def render_collector_identity
-    if @obs.collector_user
-      render_user_link(@obs.collector_user)
-    elsif @obs.collector.present?
-      plain(@obs.collector)
-    else
-      render_user_link(@obs.user)
-    end
-  end
-
-  def render_user_link(target)
-    if @user
-      Link(type: :user, user: target)
-    else
-      plain(target.unique_text_name)
-    end
-  end
-
-  def show_send_question?
-    @user && @obs.user != @user &&
-      !@obs.user&.no_emails && @obs.user&.email_general_question
-  end
-
-  def render_send_question_link
-    InlineLinkBlock(items: [send_question_button])
-  end
-
-  def send_question_button
-    Components::Button.new(
-      type: :modal,
-      name: :show_observation_send_question.l,
-      target: new_question_for_observation_path(@obs.id),
-      modal_id: "observation_email",
-      variant: :strip, icon: :email,
-      class: Components::InlineLinkBlock.item_class
-    )
   end
 
   # ---- field slip -----------------------------------------------

--- a/test/components/image/lightbox/caption_test.rb
+++ b/test/components/image/lightbox/caption_test.rb
@@ -128,6 +128,24 @@ class LightboxCaptionTest < ComponentTestCase
     assert_includes(html, :show_observation_seen_at.l)
   end
 
+  # #4884: the who line mirrors the obs show page's Collector /
+  # Entered-by semantics (via Components::ObservationWho) instead of
+  # the old "Who:" label. Branch coverage lives in ObservationWhoTest;
+  # this pins the caption's wiring.
+  def test_who_line_uses_collector_entered_by_semantics
+    obs = observations(:detailed_unknown_obs)
+    obs.collector = "Jane Forager"
+    obs.collector_user_id = nil
+
+    html = render_caption(obs: obs, image: nil)
+    text = Nokogiri::HTML.fragment(html).at_css("#observation_who").text
+
+    assert_includes(text, :collector.ti)
+    assert_includes(text, "Jane Forager")
+    assert_includes(text, :entered_by.ti)
+    assert_not_includes(text, "#{:who.ti}: ")
+  end
+
   def test_renders_contact_link_when_owner_accepts_general_questions
     obs = observations(:owner_accepts_general_questions)
     viewer = users(:rolf)

--- a/test/components/image/lightbox/caption_test.rb
+++ b/test/components/image/lightbox/caption_test.rb
@@ -203,41 +203,15 @@ class LightboxCaptionTest < ComponentTestCase
     assert_includes(html, "caption-image-links")
   end
 
-  # The lightbox overlay is populated from this component's rendered HTML
-  # (read out of the theater button's `data-sub-html`). It now embeds the
-  # vote interface so users can vote without leaving the overlay —
-  # matching the in-page image-show panel.
-  def test_renders_vote_section_for_logged_in_user
+  # No vote UI in the lightbox caption (#4884). The global
+  # `.vote-section` styling is an absolute bottom-pinned, opacity-0
+  # thumbnail hover-overlay; inside `.lg-sub-html` it becomes an
+  # invisible strip covering the caption's bottom links row and
+  # swallowing clicks. Vote updates also can't sync to the caption
+  # (it's a clone stored in `data-sub-html`), so the caption skips
+  # the vote interface entirely.
+  def test_does_not_render_vote_section
     html = render_caption
-
-    assert_html(html, ".vote-section#image_vote_#{@image.id}")
-    assert_html(html, ".vote-meter.progress")
-    assert_html(html, ".vote-buttons .image-vote-links")
-  end
-
-  # Anonymous viewers can't vote, so the section is suppressed entirely
-  # (matches `images/show/_image_panel.html.erb`'s `if @user` gate).
-  def test_does_not_render_vote_section_for_logged_out_user
-    html = render_caption(user: nil)
-
-    assert_no_html(html, ".vote-section")
-    assert_no_html(html, ".vote-meter")
-  end
-
-  # No image in scope (e.g. obs-only pre-render contexts) → no votes.
-  def test_does_not_render_vote_section_without_image
-    html = render_caption(image: nil)
-
-    assert_no_html(html, ".vote-section")
-  end
-
-  # `votes: false` propagates from the parent `BaseImage` and
-  # suppresses the lightbox vote section — needed on pages that
-  # don't pre-load `:image_votes` (e.g. account/profile/images
-  # reuse page), otherwise `Image#users_vote(@user)` triggers a
-  # Bullet N+1 inside the vote interface.
-  def test_does_not_render_vote_section_when_votes_disabled
-    html = render_caption(votes: false)
 
     assert_no_html(html, ".vote-section")
     assert_no_html(html, ".vote-meter")

--- a/test/components/observation_who_test.rb
+++ b/test/components/observation_who_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Collector / Entered-by identity lines (#4211), shared by the obs show
+# Details panel and the lightbox caption. Details/Caption tests cover
+# their wrapper wiring; branch coverage of the line contents lives here.
+class ObservationWhoTest < ComponentTestCase
+  def setup
+    super
+    @user = users(:rolf)
+    @obs = observations(:detailed_unknown_obs)
+  end
+
+  def test_collector_is_creator_no_entered_by
+    @obs.collector = @obs.user.unique_text_name
+    @obs.collector_user_id = @obs.user_id
+
+    html = render_who(@obs)
+    text = who_text(html)
+
+    assert_includes(text, :collector.ti)
+    assert_html(html, "a[href='#{routes.user_path(@obs.user_id)}']")
+    assert_not_includes(text, :entered_by.ti)
+  end
+
+  def test_free_text_collector_shows_entered_by
+    @obs.collector = "Jane Forager"
+    @obs.collector_user_id = nil
+
+    text = who_text(render_who(@obs))
+
+    assert_includes(text, "Jane Forager")
+    assert_includes(text, :entered_by.ti)
+  end
+
+  def test_collector_user_links_and_entered_by
+    # A collector who is not the obs owner (detailed_unknown_obs is
+    # mary's).
+    collector = users(:katrina)
+    @obs.collector_user = collector
+    @obs.collector = collector.unique_text_name
+
+    html = render_who(@obs)
+
+    assert_html(html, "a[href='#{routes.user_path(collector.id)}']")
+    assert_includes(who_text(html), :entered_by.ti)
+  end
+
+  def test_plain_text_when_logged_out
+    @obs.collector = @obs.user.unique_text_name
+    @obs.collector_user_id = @obs.user_id
+
+    html = render_who(@obs, user: nil)
+
+    assert_includes(who_text(html), @obs.user.unique_text_name)
+    assert_no_html(html, "a")
+  end
+
+  def test_collector_unrecorded_suppresses_collector_line
+    obs = observations(:minimal_unknown_obs)
+    assert(obs.field_slip_id.present?, "fixture should have a field slip")
+    obs.collector = nil
+    obs.collector_user_id = nil
+
+    text = who_text(render_who(obs))
+
+    assert_not_includes(text, :collector.ti)
+    assert_includes(text, :entered_by.ti)
+    assert_includes(text, obs.user.unique_text_name)
+  end
+
+  def test_send_question_link_when_allowed
+    obs = observations(:owner_accepts_general_questions)
+    assert_not_equal(obs.user, @user)
+
+    html = render_who(obs)
+
+    assert_html(html, "a[data-controller='modal-toggle']" \
+                      "[href='#{routes.new_question_for_observation_path(
+                        obs.id
+                      )}']")
+  end
+
+  def test_no_send_question_link_for_own_observation
+    obs = observations(:owner_accepts_general_questions)
+
+    html = render_who(obs, user: obs.user)
+
+    assert_no_html(html, "a[data-controller='modal-toggle']")
+  end
+
+  private
+
+  def who_text(html)
+    Nokogiri::HTML.fragment(html).text
+  end
+
+  def render_who(obs, user: @user)
+    render(Components::ObservationWho.new(obs: obs, user: user))
+  end
+end

--- a/test/system/lightbox_image_links_system_test.rb
+++ b/test/system/lightbox_image_links_system_test.rb
@@ -4,12 +4,14 @@ require("application_system_test_case")
 
 # Regression tests for issue #4884: the "Show Original Image" and
 # "Show EXIF Header" links at the bottom of the lightbox caption were
-# dead. The global `.vote-section` thumbnail hover-overlay styling
-# (absolute bottom-pinned, opacity 0) leaked into `.lg-sub-html`,
-# leaving an invisible strip covering the links row and swallowing
-# every click. Clicking each link here fails with Cuprite's
-# "another element would receive the click" error if that overlay
-# ever comes back.
+# dead. The caption embedded the image vote interface, and the global
+# `.vote-section` thumbnail hover-overlay styling (absolute
+# bottom-pinned, opacity 0) leaked into `.lg-sub-html`, leaving an
+# invisible strip covering the links row and swallowing every click.
+# The caption no longer renders a vote section (its votes couldn't
+# sync anyway — the caption is a clone stored in `data-sub-html`);
+# clicking each link here fails with Cuprite's "another element would
+# receive the click" error if any such overlay ever comes back.
 class LightboxImageLinksSystemTest < ApplicationSystemTestCase
   def test_lightbox_original_and_exif_links
     rolf = users("rolf")
@@ -25,10 +27,9 @@ class LightboxImageLinksSystemTest < ApplicationSystemTestCase
     first(".theater-btn", visible: :all).trigger("click")
     assert_selector(".lg-sub-html")
 
-    # The vote interface renders visibly in the caption (not as the
-    # thumbnail-style invisible hover overlay).
+    # No vote UI in the caption — see class comment.
     within(".lg-sub-html") do
-      assert_selector(".vote-section .image-vote-links")
+      assert_no_selector(".vote-section", visible: :all)
     end
 
     # EXIF link opens the EXIF modal.

--- a/test/system/lightbox_image_links_system_test.rb
+++ b/test/system/lightbox_image_links_system_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require("application_system_test_case")
+
+# Regression tests for issue #4884: the "Show Original Image" and
+# "Show EXIF Header" links at the bottom of the lightbox caption were
+# dead. The global `.vote-section` thumbnail hover-overlay styling
+# (absolute bottom-pinned, opacity 0) leaked into `.lg-sub-html`,
+# leaving an invisible strip covering the links row and swallowing
+# every click. Clicking each link here fails with Cuprite's
+# "another element would receive the click" error if that overlay
+# ever comes back.
+class LightboxImageLinksSystemTest < ApplicationSystemTestCase
+  def test_lightbox_original_and_exif_links
+    rolf = users("rolf")
+    login!(rolf)
+
+    obs = observations(:detailed_unknown_obs)
+    image = obs.thumb_image
+    stage_original_file(image)
+
+    visit("/#{obs.id}")
+    assert_selector("body.observations__show")
+
+    first(".theater-btn", visible: :all).trigger("click")
+    assert_selector(".lg-sub-html")
+
+    # The vote interface renders visibly in the caption (not as the
+    # thumbnail-style invisible hover overlay).
+    within(".lg-sub-html") do
+      assert_selector(".vote-section .image-vote-links")
+    end
+
+    # EXIF link opens the EXIF modal.
+    within(".lg-sub-html") do
+      find("a", text: :image_show_exif.t).click
+    end
+    assert_selector("#modal_image_exif_#{image.id}", wait: 9)
+    assert_selector("#modal_image_exif_#{image.id} #exif_data_table")
+    within("#modal_image_exif_#{image.id}") do
+      first("[data-dismiss='modal']").click
+    end
+    assert_no_selector("#modal_image_exif_#{image.id} #exif_data_table")
+
+    # Original-image link polls for the original, then opens it in a
+    # new window once ready.
+    original_window = window_opened_by do
+      within(".lg-sub-html") do
+        find("a", text: :image_show_original.l).click
+      end
+    end
+    original_window.close
+  end
+
+  private
+
+  # The EXIF endpoint shells out to exiftool on the image's local
+  # original; stage a real geotagged fixture file so it succeeds.
+  def stage_original_file(image)
+    fixture = "#{MO.root}/test/images/geotagged.jpg"
+    file = image.full_filepath("orig")
+    FileUtils.mkdir_p(File.dirname(file))
+    FileUtils.cp(fixture, file)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #4884 — the "Show Original Image | Show EXIF Header" links at the bottom of the lightbox caption were dead, and the caption's "Who" line is revised to the newer Collector/Entered-by semantics from the Observation Show page.

### Root cause of the dead links

Not a JavaScript problem — both Stimulus controllers (`modal-toggle` on the EXIF link, `image-loader` on the original-image link) connect fine inside the lightgallery overlay. The lightbox caption embedded the image vote interface, and the global `.vote-section` rule in `mo/_images.scss` styles that as a *thumbnail hover overlay*: `position: absolute; bottom: 0; left: 0; right: 0; z-index: 2; opacity: 0`, revealed only on `.image-sizer:hover`. There is no `.image-sizer` in the lightbox, so the vote UI stayed permanently invisible while remaining an absolutely-positioned strip pinned to the bottom of `.lg-sub-html` — sitting exactly on top of the caption's last row (the original/EXIF links) and swallowing every click. The links higher up (ID badge, location, who) sit above the strip, which is why they still worked.

### Fix: remove the vote interface from the caption

Manual testing of a make-it-visible fix showed the caption's vote UI was never viable there anyway: vote turbo-stream updates target the in-page vote section by id, so the caption clone (stored in the theater button's `data-sub-html` and re-injected by lightgallery) goes stale after voting, and the visible section disrupted the caption layout. The matrix-box hover-overlay treatment isn't reproducible in the lightbox either — the caption renders in lightgallery's components area below the image, not over it. So the caption simply no longer renders a vote section (and its `votes:` prop plumbing is gone). That alone unshields the links. The in-page vote section below carousel/interactive images is untouched.

### Who → Collector / Entered by

The collector/entered-by rendering (#4211) is extracted from `Views::Controllers::Observations::Show::Details` into a new shared `Components::ObservationWho`, rendered by both `Details` (unchanged output) and the lightbox caption (replacing the old "Who:" line). Named flat under `Components` deliberately — a `Components::Observation::…` namespace would shadow the `Observation` model constant inside components via the Kit mixin.

Matrix-box captions now read `obs.collector_user`, so `:collector_user` is added to `Observation.matrix_box_includes` (Bullet flagged the N+1 on index pages; `show_includes_tree` already had it).

### Tests

- `test/system/lightbox_image_links_system_test.rb` — regression for #4884: opens the lightbox, asserts no vote section in the caption, clicks the EXIF link (fails with Cuprite's "another element would receive the click" error if an invisible overlay ever returns), asserts the modal + EXIF table, and asserts the original-image link opens a new window.
- `test/components/observation_who_test.rb` — branch coverage: collector-is-creator, free-text collector, distinct collector user, logged-out plain text, collector-unrecorded (field slip), send-question link shown/suppressed.
- Caption component test pins the no-vote-section contract and the new who-line wiring; existing `Details` who tests pass unchanged.

### Noticed but left alone

When exiftool fails, `Images::EXIFController` renders the error modal with HTTP 500, and `modal-toggle_controller.js` silently drops non-ok responses — so that error modal is currently unreachable. Worth a separate issue if we want exiftool failures surfaced in the lightbox.

## Test plan

- Log in, open any observation with images, click the expand (theater) button on an image.
- Click "Show EXIF Header" → the EXIF modal opens above the overlay.
- Click "Show Original Image" → link shows a loading animation, then the original opens in a new tab.
- Confirm no vote UI appears in the lightbox caption, and the caption layout looks clean.
- Check the caption's who line: an obs with a distinct collector shows "Collector: … / Entered by: …"; a field-slip obs with no recorded collector shows only "Entered by: …" — matching the Observation Show page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
