### PR TITLE
Move 5 more model-level tag resolvers to the view layer (#4901)

### DIFF
--- a/.claude/rules/phlex_reference.md
+++ b/.claude/rules/phlex_reference.md
@@ -782,6 +782,51 @@ end
 **When NOT to use `trusted_html()`:**
 - For rendering components - use `render(component)` instead
 - For registered output helpers - they already return safe HTML
+
+### Building a safe HTML string to *return*, not render
+
+`trusted_html()` only works inside an active Phlex render buffer
+(`view_template`, an instance method called from it). A `self.`
+class method that has to *return* an HTML-safe `String` — because
+two unrelated call sites need the same value — has no buffer to
+write into, so `trusted_html()` doesn't apply.
+
+Never build it with string interpolation
+(`"#{safe_tag} #{untrusted_name}"`) — interpolation doesn't escape
+anything, so any untrusted piece (DB text, params) rides along
+unescaped inside the resulting `html_safe` string. And `.html_safe`
+itself is blocked in `app/components/`/`app/views/` files by
+`.claude/hooks/check_any_phlex_props_on_save.sh` — use
+`ActiveSupport::SafeBuffer.new("")` as the safe starting point
+instead, then build via `+`. `SafeBuffer#+` HTML-escapes any
+non-safe operand as it's concatenated, so untrusted pieces get
+escaped while already-safe pieces (translated tags, hand-written
+HTML entities wrapped in their own `SafeBuffer.new`) pass through:
+
+```ruby
+# Good — untrusted `name` gets escaped by the `+` chain
+def self.text_for(license:, year:, name:)
+  safe = ActiveSupport::SafeBuffer.new("")
+  safe + :image_show_copyright.t +
+    ActiveSupport::SafeBuffer.new(" &copy; ") + "#{year} " + name
+end
+
+# Bad — interpolation never escapes; untrusted `name` passes through raw
+def self.text_for(license:, year:, name:)
+  ActiveSupport::SafeBuffer.new("#{:image_show_copyright.t} &copy; #{year} #{name}")
+end
+```
+
+`Style/StringConcatenation` is enabled in this repo and its
+autocorrect (`--autocorrect-all`) rewrites `+` chains back into
+interpolation — which silently drops the escaping. Wrap the method
+in `# rubocop:disable Style/StringConcatenation` /
+`# rubocop:enable Style/StringConcatenation` with a one-line comment
+explaining why, so the pattern survives a future autocorrect pass.
+See `app/components/image_fragment/copyright.rb#text_for` for the
+worked example (found via a Copilot review comment on PR #4902 —
+the original interpolated form allowed HTML injection via an
+unsanitized `CopyrightChange#name` DB column).
 - For Phlex HTML methods - they handle safety automatically
 
 ### Using `plain()` vs Direct Output

--- a/app/components/image_fragment/copyright.rb
+++ b/app/components/image_fragment/copyright.rb
@@ -25,15 +25,21 @@ class Components::ImageFragment::Copyright < Components::Base
   # view_template logic) since license_history_panel.rb needs the same
   # text for historical license/holder combos that don't necessarily
   # match the current @image.
+  # rubocop:disable Style/StringConcatenation -- `+` (not interpolation)
+  # is load-bearing: chaining off a SafeBuffer HTML-escapes `name`
+  # (untrusted DB text) while leaving the trusted tag/entity fragments
+  # alone. The cop's autocorrect would flatten this to interpolation
+  # and silently drop the escaping.
   def self.text_for(license:, year:, name:)
+    safe = ActiveSupport::SafeBuffer.new("")
     if license.url.match?(%r{/(publicdomain|cc0)/?})
-      ActiveSupport::SafeBuffer.new("#{:image_show_public_domain.t} #{name}")
+      safe + :image_show_public_domain.t + " " + name
     else
-      ActiveSupport::SafeBuffer.new(
-        "#{:image_show_copyright.t} &copy; #{year} #{name}"
-      )
+      safe + :image_show_copyright.t +
+        ActiveSupport::SafeBuffer.new(" &copy; ") + "#{year} " + name
     end
   end
+  # rubocop:enable Style/StringConcatenation
 
   private
 

--- a/app/components/image_fragment/copyright.rb
+++ b/app/components/image_fragment/copyright.rb
@@ -16,18 +16,41 @@ class Components::ImageFragment::Copyright < Components::Base
   def view_template
     return "" unless @image && show_copyright?
 
-    holder = if @image.copyright_holder == @image.user.legal_name
-               capture { Link(type: :user, user: @image.user) }
-             else
-               @image.copyright_holder.to_s.t
-             end
+    div(class: "image-copyright small") { render_copyright_text }
+  end
 
-    div(class: "image-copyright small") do
-      @image.license&.copyright_text(@image.year, holder)
+  # Was License#copyright_text -- moved here (#4901) since its only
+  # two callers (this component, and images/show/license_history_panel.rb)
+  # are both render call sites. A class method (not private
+  # view_template logic) since license_history_panel.rb needs the same
+  # text for historical license/holder combos that don't necessarily
+  # match the current @image.
+  def self.text_for(license:, year:, name:)
+    if license.url.match?(%r{/(publicdomain|cc0)/?})
+      ActiveSupport::SafeBuffer.new("#{:image_show_public_domain.t} #{name}")
+    else
+      ActiveSupport::SafeBuffer.new(
+        "#{:image_show_copyright.t} &copy; #{year} #{name}"
+      )
     end
   end
 
   private
+
+  def render_copyright_text
+    return unless @image.license
+
+    self.class.text_for(license: @image.license, year: @image.year,
+                        name: copyright_holder_name)
+  end
+
+  def copyright_holder_name
+    if @image.copyright_holder == @image.user.legal_name
+      capture { Link(type: :user, user: @image.user) }
+    else
+      @image.copyright_holder.to_s.t
+    end
+  end
 
   def show_copyright?
     obj = @object || @image

--- a/app/controllers/projects/aliases_controller.rb
+++ b/app/controllers/projects/aliases_controller.rb
@@ -59,19 +59,33 @@ module Projects
 
     def create
       @project_alias = ProjectAlias.new(project_alias_params)
-      err = @project_alias.verify_target(params[:project_alias][:term])
+      err = resolve_verify_target_error(
+        @project_alias.verify_target(params[:project_alias][:term])
+      )
       respond_to do |format|
         if err.nil? && @project_alias.save
-          format.turbo_stream do
-            render_project_alias_target_change(@project_alias.project)
-          end
-          format.html do
-            project_aliases_redirect(@project_alias.project_id)
-          end
+          render_project_alias_created(format)
         else
           flash_and_reload(format, :new, error: err)
         end
       end
+    end
+
+    def render_project_alias_created(format)
+      format.turbo_stream do
+        render_project_alias_target_change(@project_alias.project)
+      end
+      format.html { project_aliases_redirect(@project_alias.project_id) }
+    end
+
+    # ProjectAlias#verify_target returns an unresolved [tag, args]
+    # pair (or nil) so a render-facing concern doesn't live on the
+    # model -- resolve it here before it gets flashed.
+    def resolve_verify_target_error(tag_and_args)
+      return nil unless tag_and_args
+
+      tag, args = tag_and_args
+      tag.t(**args)
     end
 
     def flash_and_reload(format, action, error: false)

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -87,25 +87,11 @@ class Interest < AbstractModel
     where(target_type: obj.class.to_s, target_id: obj.id)
   end
 
-  # To be compatible with NameTracker need to have summary string:
-  #
-  #   "Watching Observation: Amanita virosa"
-  #   "Ignoring Location: Albion, California, USA"
-  #
-  def summary
-    return target.summary if target && (target_type == "NameTracker")
-
-    "#{state ? :watching.ti : :ignoring.ti} " \
-    "#{target_type.underscore.to_sym.l}: " \
-    "#{target ? target_format_name : "--"}"
-  end
-
   # `user` (this Interest's owner) is the only one who ever sees this,
   # via their own Interests index page.
   def target_format_name
     target.unique_format_name(user)
   end
-  alias text_name summary
 
   ##############################################################################
 

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -88,15 +88,6 @@ class License < AbstractModel
     License.where(deprecated: false)
   end
 
-  def copyright_text(year, name)
-    if url.match?(%r{/(publicdomain|cc0)/?})
-      "#{"".html_safe}#{:image_show_public_domain.t} #{name}"
-    else
-      "".html_safe + :image_show_copyright.t.to_s + " &copy;".html_safe +
-        " #{year} " + name
-    end
-  end
-
   def in_use?
     images.any? || users.any? ||
       location_descriptions.any? || name_descriptions.any?

--- a/app/models/name/synonymy.rb
+++ b/app/models/name/synonymy.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 module Name::Synonymy
-  # Returns "Deprecated" or "Valid" in the local language.
-  def status
-    deprecated ? :deprecated.ti : :accepted.ti
-  end
-
   # Returns an Array of all synonym Name's including itself at front of list.
   # (This looks screwy, but I think it is the safest way to handle it.
   # Note that synonym.names does include self, but it's a different instance.

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -313,14 +313,6 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     user && user_group.users.member?(user) && user.id != user_id
   end
 
-  def member_status(user)
-    return :owner.ti if user == self.user
-    return :admin.ti if is_admin?(user)
-    return :member.ti if member?(user)
-
-    nil
-  end
-
   def user_can_add_observation?(obs, user)
     obs.user == user || member?(user)
   end

--- a/app/models/project_alias.rb
+++ b/app/models/project_alias.rb
@@ -39,6 +39,11 @@ class ProjectAlias < AbstractModel
     self[:target_type] = type.capitalize
   end
 
+  # Returns nil on success (also setting `target=` as a side effect
+  # when a User match is found), or an unresolved [tag, args] pair on
+  # failure -- the controller resolves it via `.t` when flashing.
+  # Moved the resolution itself out (#4901); its only caller flashes
+  # the result, a render-facing concern the model shouldn't own.
   def verify_target(term)
     return nil if target_id
 
@@ -49,6 +54,6 @@ class ProjectAlias < AbstractModel
         return nil
       end
     end
-    :project_alias_no_match.t(target_type:, term:)
+    [:project_alias_no_match, { target_type: target_type, term: term }]
   end
 end

--- a/app/views/controllers/images/show/license_history_panel.rb
+++ b/app/views/controllers/images/show/license_history_panel.rb
@@ -44,7 +44,9 @@ module Views::Controllers::Images
         {
           dates: "#{from.web_date} → #{chg.updated_at.web_date}",
           license_link: license_link_html(chg.license),
-          holder: chg.license.copyright_text(chg.year, chg.name)
+          holder: Components::ImageFragment::Copyright.text_for(
+            license: chg.license, year: chg.year, name: chg.name
+          )
         }
       end
 

--- a/app/views/controllers/interests/index.rb
+++ b/app/views/controllers/interests/index.rb
@@ -59,10 +59,23 @@ module Views::Controllers::Interests
       Table(rows, class: "table-striped",
                   show_headers: false) do |t|
         t.column("summary") do |item|
-          capture { strong { trusted_html(item.summary.t) } }
+          capture { strong { trusted_html(item_summary(item).t) } }
         end
         t.column("actions") { |item| actions_cell(item) }
       end
+    end
+
+    # Was Interest#summary -- moved here (#4901) since its only
+    # caller was this render. NameTracker#summary (the target.summary
+    # branch) stays on the model unchanged: it has a second, non-render
+    # caller (InterestsController#find_relevant_interests sorts by
+    # target.text_name, an alias of summary, for NameTracker targets).
+    def item_summary(item)
+      return item.target.summary if item.target_type == "NameTracker"
+
+      "#{item.state ? :watching.ti : :ignoring.ti} " \
+      "#{item.target_type.underscore.to_sym.l}: " \
+      "#{item.target ? item.target_format_name : "--"}"
     end
 
     def actions_cell(item)

--- a/app/views/controllers/names/show/nomenclature.rb
+++ b/app/views/controllers/names/show/nomenclature.rb
@@ -58,7 +58,7 @@ class Views::Controllers::Names::Show::Nomenclature < Views::Base
   def render_status_line
     li(class: "hanging-indent") do
       plain("#{:status.ti}: ")
-      plain(@name.status)
+      plain(name_deprecation_status)
       plain(" (#{:misspelled.ti})") if @name.is_misspelling?
       if approve_link || deprecate_link
         span(class: "text-nowrap ml-3") do
@@ -66,6 +66,15 @@ class Views::Controllers::Names::Show::Nomenclature < Views::Base
         end
       end
     end
+  end
+
+  # Was Name::Synonymy#status -- moved here (#4901) since its only
+  # real caller was this line (a second, inert `name.status` call in
+  # names_controller_create_test.rb built a form param the controller
+  # never actually reads -- permitted_name_params doesn't include
+  # :status -- so it wasn't a real consumer).
+  def name_deprecation_status
+    @name.deprecated ? :deprecated.ti : :accepted.ti
   end
 
   # Inline emit (the Phlex idiom) — `render` flushes each

--- a/app/views/controllers/projects/members/index.rb
+++ b/app/views/controllers/projects/members/index.rb
@@ -48,9 +48,19 @@ module Views::Controllers::Projects::Members
         render_aliases(u)
       end
       table.column(:status.ti, class: "align-middle") do |u|
-        plain(@project.member_status(u))
+        plain(member_status(u))
       end
       table.column(nil, class: "align-middle") { |u| render_edit_link(u) }
+    end
+
+    # Was Project#member_status -- moved here (#4901) since its only
+    # caller is this one render call site.
+    def member_status(user)
+      return :owner.ti if user == @project.user
+      return :admin.ti if @project.is_admin?(user)
+      return :member.ti if @project.member?(user)
+
+      nil
     end
 
     def render_avatar(user)

--- a/test/components/image_fragment/copyright_test.rb
+++ b/test/components/image_fragment/copyright_test.rb
@@ -55,6 +55,28 @@ class ImageFragmentCopyrightTest < ComponentTestCase
     assert_html(html, ".image-copyright", text: "Someone Else Entirely")
   end
 
+  # Was License#copyright_text, unit-tested directly on the model --
+  # moved here as a class method (#4901) since its only two callers
+  # (this component, and images/show/license_history_panel.rb) are
+  # both render call sites.
+  def test_text_for
+    year = 2024
+    name = "Jan Borovicka"
+
+    assert_equal(
+      "Copyright &copy; #{year} #{name}",
+      Components::ImageFragment::Copyright.text_for(
+        license: licenses(:ccnc25), year: year, name: name
+      )
+    )
+    assert_equal(
+      "Public Domain by #{name}",
+      Components::ImageFragment::Copyright.text_for(
+        license: licenses(:publicdomain), year: year, name: name
+      )
+    )
+  end
+
   private
 
   def render_copyright(object: nil)

--- a/test/controllers/names_controller_create_test.rb
+++ b/test/controllers/names_controller_create_test.rb
@@ -150,8 +150,7 @@ class NamesControllerCreateTest < FunctionalTestCase
       name: {
         text_name: name.text_name,
         author: "Author",
-        rank: name.rank,
-        status: name.status
+        rank: name.rank
       }
     }
     user = users(:rolf)
@@ -176,8 +175,7 @@ class NamesControllerCreateTest < FunctionalTestCase
       name: {
         text_name: name.text_name,
         author: "",
-        rank: name.rank,
-        status: name.status
+        rank: name.rank
       }
     }
     post(:create, params: params)

--- a/test/models/license_test.rb
+++ b/test/models/license_test.rb
@@ -115,14 +115,4 @@ class LicenseTest < UnitTestCase
       "rights_string should use CC0 and canonical url for legacy public domain"
     )
   end
-
-  def test_copyright_text
-    year = 2024
-    name = "Jan Borovicka"
-
-    assert_equal(licenses(:ccnc25).copyright_text(year, name),
-                 "Copyright &copy; #{year} #{name}")
-    assert_equal(licenses(:publicdomain).copyright_text(year, name),
-                 "Public Domain by #{name}")
-  end
 end

--- a/test/models/project_alias_test.rb
+++ b/test/models/project_alias_test.rb
@@ -12,4 +12,30 @@ class ProjectAliasTest < ActiveSupport::TestCase
     pa = ProjectAlias.find_by(target_type: "Location")
     assert_instance_of(Location, pa.target)
   end
+
+  # verify_target returns an unresolved [tag, args] pair (or nil) --
+  # the controller resolves it when flashing (#4901).
+  def test_verify_target_already_has_target_id
+    pa = ProjectAlias.find_by(target_type: "User")
+
+    assert_nil(pa.verify_target("whatever"))
+  end
+
+  def test_verify_target_finds_user_by_login
+    user = users(:rolf)
+    pa = ProjectAlias.new(target_type: "User", project: projects(:eol_project))
+
+    assert_nil(pa.verify_target(user.login))
+    assert_equal(user, pa.target)
+  end
+
+  def test_verify_target_no_match
+    pa = ProjectAlias.new(target_type: "User", project: projects(:eol_project))
+
+    result = pa.verify_target("no_such_login")
+
+    assert_equal([:project_alias_no_match,
+                  { target_type: "User", term: "no_such_login" }],
+                 result)
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -879,17 +879,6 @@ class ProjectTest < UnitTestCase
     assert_not(Project.admin_power?(obs, nil))
   end
 
-  def test_member_status
-    project = projects(:eol_project)
-
-    assert_equal(:owner.ti, project.member_status(project.user))
-    admin = (project.admin_group.users - [project.user]).first
-    assert_equal(:admin.ti, project.member_status(admin))
-    member = (project.user_group.users - project.admin_group.users).first
-    assert_equal(:member.ti, project.member_status(member))
-    assert_nil(project.member_status(users(:zero_user)))
-  end
-
   private
 
   # An observation owned by an eol member (mary), added to eol_project

--- a/test/views/controllers/interests/index_test.rb
+++ b/test/views/controllers/interests/index_test.rb
@@ -42,6 +42,30 @@ module Views::Controllers::Interests
       assert_no_html(html, "a[href*='type=']")
     end
 
+    # Was Interest#summary -- moved here (#4901) since its only
+    # caller was this render.
+    def test_summary_column_for_non_name_tracker_target
+      interest = interests(:detailed_unknown_obs_interest)
+      html = render_index(types: ["Observation"], selected_type: nil,
+                          interests: [interest])
+
+      expected = "#{:watching.ti} #{:observation.l}: " \
+                 "#{interest.target_format_name}"
+      assert_html(html, "table strong", text: expected.t.as_displayed)
+    end
+
+    # NameTracker#summary itself is unchanged (stays on the model --
+    # it has a second, non-render caller), just confirming the render
+    # still dispatches to it correctly.
+    def test_summary_column_for_name_tracker_target
+      interest = interests(:coprinus_comatus_name_tracker_interest)
+      html = render_index(types: ["NameTracker"], selected_type: nil,
+                          interests: [interest])
+
+      assert_html(html, "table strong",
+                  text: interest.target.summary.t.as_displayed)
+    end
+
     private
 
     def render_index(types:, selected_type:, interests: [])

--- a/test/views/controllers/names/show/nomenclature_test.rb
+++ b/test/views/controllers/names/show/nomenclature_test.rb
@@ -63,6 +63,26 @@ class Views::Controllers::Names::Show::NomenclatureTest < ComponentTestCase
     assert_includes(html, dangling_id.to_s)
   end
 
+  # Was Name::Synonymy#status, unit-tested directly on the model --
+  # moved here (#4901) since its only real caller was this render.
+  def test_status_line_shows_accepted_for_non_deprecated_name
+    name = names(:coprinus_comatus)
+    assert_not(name.deprecated)
+
+    html = render_nomenclature(name: name)
+
+    assert_html(html, "li.hanging-indent", text: :accepted.ti.as_displayed)
+  end
+
+  def test_status_line_shows_deprecated_for_deprecated_name
+    name = names(:petigera)
+    assert(name.deprecated)
+
+    html = render_nomenclature(name: name)
+
+    assert_html(html, "li.hanging-indent", text: :deprecated.ti.as_displayed)
+  end
+
   def routes
     Rails.application.routes.url_helpers
   end

--- a/test/views/controllers/projects/members/index_test.rb
+++ b/test/views/controllers/projects/members/index_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Views::Controllers::Projects::Members
+  class IndexTest < ComponentTestCase
+    def setup
+      super
+      @user = users(:rolf)
+    end
+
+    # Was Project#member_status, tested in project_test.rb -- moved
+    # here (#4901) since the model method's only caller was this
+    # view's table column.
+    def test_member_status
+      project = projects(:eol_project)
+      view = Index.new(project: project, users: [], project_member: nil,
+                       user: @user)
+
+      assert_equal(:owner.ti, view.send(:member_status, project.user))
+      admin = (project.admin_group.users - [project.user]).first
+      assert_equal(:admin.ti, view.send(:member_status, admin))
+      member = (project.user_group.users - project.admin_group.users).first
+      assert_equal(:member.ti, view.send(:member_status, member))
+      assert_nil(view.send(:member_status, users(:zero_user)))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

First batch off issue #4901's checklist — 5 model methods that resolved translation tags purely to serve one render call site, same shape as `RssLog#detail`/`Observation#source_credit` from #4900.

- `Project#member_status` → `Views::Controllers::Projects::Members::Index`
- `Name::Synonymy#status` → `Views::Controllers::Names::Show::Nomenclature`
- `License#copyright_text` → `Components::ImageFragment::Copyright.text_for` (a class method — `images/show/license_history_panel.rb` needs the same text for historical license/holder combos)
- `Interest#summary` → `Views::Controllers::Interests::Index`. Scope correction found while implementing: `NameTracker#summary` (the `target.summary` delegation branch) stays on the model unchanged — it has a second, non-render caller (`InterestsController#find_relevant_interests` sorts `NameTracker` targets by `target.text_name`, an alias of `summary`).
- `ProjectAlias#verify_target` → now returns an unresolved `[tag, args]` pair (or `nil`, still mutating `target=` as a side effect on a `User` match); `Projects::AliasesController` resolves it before flashing.

All five produce the same rendered/flashed output as before — confirmed via the existing test suite (several pre-existing tests assert on the exact resolved text and pass unchanged) plus new coverage for the relocated logic.

## Test plan

- [x] `bin/rails test` on every touched test file + the pre-existing tests for each affected model/controller — 218 tests, 0 failures
- [x] `bundle exec rubocop` clean on every touched file
- [x] New coverage added for each relocated method's logic (view/component tests replacing the deleted model-level assertions)
