### PR TITLE
Anchor autocompleter pulldown to the input's bottom edge, not the `form-group` bottom

### DIFF
--- a/app/javascript/controllers/autocompleter/base_controller.js
+++ b/app/javascript/controllers/autocompleter/base_controller.js
@@ -789,6 +789,7 @@ export default class BaseAutocompleterController extends Controller {
 
       this.setWidth();
       this.updateWidth();
+      this.positionPulldown();
 
       if (matches.length > 1 || this.getSearchToken() != matches[0]['name']) {
         this.clearHide();
@@ -805,6 +806,18 @@ export default class BaseAutocompleterController extends Controller {
   hidePulldown() {
     this.wrapTarget?.classList?.remove('open');
     this.menu_up = false;
+  }
+
+  // Anchor the menu to the input's bottom edge. The `.dropdown`
+  // positioning context is the whole form-group, so Bootstrap's default
+  // `top: 100%` opens the menu below anything rendered under the input —
+  // e.g. the locality field's help block on the observation form (#4909).
+  positionPulldown() {
+    if (!this.hasWrapTarget) return;
+
+    const wrap_top = this.wrapTarget.getBoundingClientRect().top,
+      input_bottom = this.inputTarget.getBoundingClientRect().bottom;
+    this.pulldownTarget.style.top = (input_bottom - wrap_top) + "px";
   }
 
   updateWidth() {

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -250,6 +250,36 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     assert_match(/\n/, final_value, "Locations should be separated by newline")
   end
 
+  # The pulldown must open flush under the input. The `.dropdown`
+  # positioning context is the whole form-group, and the locality field
+  # renders a help block between the input and the menu, so Bootstrap's
+  # default top:100% would open the menu below the help text (#4909).
+  def test_locality_pulldown_opens_under_the_input
+    login!(@roy)
+    visit("/observations/new")
+    assert_selector("body.observations__new")
+
+    field = find_field("observation_place_name")
+    field.click
+    field.set("")
+    @browser.keyboard.type("burbank")
+    within("#observation_location_autocompleter") do
+      assert_selector(".auto_complete ul li a", text: /Burbank/i, wait: 3)
+    end
+
+    input_bottom = evaluate_script(
+      "document.getElementById('observation_place_name')" \
+      ".getBoundingClientRect().bottom"
+    )
+    menu_top = evaluate_script(
+      "document.querySelector('#observation_location_autocompleter " \
+      ".auto_complete').getBoundingClientRect().top"
+    )
+    assert_in_delta(input_bottom, menu_top, 2,
+                    "pulldown should open flush under the locality input, " \
+                    "not below its help text")
+  end
+
   def test_autocompleter_in_naming_modal
     browser = page.driver.browser
     rolf = users("rolf")


### PR DESCRIPTION
Fixes #4909

## Root cause

The autocompleter's dropdown menu is rendered inside the field's `form-group` wrapper, which carries the Bootstrap `.dropdown` class and is therefore the menu's absolute-positioning context. Bootstrap's `.dropdown-menu` default of `top: 100%` opens the menu at the bottom of the *whole form-group*. The locality field on the observation form renders an always-visible help block (`Form::LocationHelp`) between the input and the menu, so the menu opened below the help text — 219px adrift in the reproduction — instead of right under the input. Any autocompleter field with an always-visible help block gets the same displacement; fields without one never show it, which is why it looked locality-specific.

## History

- **Pre-July 2024** (ERB era): the where-help sat in a separate column *beside* the field, so nothing intervened and placement was correct.
- **July 2024** (`e4b2c4fb6a`): the help moved below the field but stayed collapsed behind an info trigger, and the menu rendered before it — still effectively correct.
- **January 9, 2026** (PR #3698, Phlex observation form conversion): the help became the field's always-visible `with_help` slot, rendered inside the form-group between the input and the menu — the moment the reported symptom appeared. The underlying quirk (menu anchored to the form-group rather than the input) had been latent since the Stimulus autocompleter markup landed in June 2024. The collector field on the same form avoids the bug only because its help uses `help_collapse: true`.

## Fix

`base_controller.js` gets a `positionPulldown()` method that sets the menu's `top` to the input's bottom edge (via `getBoundingClientRect` of the input vs. the wrap element), called from `makePulldownVisible()` each time the pulldown is drawn. This fixes every autocompleter uniformly — with no help text the computed value equals Bootstrap's default, so nothing else shifts.

## Tests

New system test `test_locality_pulldown_opens_under_the_input` types into the locality field on `/observations/new` and asserts the menu's top is within 2px of the input's bottom. It fails without the fix (off by 219px — the help block's height) and passes with it. Full `autocompleter_system_test.rb` (15 tests) and `observation_form_system_test.rb` (12 tests) pass.

## Test plan

1. Open the create observation form and start typing in the locality field.
2. The suggestion menu should appear directly under the text input, covering the help text, rather than below the help paragraphs.
3. Spot-check another autocompleter without help text (e.g. the name field on observation search) — the menu should open exactly where it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
