### PR TITLE
Move external-link badge tooltip to top

### DIFF
--- a/app/views/controllers/observations/show/details/external_links.rb
+++ b/app/views/controllers/observations/show/details/external_links.rb
@@ -96,7 +96,7 @@ class Views::Controllers::Observations::Show::Details::ExternalLinks < Views::Ba
          data: {
            parent: "#external_links_accordion",
            turbo_frame: "external_link_frame_#{link.id}",
-           tooltip_target: "tip", placement: "bottom",
+           tooltip_target: "tip", placement: "top",
            title: :show_observation_shared_with_tooltip.l(
              site: site_name
            )


### PR DESCRIPTION
## Summary

- The "Shared with `[iNat]`/`[MCP]`" external-link badges' tooltip pointed down (`placement: "bottom"`). Flips it to `"top"` so it doesn't overlap the collapse pane the badge itself triggers open right below it.

## Test plan

- [x] `bin/rails test test/views/controllers/observations/show/details/external_links_test.rb` — green, no assertions on tooltip placement to update.
- [ ] Visually confirm on an observation with external links: hover a badge, tooltip appears above it instead of below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
