### PR TITLE
Key `NamingConsensus` vote table by canonical value, not resolved text (#4901)

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -23,9 +23,9 @@ class InfoController < ApplicationController
 
   # Help page.
   def how_to_use
-    @min_pos_vote = Vote.confidence(Vote.min_pos_vote)
-    @min_neg_vote = Vote.confidence(Vote.min_neg_vote)
-    @maximum_vote = Vote.confidence(Vote.maximum_vote)
+    @min_pos_vote = Vote.confidence_string(Vote.min_pos_vote)
+    @min_neg_vote = Vote.confidence_string(Vote.min_neg_vote)
+    @maximum_vote = Vote.confidence_string(Vote.maximum_vote)
     render(Views::Controllers::Info::HowToUse.new(
              min_pos_vote: @min_pos_vote,
              min_neg_vote: @min_neg_vote,

--- a/app/models/observation/naming_consensus.rb
+++ b/app/models/observation/naming_consensus.rb
@@ -233,13 +233,16 @@ class Observation
 
     # Generate a table the number of User's who cast each level of Vote for a
     # single Naming. (This refreshes the naming.vote_cache while it's at it.)
+    # Keyed by the vote level's canonical numeric value (a stable,
+    # locale-independent identity) rather than resolved text -- resolve
+    # `tag` yourself, in whatever locale you need, at render time.
     #
     #   table = consensus.calc_vote_table(naming)
-    #   for key, record in table
-    #     str    = key.l
+    #   for value, record in table
+    #     tag    = record[:tag]    # Translation tag for this vote level
+    #     str    = tag.l
     #     num    = record[:num]    # Number of users who voted near this level.
     #     weight = record[:wgt]    # Sum of users' weights.
-    #     value  = record[:value]  # Value of this vote level (arbitrary scale)
     #     votes  = record[:votes]  # List of actual votes.
     #   end
     #
@@ -363,19 +366,19 @@ class Observation
 
     def init_vote_table
       table = {}
-      Vote.opinion_menu.each do |str, val|
-        table[str] = { num: 0, wgt: 0.0, value: val, votes: [] }
+      ([Vote::NO_OPINION_VAL] + Vote::CONFIDENCE_VALS).each do |tag, val|
+        table[val] = { num: 0, wgt: 0.0, tag: tag, votes: [] }
       end
       table
     end
 
     def populate_vote_table(table, vote_list)
       vote_list.each do |v|
-        str = Vote.confidence(v.value)
+        val = Vote.confidence_value(v.value)
         wgt = v.user_weight
-        table[str][:num] += 1
-        table[str][:wgt] += wgt
-        table[str][:votes] << v
+        table[val][:num] += 1
+        table[val][:wgt] += wgt
+        table[val][:votes] << v
       end
     end
 

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -309,10 +309,10 @@ class Vote < AbstractModel
 
   protected
 
-  # Find label of closest value in a given enumerated lists.
+  # Find label of closest value in a given enumerated list.
   # Returns the whole winning [tag, value] pair (not just one field),
   # so callers can extract whichever they need -- resolved text
-  # (`confidence`), the canonical value (`confidence_value`), or the
+  # (`confidence_string`), the canonical value (`confidence_value`), or the
   # tag (`confidence_tag`).
   def self.lookup_value(val, list) # :nodoc:
     last_pair = nil

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -34,7 +34,9 @@
 #  ==== Vote labels
 #  confidence_menu::    Structure used by form helper +select+
 #                       to create pulldown menu.
-#  confidence::         Classify value as confidence level, String.
+#  confidence_string::  Classify value as confidence level, String.
+#  confidence_value::   Classify value as confidence level, canonical Float.
+#  confidence_tag::     Classify value as confidence level, tag Symbol.
 #
 #  == Instance methods
 #
@@ -178,10 +180,29 @@ class Vote < AbstractModel
 
   # Find label of closest value in the "confidence" menu.
   # Special case: 0 returns "No Opinion"
-  def self.confidence(val)
+  def self.confidence_string(val)
     return no_opinion if val.to_f.zero?
 
-    lookup_value(val, confidence_menu)
+    lookup_value(val, confidence_menu)[0]
+  end
+
+  # Like `confidence_string`, but returns the canonical numeric value instead
+  # of resolved text -- for callers needing a stable, locale-independent
+  # identity (e.g. NamingConsensus's internal vote-tallying table),
+  # not display text.
+  def self.confidence_value(val)
+    return NO_OPINION_VAL[1] if val.to_f.zero?
+
+    lookup_value(val, CONFIDENCE_VALS)[1]
+  end
+
+  # Like `confidence_value`, but returns the untranslated tag Symbol --
+  # for callers that need to resolve display text themselves, later,
+  # in whatever locale is current at render time.
+  def self.confidence_tag(val)
+    return NO_OPINION_VAL[0] if val.to_f.zero?
+
+    lookup_value(val, CONFIDENCE_VALS)[0]
   end
 
   # ----------------------------
@@ -289,17 +310,19 @@ class Vote < AbstractModel
   protected
 
   # Find label of closest value in a given enumerated lists.
+  # Returns the whole winning [tag, value] pair (not just one field),
+  # so callers can extract whichever they need -- resolved text
+  # (`confidence`), the canonical value (`confidence_value`), or the
+  # tag (`confidence_tag`).
   def self.lookup_value(val, list) # :nodoc:
     last_pair = nil
     list.each do |pair|
       next unless pair[1] != 0
-      if !last_pair.nil? && val > (last_pair[1] + pair[1]) / 2
-        return last_pair[0]
-      end
+      return last_pair if !last_pair.nil? && val > (last_pair[1] + pair[1]) / 2
 
       last_pair = pair
     end
-    last_pair[0]
+    last_pair
   end
 
   validate :check_requirements

--- a/app/views/controllers/observations/namings/votes/table.rb
+++ b/app/views/controllers/observations/namings/votes/table.rb
@@ -57,29 +57,27 @@ module Views::Controllers::Observations::Namings::Votes
     end
 
     # Sort by descending vote value so "I'd Call It That" rows
-    # rise to the top. Zero-value rows are skipped.
+    # rise to the top. Zero-value rows are skipped. The table is keyed
+    # by the vote level's canonical numeric value (#4901).
     def sorted_vote_keys
-      @vote_table.keys.sort do |x, y|
-        @vote_table[y][:value] <=> @vote_table[x][:value]
-      end
+      @vote_table.keys.sort.reverse
     end
 
     def render_value_rows
-      sorted_vote_keys.each do |str|
-        row = @vote_table[str]
-        next if row[:value].zero?
+      sorted_vote_keys.each do |value|
+        next if value.zero?
 
-        render_value_row(str, row)
+        render_value_row(value, @vote_table[value])
       end
     end
 
     # `String#%` (rather than `Kernel#format`) is used throughout
     # because `format` resolves to Phlex's `<format>` HTML element
     # method inside a view's render scope.
-    def render_value_row(str, row) # rubocop:disable Metrics/AbcSize
+    def render_value_row(value, row) # rubocop:disable Metrics/AbcSize
       tr(class: "text-nowrap") do
-        td { trusted_html(str.t) }
-        td(align: "center") { plain(row[:value].to_s) }
+        td { trusted_html(row[:tag].t) }
+        td(align: "center") { plain(value.to_s) }
         td(align: "center") { plain("%.2f" % row[:wgt]) }
         td(align: "center") { plain(row[:num].to_s) }
         td(align: "left") { small { render_voter_links(row[:votes]) } }

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -224,7 +224,7 @@ module Views::Layouts
     # the array form (`[2.0]`) at validation time, so the array
     # branch is always taken; no scalar fallback needed.
     def confidence_val_as_label(val)
-      val.map { |v| Vote.confidence(v.to_f) }.join(" – ")
+      val.map { |v| Vote.confidence_string(v.to_f) }.join(" – ")
     end
 
     def param_val_itself(key, val, truncate:)

--- a/test/controllers/observations/namings/votes_controller_test.rb
+++ b/test/controllers/observations/namings/votes_controller_test.rb
@@ -41,15 +41,15 @@ module Observations::Namings
       obs = Observation.naming_includes.find(nam.observation_id)
       consensus = ::Observation::NamingConsensus.new(obs)
       table = consensus.calc_vote_table(nam)
-      str1 = Vote.confidence(votes(:coprinus_comatus_owner_vote).value)
-      str2 = Vote.confidence(votes(:coprinus_comatus_other_vote).value)
-      table.each_key do |str|
-        if str == str1 && str1 == str2
-          assert_equal(2, table[str][:num])
-        elsif str == str1 || str == str2
-          assert_equal(1, table[str][:num])
+      val1 = Vote.confidence_value(votes(:coprinus_comatus_owner_vote).value)
+      val2 = Vote.confidence_value(votes(:coprinus_comatus_other_vote).value)
+      table.each_key do |val|
+        if val == val1 && val1 == val2
+          assert_equal(2, table[val][:num])
+        elsif val == val1 || val == val2
+          assert_equal(1, table[val][:num])
         else
-          assert_equal(0, table[str][:num])
+          assert_equal(0, table[val][:num])
         end
       end
     end

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -143,16 +143,38 @@ class VoteTest < UnitTestCase
     end
   end
 
-  def test_confidence_returns_no_opinion_for_zero
-    # Bug: Vote.confidence(0) was returning "Doubtful" instead of "No Opinion"
-    assert_equal("No Opinion", Vote.confidence(0))
-    assert_equal("No Opinion", Vote.confidence(0.0))
+  def test_confidence_string_returns_no_opinion_for_zero
+    # Bug: Vote.confidence_string(0) returned "Doubtful" not "No Opinion"
+    assert_equal("No Opinion", Vote.confidence_string(0))
+    assert_equal("No Opinion", Vote.confidence_string(0.0))
   end
 
-  def test_confidence_returns_labels_for_nonzero_values
-    assert_equal("I'd Call It That", Vote.confidence(3.0))
-    assert_equal("Doubtful", Vote.confidence(-1.0))
-    assert_equal("As If!", Vote.confidence(-3.0))
+  def test_confidence_string_returns_labels_for_nonzero_values
+    assert_equal("I'd Call It That", Vote.confidence_string(3.0))
+    assert_equal("Doubtful", Vote.confidence_string(-1.0))
+    assert_equal("As If!", Vote.confidence_string(-3.0))
+  end
+
+  def test_confidence_value_returns_zero_for_zero
+    assert_equal(0, Vote.confidence_value(0))
+    assert_equal(0, Vote.confidence_value(0.0))
+  end
+
+  def test_confidence_value_returns_canonical_values
+    assert_in_delta(3.0, Vote.confidence_value(3.0))
+    assert_in_delta(-1.0, Vote.confidence_value(-1.0))
+    assert_in_delta(-3.0, Vote.confidence_value(-3.0))
+  end
+
+  def test_confidence_tag_returns_no_opinion_for_zero
+    assert_equal(:vote_no_opinion, Vote.confidence_tag(0))
+    assert_equal(:vote_no_opinion, Vote.confidence_tag(0.0))
+  end
+
+  def test_confidence_tag_returns_tags_for_nonzero_values
+    assert_equal(:vote_confidence_100, Vote.confidence_tag(3.0))
+    assert_equal(:vote_confidence_40, Vote.confidence_tag(-1.0))
+    assert_equal(:vote_confidence_0, Vote.confidence_tag(-3.0))
   end
 
   def test_show_controller

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -618,10 +618,10 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     assert_field("observation_naming_name", with: "Agaricus campestris")
     # Vote/reasons collapse should expand when name is filled
     assert_selector("[data-autocompleter--name-target='collapseFields'].in")
-    select(Vote.confidence(Vote.next_best_vote),
+    select(Vote.confidence_string(Vote.next_best_vote),
            from: "observation_naming_vote_value")
     assert_select("observation_naming_vote_value",
-                  selected: Vote.confidence(Vote.next_best_vote))
+                  selected: Vote.confidence_string(Vote.next_best_vote))
 
     within("#observation_form") { click_commit }
 

--- a/test/views/controllers/observations/namings/votes/table_test.rb
+++ b/test/views/controllers/observations/namings/votes/table_test.rb
@@ -44,6 +44,21 @@ module Views::Controllers::Observations::Namings::Votes
                    "totals-row spacer cell must hold U+00A0")
     end
 
+    # #4901: the table is keyed by canonical numeric value, and each
+    # row resolves its own tag via `.t` at render time -- confirm the
+    # displayed label actually matches that resolution (not, say, a
+    # leftover pre-resolved string from before the refactor).
+    def test_renders_resolved_confidence_label_per_row
+      html = render(Table.new(naming: @naming))
+
+      @naming.votes.map(&:value).uniq.each do |val|
+        next if val.zero?
+
+        expected_label = Vote.confidence_tag(val).t
+        assert_includes(html, expected_label)
+      end
+    end
+
     def test_renders_voter_user_links_for_non_anonymous_votes
       html = render(Table.new(naming: @naming))
 

--- a/test/views/layouts/header/index_bar/filter_caption_test.rb
+++ b/test/views/layouts/header/index_bar/filter_caption_test.rb
@@ -134,7 +134,7 @@ module Views::Layouts
                                               confidence: [2.0]))
 
       assert_html(html, "#caption-truncated .small b",
-                  text: Vote.confidence(2.0))
+                  text: Vote.confidence_string(2.0))
     end
 
     def test_confidence_range_joins_two_labels
@@ -143,7 +143,7 @@ module Views::Layouts
 
       assert_html(
         html, "#caption-truncated .small b",
-        text: "#{Vote.confidence(-1.0)} – #{Vote.confidence(2.0)}"
+        text: "#{Vote.confidence_string(-1.0)} – #{Vote.confidence_string(2.0)}"
       )
     end
 


### PR DESCRIPTION
## Summary

The last "hard" item off issue #4901's checklist — `Vote.confidence_menu`/`opinion_menu`, flagged as entangled rather than just misplaced.

`Observation::NamingConsensus#init_vote_table`/`#populate_vote_table` built an internal vote-tallying `Hash` keyed by `Vote.opinion_menu`'s **resolved translated label**, not just as final display output. Real correctness risk: two confidence tags resolving to identical text in some locale, or resolution running under different locales between building and populating the table, could silently misattribute votes to the wrong bucket.

Investigating further turned up a live bug in the render path, not just a latent risk: `app/views/controllers/observations/namings/votes/table.rb#render_value_row` already calls `.t` on the table key, clearly expecting a tag — but the key was already a resolved `String`, so `str.t` was silently calling `String#t` (a textile no-op) instead of `Symbol#t` (a real translation lookup). `calc_vote_table`'s own doc comment already documented `key.l` as the intended usage; this PR makes that comment accurate for the first time.

### Fix

Key the table by the confidence **value** (`Vote::CONFIDENCE_VALS`' canonical `Float`, e.g. `3.0`/`2.0`/.../`-3.0`/`0`) instead of resolved text or even a tag Symbol — the most root-aligned identity, and it's literally what was already stored redundantly as `row[:value]`.

- `Vote.lookup_value` now returns the whole winning `[tag, value]` pair instead of just one field, so three sibling methods can share it: `Vote.confidence_string` (was `Vote.confidence` — renamed for symmetry, see below), `Vote.confidence_value` (new — canonical `Float`), `Vote.confidence_tag` (new — tag `Symbol`).
- `init_vote_table`/`populate_vote_table` key off the value; `:value` field dropped from each row (redundant with the key), `:tag` field added so the view can resolve display text itself.
- `votes/table.rb`: `sorted_vote_keys` sorts the keys directly; `render_value_row` now does `row[:tag].t` — a real resolution instead of the accidental no-op.
- `Vote.confidence` → `Vote.confidence_string`: mid-review the naming felt asymmetric (two new siblings both self-describing, the original bare `confidence` wasn't) — renamed, updated both external callers (`info_controller.rb`, `filter_caption.rb`) and the doc comment.

Other `Vote.opinion_menu`/`confidence_menu`/`confidence_string` callers (search filter select options, `info_controller.rb`, `filter_caption.rb`) confirmed unaffected — all genuine render-only or single-value display uses, no bucketing/keying involved.

## Test plan

- [x] `bin/rails test` — `vote_test.rb` (new coverage for `confidence_value`/`confidence_tag`/renamed `confidence_string`), `votes_controller_test.rb` (rewrote the vote-tallying assertion to key off value instead of string), `votes/table_test.rb` (added a test confirming each row's rendered label actually matches its tag's `.t` resolution — the concrete regression guard for the render-path bug found above), `filter_caption_test.rb`, `info_controller_test.rb` — 101 tests, 0 failures
- [x] `bundle exec rubocop` clean on every touched file
- [x] Ran `test/system/observation_form_system_test.rb` (touches the renamed `Vote.confidence_string` call) — 5 pre-existing failures, all map/geolocation-field related and unrelated to this change (Capybara booted on port 3001; Maps API key is referer-restricted to port 3000, a known documented infra limitation)
