### PR TITLE
Move `page_title`/`document_title` from 16 models to a `Title::` PORO family (#4901)

### DIFF
--- a/app/classes/title.rb
+++ b/app/classes/title.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Computes the page heading (`page_title`) and browser-tab title
+# (`document_title`) for an arbitrary AbstractModel instance. Moved off
+# the models themselves (#4901) -- was a polymorphic method contract
+# with 14 per-model overrides directly on the AR classes, several
+# resolving translation tags. Consumed only from Phlex views
+# (app/views/layouts/header/object_title.rb,
+# app/views/full_page_base/title.rb), so this lives at the view-facing
+# edge rather than on the model, same shape as ViewerAwareFormat and
+# the Tab:: PORO family.
+#
+# One subclass per model that needs bespoke logic, discovered by
+# naming convention -- same mechanism as ApplicationMailer's
+# `mailer_view_class` (`"Views::Mailers::#{class_name}".constantize`).
+# Models with no Title:: subclass fall through to this base class's
+# defaults, matching AbstractModel#type_tag's localized label -- the
+# same default the models themselves used to inherit.
+class Title
+  # Walks up the class hierarchy (not just object.class itself) so
+  # NameDescription/LocationDescription -- concrete subclasses of the
+  # abstract Description, which is where the title logic actually
+  # lives -- resolve to Title::Description instead of silently
+  # falling through to the generic default.
+  def self.for(object)
+    klass = object.class
+    while klass
+      title_class = "Title::#{klass.name}".safe_constantize
+      return title_class.new(object) if title_class
+      break if klass == AbstractModel
+
+      klass = klass.superclass
+    end
+    new(object)
+  end
+
+  def initialize(object)
+    @object = object
+  end
+
+  def page_title(_user = nil)
+    @object.type_tag.ti
+  end
+
+  def document_title
+    @object.type_tag.ti
+  end
+end

--- a/app/classes/title/article.rb
+++ b/app/classes/title/article.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Page heading: bold-textile + `.t` (HTML). Doc title: plain title.
+class Title::Article < Title
+  def page_title(_user = nil)
+    @object.display_title.t
+  end
+
+  def document_title
+    @object.title
+  end
+end

--- a/app/classes/title/collection_number.rb
+++ b/app/classes/title/collection_number.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Page heading + browser tab title — `format_name` is plain text
+# (collector "name number"). The page-title side applies `.t` to keep
+# the binomial-in-name italicized.
+class Title::CollectionNumber < Title
+  def page_title(_user = nil)
+    @object.format_name.t
+  end
+
+  def document_title
+    @object.format_name
+  end
+end

--- a/app/classes/title/description.rb
+++ b/app/classes/title/description.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Page heading: textilized parent-inclusive name. Doc title: plain
+# (Description#text_name already strips HTML/textile down to ASCII).
+class Title::Description < Title
+  def page_title(_user = nil)
+    @object.format_name.t
+  end
+
+  def document_title
+    @object.text_name
+  end
+end

--- a/app/classes/title/glossary_term.rb
+++ b/app/classes/title/glossary_term.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Page heading + browser tab title — both just `name` (plain text).
+class Title::GlossaryTerm < Title
+  def page_title(_user = nil)
+    @object.name
+  end
+
+  def document_title
+    @object.name
+  end
+end

--- a/app/classes/title/herbarium.rb
+++ b/app/classes/title/herbarium.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Page heading: textilize so apostrophes etc. become smart-quoted
+# (and bold/italic markers, if any user typed them into the name,
+# render correctly). Doc title is plain `format_name` — the browser
+# tab doesn't render HTML or smart-quote.
+class Title::Herbarium < Title
+  def page_title(_user = nil)
+    @object.format_name.t
+  end
+
+  def document_title
+    @object.format_name
+  end
+end

--- a/app/classes/title/herbarium_record.rb
+++ b/app/classes/title/herbarium_record.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Page heading uses the textilized herbarium_label (binomial inside
+# gets italicized). Doc title uses the plain accession string.
+class Title::HerbariumRecord < Title
+  def page_title(_user = nil)
+    @object.herbarium_label.t
+  end
+
+  def document_title
+    @object.herbarium_label
+  end
+end

--- a/app/classes/title/image.rb
+++ b/app/classes/title/image.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Page heading (rendered HTML — textile applied + author wrapping).
+# User arg is ignored — images aggregate multiple obs's names, no
+# single user preference applies.
+class Title::Image < Title
+  def page_title(_user = nil)
+    @object.format_name.t.small_author
+  end
+
+  # Plain-text title for the browser tab `<title>`. Mirrors
+  # `unique_text_name` but without the trailing "(<id>)" — the title
+  # helper prepends "IMAGE <id>:" so we'd otherwise duplicate the id.
+  def document_title
+    @object.title_subjects(:text_name).presence || :image.l
+  end
+end

--- a/app/classes/title/location.rb
+++ b/app/classes/title/location.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Page heading + browser tab title. `display_name` is plain text for
+# the visible heading (place name; no textile); `text_name` is the
+# ASCII form for the doc title.
+class Title::Location < Title
+  def page_title(user = nil)
+    @object.display_name(user)
+  end
+
+  def document_title
+    @object.text_name
+  end
+end

--- a/app/classes/title/name.rb
+++ b/app/classes/title/name.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Page heading (rendered HTML — textile applied + author wrapping).
+# `user` arg lets us respect hide_authors prefs. When nil we use the
+# raw display_name (no user-specific transforms).
+class Title::Name < Title
+  def page_title(user = nil)
+    @object.display_name(user).t.small_author
+  end
+
+  # Plain-text title for the browser tab `<title>`. Helper prepends
+  # the type-tag + id; `text_name` is the binomial-only column.
+  def document_title
+    @object.text_name
+  end
+end

--- a/app/classes/title/observation.rb
+++ b/app/classes/title/observation.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Plain-text title for the browser tab `<title>`. `text_name` is the
+# denormalized binomial-only column — no author, no id, no markup. The
+# title helper prepends "OBSERVATION <id>:" so we don't need those
+# here. (The visible page heading is built by
+# `Views::Layouts::Header::ObjectTitle` via
+# `Observations::ConsensusNameLink` -- wraps the consensus name in a
+# link, so Observation never reaches `page_title` at all; no override
+# needed here, the base Title#page_title default is unused for it.)
+class Title::Observation < Title
+  def document_title
+    @object.text_name
+  end
+end

--- a/app/classes/title/project.rb
+++ b/app/classes/title/project.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Page heading + browser tab title — both plain `title`.
+class Title::Project < Title
+  def page_title(_user = nil)
+    @object.title
+  end
+
+  def document_title
+    @object.title
+  end
+end

--- a/app/classes/title/sequence.rb
+++ b/app/classes/title/sequence.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Page heading + browser tab title. The locus is shown in the page
+# body ("Locus: …") so the title identifies the sequence by its
+# observation instead. Was a zero-arg method on the model
+# (`def page_title; ...; end`, aliased for document_title) --
+# standardized to accept (and ignore) `user` like every other Title
+# subclass, so the object_title.rb consumer doesn't need to
+# arity-inspect each model's method to decide whether to pass it.
+class Title::Sequence < Title
+  def page_title(_user = nil)
+    :show_sequence_title.l(id: @object.observation_id)
+  end
+  alias document_title page_title
+end

--- a/app/classes/title/species_list.rb
+++ b/app/classes/title/species_list.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Page heading + browser tab title — both plain `title`.
+class Title::SpeciesList < Title
+  def page_title(_user = nil)
+    @object.title
+  end
+
+  def document_title
+    @object.title
+  end
+end

--- a/app/classes/title/user.rb
+++ b/app/classes/title/user.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Both the page heading and the browser tab title use the
+# "About <Full Name (login)>" i18n template — the "About" prefix
+# is the show-page's identity (vs. e.g. an edit page).
+class Title::User < Title
+  def page_title(_user = nil)
+    :show_user_about.t(user: @object.unique_text_name)
+  end
+
+  def document_title
+    :show_user_about.t(user: @object.unique_text_name)
+  end
+end

--- a/app/classes/title/visual_group.rb
+++ b/app/classes/title/visual_group.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Page heading + browser tab title — both just `name`.
+class Title::VisualGroup < Title
+  def page_title(_user = nil)
+    @object.name
+  end
+
+  def document_title
+    @object.name
+  end
+end

--- a/app/classes/title/visual_model.rb
+++ b/app/classes/title/visual_model.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Page heading + browser tab title — both just `name`.
+class Title::VisualModel < Title
+  def page_title(_user = nil)
+    @object.name
+  end
+
+  def document_title
+    @object.name
+  end
+end

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -85,23 +85,6 @@ class AbstractModel < ApplicationRecord
     self.class.name.underscore.to_sym
   end
 
-  # Default title strings for the `header/title_helper` helpers
-  # (`add_show_title` / `add_edit_title`). Subclasses override when
-  # there's a more meaningful per-instance string — e.g. an
-  # Observation's binomial, a SpeciesList's title.
-  #
-  # `page_title(user)` — rendered HTML/textile for the visible page
-  # heading. Defaults to the localized type-tag label.
-  # `document_title` — plain text for the browser tab `<title>`.
-  # Defaults to the same label (it's already plain).
-  def page_title(_user = nil)
-    type_tag.ti
-  end
-
-  def document_title
-    type_tag.ti
-  end
-
   ##############################################################################
   #
   #  :section: "Find" Extensions

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -56,17 +56,6 @@ class Article < AbstractModel
     title.to_s.t.html_to_ascii
   end
 
-  # Page heading: bold-textile + `.t` (HTML). Doc title: plain title.
-  # (Can't `alias document_title title` — the `title` AR accessor
-  # isn't defined yet at class-load time.)
-  def page_title(_user = nil)
-    display_title.t
-  end
-
-  def document_title
-    title
-  end
-
   # used by MatrixBoxPresenter to show unorphaned obects
   def unique_format_name(_user = nil)
     string_with_id(title)

--- a/app/models/collection_number.rb
+++ b/app/models/collection_number.rb
@@ -110,14 +110,6 @@ class CollectionNumber < AbstractModel
     "#{name_was} #{number_was}"
   end
 
-  # Page heading + browser tab title — `format_name` is plain text
-  # (collector "name number"). The view applies `.t` on the page-
-  # title side to keep the binomial-in-name italicized.
-  def page_title(_user = nil)
-    format_name.t
-  end
-  alias document_title format_name
-
   def can_edit?(user)
     return false unless user
 

--- a/app/models/description.rb
+++ b/app/models/description.rb
@@ -151,12 +151,6 @@ class Description < AbstractModel
     put_together_name(:full)
   end
 
-  # Page heading: textilized parent-inclusive name. Doc title: plain.
-  def page_title(_user = nil)
-    format_name.t
-  end
-  alias document_title text_name
-
   # Same as +format_name+ but with id tacked on.
   def unique_format_name(_user = nil)
     string_with_id(format_name)

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -87,16 +87,6 @@ class GlossaryTerm < AbstractModel
     name
   end
 
-  # Page heading + browser tab title — both just `name` (plain text).
-  # (Can't `alias` to AR column — accessor not defined at class-load.)
-  def page_title(_user = nil)
-    name
-  end
-
-  def document_title
-    name
-  end
-
   def unique_format_name(_user = nil)
     unique_text_name
   end

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -151,18 +151,6 @@ class Herbarium < AbstractModel
     code.blank? ? name : "#{name} (#{code})"
   end
 
-  # Page heading: textilize so apostrophes etc. become smart-quoted
-  # (and bold/italic markers, if any user typed them into the name,
-  # render correctly). Doc title is plain `format_name` — the
-  # browser tab doesn't render HTML or smart-quote.
-  def page_title(_user = nil)
-    format_name.t
-  end
-
-  def document_title
-    format_name
-  end
-
   def unique_format_name(_user = nil)
     "#{format_name} (#{id})"
   end

--- a/app/models/herbarium_record.rb
+++ b/app/models/herbarium_record.rb
@@ -124,13 +124,6 @@ class HerbariumRecord < AbstractModel
     herbarium_label
   end
 
-  # Page heading uses the textilized herbarium_label (binomial inside
-  # gets italicized). Doc title uses the plain accession string.
-  def page_title(_user = nil)
-    herbarium_label.t
-  end
-  alias document_title herbarium_label
-
   def accession_at_herbarium
     # Use the loaded association when available (no extra query on
     # the edit path); fall back to an FK fetch on freshly-built

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -371,20 +371,6 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     title_subjects || :image.l
   end
 
-  # Page heading (rendered HTML — textile applied + author wrapping).
-  # User arg is ignored — images aggregate multiple obs's names, no
-  # single user preference applies.
-  def page_title(_user = nil)
-    format_name.t.small_author
-  end
-
-  # Plain-text title for the browser tab `<title>`. Mirrors
-  # `unique_text_name` but without the trailing "(<id>)" — the title
-  # helper prepends "IMAGE <id>:" so we'd otherwise duplicate the id.
-  def document_title
-    title_subjects(:text_name).presence || :image.l
-  end
-
   # How this image is refered to in the rss logs.
   def log_name
     "##{id || was || "?"}"

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -410,12 +410,6 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     display_name(user)
   end
 
-  # Page heading + browser tab title. `display_name` is plain text
-  # for the visible heading (place name; no textile); `text_name` is
-  # the ASCII form for the doc title.
-  alias page_title display_name
-  alias document_title text_name
-
   def textile_name(user = nil)
     display_name(user)
   end

--- a/app/models/name/format.rb
+++ b/app/models/name/format.rb
@@ -85,21 +85,6 @@ module Name::Format
     Name.display_to_real_search(self, user)
   end
 
-  # Page heading (rendered HTML — textile applied + author wrapping).
-  # `user` arg lets us respect hide_authors prefs. When nil we use the
-  # raw display_name (no user-specific transforms).
-  def page_title(user = nil)
-    display_name(user).t.small_author
-  end
-
-  # Plain-text title for the browser tab `<title>`. Helper prepends
-  # the type-tag + id; `text_name` is the binomial-only column.
-  # (Can't `alias` to AR column from a module — accessor not in
-  # scope at class-load.)
-  def document_title
-    text_name
-  end
-
   def sensu_stricto
     text_name.sub(GROUP_AT_END_OF_TEXT_NAME, "")
   end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -952,18 +952,6 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     name.observation_name(user)
   end
 
-  # Plain-text title for the browser tab `<title>`. `text_name` is
-  # the denormalized binomial-only column — no author, no id, no
-  # markup. The title helper prepends "OBSERVATION <id>:" so we
-  # don't need those here. (The visible page heading is built by
-  # `header/title_helper#page_title_for` via
-  # `Observations::ConsensusNameLink` — wraps the consensus name
-  # in a link, which is view-layer work that can't live cleanly on
-  # the model.)
-  def document_title
-    text_name
-  end
-
   # Textile-marked-up name with id to make it unique, never nil.
   def unique_format_name(user = nil)
     string_with_id(name.observation_name(user))

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -237,17 +237,6 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     unique_text_name
   end
 
-  # Page heading + browser tab title — both plain `title`. (Can't
-  # `alias` to `title` — the AR column accessor isn't defined yet
-  # at class-load time.)
-  def page_title(_user = nil)
-    title
-  end
-
-  def document_title
-    title
-  end
-
   # Is +user+ a member of this Project? Reflects actual user_group
   # membership only — Site Admins (user.admin == true) get no implicit
   # membership; they self-promote via the Administer Project button.

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -124,14 +124,6 @@ class Sequence < AbstractModel
     locus.truncate(locus_width, separator: " ")
   end
 
-  # Page heading + browser tab title. The locus is shown in the
-  # page body ("Locus: …") so the title identifies the sequence
-  # by its observation instead.
-  def page_title
-    :show_sequence_title.l(id: observation_id)
-  end
-  alias document_title page_title
-
   # used in views and by MatrixBoxPresenter to show unorphaned obects
   def unique_format_name(_user = nil)
     format_name + " (Sequence #{id || "?"})"

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -270,17 +270,6 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
     title
   end
 
-  # Page heading + browser tab title — both plain `title`. (Can't
-  # `alias` to `title` — the AR column accessor isn't defined yet
-  # at class-load time.)
-  def page_title(_user = nil)
-    title
-  end
-
-  def document_title
-    title
-  end
-
   # Return formatted title with id appended to make unique.
   def unique_format_name(_user = nil)
     title = self.title

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -398,17 +398,6 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
-  # Both the page heading and the browser tab title use the
-  # "About <Full Name (login)>" i18n template — the "About" prefix
-  # is the show-page's identity (vs. e.g. an edit page).
-  def page_title(_user = nil)
-    :show_user_about.t(user: unique_text_name)
-  end
-
-  def document_title
-    :show_user_about.t(user: unique_text_name)
-  end
-
   def format_name(_user = nil)
     unique_text_name
   end

--- a/app/models/visual_group.rb
+++ b/app/models/visual_group.rb
@@ -12,16 +12,6 @@ class VisualGroup < AbstractModel
     without: /\t/, message: proc { :cannot_include_tabs.t }
   }
 
-  # Page heading + browser tab title — both just `name`. (Can't
-  # `alias` to AR column — accessor not defined at class-load.)
-  def page_title(_user = nil)
-    name
-  end
-
-  def document_title
-    name
-  end
-
   def image_count(status = true)
     return visual_group_images.count if status.nil? || status == "needs_review"
 

--- a/app/models/visual_model.rb
+++ b/app/models/visual_model.rb
@@ -10,16 +10,6 @@ class VisualModel < AbstractModel
     without: /\t/, message: proc { :cannot_include_tabs.t }
   }
 
-  # Page heading + browser tab title — both just `name`. (Can't
-  # `alias` to AR column — accessor not defined at class-load.)
-  def page_title(_user = nil)
-    name
-  end
-
-  def document_title
-    name
-  end
-
   def to_json(_)
     {
       name: name,

--- a/app/views/full_page_base/title.rb
+++ b/app/views/full_page_base/title.rb
@@ -110,13 +110,12 @@ module Views::FullPageBase::Title
 
   private
 
-  # Models without `document_title` fall back to their localized type
-  # tag (`observation`, `location`, etc.). The browser-tab text renders
-  # as plain text, so textile / HTML must NOT leak through.
+  # Models with no `Title::` subclass (see app/classes/title.rb) fall
+  # back to their localized type tag (`observation`, `location`, etc.).
+  # The browser-tab text renders as plain text, so textile / HTML must
+  # NOT leak through.
   def document_title_for(object)
-    return object.type_tag.ti unless object.respond_to?(:document_title)
-
-    object.document_title
+    Title.for(object).document_title
   end
 
   # `Observation 23435: Amanita novinupta`

--- a/app/views/layouts/header/object_title.rb
+++ b/app/views/layouts/header/object_title.rb
@@ -10,10 +10,10 @@
 # The title piece itself is:
 # - Observation → `Views::Controllers::Observations::ConsensusNameLink`
 #   (wraps the consensus name in a link to the name page).
-# - Any other model → its `#page_title` (arity-aware so models can
-#   alias to a zero-arg method). `AbstractModel#page_title` defaults
-#   to the type-tag label, so models that don't override still get a
-#   sensible string.
+# - Any other model → `Title.for(object).page_title` (see
+#   app/classes/title.rb). Models with no `Title::` subclass get
+#   `Title`'s own default, the type-tag label, so models that don't
+#   need bespoke title logic still get a sensible string.
 module Views::Layouts
   class Header::ObjectTitle < Views::Base
     prop :object, ::AbstractModel
@@ -52,15 +52,8 @@ module Views::Layouts
       end
     end
 
-    # Models can alias `page_title` to a zero-arg accessor (e.g.
-    # `alias page_title title`) instead of writing a one-line wrapper
-    # that ignores `user`. The arity check lets both shapes work.
     def model_page_title
-      if @object.method(:page_title).arity.zero?
-        @object.page_title
-      else
-        @object.page_title(@user)
-      end
+      Title.for(@object).page_title(@user)
     end
   end
 end

--- a/test/classes/title/article_test.rb
+++ b/test/classes/title/article_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::ArticleTest < UnitTestCase
+  def test_page_title
+    article = articles(:premier_article)
+
+    assert_equal(article.display_title.t, Title.for(article).page_title)
+  end
+
+  def test_document_title
+    article = articles(:premier_article)
+
+    assert_equal(article.title, Title.for(article).document_title)
+  end
+end

--- a/test/classes/title/collection_number_test.rb
+++ b/test/classes/title/collection_number_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::CollectionNumberTest < UnitTestCase
+  def test_page_title
+    cn = collection_numbers(:minimal_unknown_coll_num)
+
+    assert_equal(cn.format_name.t, Title.for(cn).page_title)
+  end
+
+  def test_document_title
+    cn = collection_numbers(:minimal_unknown_coll_num)
+
+    assert_equal(cn.format_name, Title.for(cn).document_title)
+  end
+end

--- a/test/classes/title/description_test.rb
+++ b/test/classes/title/description_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Description is abstract -- NameDescription/LocationDescription are
+# the concrete subclasses that actually get titled. Both must dispatch
+# to Title::Description via Title.for's class-hierarchy walk.
+class Title::DescriptionTest < UnitTestCase
+  def test_page_title_and_document_title_for_name_description
+    desc = name_descriptions(:agaricus_campestras_desc)
+    title = Title.for(desc)
+
+    assert_instance_of(Title::Description, title)
+    assert_equal(desc.format_name.t, title.page_title)
+    assert_equal(desc.text_name, title.document_title)
+  end
+
+  def test_page_title_and_document_title_for_location_description
+    desc = location_descriptions(:albion_desc)
+    title = Title.for(desc)
+
+    assert_instance_of(Title::Description, title)
+    assert_equal(desc.format_name.t, title.page_title)
+    assert_equal(desc.text_name, title.document_title)
+  end
+end

--- a/test/classes/title/glossary_term_test.rb
+++ b/test/classes/title/glossary_term_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::GlossaryTermTest < UnitTestCase
+  def test_page_title_and_document_title
+    term = glossary_terms(:conic_glossary_term)
+    title = Title.for(term)
+
+    assert_equal(term.name, title.page_title)
+    assert_equal(term.name, title.document_title)
+  end
+end

--- a/test/classes/title/herbarium_record_test.rb
+++ b/test/classes/title/herbarium_record_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::HerbariumRecordTest < UnitTestCase
+  def test_page_title
+    rec = herbarium_records(:interesting_unknown)
+
+    assert_equal(rec.herbarium_label.t, Title.for(rec).page_title)
+  end
+
+  def test_document_title
+    rec = herbarium_records(:interesting_unknown)
+
+    assert_equal(rec.herbarium_label, Title.for(rec).document_title)
+  end
+end

--- a/test/classes/title/herbarium_test.rb
+++ b/test/classes/title/herbarium_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::HerbariumTest < UnitTestCase
+  def test_page_title
+    herb = herbaria(:nybg_herbarium)
+
+    assert_equal(herb.format_name.t, Title.for(herb).page_title)
+  end
+
+  def test_document_title
+    herb = herbaria(:nybg_herbarium)
+
+    assert_equal(herb.format_name, Title.for(herb).document_title)
+  end
+end

--- a/test/classes/title/image_test.rb
+++ b/test/classes/title/image_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::ImageTest < UnitTestCase
+  def test_page_title
+    img = images(:in_situ_image)
+
+    assert_equal(img.format_name.t.small_author, Title.for(img).page_title)
+  end
+
+  def test_document_title
+    img = images(:in_situ_image)
+
+    assert_equal(img.title_subjects(:text_name).presence || :image.l,
+                 Title.for(img).document_title)
+  end
+
+  def test_document_title_falls_back_to_image_tag
+    img = Image.new
+
+    assert_equal(:image.l, Title.for(img).document_title)
+  end
+end

--- a/test/classes/title/location_test.rb
+++ b/test/classes/title/location_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::LocationTest < UnitTestCase
+  def test_page_title_no_user
+    loc = locations(:albion)
+
+    assert_equal(loc.display_name(nil), Title.for(loc).page_title)
+  end
+
+  # Location has two display formats -- postfix ("City, State, USA")
+  # for most users, scientific ("USA, State, City") when the user's
+  # `location_format` pref says so. `display_name(user)` switches
+  # between `name`/`scientific_name` based on that pref, so page_title
+  # needs covering under both, not just the default.
+  def test_page_title_postfix_format_user
+    loc = locations(:albion)
+    user = users(:rolf) # postfix (default) format
+
+    assert_equal(loc.name, Title.for(loc).page_title(user))
+  end
+
+  def test_page_title_scientific_format_user
+    loc = locations(:albion)
+    user = users(:roy) # scientific format
+
+    assert_equal(loc.scientific_name, Title.for(loc).page_title(user))
+  end
+
+  def test_document_title
+    loc = locations(:albion)
+
+    assert_equal(loc.text_name, Title.for(loc).document_title)
+  end
+end

--- a/test/classes/title/name_test.rb
+++ b/test/classes/title/name_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::NameTest < UnitTestCase
+  def test_page_title
+    name = names(:agaricus_campestris)
+
+    assert_equal(name.display_name(nil).t.small_author,
+                 Title.for(name).page_title)
+  end
+
+  def test_page_title_respects_user_hide_authors_pref
+    name = names(:agaricus_campestris)
+    user = users(:rolf)
+
+    assert_equal(name.display_name(user).t.small_author,
+                 Title.for(name).page_title(user))
+  end
+
+  def test_document_title
+    name = names(:agaricus_campestris)
+
+    assert_equal(name.text_name, Title.for(name).document_title)
+  end
+end

--- a/test/classes/title/observation_test.rb
+++ b/test/classes/title/observation_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::ObservationTest < UnitTestCase
+  def test_document_title
+    obs = observations(:minimal_unknown_obs)
+
+    assert_equal(obs.text_name, Title.for(obs).document_title)
+  end
+
+  # Observation has no page_title override -- the visible heading is
+  # built separately by Views::Layouts::Header::ObjectTitle via
+  # ConsensusNameLink, so Title::Observation only defines
+  # document_title. Confirm page_title still falls through safely to
+  # the base Title default rather than erroring.
+  def test_page_title_falls_back_to_base_default
+    obs = observations(:minimal_unknown_obs)
+
+    assert_equal(:observation.ti, Title.for(obs).page_title)
+  end
+end

--- a/test/classes/title/project_test.rb
+++ b/test/classes/title/project_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::ProjectTest < UnitTestCase
+  def test_page_title_and_document_title
+    project = projects(:eol_project)
+    title = Title.for(project)
+
+    assert_equal(project.title, title.page_title)
+    assert_equal(project.title, title.document_title)
+  end
+end

--- a/test/classes/title/sequence_test.rb
+++ b/test/classes/title/sequence_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# `page_title` is used by `Views::FullPageBase#add_show_title` as the
+# H1 + browser-tab title. Sequence's locus is shown in the body, so
+# the title identifies the sequence by its observation.
+class Title::SequenceTest < UnitTestCase
+  def test_page_title_and_document_title
+    seq = sequences(:local_sequence)
+    title = Title.for(seq)
+
+    assert_equal(:show_sequence_title.l(id: seq.observation_id),
+                 title.page_title)
+    # `document_title` is aliased to `page_title`.
+    assert_equal(title.page_title, title.document_title)
+  end
+end

--- a/test/classes/title/species_list_test.rb
+++ b/test/classes/title/species_list_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::SpeciesListTest < UnitTestCase
+  def test_page_title_and_document_title
+    spl = species_lists(:first_species_list)
+    title = Title.for(spl)
+
+    assert_equal(spl.title, title.page_title)
+    assert_equal(spl.title, title.document_title)
+  end
+end

--- a/test/classes/title/user_test.rb
+++ b/test/classes/title/user_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::UserTest < UnitTestCase
+  def test_page_title_and_document_title
+    user = users(:rolf)
+    title = Title.for(user)
+    expected = :show_user_about.t(user: user.unique_text_name)
+
+    assert_equal(expected, title.page_title)
+    assert_equal(expected, title.document_title)
+  end
+end

--- a/test/classes/title/visual_group_test.rb
+++ b/test/classes/title/visual_group_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::VisualGroupTest < UnitTestCase
+  def test_page_title_and_document_title
+    vg = visual_groups(:visual_group_one)
+    title = Title.for(vg)
+
+    assert_equal(vg.name, title.page_title)
+    assert_equal(vg.name, title.document_title)
+  end
+end

--- a/test/classes/title/visual_model_test.rb
+++ b/test/classes/title/visual_model_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Title::VisualModelTest < UnitTestCase
+  def test_page_title_and_document_title
+    vm = visual_models(:visual_model_one)
+    title = Title.for(vm)
+
+    assert_equal(vm.name, title.page_title)
+    assert_equal(vm.name, title.document_title)
+  end
+end

--- a/test/classes/title_test.rb
+++ b/test/classes/title_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class TitleTest < UnitTestCase
+  def test_for_dispatches_to_matching_subclass
+    seq = sequences(:local_sequence)
+
+    assert_instance_of(Title::Sequence, Title.for(seq))
+  end
+
+  def test_for_falls_back_to_base_for_model_with_no_subclass
+    # Publication has no Title:: subclass -- confirm the dispatcher
+    # doesn't raise and falls through to the base default.
+    pub = publications(:one_pub)
+
+    assert_instance_of(Title, Title.for(pub))
+  end
+
+  def test_for_walks_class_hierarchy_for_description_subclasses
+    # NameDescription/LocationDescription are concrete subclasses of
+    # the abstract Description, where the title logic actually lives.
+    # Title.for must resolve to Title::Description via the class
+    # hierarchy, not just object.class.name.
+    desc = name_descriptions(:agaricus_campestras_desc)
+
+    assert_instance_of(Title::Description, Title.for(desc))
+  end
+
+  def test_base_defaults_resolve_type_tag
+    pub = publications(:one_pub)
+    title = Title.for(pub)
+
+    assert_equal(:publication.ti, title.page_title)
+    assert_equal(:publication.ti, title.document_title)
+  end
+
+  def test_for_handles_non_abstract_model_objects_gracefully
+    # A non-AbstractModel object (anonymous class -> object.class.name
+    # is nil) with no matching Title:: subclass -- confirm the
+    # dispatcher still returns the base Title rather than raising
+    # during the hierarchy walk.
+    fake_class = Struct.new(:type_tag)
+    fake = fake_class.new(:observation)
+
+    assert_instance_of(Title, Title.for(fake))
+  end
+end

--- a/test/models/sequence_test.rb
+++ b/test/models/sequence_test.rb
@@ -3,17 +3,6 @@
 require("test_helper")
 
 class SequenceTest < UnitTestCase
-  # `page_title` is used by `Views::FullPageBase#add_show_title` as
-  # the H1 + browser-tab title. Sequence's locus is shown in the
-  # body, so the title identifies the sequence by its observation.
-  def test_page_title_aliases
-    seq = sequences(:local_sequence)
-    assert_equal(:show_sequence_title.l(id: seq.observation_id),
-                 seq.page_title)
-    # `document_title` is aliased to `page_title`.
-    assert_equal(seq.page_title, seq.document_title)
-  end
-
   def test_validators
     # Prove that Sequence with all proper fields is valid.
     sequence = Sequence.new(


### PR DESCRIPTION
## Summary

The last flagged-but-unscheduled architectural item on issue #4901.

Models up til now define a `page_title(user)`/`document_title` with a fallback in `AbstractModel` (`type_tag.ti`), and 15 models overrode it with their own logic, several resolving tags directly (`Image#page_title` calls `.t`, `User`'s both call `:show_user_about.t`, `Sequence#page_title` calls `.l`, etc.). But translated strings aren't Model logic, they're presentation logic.

A full survey found that there are **only 2 Phlex callers of both methods** — `app/views/layouts/header/object_title.rb` (`page_title`) and `app/views/full_page_base/title.rb` (`document_title`). Unlike `RssLog::Title` (which needed a PORO specifically *because* of live non-Phlex callers — the RSS feed, `ViewerAwareFormat`), nothing here forces the logic to stay reachable outside a render context.

Still chose a PORO family over inlining a large dispatch into the two consumer views — this is a cross-cutting per-model concern, same shape as `app/classes/viewer_aware_format.rb` and the `Tab::` PORO family (both at `app/classes/`, not nested under any single model or controller).

### `Title` PORO Design

`app/classes/title.rb` — base class + naming-convention dispatcher, mirroring the already-established `ApplicationMailer#mailer_view_class` pattern (`"Views::Mailers::#{class_name}".constantize`). Walks the class hierarchy (not just `object.class`) so `NameDescription`/`LocationDescription` — concrete subclasses of the abstract `Description`, where the title logic actually lives — resolve to `Title::Description` correctly.

One subclass per model, moved verbatim from its former override: `Image`, `Article`, `Project`, `VisualGroup`, `GlossaryTerm`, `VisualModel`, `CollectionNumber`, `Sequence`, `Herbarium`, `HerbariumRecord`, `Description`, `User`, `SpeciesList`, `Observation` (document_title only), `Name`, and `Location`.

`Sequence#page_title` was a zero-arg method; standardized to accept (and ignore) `user` like every other subclass, which let `object_title.rb`'s consumer drop its arity-inspection dance entirely. `full_page_base/title.rb`'s `respond_to?(:document_title)` guard likewise becomes unnecessary — `Title.for` already degrades to the base default for any object without a matching subclass (confirmed via the existing test that exercises this with a bare `Struct` stand-in).

### Bonus: closes a (sort-of) coverage gap

13 of 14 models previously had **no unit coverage** of `page_title`/`document_title` — although they got indirect coverage via `assert_page_title` controller/integration checks. Every `Title::` subclass gets its own test now.

## Test plan

- [x] `bin/rails test` — new `test/classes/title_test.rb` (dispatcher + base defaults, including the `Description` hierarchy-walk case) + one `test/classes/title/<model>_test.rb` per subclass, `test/views/full_page_base/title_test.rb` (unchanged, passes against the new dispatch), `test/models/sequence_test.rb` (old test moved), full model-test sweep for all 16 touched models, representative `assert_page_title` end-to-end controller tests (`herbaria`, `sequences`, `species_lists`) — 0 failures
- [x] `bundle exec rubocop` clean on every touched/new file (54 files)
- [x] Grepped `app/models/` for `def page_title`/`def document_title`/any `alias`/`alias_method` variant — zero remain
