### PR TITLE
Extract `RssLog::Title` PORO; move `Project::Date#date_range` to views (#4901)

### DIFF
--- a/app/models/project/date.rb
+++ b/app/models/project/date.rb
@@ -5,13 +5,6 @@ module Project::Date
     !future? && !past?
   end
 
-  # convenience method for date range display
-  def date_range(format = "%Y-%m-%d")
-    return :form_projects_any.l unless start_date.present? && end_date.present?
-
-    "#{start_date.strftime(format)} to #{end_date.strftime(format)}"
-  end
-
   ####################################################################
 
   private

--- a/app/models/rss_log.rb
+++ b/app/models/rss_log.rb
@@ -126,9 +126,9 @@
 #
 #  add_with_date::      Same, but adds timestamp.
 #  orphan::             About to delete object: add object title and notes.
-#  orphan_title::       Get old title from top line of orphaned log.
 #  orphan?::            Has rss_log been orphaned? (i.e., target destroyed?)
 #  target::             Return owner object: Observation, Name, etc.
+#  title::              RssLog::Title instance (text_name/format_name/etc.).
 #  text_name::          Return title string of associated object.
 #  format_name::        Return formatted title string of associated object.
 #  unique_text_name::   (same, with id tacked on to make unique)
@@ -215,68 +215,24 @@ class RssLog < AbstractModel
     self
   end
 
-  # The top line of log should be the old object's name after it is destroyed.
-  def orphan_title
-    name = notes.to_s.split("\n", 2).first
-    if /^\d{14}/.match?(name)
-      # This is an occasional error, when a log wasn't orphaned properly.
-      _tag, args, _time = parse_log.first
-      args[:this] || :rss_log_of_deleted_item.l
-    else
-      unescape(name)
-    end
-  end
-
   # Has target been destroyed (orphaning this log)?  Top line of log should be
   # the old object's name after it is destroyed.
   def orphan?
     !target_type || !notes.match?(/\A\d{14}/)
   end
 
-  # Returns plain text title of the associated object.
-  def text_name
-    if target
-      if target.respond_to?(:real_text_name)
-        target.real_text_name
-      else
-        target.text_name
-      end
-    else
-      orphan_title.t.html_to_ascii.sub(/ (\d+)$/, "")
-    end
+  # text_name/unique_text_name/format_name/unique_format_name/url all
+  # live on RssLog::Title (#4901) -- delegated here so every existing
+  # caller keeps working unchanged.
+  def title
+    @title ||= RssLog::Title.new(self)
   end
+  delegate :text_name, :unique_text_name, :format_name,
+           :unique_format_name, :url, to: :title
 
-  # Returns plain text title of the associated object, with id tacked on.
-  def unique_text_name
-    if target
-      target.unique_text_name
-    else
-      orphan_title.t.html_to_ascii
-    end
-  end
-
-  # Returns formatted title of the associated object.
-  def format_name(user = nil)
-    if target
-      target.format_name(user)
-    else
-      orphan_title.sub(/ (\d+)$/, "")
-    end
-  end
-
-  # Returns formatted title of the associated object, with id tacked on.
-  def unique_format_name(user = nil)
-    if target
-      target.unique_format_name(user)
-    else
-      orphan_title
-    end
-  end
-
-  # Returns URL of <tt>show_#{object}</tt> action for the associated object.
-  # The time thing might have something to do with RSS log requirements?
-  def url
-    "#{(target || self).show_url}?time=#{updated_at.tv_sec}"
+  # Public so RssLog::Title#orphan_title can reach it too.
+  def self.unescape(str)
+    str.to_s.gsub(/%(..)/) { Regexp.last_match(1).hex.chr }
   end
 
   # Add entry to top of notes and save.  Pass in a localization key and a hash
@@ -446,7 +402,7 @@ class RssLog < AbstractModel
 
   # Reverse protection of special characters in string for log encoder/decoder.
   def unescape(str)
-    str.to_s.gsub(/%(..)/) { Regexp.last_match(1).hex.chr }
+    self.class.unescape(str)
   end
 
   # Add line to top of notes field, truncating it to keep it within the MySQL

--- a/app/models/rss_log/title.rb
+++ b/app/models/rss_log/title.rb
@@ -60,8 +60,13 @@ class RssLog::Title
 
   private
 
+  # Memoized: RssLog#target isn't memoized on the model itself (fresh
+  # find_by when the association isn't preloaded), and every title
+  # method above calls this 2-3 times.
   def target
-    @rss_log.target
+    return @target if defined?(@target)
+
+    @target = @rss_log.target
   end
 
   # The top line of log should be the old object's name after it is

--- a/app/models/rss_log/title.rb
+++ b/app/models/rss_log/title.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
-# RssLog's text_name/format_name family, split out of the model (#4901).
-# Real non-Phlex consumers -- the RSS/Atom feed
-# (app/views/controllers/rss_logs/rss.xml.builder) and the shared
-# text_name/format_name polymorphic contract other models implement,
-# reachable generically via ViewerAwareFormat from non-render controller
-# code -- meant this couldn't just move into the view layer outright.
 # RssLog delegates its public text_name/unique_text_name/format_name/
-# unique_format_name/url methods here.
+# unique_format_name/url methods here, but also may render the translated
+# orphan_title.
+#
+# Split out of RssLog into its own object, unlike other models. RssLog
+# usually just forwards to `target`, and only computes anything of its own
+# when orphaned (target destroyed) -- that path resolves a
+# translation tag (:rss_log_of_deleted_item.l) plus textile cleanup,
+# work that doesn't belong in the model.
+#
+# Has callers outside of views:
+# - RSS/Atom feed template (app/views/controllers/rss_logs/rss.xml.builder)
+# - ViewerAwareFormat's generic dispatch, reachable from non-render controller
+#   code for the shared text_name/format_name contract other models implement.
 class RssLog::Title
   def initialize(rss_log)
     @rss_log = rss_log

--- a/app/models/rss_log/title.rb
+++ b/app/models/rss_log/title.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# RssLog's text_name/format_name family, split out of the model (#4901).
+# Real non-Phlex consumers -- the RSS/Atom feed
+# (app/views/controllers/rss_logs/rss.xml.builder) and the shared
+# text_name/format_name polymorphic contract other models implement,
+# reachable generically via ViewerAwareFormat from non-render controller
+# code -- meant this couldn't just move into the view layer outright.
+# RssLog delegates its public text_name/unique_text_name/format_name/
+# unique_format_name/url methods here.
+class RssLog::Title
+  def initialize(rss_log)
+    @rss_log = rss_log
+  end
+
+  # Returns plain text title of the associated object.
+  def text_name
+    if target
+      if target.respond_to?(:real_text_name)
+        target.real_text_name
+      else
+        target.text_name
+      end
+    else
+      orphan_title.t.html_to_ascii.sub(/ (\d+)$/, "")
+    end
+  end
+
+  # Returns plain text title of the associated object, with id tacked on.
+  def unique_text_name
+    if target
+      target.unique_text_name
+    else
+      orphan_title.t.html_to_ascii
+    end
+  end
+
+  # Returns formatted title of the associated object.
+  def format_name(user = nil)
+    if target
+      target.format_name(user)
+    else
+      orphan_title.sub(/ (\d+)$/, "")
+    end
+  end
+
+  # Returns formatted title of the associated object, with id tacked on.
+  def unique_format_name(user = nil)
+    if target
+      target.unique_format_name(user)
+    else
+      orphan_title
+    end
+  end
+
+  # Returns URL of <tt>show_#{object}</tt> action for the associated object.
+  def url
+    "#{(target || @rss_log).show_url}?time=#{@rss_log.updated_at.tv_sec}"
+  end
+
+  private
+
+  def target
+    @rss_log.target
+  end
+
+  # The top line of log should be the old object's name after it is
+  # destroyed.
+  def orphan_title
+    name = @rss_log.notes.to_s.split("\n", 2).first
+    if /^\d{14}/.match?(name)
+      # This is an occasional error, when a log wasn't orphaned properly.
+      _tag, args, _time = @rss_log.parse_log.first
+      args[:this] || :rss_log_of_deleted_item.l
+    else
+      RssLog.unescape(name)
+    end
+  end
+end

--- a/app/views/controllers/projects/banner.rb
+++ b/app/views/controllers/projects/banner.rb
@@ -118,8 +118,15 @@ module Views::Controllers::Projects
                      end
 
       div(class: date_classes) do
-        b { @project.date_range }
+        b { project_date_range }
       end
+    end
+
+    # Only called when both dates are present (see the guard above),
+    # so no ":form_projects_any.l" fallback is needed here (#4901).
+    def project_date_range
+      "#{@project.start_date.strftime("%Y-%m-%d")} to " \
+        "#{@project.end_date.strftime("%Y-%m-%d")}"
     end
   end
 end

--- a/app/views/controllers/projects/violations/form.rb
+++ b/app/views/controllers/projects/violations/form.rb
@@ -77,6 +77,17 @@ module Views::Controllers::Projects::Violations
       :"form_violations_kind_#{kind}".l
     end
 
+    # A :date violation only requires start_date OR end_date to be set
+    # (see Project#collect_date_violation_ids), so the fallback below
+    # is reachable here, unlike in the project banner (#4901).
+    def project_date_range
+      return :form_projects_any.l unless @project.start_date &&
+                                         @project.end_date
+
+      "#{@project.start_date.strftime("%Y-%m-%d")} to " \
+        "#{@project.end_date.strftime("%Y-%m-%d")}"
+    end
+
     def render_details(obs, kinds)
       parts = kinds.filter_map { |k| detail_for(obs, k) }
       parts.each_with_index do |line, i|
@@ -88,7 +99,7 @@ module Views::Controllers::Projects::Violations
     def detail_for(obs, kind)
       case kind
       when :date
-        "#{kind_label(:date)}: #{obs.when} (#{@project.date_range})"
+        "#{kind_label(:date)}: #{obs.when} (#{project_date_range})"
       when :bbox
         bbox_detail(obs)
       when :target_name

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -219,8 +219,10 @@ class ProjectsControllerTest < FunctionalTestCase
     login
     get(:show, params: { id: project.id })
     assert_response(:success)
+    expected_range = "#{project.start_date.strftime("%Y-%m-%d")} to " \
+                      "#{project.end_date.strftime("%Y-%m-%d")}"
     # NOTE: this project has no banner_image
-    assert_select("#header", { text: /#{project.date_range}/ },
+    assert_select("#header", { text: /#{expected_range}/ },
                   "Date range missing from Project header")
   end
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -113,15 +113,6 @@ class ProjectTest < UnitTestCase
     assert_not(projects(:future_project).current?)
   end
 
-  def test_date_strings
-    proj = projects(:pinned_date_range_project)
-    assert_equal("#{proj.start_date} to #{proj.end_date}",
-                 proj.date_range, "Wrong date range string")
-
-    assert_equal(:form_projects_any.l, projects(:unlimited_project).date_range,
-                 "Wrong date range string")
-  end
-
   def test_out_of_range_observations
     assert_out_of_range_observations(projects(:current_project), expect: 0)
     assert_out_of_range_observations(projects(:unlimited_project), expect: 0)

--- a/test/models/rss_log/title_test.rb
+++ b/test/models/rss_log/title_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Tests for RssLog::Title (app/models/rss_log/title.rb)
+class RssLog::TitleTest < UnitTestCase
+  def test_orphan_title
+    log = rss_logs(:location_rss_log)
+    # If log doesn't look orphaned, it should return generic "deleted item".
+    assert_equal(:rss_log_of_deleted_item.l, log.title.send(:orphan_title))
+
+    # When it is orphaned, it should put the target title in the first line
+    # of the log, and that's what orphan_title should return.
+    log.update(notes: "Target Title\n#{log.notes}")
+    assert_equal("Target Title", log.title.send(:orphan_title))
+  end
+
+  def test_text_name
+    # Name responds to real_text_name directly.
+    name_log = create_rss_log(:name)
+    assert_equal(Name.first.real_text_name, name_log.text_name)
+
+    # Observation doesn't define real_text_name, falls to text_name.
+    obs_log = create_rss_log(:observation)
+    assert_equal(Observation.first.text_name, obs_log.text_name)
+
+    # Orphaned (no target at all).
+    orphan_log = RssLog.new
+    assert_equal(
+      orphan_log.title.send(:orphan_title).t.html_to_ascii.sub(/ (\d+)$/, ""),
+      orphan_log.text_name
+    )
+  end
+
+  def test_unique_text_name
+    log = create_rss_log(:species_list)
+    assert_equal(SpeciesList.first.unique_text_name, log.unique_text_name)
+
+    orphan_log = RssLog.new
+    assert_equal(orphan_log.title.send(:orphan_title).t.html_to_ascii,
+                 orphan_log.unique_text_name)
+  end
+
+  def test_format_name
+    log = create_rss_log(:species_list)
+    assert_equal(SpeciesList.first.format_name, log.format_name)
+
+    orphan_log = RssLog.new
+    assert_equal(orphan_log.title.send(:orphan_title).sub(/ (\d+)$/, ""),
+                 orphan_log.format_name)
+  end
+
+  def test_unique_format_name
+    log = create_rss_log(:species_list)
+    assert_equal(SpeciesList.first.unique_format_name, log.unique_format_name)
+
+    orphan_log = RssLog.new
+    assert_equal(orphan_log.title.send(:orphan_title),
+                 orphan_log.unique_format_name)
+  end
+
+  # ---------- helpers ---------------------------------------------------
+
+  def model(type)
+    type.to_s.camelize.constantize
+  end
+
+  # rss_log factory
+  def create_rss_log(type)
+    # Target must have id; use an existing object to avoid hitting db
+    target = model(type).first
+    rss_log = RssLog.new
+    rss_log[:"#{type}_id"] = target.id
+    rss_log.updated_at = Time.zone.now
+    rss_log
+  end
+end

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -17,17 +17,6 @@ class RssLogTest < UnitTestCase
     end
   end
 
-  def test_orphan_title
-    log = rss_logs(:location_rss_log)
-    # If log doesn't look orphaned, it should return generic "deleted item".
-    assert_equal(:rss_log_of_deleted_item.l, log.orphan_title)
-
-    # When it is orphaned, it should put the target title in the first line
-    # of the log, and that's what orphan_title should return.
-    log.update(notes: "Target Title\n#{log.notes}")
-    assert_equal("Target Title", log.orphan_title)
-  end
-
   def test_add_with_date_refuses_to_write_to_orphaned_log
     log = rss_logs(:location_rss_log)
     # Orphan it the way #orphan does: clear the target ids and prepend a
@@ -71,47 +60,6 @@ class RssLogTest < UnitTestCase
     log.add_with_date(:log_observation_created, user: "mary")
 
     assert_match(/log_observation_created/, log.notes)
-  end
-
-  def test_text_name
-    # Name responds to real_text_name directly.
-    name_log = create_rss_log(:name)
-    assert_equal(Name.first.real_text_name, name_log.text_name)
-
-    # Observation doesn't define real_text_name, falls to text_name.
-    obs_log = create_rss_log(:observation)
-    assert_equal(Observation.first.text_name, obs_log.text_name)
-
-    # Orphaned (no target at all).
-    orphan_log = RssLog.new
-    assert_equal(orphan_log.orphan_title.t.html_to_ascii.sub(/ (\d+)$/, ""),
-                 orphan_log.text_name)
-  end
-
-  def test_unique_text_name
-    log = create_rss_log(:species_list)
-    assert_equal(SpeciesList.first.unique_text_name, log.unique_text_name)
-
-    orphan_log = RssLog.new
-    assert_equal(orphan_log.orphan_title.t.html_to_ascii,
-                 orphan_log.unique_text_name)
-  end
-
-  def test_format_name
-    log = create_rss_log(:species_list)
-    assert_equal(SpeciesList.first.format_name, log.format_name)
-
-    orphan_log = RssLog.new
-    assert_equal(orphan_log.orphan_title.sub(/ (\d+)$/, ""),
-                 orphan_log.format_name)
-  end
-
-  def test_unique_format_name
-    log = create_rss_log(:species_list)
-    assert_equal(SpeciesList.first.unique_format_name, log.unique_format_name)
-
-    orphan_log = RssLog.new
-    assert_equal(orphan_log.orphan_title, orphan_log.unique_format_name)
   end
 
   def test_really_long_notes

--- a/test/views/controllers/projects/banner_test.rb
+++ b/test/views/controllers/projects/banner_test.rb
@@ -99,7 +99,7 @@ module Views::Controllers::Projects
       # past_project has no image, so no banner-image-text class
       assert_html(html, ".project_date_range")
       assert_no_html(html, ".banner-image-text")
-      assert_includes(html, project.date_range)
+      assert_includes(html, expected_date_range(project))
     end
 
     def test_renders_both_location_and_date_range_when_both_present
@@ -111,7 +111,7 @@ module Views::Controllers::Projects
       assert_html(html, ".project_date_range")
       assert_no_html(html, ".banner-image-text")
       assert_includes(html, project.place_name)
-      assert_includes(html, project.date_range)
+      assert_includes(html, expected_date_range(project))
     end
 
     def test_renders_project_tabs_when_project_has_observations
@@ -195,6 +195,11 @@ module Views::Controllers::Projects
       render(Banner.new(project: project,
                         user: user,
                         current_tab: current_tab))
+    end
+
+    def expected_date_range(project)
+      "#{project.start_date.strftime("%Y-%m-%d")} to " \
+        "#{project.end_date.strftime("%Y-%m-%d")}"
     end
   end
 end

--- a/test/views/controllers/projects/violations/form_test.rb
+++ b/test/views/controllers/projects/violations/form_test.rb
@@ -79,6 +79,19 @@ module Views::Controllers::Projects::Violations
                   "input[type='hidden'][name='project[do]'][value='extend']")
     end
 
+    # A :date violation only requires one of start_date/end_date, so the
+    # detail line's ":form_projects_any.l" fallback (#4901) is reachable.
+    def test_date_violation_detail_shows_any_fallback_for_partial_range
+      proj = setup_partial_date_range_violation_project
+      date_v = proj.violations.find { |v| v.kinds.include?(:date) }
+      assert(date_v, "Setup must produce a date violation")
+
+      html = render_form(project: proj, violations: proj.violations,
+                         user: proj.user)
+
+      assert_includes(html, :form_projects_any.l)
+    end
+
     def test_admin_sees_add_target_name_button_on_target_name_violation
       proj = setup_target_name_violation_project
       name_v = proj.violations.find { |v| v.kinds.include?(:target_name) }
@@ -182,6 +195,16 @@ module Views::Controllers::Projects::Violations
       # there's at least one obs owned by `roy`.
       roy_obs = observations(:nybg_2023_09_obs)
       roy_obs.update!(user: users(:roy)) unless roy_obs.user == users(:roy)
+      proj
+    end
+
+    def setup_partial_date_range_violation_project
+      proj = projects(:rare_fungi_project)
+      proj.project_target_locations.destroy_all
+      proj.project_target_names.destroy_all
+      proj.update!(start_date: Time.zone.today, end_date: nil, location: nil)
+      off_target = observations(:peltigera_obs)
+      proj.add_observation(off_target)
       proj
     end
 


### PR DESCRIPTION
## Summary

Batch 2 off issue #4901's checklist — the "6 internal helpers" item. Verified every real call site before touching anything (same discipline that already forced walkbacks on `Vote` menus, `Interest#summary`, and `Location.dubious_reasons_for`); only 2 of the 6 turned out to be actionable this round.

- **`RssLog#text_name`/`unique_text_name`/`format_name`/`unique_format_name`/`url`** → new `RssLog::Title` PORO (`app/models/rss_log/title.rb`). Unlike the render-only relocations in #4900/#4902, these have real non-Phlex callers — the live RSS/Atom feed template (`app/views/controllers/rss_logs/rss.xml.builder`) and `ViewerAwareFormat`'s generic dispatch, which is included into `ApplicationController` for plain controller code, not just Phlex components — plus they implement a `text_name`/`format_name` polymorphic contract shared by ~18 other models. So they couldn't move into `app/views/` outright; the fix is a PORO instead, same shape as the existing `Observation::NamingConsensus` precedent. `RssLog` keeps a memoized `title` reader and `delegate`s the five public methods to it, so every existing caller keeps working with zero changes.
- **`Project::Date#date_range`** → deleted, inlined as a private `project_date_range` in both Phlex callers (`Views::Controllers::Projects::Banner`, `Views::Controllers::Projects::Violations::Form`). The banner's caller already guards on both dates being present, so its version drops the `:form_projects_any.l` fallback (confirmed unreachable there); the violations form keeps the fallback since a `:date` violation only requires one of `start_date`/`end_date` to be set (`Project#collect_date_violation_ids`) — added a test constructing a partial-date-range violation to cover that branch.

The other 4 items from the original "6 internal helpers" audit turned out entangled or not applicable — findings written up on #4901, not attempted here:
- `RssLog#user_login` — write-time only (baked into `notes` on log creation), never executes in a render context, not a relocation candidate at all.
- `Name::Format.names_for_unknown` — consumed by real business logic (name-parsing corrections, creation-time validation), not display; the translated array is an input to a data rule, not something rendered.
- `User#personal_herbarium_name` — used for branch/comparison logic in two controllers, and its return value is persisted as a `Herbarium#name` at creation time.
- `merge_info` on `Location`/`Herbarium`/`Name::Format` — resolved entirely inside `Admin::Emails::MergeRequestsController` before the (deliberately generic, 3-controller-shared) `WebmasterMailer` Phlex view ever runs. Real fix needs a dedicated `MergeRequestMailer` + Phlex view; scoped as its own follow-up (batch 3), not folded in here.

## Test plan

- [x] `bin/rails test` on every touched/related file (rss_log, rss_log/title, project, projects controller, banner, violations form, matrix box render_data, rss_logs controller/views) — 174 tests, 0 failures
- [x] `bundle exec rubocop` clean on every touched file
- [x] New coverage: `RssLog::TitleTest` (moved + adapted from `RssLogTest`), a partial-date-range violation test covering the `:form_projects_any.l` fallback in the violations form
