### PR TITLE
Memoize `User#in_group?` per-instance (#4896)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -359,6 +359,7 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     @projects_member = nil
     @all_editable_species_lists = nil
     @interests = nil
+    @user_group_names = nil
     super
   end
 
@@ -544,12 +545,11 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   #
   #   user.in_group?('reviewers')
   #
+  # Memoized per-instance (#4896) -- checking more than one group on
+  # the same User used to re-query once per group.
   def in_group?(group)
-    if group.is_a?(UserGroup)
-      user_groups.include?(group)
-    else
-      user_groups.any? { |g| g.name == group.to_s }
-    end
+    name = group.is_a?(UserGroup) ? group.name : group.to_s
+    user_group_names.include?(name)
   end
 
   # Return an Array of Project's that this User is an admin for.
@@ -1045,6 +1045,10 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   ##############################################################################
 
   private
+
+  def user_group_names
+    @user_group_names ||= user_groups.map(&:name)
+  end
 
   validate :user_requirements
   validate :check_password, on: :create

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -134,6 +134,32 @@ class UserTest < UnitTestCase
     assert_user_arrays_equal([], group2.users, :sort)
   end
 
+  def test_in_group_by_name
+    assert(rolf.in_group?("reviewers"))
+    assert(rolf.in_group?(:reviewers))
+    assert_not(rolf.in_group?("no_such_group"))
+  end
+
+  def test_in_group_by_user_group_object
+    assert(rolf.in_group?(user_groups(:reviewers)))
+    assert_not(rolf.in_group?(user_groups(:mary_only)))
+  end
+
+  # #4896: `in_group?` memoizes user_groups per-instance -- a group
+  # change made after the first call shouldn't affect a second call
+  # on the same (now-stale) User instance.
+  def test_in_group_memoizes_per_instance
+    user = users(:mary)
+    assert_not(user.in_group?("reviewers"))
+
+    UserGroup.reviewers.users << user
+    assert_not(user.in_group?("reviewers"),
+               "in_group? should reuse the cached result, not re-query")
+
+    assert(user.reload.in_group?("reviewers"),
+           "a fresh reload should see the new membership")
+  end
+
   # Bug seen in the wild: myxomop created a username which was just under 80
   # characters long, but which had a few accents, so it was > 80 *bytes* long,
   # and it truncated right in the middle of a utf-8 sequence.  Broke the front


### PR DESCRIPTION
## Summary
`User#in_group?` re-queried `user_groups` on every call. The `UserGroup`-object branch used `CollectionProxy#include?`, which issues a fresh `EXISTS`-style query each time the association isn't already loaded — so checking several groups on the same `User` (a common pattern, e.g. `reviewer?`/`admin?`-style checks) cost one query per group instead of one query total.

Memoizes the group-name list per-instance (`@user_group_names ||= user_groups.map(&:name)`) and clears it in the existing `#reload` override alongside the other memoized ivars.

Fixes #4896.

## Test plan
- [x] `bin/rails test test/models/user_test.rb`
- [x] `bundle exec rubocop app/models/user.rb test/models/user_test.rb`
