### PR TITLE
Return unresolved `[tag, args]` pairs from `Location`'s dubious-name checks (#4901)

### DIFF
--- a/app/classes/api2/core/helpers.rb
+++ b/app/classes/api2/core/helpers.rb
@@ -55,7 +55,7 @@ module API2::Helpers
       Location.check_for_bad_country_or_state(name) +
       Location.check_for_bad_terms(name) +
       Location.check_for_bad_chars(name)
-    reasons.map { |tag, args| tag.t(**(args || {})) }
+    reasons.map { |tag, args| tag.t(**args) }
   end
 
   def parse_bounding_box!

--- a/app/classes/api2/core/helpers.rb
+++ b/app/classes/api2/core/helpers.rb
@@ -39,15 +39,23 @@ module API2::Helpers
   def make_sure_location_isnt_dubious!(name)
     return if name.blank? || Location.where(name: name).any?
 
-    citations =
+    citations = dubious_location_citations(name)
+    return if citations.none?
+
+    raise(API2::DubiousLocationName.new(citations))
+  end
+
+  # [tag, args] pairs from Location's check_* methods, resolved here
+  # (rather than on the model) into the plain strings
+  # API2::DubiousLocationName expects (#4901).
+  def dubious_location_citations(name)
+    reasons =
       Location.check_for_empty_name(name) +
       Location.check_for_dubious_commas(name) +
       Location.check_for_bad_country_or_state(name) +
       Location.check_for_bad_terms(name) +
       Location.check_for_bad_chars(name)
-    return if citations.none?
-
-    raise(API2::DubiousLocationName.new(citations))
+    reasons.map { |tag, args| tag.t(**(args || {})) }
   end
 
   def parse_bounding_box!

--- a/app/components/form/location_feedback.rb
+++ b/app/components/form/location_feedback.rb
@@ -3,7 +3,7 @@
 # Displays feedback about dubious location reasons when creating/editing
 # observations, species lists, or locations.
 #
-# @param dubious_where_reasons [Array<Array(Symbol, Hash)>, nil] unresolved
+# @param dubious_where_reasons [Array<[Symbol, Hash]>, nil] unresolved
 #   [tag, args] pairs from Location.dubious_reasons_for -- resolved here,
 #   not on the model, since API2::Helpers needs the same data in a
 #   different final form (#4901).
@@ -27,7 +27,7 @@ class Components::Form::LocationFeedback < Components::Base
         @dubious_where_reasons.each_with_index do |reason, index|
           br if index.positive?
           tag, args = reason
-          trusted_html(tag.t(**(args || {})))
+          trusted_html(tag.t(**args))
         end
       end
       Help(element: :span,

--- a/app/components/form/location_feedback.rb
+++ b/app/components/form/location_feedback.rb
@@ -3,10 +3,14 @@
 # Displays feedback about dubious location reasons when creating/editing
 # observations, species lists, or locations.
 #
-# @param dubious_where_reasons [Array<String>, nil] dubious reasons
+# @param dubious_where_reasons [Array<Array(Symbol, Hash)>, nil] unresolved
+#   [tag, args] pairs from Location.dubious_reasons_for -- resolved here,
+#   not on the model, since API2::Helpers needs the same data in a
+#   different final form (#4901).
 # @param button [String, Symbol] button name for help text
 class Components::Form::LocationFeedback < Components::Base
-  prop :dubious_where_reasons, _Nilable(_Array(String)), default: nil
+  prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
+       default: nil
   prop :button, _Union(String, Symbol) do |value|
     value.is_a?(Symbol) ? value.l : value
   end
@@ -22,7 +26,8 @@ class Components::Form::LocationFeedback < Components::Base
       div do
         @dubious_where_reasons.each_with_index do |reason, index|
           br if index.positive?
-          trusted_html(reason)
+          tag, args = reason
+          trusted_html(tag.t(**(args || {})))
         end
       end
       Help(element: :span,

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -625,16 +625,22 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     dubious_name?(db_name, true) || []
   end
 
+  # Each check_* method below returns an Array of [tag, args] pairs
+  # (unresolved) rather than resolved strings -- the two consumers
+  # (Components::Form::LocationFeedback, API2::Helpers#make_sure_
+  # location_isnt_dubious!) need different final forms (HTML-safe
+  # per-line text vs. a joined API error message), so resolution via
+  # `tag.t(**args)` happens at each consumer instead of here (#4901).
   def self.check_for_empty_name(name)
     return [] if name.present?
 
-    [:location_dubious_empty.l]
+    [[:location_dubious_empty, {}]]
   end
 
   def self.check_for_dubious_commas(name)
     return [] unless comma_test(name)
 
-    [:location_dubious_commas.l]
+    [[:location_dubious_commas, {}]]
   end
 
   def self.check_for_bad_country_or_state(name)
@@ -650,15 +656,15 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   def self.check_country_validity(real_country, this_country)
     return [] if real_country
 
-    [:location_dubious_unknown_country.t(country: this_country)]
+    [[:location_dubious_unknown_country, { country: this_country }]]
   end
 
   def self.check_state_validity(real_country, this_country, this_state)
     if real_country && has_known_states?(real_country)
       check_known_state_validity(real_country, this_country, this_state)
     elsif this_state && understood_country?(this_state)
-      [:location_dubious_redundant_state.t(country: real_country,
-                                           state: this_state)]
+      [[:location_dubious_redundant_state,
+        { country: real_country, state: this_state }]]
     else
       []
     end
@@ -670,11 +676,11 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     if this_state
       return [] unless understood_state?(this_state, real_country).nil?
 
-      [:location_dubious_unknown_state.t(country: real_country,
-                                         state: this_state)]
+      [[:location_dubious_unknown_state,
+        { country: real_country, state: this_state }]]
     elsif this_country != real_country &&
           understood_state?(this_country, real_country)
-      [:location_dubious_ambiguous_country.t(country: this_country)]
+      [[:location_dubious_ambiguous_country, { country: this_country }]]
     else
       []
     end
@@ -687,7 +693,8 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     BAD_TERMS.each_key do |key|
       next unless name.index(key)
 
-      reasons << :location_dubious_bad_term.t(bad: key, good: BAD_TERMS[key])
+      reasons << [:location_dubious_bad_term,
+                  { bad: key, good: BAD_TERMS[key] }]
     end
     reasons
   end
@@ -699,7 +706,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     # For some reason BAD_CHARS.chars.each doesn't work
     count = 0
     while (c = BAD_CHARS[count])
-      reasons << :location_dubious_bad_char.t(char: c) if name.index(c)
+      reasons << [:location_dubious_bad_char, { char: c }] if name.index(c)
       count += 1
     end
     reasons

--- a/app/views/controllers/locations/edit.rb
+++ b/app/views/controllers/locations/edit.rb
@@ -6,7 +6,8 @@ module Views::Controllers::Locations
   class Edit < Views::FullPageBase
     prop :location, ::Location
     prop :display_name, _Nilable(::String), default: nil
-    prop :dubious_where_reasons, _Nilable(_Array(::String)), default: nil
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
+         default: nil
 
     def view_template
       add_edit_title(@location)

--- a/app/views/controllers/locations/new.rb
+++ b/app/views/controllers/locations/new.rb
@@ -15,7 +15,8 @@ module Views::Controllers::Locations
          _Nilable(_Union(::String, ::Integer)), default: nil
     prop :set_herbarium,
          _Nilable(_Union(::String, ::Integer)), default: nil
-    prop :dubious_where_reasons, _Nilable(_Array(::String)), default: nil
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
+         default: nil
     def view_template
       container_class(:full)
       add_new_title(:create_object, :location)

--- a/app/views/controllers/observations/edit.rb
+++ b/app/views/controllers/observations/edit.rb
@@ -12,7 +12,8 @@ module Views::Controllers::Observations
     prop :good_images, _Array(::Image), default: -> { [] }
     prop :sibling_images, _Array(::Image), default: -> { [] }
     prop :exif_data, Hash, default: -> { {} }
-    prop :dubious_where_reasons, _Nilable(Array), default: nil
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
+         default: nil
     prop :projects, _Array(::Project), default: -> { [] }
     prop :submitted_project_ids, _Nilable(Array), default: nil
     prop :lists, _Array(::SpeciesList), default: -> { [] }

--- a/app/views/controllers/observations/form/details.rb
+++ b/app/views/controllers/observations/form/details.rb
@@ -18,7 +18,8 @@ class Views::Controllers::Observations::Form::Details < Views::Base
   prop :button_name, String
   prop :location, _Nilable(Location), default: nil
   prop :default_place_name, _Nilable(String), default: nil
-  prop :dubious_where_reasons, _Nilable(_Array(String)), default: nil
+  prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
+       default: nil
 
   def view_template
     Row do

--- a/app/views/controllers/observations/new.rb
+++ b/app/views/controllers/observations/new.rb
@@ -14,7 +14,8 @@ module Views::Controllers::Observations
     prop :given_name, _Nilable(String), default: nil
     prop :place_name, _Nilable(String), default: nil
     prop :default_place_name, _Nilable(String), default: nil
-    prop :dubious_where_reasons, _Nilable(Array), default: nil
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
+         default: nil
     prop :vote, _Nilable(::Vote), default: nil
     prop :names, _Nilable(Array), default: nil
     prop :valid_names, _Nilable(Array), default: nil

--- a/test/classes/api2/locations_test.rb
+++ b/test/classes/api2/locations_test.rb
@@ -115,6 +115,28 @@ class API2::LocationsTest < UnitTestCase
     assert_last_location_correct
   end
 
+  # Location.check_for_* return unresolved [tag, args] pairs (#4901);
+  # API2::Helpers#make_sure_location_isnt_dubious! resolves them into
+  # the DubiousLocationName error text. Confirm the resolved text
+  # actually made it through, not just that the request failed.
+  def test_posting_location_with_dubious_name_reports_resolved_reason
+    params = {
+      method: :post,
+      action: :location,
+      api_key: @api_key.key,
+      name: "Evil Lair, Latveria",
+      north: 39.64,
+      south: 39.39,
+      east: -119.70,
+      west: -119.94
+    }
+
+    assert_api_fail(params)
+    message = @api.errors.first.to_s
+    assert_match(/Latveria/, message)
+    assert_match(/Unknown country/, message)
+  end
+
   def test_patching_locations
     albion = locations(:albion)
     burbank = locations(:burbank)

--- a/test/classes/api2/locations_test.rb
+++ b/test/classes/api2/locations_test.rb
@@ -68,6 +68,16 @@ class API2::LocationsTest < UnitTestCase
     assert_api_results(locs)
   end
 
+  # All four edges present (passes all_edges?) but geometrically invalid
+  # (south > north) -- Mappable::Box#valid? rejects it, hitting the
+  # second NeedAllFourEdges raise in parse_bounding_box!, distinct from
+  # the missing-edge case above.
+  def test_getting_locations_in_invalid_box
+    assert_api_fail(
+      params_get(north: 39, south: 40, east: -123, west: -124)
+    )
+  end
+
   def test_posting_locations
     name1  = "Reno, Nevada, USA"
     name2  = "Sparks, Nevada, USA"

--- a/test/components/form/location_feedback_test.rb
+++ b/test/components/form/location_feedback_test.rb
@@ -9,12 +9,13 @@ class FormLocationFeedbackTest < ComponentTestCase
   end
 
   def test_renders_warning_alert_with_reasons
-    html = render_feedback(["Location not found".html_safe])
+    html = render_feedback([[:location_dubious_empty, {}]])
 
     # `#dubious_location_messages` is the durable identifier; the
     # `.alert-warning` / `.my-3` Bootstrap classes are pure paint.
     assert_html(html, "#dubious_location_messages")
-    assert_html(html, "body", text: "Location not found")
+    assert_html(html, "#dubious_location_messages",
+                text: :location_dubious_empty.t.as_displayed)
     assert_html(html, ".help-note")
     # Help text should include the button name
     help_note = Nokogiri::HTML(html).at_css(".help-note")
@@ -22,15 +23,26 @@ class FormLocationFeedbackTest < ComponentTestCase
   end
 
   def test_renders_multiple_reasons_with_br_tags
-    reasons = ["First reason", "Second reason", "Third reason"].map(&:html_safe)
+    reasons = [
+      [:location_dubious_empty, {}],
+      [:location_dubious_commas, {}],
+      [:location_dubious_bad_char, { char: "@" }]
+    ]
     html = render_feedback(reasons)
 
-    reasons.each { |r| assert_html(html, "body", text: r) }
+    reasons.each do |tag, args|
+      assert_html(html, "#dubious_location_messages",
+                  text: tag.t(**args).as_displayed)
+    end
     assert_html(html, "br", count: 2)
   end
 
   def test_renders_html_entities_without_double_escaping
-    html = render_feedback(["Unknown country &#8216;Test&#8217;".html_safe])
+    # Textile turns the straight quotes in location_dubious_unknown_country
+    # ("Unknown country '[country]'") into smart-quote entities.
+    html = render_feedback(
+      [[:location_dubious_unknown_country, { country: "Test" }]]
+    )
 
     assert_includes(html, "&#8216;")
     assert_not_includes(html, "&amp;#8216;")
@@ -38,7 +50,7 @@ class FormLocationFeedbackTest < ComponentTestCase
 
   def test_accepts_symbol_button_parameter
     html = render(Components::Form::LocationFeedback.new(
-                    dubious_where_reasons: ["Reason".html_safe],
+                    dubious_where_reasons: [[:location_dubious_empty, {}]],
                     button: :create
                   ))
 

--- a/test/views/controllers/locations/form_test.rb
+++ b/test/views/controllers/locations/form_test.rb
@@ -93,17 +93,20 @@ module Views::Controllers::Locations
     end
 
     def test_renders_dubious_location_warning_container_when_provided
+      reasons = [[:location_dubious_empty, {}], [:location_dubious_commas, {}]]
       html = render(Form.new(
                       @location,
                       display_name: "test",
                       original_name: "test",
-                      dubious_where_reasons: ["Reason 1", "Reason 2"],
+                      dubious_where_reasons: reasons,
                       local: true
                     ))
 
       assert_html(html, "#dubious_location_messages.alert-warning")
-      assert_html(html, "#dubious_location_messages", text: "Reason 1")
-      assert_html(html, "#dubious_location_messages", text: "Reason 2")
+      reasons.each do |tag, args|
+        assert_html(html, "#dubious_location_messages",
+                    text: tag.t(**args).as_displayed)
+      end
     end
 
     def test_renders_locked_display_for_locked_location

--- a/test/views/controllers/species_lists/form_test.rb
+++ b/test/views/controllers/species_lists/form_test.rb
@@ -236,7 +236,7 @@ module Views::Controllers::SpeciesLists
       # `dubious_where_reasons` through.
       html = render_form(
         species_list: SpeciesList.new,
-        dubious_where_reasons: ["dubious_county_unrecognized"]
+        dubious_where_reasons: [[:location_dubious_empty, {}]]
       )
       assert_html(html, "#dubious_location_messages")
     end


### PR DESCRIPTION
## Summary

The 7th checklist item off issue #4901 — `Location.dubious_reasons_for` and its `check_*` helpers, flagged during batch 1 as harder than a simple relocation once a 7th, non-Phlex consumer turned up.

`Location.check_for_empty_name`/`check_for_dubious_commas`/`check_country_validity`/`check_state_validity`/`check_known_state_validity`/`check_for_bad_terms`/`check_for_bad_chars` all resolved tags to strings directly on the model (`:location_dubious_unknown_country.t(country: ...)` etc.), same shape as `ProjectAlias#verify_target` from #4902 — except here there are **two** structurally different consumers instead of one:

1. **`Components::Form::LocationFeedback`** — the single shared Phlex component all 6 controller call sites (`locations_controller.rb`, `species_lists_controller.rb`, `observations_controller/validators.rb`, `species_lists/write_in_controller.rb`) eventually funnel `dubious_where_reasons` into, through several layers of pass-through props. It now resolves each pair via `tag.t(**args)` right before rendering.
2. **`API2::Helpers#make_sure_location_isnt_dubious!`** — calls the same `check_for_*` methods directly to build an API error citation, not a render. It now resolves the same pairs into plain strings before constructing `API2::DubiousLocationName`, whose own contract is unchanged.

Fix: the `check_*` methods now return unresolved `[tag, args]` pairs instead of resolved strings, and each consumer resolves via `tag.t(**args)` at the point it actually needs text — no shared resolver helper, since that's a one-liner (same call already made for `Projects::AliasesController#resolve_verify_target_error` in #4902).

All 8 tags use plain sentences with straight quotes (no textile markup), confirmed via the translation source — safe to resolve uniformly via `.t` even though 2 of the 8 originally used `.l`.

## Test plan

- [x] `bin/rails test` — `location_test.rb` (unaffected, only checks array emptiness), rewritten `location_feedback_test.rb` (pairs instead of pre-built strings; the entity-escaping test now uses a real tag, `location_dubious_unknown_country`, instead of a synthetic string), `api2/locations_test.rb` (added a dedicated test — `make_sure_location_isnt_dubious!` had zero prior coverage despite being a real endpoint-validation path — asserting the resolved error text actually made it through, not just that the request failed), `api2/error_test.rb`, `species_lists_controller_test.rb` — 92 tests, 0 failures
- [x] `bundle exec rubocop` clean on every touched file
