### PR TITLE
Fix `ensure_thumb_image` discarding a newly uploaded image chosen as thumbnail

### DIFF
--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -112,6 +112,7 @@ module ObservationsController::EditAndUpdate
     validate_projects
     detach_removed_images
     try_to_upload_images
+    ensure_thumb_image
     try_to_save_location_if_new(@observation)
     try_to_update_observation_if_there_are_changes
   end
@@ -140,12 +141,14 @@ module ObservationsController::EditAndUpdate
       img.log_remove_from(@observation)
       flash_notice(:runtime_image_remove_success.t(id: img.id))
     end
-    ensure_thumb_image
   end
 
   # Fix for issue #3995: update_permitted_observation_attributes runs before
   # detach_removed_images, so the form's blank thumb_image_id overwrites the
   # real value before remove_image can detect it needs reassignment.
+  # Must run after attach_good_images: a just-uploaded image isn't in
+  # image_ids until then, and validating earlier discarded it as the
+  # chosen thumbnail (issue #4737).
   def ensure_thumb_image
     return if @observation.thumb_image_id.present? &&
               valid_thumb_image_ids.include?(@observation.thumb_image_id)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1005,7 +1005,10 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   def add_image(img)
     unless images.include?(img)
       images << img
-      self.thumb_image = img unless thumb_image
+      # Check the FK, not the association: reading `thumb_image` after
+      # the form assigned a new thumb_image_id would lazy-load, which
+      # strict_loading (edit_includes) forbids.
+      self.thumb_image = img unless thumb_image_id
       self.updated_at = Time.zone.now
       track_change(:added_image)
       save

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -728,6 +728,8 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
   def test_update_observation_new_image_can_be_thumbnail
     obs = observations(:detailed_unknown_obs)
     new_image = images(:disconnected_coprinus_comatus_image)
+    # The JS uploader creates the image as the logged-in user.
+    new_image.update_columns(user_id: obs.user_id)
     assert_not_includes(obs.image_ids, new_image.id)
 
     login(obs.user.login)

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -721,6 +721,35 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     )
   end
 
+  # Issue #4737: the JS uploader creates the Image before the form
+  # submits, so at update time the chosen thumb_image_id is a real image
+  # that isn't attached to the observation yet. It must survive the
+  # update instead of being reverted to an already-attached image.
+  def test_update_observation_new_image_can_be_thumbnail
+    obs = observations(:detailed_unknown_obs)
+    new_image = images(:disconnected_coprinus_comatus_image)
+    assert_not_includes(obs.image_ids, new_image.id)
+
+    login(obs.user.login)
+    put(:update, params: {
+          id: obs.id,
+          observation: {
+            place_name: obs.place_name,
+            when: obs.when,
+            notes: obs.notes.to_h,
+            specimen: obs.specimen,
+            thumb_image_id: new_image.id.to_s,
+            good_image_ids: (obs.image_ids + [new_image.id]).join(" ")
+          }
+        })
+
+    obs.reload
+    assert_includes(obs.image_ids, new_image.id,
+                    "New image should be attached to the observation")
+    assert_equal(new_image.id, obs.thumb_image_id,
+                 "Newly uploaded image chosen as thumbnail should stick")
+  end
+
   # ---------- field slip code on update ----------
 
   def test_update_adds_field_slip_code


### PR DESCRIPTION
Fixes #4737

## Root cause

When a new image is added on the edit observation form, the JS uploader creates the Image record before the form submits, rewrites the thumbnail radio's value to the real image id, and appends the id to `good_image_ids` — so the browser submits the correct `observation[thumb_image_id]`. But on the server, `ensure_thumb_image` (the guard added for #3995) ran at the end of `detach_removed_images`, which executes before `attach_good_images` attaches the newly uploaded image. The guard validates the chosen thumbnail against `@observation.image_ids` (currently attached images only), so the new image's id looked invalid and the thumbnail was silently reverted to an already-attached image. On a second edit the image is already attached, so the same choice sticks — exactly the behavior reported.

## Fix

- `app/controllers/observations_controller/edit_and_update.rb`: move the `ensure_thumb_image` call out of `detach_removed_images` and into `apply_observation_changes`, after `try_to_upload_images`. It still runs after detachment (the #3995 removed-thumbnail fallback keeps working; its test still passes), but now also after attachment, so a just-uploaded image is a legal thumbnail choice.
- `app/models/observation.rb`: the reorder exposed a latent strict-loading problem — `add_image` read the `thumb_image` association, which goes stale the moment the form assigns a new `thumb_image_id`, and reloading it violates `edit_includes`' `strict_loading`. (Previously `ensure_thumb_image` happened to prime the association first, an accident of ordering.) `add_image` only needs to know whether a thumbnail is set, so check the FK attribute: `self.thumb_image = img unless thumb_image_id`.
- `test/controllers/observations_controller_update_test.rb`: new `test_update_observation_new_image_can_be_thumbnail` simulating the JS flow (pre-created unattached image, its id in both `thumb_image_id` and `good_image_ids`). Verified it fails on the unfixed controller and passes with the fix.

## Test plan

1. Edit an observation that already has at least one image.
2. Add a new image and click "Set as Default Thumbnail" on it before saving.
3. Save. The observation's thumbnail should now be the newly uploaded image (previously it reverted to one of the pre-existing images).
4. Also try removing the current thumbnail image in the same edit — the thumbnail should still fall back to another attached image (#3995 behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
