### PR TITLE
Fix `FieldSlip#users_last_location` picking the oldest slip; smarter location fallbacks

### DIFF
--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -226,21 +226,35 @@ class FieldSlip < AbstractModel
     location&.id
   end
 
+  # Default location for a new slip, strongest signal first: the user's
+  # latest slip in this project, then the project location, then their
+  # latest located observation. The project outranks the observation
+  # because a user traveling to a foray likely hasn't entered anything
+  # located at the foray site yet, while the project location should
+  # contain it (issue #4907).
   def calc_location
-    result = observation&.location || users_last_location
-    return result if result
-
-    project&.location
+    observation&.location || users_last_location ||
+      project&.location || users_last_observation_location
   end
 
+  # Location of the user's most recently updated field slip in this
+  # project that has a located observation (slips without one are
+  # skipped).
   def users_last_location
-    user = @current_user
-    return nil unless user
+    return nil unless @current_user
 
-    field_slip = user.field_slips.where(project:).
-                 order(updated_at: :desc).last
-    obs = field_slip&.observation
-    obs&.location
+    Location.joins(observations: { occurrence: :field_slip }).
+      where(field_slips: { user_id: @current_user.id,
+                           project_id: project&.id }).
+      order(FieldSlip.arel_table[:updated_at].desc,
+            FieldSlip.arel_table[:id].desc).first
+  end
+
+  def users_last_observation_location
+    return nil unless @current_user
+
+    @current_user.observations.where.not(location_id: nil).
+      order(created_at: :desc).first&.location
   end
 
   # Plain collector string for the form's autocompleter input (the

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -226,12 +226,12 @@ class FieldSlip < AbstractModel
     location&.id
   end
 
-  # Default location for a new slip, strongest signal first: the user's
-  # latest slip in this project, then the project location, then their
-  # latest located observation. The project outranks the observation
-  # because a user traveling to a foray likely hasn't entered anything
-  # located at the foray site yet, while the project location should
-  # contain it (issue #4907).
+  # Default location, strongest signal first: this slip's own
+  # observation, then the user's latest slip in this project, then the
+  # project location, then their latest located observation. The
+  # project outranks the observation because a user traveling to a
+  # foray likely hasn't entered anything located at the foray site
+  # yet, while the project location should contain it (issue #4907).
   def calc_location
     observation&.location || users_last_location ||
       project&.location || users_last_observation_location
@@ -254,7 +254,7 @@ class FieldSlip < AbstractModel
     return nil unless @current_user
 
     @current_user.observations.where.not(location_id: nil).
-      order(created_at: :desc).first&.location
+      order(created_at: :desc, id: :desc).first&.location
   end
 
   # Plain collector string for the form's autocompleter input (the

--- a/test/models/field_slip_test.rb
+++ b/test/models/field_slip_test.rb
@@ -54,4 +54,76 @@ class FieldSlipTest < UnitTestCase
     assert_not(slip.can_edit?(rolf),
                "Project admin must not edit a non-member's field slip")
   end
+
+  # ---------- default location (issue #4907) ----------
+  # mary's slips in eol_project: field_slip_one (obs minimal_unknown_obs),
+  # field_slip_two (obs owner_accepts_general_questions), field_slip_no_obs
+  # (no occurrence). eol_project has no location fixture.
+
+  def test_location_uses_latest_project_slip_with_located_obs
+    observations(:minimal_unknown_obs).
+      update_columns(location_id: locations(:albion).id)
+    observations(:owner_accepts_general_questions).
+      update_columns(location_id: locations(:burbank).id)
+    field_slips(:field_slip_one).update_columns(updated_at: 2.days.ago)
+    field_slips(:field_slip_two).update_columns(updated_at: 1.day.ago)
+
+    # Newest slip has no observation: it must be skipped, not end the
+    # search. And the result must be the newest located slip's location,
+    # not the oldest's (the old `order(...desc).last` bug).
+    slip = field_slips(:field_slip_no_obs)
+    slip.update_columns(updated_at: 1.hour.ago)
+    slip.current_user = mary
+
+    assert_equal(locations(:burbank), slip.location)
+  end
+
+  def test_location_falls_back_to_project_location
+    observations(:minimal_unknown_obs).update_columns(location_id: nil)
+    observations(:owner_accepts_general_questions).
+      update_columns(location_id: nil)
+    projects(:eol_project).update_columns(location_id: locations(:albion).id)
+
+    slip = field_slips(:field_slip_no_obs)
+    slip.current_user = mary
+
+    assert_equal(locations(:albion), slip.location)
+  end
+
+  def test_location_falls_back_to_users_latest_located_observation
+    observations(:minimal_unknown_obs).update_columns(location_id: nil)
+    observations(:owner_accepts_general_questions).
+      update_columns(location_id: nil)
+    latest = observations(:detailed_unknown_obs)
+    latest.update_columns(location_id: locations(:burbank).id,
+                          created_at: Time.zone.now)
+
+    slip = field_slips(:field_slip_no_obs)
+    slip.current_user = mary
+
+    assert_equal(locations(:burbank), slip.location)
+  end
+
+  def test_location_nil_when_no_signal_available
+    slip = field_slips(:field_slip_no_obs)
+    slip.current_user = users(:zero_user)
+
+    assert_nil(slip.location)
+  end
+
+  def test_location_prefers_own_observation
+    observations(:minimal_unknown_obs).
+      update_columns(location_id: locations(:albion).id)
+    observations(:owner_accepts_general_questions).
+      update_columns(location_id: locations(:burbank).id)
+    field_slips(:field_slip_two).update_columns(updated_at: 1.hour.ago)
+
+    # field_slip_one's own observation wins even though another slip in
+    # the project is more recent.
+    slip = field_slips(:field_slip_one)
+    slip.update_columns(updated_at: 2.days.ago)
+    slip.current_user = mary
+
+    assert_equal(locations(:albion), slip.location)
+  end
 end


### PR DESCRIPTION
Fixes #4907

## Root cause

The new field slip form's default location comes from `FieldSlip#calc_location`, whose second tier (`users_last_location`) was *intended* to use the user's most recent field slip in the project — but `order(updated_at: :desc).last` reverses the order and returns the last row, i.e. the user's **oldest** slip in the project. The form therefore prefilled the location of the first slip the user ever filed for the project (e.g. a prior year's foray site), which is why the default looked "generally wrong" but not random. It also gave up entirely (falling back to the project location) whenever that one slip had no observation attached.

## Fix

`FieldSlip#calc_location` now resolves, strongest signal first:

1. The slip's own observation's location (unchanged — existing slips).
2. The user's most recently updated field slip in the same project that has a located observation (slips without one are skipped instead of ending the search). Single query joining `Location → observations → occurrence → field_slip`, ordered by slip `updated_at` desc with an id tiebreaker.
3. The project's location.
4. The user's most recently created located observation.

The project location outranks the user's recent observation deliberately: a user traveling to a foray hasn't entered anything located at the foray site yet, while the project location should contain where such an observation was made.

## Tests

Five new tests in `test/models/field_slip_test.rb` cover each tier plus both bug behaviors: the newest located slip wins (not the oldest), and an observation-less newer slip is skipped rather than ending the search. The first and the observation-fallback test fail against the old code.

## Test plan

1. As a user with existing field slips in a project, open a new field slip URL for that project (e.g. scan/enter a fresh code like CCMS-5432). The location should prefill from your most recently updated slip in that project, not your first one.
2. As a user with no slips in the project, the location should prefill with the project's location.
3. If the project has no location, it should fall back to your most recently entered located observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
