### PR TITLE
Move `Location`/`Herbarium`/`Name::Format#merge_info` to a dedicated mailer (#4901)

### DIFF
--- a/app/controllers/admin/emails/merge_requests_controller.rb
+++ b/app/controllers/admin/emails/merge_requests_controller.rb
@@ -3,8 +3,6 @@
 module Admin
   module Emails
     class MergeRequestsController < ApplicationController
-      include ::Emailable
-
       before_action :login_required
 
       def new
@@ -75,31 +73,20 @@ module Admin
 
       def send_merge_request
         # Migrated from QueuedEmail::Webmaster to ActionMailer + ActiveJob.
-        temporarily_set_locale(MO.default_locale) do
-          message = WebmasterMailer.prepend_user(@user, merge_request_content)
-          WebmasterMailer.build(
-            sender_email: @user.email,
-            subject: "#{@model.name} Merge Request",
-            message:
-          ).deliver_later
-        end
+        # No temporarily_set_locale wrapper needed here (unlike the
+        # sibling email controllers) -- MergeRequestMailer#build sets
+        # the locale itself, since the tag resolution now happens in
+        # its Phlex view, not eagerly in this action.
+        notes = params.dig(:email, :message)
+        MergeRequestMailer.build(
+          sender_email: @user.email,
+          old_obj: @old_obj,
+          new_obj: @new_obj,
+          user: @user,
+          notes: notes.to_s.strip_html.strip_squeeze
+        ).deliver_later
         flash_notice(:email_merge_request_success.t)
         redirect_to(@old_obj.show_link_args)
-      end
-
-      def merge_request_content
-        notes = params.dig(:email, :message)
-        :email_merge_objects.l(
-          user: @user.login,
-          type: @model.type_tag,
-          this: @old_obj.merge_info,
-          that: @new_obj.merge_info,
-          show_this_url: @old_obj.show_url,
-          show_that_url: @new_obj.show_url,
-          edit_this_url: @old_obj.edit_url,
-          edit_that_url: @new_obj.edit_url,
-          notes: notes.to_s.strip_html.strip_squeeze
-        )
       end
     end
   end

--- a/app/mailers/merge_request_mailer.rb
+++ b/app/mailers/merge_request_mailer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# User wants two Locations/Herbariums/Names merged. Split out of the
+# generic WebmasterMailer (#4901) so the Location/Herbarium/Name
+# type-dispatch that used to live on those models' own `merge_info`
+# methods can move into this mailer's Phlex view instead, without
+# dragging that dispatch into WebmasterMailer -- which stays a plain
+# "send this text to the webmaster" pipe shared by two other
+# controllers that have nothing to do with merging.
+class MergeRequestMailer < ApplicationMailer
+  after_action :webmaster_delivery, only: [:build]
+
+  # `build`'s body (this whole method, including the Phlex view
+  # render inside mo_mail) only actually executes when the
+  # `deliver_later` job runs, not synchronously in the controller --
+  # so setting the locale here, rather than relying on the
+  # controller's request-time locale, is what actually governs the
+  # `.ti`/`.l` resolution the view does.
+  def build(sender_email:, old_obj:, new_obj:, user:, notes:)
+    I18n.locale = MO.default_locale
+    mo_mail("#{old_obj.class.name} Merge Request",
+            to: MO.webmaster_email_address,
+            from: MO.webmaster_email_address,
+            reply_to: sender_email,
+            content_style: "plain",
+            view_params: { old_obj:, new_obj:, user:, notes: })
+  end
+end

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -194,13 +194,6 @@ class Herbarium < AbstractModel
     herbarium_records.all? { |r| r.user_id == user.id }
   end
 
-  # Info to include about each herbarium in merge requests.
-  def merge_info
-    num_cur = curators.count
-    num_rec = herbarium_records.count
-    "#{:herbarium.ti} ##{id}: #{name} [#{num_cur} curators, #{num_rec} records]"
-  end
-
   def merge(src)
     return src if src == self
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -430,12 +430,6 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     string_with_id(format_name(user))
   end
 
-  # Info to include about each location in merge requests.
-  def merge_info
-    num_obs = observations.count
-    "#{:location.ti} ##{id}: #{name} [o=#{num_obs}]"
-  end
-
   # Strip out special characters, punctuation, and small words from a name.
   # This is supposed to make it easier to search for a name if you don't know
   # how it is worded.  I'm not so sure anymore...

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -117,17 +117,6 @@ module Name::Format
     text_name == "Imageless"
   end
 
-  ##### Miscellaneous #########################################################
-
-  # Info to include about each name in merge requests.
-  def merge_info
-    num_obs     = observations.count
-    num_namings = namings.count
-    num_notify  = interests.count # includes name_trackers
-    "#{:name.ti} ##{id}: #{real_search_name} [#obs: #{num_obs}, " \
-      "#namings: #{num_namings}, #users_with_interest: #{num_notify}]"
-  end
-
   #############################################################################
 
   private

--- a/app/views/mailers/merge_request_mailer.rb
+++ b/app/views/mailers/merge_request_mailer.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Merge-request email body. Always plain text (see
+# MergeRequestMailer#build's `content_style: "plain"`).
+#
+# `old_obj`/`new_obj`'s summary lines (was Location/Herbarium/
+# Name::Format#merge_info, moved here per #4901) are resolved per
+# type -- each model's merge summary needs different data (obs count,
+# curator/record counts, naming/interest counts), so the dispatch has
+# to live somewhere that knows about all three, same shape as
+# Components::ImageFragment's DISPATCH.
+class Views::Mailers::MergeRequestMailer < Views::Mailers::Base
+  prop :old_obj, _Union(::Location, ::Herbarium, ::Name)
+  prop :new_obj, _Union(::Location, ::Herbarium, ::Name)
+  prop :user, ::User
+  prop :notes, ::String, default: ""
+
+  def view_template
+    trusted_text(ApplicationMailer.prepend_user(@user, message_body))
+  end
+
+  private
+
+  def message_body
+    :email_merge_objects.l(
+      user: @user.login,
+      type: @old_obj.type_tag,
+      this: merge_summary(@old_obj),
+      that: merge_summary(@new_obj),
+      show_this_url: @old_obj.show_url,
+      edit_this_url: @old_obj.edit_url,
+      show_that_url: @new_obj.show_url,
+      edit_that_url: @new_obj.edit_url,
+      notes: @notes
+    )
+  end
+
+  def merge_summary(obj)
+    case obj
+    when ::Location then location_merge_summary(obj)
+    when ::Herbarium then herbarium_merge_summary(obj)
+    when ::Name then name_merge_summary(obj)
+    end
+  end
+
+  def location_merge_summary(loc)
+    "#{:location.ti} ##{loc.id}: #{loc.name} [o=#{loc.observations.count}]"
+  end
+
+  def herbarium_merge_summary(herb)
+    "#{:herbarium.ti} ##{herb.id}: #{herb.name} " \
+      "[#{herb.curators.count} curators, " \
+      "#{herb.herbarium_records.count} records]"
+  end
+
+  def name_merge_summary(name)
+    "#{:name.ti} ##{name.id}: #{name.real_search_name} " \
+      "[#obs: #{name.observations.count}, " \
+      "#namings: #{name.namings.count}, " \
+      "#users_with_interest: #{name.interests.count}]"
+  end
+end

--- a/app/views/mailers/merge_request_mailer.rb
+++ b/app/views/mailers/merge_request_mailer.rb
@@ -40,6 +40,11 @@ class Views::Mailers::MergeRequestMailer < Views::Mailers::Base
     when ::Location then location_merge_summary(obj)
     when ::Herbarium then herbarium_merge_summary(obj)
     when ::Name then name_merge_summary(obj)
+    else
+      raise(ArgumentError.new(
+              "Unknown MergeRequestMailer merge type: #{obj.class}. " \
+              "Valid types: Location, Herbarium, Name."
+            ))
     end
   end
 

--- a/test/classes/symbol_extensions_test.rb
+++ b/test/classes/symbol_extensions_test.rb
@@ -3,26 +3,17 @@
 require("test_helper")
 
 class SymbolExtensionsTest < UnitTestCase
-  # Symbol.titleize_localized (and I18n.with_locale generally) is a
-  # pure function of I18n.locale -- it never touches
-  # TranslationString/Language. But I18n.available_locales is derived
-  # from whichever config/locales/*.yml files exist, which `rails
-  # lang:update` generates only for locales with a Language row in
-  # whatever DB it ran against. CI's test DB only has the 6 languages
-  # fixtures.yml defines, so I18n.with_locale(:pl) (etc.) would raise
-  # I18n::InvalidLocale there even though the fixture set has nothing
-  # to do with what these tests are actually exercising. Widened once
-  # for the whole class rather than per-test, since multiple tests in
-  # this file need locales outside the fixture set.
+  # See expand_available_locales in test_helper.rb for why this is
+  # needed. Widened once for the whole class rather than per-test,
+  # since multiple tests in this file need locales outside the
+  # fixture set.
   def setup
     super
-    @original_locales = I18n.available_locales
-    I18n.available_locales =
-      (@original_locales + TI_TEST_STRINGS.keys).uniq
+    expand_available_locales(*TI_TEST_STRINGS.keys)
   end
 
   def teardown
-    I18n.available_locales = @original_locales
+    restore_available_locales
     super
   end
 

--- a/test/mailers/merge_request_mailer_test.rb
+++ b/test/mailers/merge_request_mailer_test.rb
@@ -49,6 +49,15 @@ class MergeRequestMailerTest < MailerTestCase
     assert_includes(body, "herb merge")
   end
 
+  def test_merge_summary_raises_for_unsupported_type
+    loc = locations(:albion)
+    view = Views::Mailers::MergeRequestMailer.new(
+      old_obj: loc, new_obj: loc, user: users(:mary)
+    )
+
+    assert_raises(ArgumentError) { view.send(:merge_summary, loc.user) }
+  end
+
   # MergeRequestMailer#build's I18n.locale line is what actually governs
   # resolution (the Phlex view render happens inside build's own call,
   # not synchronously in whatever locale the caller happened to be in) --

--- a/test/mailers/merge_request_mailer_test.rb
+++ b/test/mailers/merge_request_mailer_test.rb
@@ -53,13 +53,17 @@ class MergeRequestMailerTest < MailerTestCase
   # resolution (the Phlex view render happens inside build's own call,
   # not synchronously in whatever locale the caller happened to be in) --
   # confirm it resolves in MO.default_locale even under a different
-  # ambient locale.
+  # ambient locale. :de may not be I18n-available on CI (see
+  # with_expanded_locales in test_helper.rb), hence the wrapper.
   def test_build_resolves_in_default_locale_regardless_of_ambient_locale
     loc1 = locations(:albion)
     loc2 = locations(:burbank)
 
-    mail = I18n.with_locale(:de) do
-      build_mail(old_obj: loc1, new_obj: loc2, user: users(:mary), notes: "x")
+    mail = with_expanded_locales(:de) do
+      I18n.with_locale(:de) do
+        build_mail(old_obj: loc1, new_obj: loc2, user: users(:mary),
+                   notes: "x")
+      end
     end
 
     expected_label = I18n.with_locale(MO.default_locale) { :location.ti }

--- a/test/mailers/merge_request_mailer_test.rb
+++ b/test/mailers/merge_request_mailer_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class MergeRequestMailerTest < MailerTestCase
+  def test_build_for_name
+    name1 = names(:agaricus_campestris)
+    name2 = names(:boletus_edulis)
+    user = users(:rolf)
+
+    mail = build_mail(old_obj: name1, new_obj: name2, user: user,
+                      notes: "please merge")
+
+    assert_includes(mail.to, MO.webmaster_email_address)
+    assert_equal(user.email, mail.reply_to.first)
+    assert_text_mail(mail)
+    body = mail.body.to_s
+    assert_match(/#{Regexp.escape(name1.real_search_name)}/, body)
+    assert_match(/#{Regexp.escape(name2.real_search_name)}/, body)
+    assert_includes(body, "please merge")
+    assert_includes(body, user.login)
+  end
+
+  def test_build_for_location
+    loc1 = locations(:albion)
+    loc2 = locations(:burbank)
+    user = users(:mary)
+
+    mail = build_mail(old_obj: loc1, new_obj: loc2, user: user,
+                      notes: "loc merge")
+
+    body = mail.body.to_s
+    assert_match(/#{Regexp.escape(loc1.name)}/, body)
+    assert_match(/#{Regexp.escape(loc2.name)}/, body)
+    assert_includes(body, "loc merge")
+  end
+
+  def test_build_for_herbarium
+    herb1 = herbaria(:nybg_herbarium)
+    herb2 = herbaria(:fundis_herbarium)
+    user = users(:mary)
+
+    mail = build_mail(old_obj: herb1, new_obj: herb2, user: user,
+                      notes: "herb merge")
+
+    body = mail.body.to_s
+    assert_match(/#{Regexp.escape(herb1.name)}/, body)
+    assert_match(/#{Regexp.escape(herb2.name)}/, body)
+    assert_includes(body, "herb merge")
+  end
+
+  # MergeRequestMailer#build's I18n.locale line is what actually governs
+  # resolution (the Phlex view render happens inside build's own call,
+  # not synchronously in whatever locale the caller happened to be in) --
+  # confirm it resolves in MO.default_locale even under a different
+  # ambient locale.
+  def test_build_resolves_in_default_locale_regardless_of_ambient_locale
+    loc1 = locations(:albion)
+    loc2 = locations(:burbank)
+
+    mail = I18n.with_locale(:de) do
+      build_mail(old_obj: loc1, new_obj: loc2, user: users(:mary), notes: "x")
+    end
+
+    expected_label = I18n.with_locale(MO.default_locale) { :location.ti }
+    assert_match(/#{Regexp.escape(expected_label)}/, mail.body.to_s)
+  end
+
+  private
+
+  def build_mail(old_obj:, new_obj:, user:, notes:)
+    MergeRequestMailer.build(
+      sender_email: user.email, old_obj:, new_obj:, user:, notes:
+    ).message
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -254,5 +254,34 @@ module ActiveSupport
       end
       ActiveSupport::TestCase.cleared_logs = true
     end
+
+    # I18n.available_locales only reflects locales with a generated
+    # config/locales/*.yml, which `rails lang:update` only creates for
+    # locales that have a Language row in whatever DB it ran against --
+    # CI's test DB only has the fixture Language set, so a locale
+    # available on a full local dev DB may not be available there. Use
+    # these when a test needs I18n.with_locale(:xx)/available_locales
+    # to include a locale outside the fixture set, purely to exercise
+    # "the ambient locale differs from the one under test" -- not to
+    # assert on that locale's actual translated content, since the
+    # locale's real translation file may not even be present.
+    def expand_available_locales(*locales)
+      @original_available_locales ||= I18n.available_locales
+      I18n.available_locales = (I18n.available_locales + locales).uniq
+    end
+
+    def restore_available_locales
+      return unless @original_available_locales
+
+      I18n.available_locales = @original_available_locales
+      @original_available_locales = nil
+    end
+
+    def with_expanded_locales(*locales)
+      expand_available_locales(*locales)
+      yield
+    ensure
+      restore_available_locales
+    end
   end
 end


### PR DESCRIPTION
## Summary

Batch 3 off issue #4901's checklist — the `merge_info` item flagged during batch 2 as needing real new-class work rather than a same-file relocation.

`Location#merge_info`/`Herbarium#merge_info`/`Name::Format#merge_info` each resolved tags to serve exactly one caller: `Admin::Emails::MergeRequestsController#merge_request_content`, which built the entire email body as a plain string before ever reaching a Phlex view — `WebmasterMailer`'s view (`trusted_text(@question)`) just emitted whatever pre-built string it was handed.

`WebmasterMailer` isn't a fair relocation target for this dispatch: it's a deliberately generic "send plain text to the webmaster" pipe shared by two unrelated controllers (`webmaster_questions_controller.rb`, `name_change_requests_controller.rb`). Stuffing `Location`/`Herbarium`/`Name`-specific type dispatch into it would contaminate it for them.

Instead: new `MergeRequestMailer` + `Views::Mailers::MergeRequestMailer`, receiving the raw `old_obj`/`new_obj`/`user`/`notes` and doing the type dispatch + `.ti` resolution itself — same dispatcher shape as `Components::ImageFragment`. The controller now just hands off the raw objects; `merge_request_content` is deleted.

**One correctness wrinkle worth flagging explicitly**: `MergeRequestMailer#build`'s body (including the Phlex render) only actually executes when the `deliver_later` job runs, not synchronously in the controller action — unlike the old code, where `merge_request_content` ran eagerly inside the controller's `temporarily_set_locale(MO.default_locale)` block. So locale-correctness now has to come from `build` itself setting `I18n.locale = MO.default_locale` (mirroring `WebmasterMailer#build`'s own line), not from the controller — the controller's `temporarily_set_locale` wrapper (and its now-unused `Emailable` include) were removed since they no longer protect anything. Added a test that forces a different ambient locale before calling `build` and confirms the resolved content still comes out in the default locale.

## Test plan

- [x] `bin/rails test` — new mailer test (4 tests, including the locale-correctness one), existing controller test (including the `perform_enqueued_jobs`/`SHAZAM` end-to-end delivery test — confirms the async path renders correctly), model tests for all three touched models, `WebmasterMailer` + all `admin/emails/*` controller tests (confirming the other two controllers' shared-mailer usage is untouched) — 0 failures
- [x] `bundle exec rubocop` clean on every touched file
