### PR TITLE
Consolidate validation-error display into `Components::Form::Errors` (#4901, phase 1)

### DIFF
--- a/app/components/form/errors.rb
+++ b/app/components/form/errors.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Shared "N errors prohibited this X from being saved" alert. Replaces
+# 4 near-duplicated `render_errors`-family methods that had
+# independently diverged across field_slips/visual_groups/
+# visual_models/projects::aliases forms (#4901) -- consolidating
+# display first, before any model validators switch to deferred tag
+# resolution, so there's exactly one place to update instead of
+# several in lockstep with every model PR.
+class Components::Form::Errors < Components::Base
+  prop :model, ::AbstractModel
+
+  def view_template
+    return unless @model.errors.any?
+
+    Alert(level: :danger, id: "error_explanation") do
+      h2 { error_count_message }
+      ul do
+        @model.errors.each { |error| li { error.full_message } }
+      end
+    end
+  end
+
+  private
+
+  def error_count_message
+    count = @model.errors.count
+    word = pluralize_tag(:error, count).t
+    "#{count} #{word} #{:errors_prohibited_save.t(type: @model.type_tag.ti)}:"
+  end
+end

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -157,7 +157,7 @@ class GlossaryTermsController < ApplicationController
   end
 
   def reload_form(form)
-    add_glossary_term_error_messages_to_flash
+    flash_object_errors(@glossary_term)
     assign_image_form_ivars
     case form
     when "new"  then render(new_form_view)
@@ -179,13 +179,6 @@ class GlossaryTermsController < ApplicationController
     Views::Controllers::GlossaryTerms::Edit.new(
       glossary_term: @glossary_term
     )
-  end
-
-  def add_glossary_term_error_messages_to_flash
-    @glossary_term.errors.messages.each_value do |val|
-      # flash_error takes a string; val is an array of size 1, e.g. ["message"]
-      flash_error(val.first)
-    end
   end
 
   # Process any image together with @glossary_term,

--- a/app/controllers/licenses_controller.rb
+++ b/app/controllers/licenses_controller.rb
@@ -40,7 +40,7 @@ class LicensesController < AdminController
       )
       redirect_to(license_path(@license.id))
     else
-      @license.errors.full_messages.each { |msg| flash_warning(msg) }
+      @license.formatted_errors.each { |msg| flash_warning(msg) }
       render_new_view
     end
   end

--- a/app/controllers/observations/external_links_controller.rb
+++ b/app/controllers/observations/external_links_controller.rb
@@ -133,7 +133,7 @@ module Observations
                         end
       redirect_params = redirect_params.merge({ back: @back }) if @back.present?
 
-      flash_error(@external_link.formatted_errors.join("\n").strip_html)
+      flash_object_errors(@external_link)
       respond_to do |format|
         format.turbo_stream { reload_external_link_modal_form_and_flash }
         format.html { redirect_to(redirect_params) and return true }

--- a/app/controllers/projects/aliases_controller.rb
+++ b/app/controllers/projects/aliases_controller.rb
@@ -90,7 +90,7 @@ module Projects
 
     def flash_and_reload(format, action, error: false)
       flash_error(error) if error
-      @project_alias.errors.each { |err| flash_error(err.full_message) }
+      flash_object_errors(@project_alias)
       format.turbo_stream { reload_modal_project_alias_form }
       format.html { send(:"render_alias_#{action}") }
     end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -711,7 +711,9 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
         file = upload_original_name.to_s
         file = "?" if file.blank?
         errors.add(:image,
-                   :validate_image_wrong_type.t(type: upload_type, file: file))
+                   :validate_image_wrong_type.t(
+                     type: upload_type, file: ERB::Util.html_escape(file)
+                   ))
         result = false
       end
     end
@@ -834,7 +836,8 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     error = Image::Processor.strip_original_gps(self, ext: ext)
     return true unless error
 
-    errors.add(:image, :runtime_failed_to_strip_gps.t(msg: error))
+    errors.add(:image,
+               :runtime_failed_to_strip_gps.t(msg: ERB::Util.html_escape(error)))
     false
   end
 

--- a/app/models/name/lifeform.rb
+++ b/app/models/name/lifeform.rb
@@ -47,7 +47,10 @@ module Name::Lifeform
     return unless unknown_words.any?
 
     unknown_words = unknown_words.map(&:inspect).join(", ")
-    errors.add(:lifeform, :validate_invalid_lifeform.t(words: unknown_words))
+    errors.add(:lifeform,
+               :validate_invalid_lifeform.t(
+                 words: ERB::Util.html_escape(unknown_words)
+               ))
   end
 
   # Add lifeform (one word only) to all children.

--- a/app/models/name/validation.rb
+++ b/app/models/name/validation.rb
@@ -120,7 +120,9 @@ module Name::Validation
     )
 
     errors.add(:base,
-               :name_error_field_start.t(field: :citation.ti, start: start))
+               :name_error_field_start.t(
+                 field: :citation.ti, start: ERB::Util.html_escape(start.to_s)
+               ))
   end
 
   # prevent assigning ICN registration identifier to unregistrable Name
@@ -128,7 +130,8 @@ module Name::Validation
     return if icn_id.blank? || registrable?
 
     errors.add(:base, :name_error_unregistrable.t(
-                        rank: rank.to_s, name: real_search_name(nil)
+                        rank: rank.to_s,
+                        name: ERB::Util.html_escape(real_search_name(nil))
                       ))
   end
 
@@ -141,7 +144,9 @@ module Name::Validation
 
     errors.add(:base, :name_error_icn_id_in_use.t(
                         number: icn_id,
-                        name: conflicting_name.real_search_name(nil)
+                        name: ERB::Util.html_escape(
+                          conflicting_name.real_search_name(nil)
+                        )
                       ))
   end
 

--- a/app/models/occurrence.rb
+++ b/app/models/occurrence.rb
@@ -232,7 +232,9 @@ class Occurrence < AbstractModel
     occ = new
     occ.errors.add(
       :base,
-      :occurrence_field_slip_conflict.t(codes: codes.join(", "))
+      :occurrence_field_slip_conflict.t(
+        codes: ERB::Util.html_escape(codes.join(", "))
+      )
     )
     raise(ActiveRecord::RecordInvalid.new(occ))
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1104,7 +1104,10 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
 
   def notes_template_forbid_other
     notes_template_bad_parts.each do |part|
-      errors.add(:notes_template, :prefs_notes_template_no_other.t(part: part))
+      errors.add(:notes_template,
+                 :prefs_notes_template_no_other.t(
+                   part: ERB::Util.html_escape(part)
+                 ))
     end
   end
 
@@ -1118,7 +1121,9 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
       next unless part.squish == "Collector"
 
       errors.add(:notes_template,
-                 :prefs_notes_template_no_collector.t(part: part.squish))
+                 :prefs_notes_template_no_collector.t(
+                   part: ERB::Util.html_escape(part.squish)
+                 ))
     end
   end
 
@@ -1128,7 +1133,10 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     squished = notes_template.split(",").map { |s| s.squish.downcase }
     dups = squished.uniq.select { |part| squished.count(part) > 1 }
     dups.each do |dup|
-      errors.add(:notes_template, :prefs_notes_template_no_dups.t(part: dup))
+      errors.add(:notes_template,
+                 :prefs_notes_template_no_dups.t(
+                   part: ERB::Util.html_escape(dup)
+                 ))
     end
   end
 

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -61,7 +61,7 @@ module Views::Controllers::FieldSlips
     # --- Main form: full field-slip editing.
 
     def render_main_form
-      render_errors if model.errors.any?
+      render(Components::Form::Errors.new(model: model))
       # Width-cap the texty fields to a comfortable reading width
       # (`.container-text`), but keep the observation matrix full-
       # width. Both must live inside the same `<form>` so the matrix
@@ -89,18 +89,6 @@ module Views::Controllers::FieldSlips
     # validation failure leaves persistence state unchanged.
     def new_record?
       model.new_record?
-    end
-
-    # --- Errors ---
-
-    def render_errors
-      count = pluralize(model.errors.count, :error.t, plural: :errors.t)
-      Alert(level: :danger) do
-        ul do
-          model.errors.each { |error| li { error.full_message } }
-        end
-      end
-      p { "#{count} #{:field_slip_errors.t}:" }
     end
 
     # --- Left-column field-slip attribute fields ---

--- a/app/views/controllers/projects/aliases/form.rb
+++ b/app/views/controllers/projects/aliases/form.rb
@@ -20,7 +20,7 @@ module Views::Controllers::Projects::Aliases
     end
 
     def view_template
-      render_errors if model.errors.any?
+      render(Components::Form::Errors.new(model: model))
       render_name_and_type_row
       render_user_autocompleter
       render_location_autocompleter
@@ -28,23 +28,6 @@ module Views::Controllers::Projects::Aliases
     end
 
     private
-
-    def render_errors
-      Alert(level: :danger, id: "error_explanation") do
-        h2 { error_count_message }
-        ul do
-          model.errors.full_messages.each do |message|
-            li { message }
-          end
-        end
-      end
-    end
-
-    def error_count_message
-      count = model.errors.count
-      "#{count} #{count == 1 ? "error" : "errors"} prohibited this " \
-        "project alias from being saved:"
-    end
 
     def render_name_and_type_row
       Row do

--- a/app/views/controllers/visual_groups/form.rb
+++ b/app/views/controllers/visual_groups/form.rb
@@ -13,7 +13,7 @@ module Views::Controllers::VisualGroups
 
     def view_template
       super do
-        render_errors if model.errors.any?
+        render(Components::Form::Errors.new(model: model))
         render_name_field
         textarea_field(:description, cols: 60, rows: 10,
                                      label: :description.ti)
@@ -23,19 +23,6 @@ module Views::Controllers::VisualGroups
     end
 
     private
-
-    def render_errors
-      count = pluralize(model.errors.count, :error.l, plural: :errors.l)
-
-      Alert(level: :danger, id: "error_explanation") do
-        h2 { "#{count} prohibited this visual_group from being saved:" }
-        ul do
-          model.errors.each do |error|
-            li { error.full_message }
-          end
-        end
-      end
-    end
 
     def render_name_field
       div(class: "form-group") do

--- a/app/views/controllers/visual_models/form.rb
+++ b/app/views/controllers/visual_models/form.rb
@@ -8,26 +8,13 @@ module Views::Controllers::VisualModels
   class Form < ::Components::ApplicationForm
     def view_template
       super do
-        render_errors if model.errors.any?
+        render(Components::Form::Errors.new(model: model))
         render_name_field
         submit(:submit.ti, center: true)
       end
     end
 
     private
-
-    def render_errors
-      count = pluralize(model.errors.count, :error.l, plural: :errors.l)
-
-      Alert(level: :danger, id: "error_explanation") do
-        h2 { "#{count} #{:visual_model_errors.l}:" }
-        ul do
-          model.errors.each do |error|
-            li { error.full_message }
-          end
-        end
-      end
-    end
 
     def render_name_field
       div(class: "form-group field") do

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -246,6 +246,7 @@
   ended: ended
   error: error
   errors: errors
+  errors_prohibited_save: prohibited this [type] from being saved
   external_link: external link
   external_links_help: How external links work
   external_links: external links
@@ -2529,9 +2530,6 @@
   # visual_models/show
   show_visual_model_index: "[:visual_model.ti] [:index.ti]"
 
-  # Visual Models
-  visual_model_errors: prohibited this visual_model from being saved
-
   # visual_models/destroy
   destroy_visual_model_success: "[:visual_model.ti] [:destroyed]"
 
@@ -2548,7 +2546,6 @@
   field_slip_destroyed: Field slip was successfully destroyed.
   field_slip_edit: "[:edit_object(type=:FIELD_SLIP)]"
   field_slip_editing: Editing Field Slip
-  field_slip_errors: prohibited this field_slip from being saved
   field_slip_filter_by: Filter by [:project.ti]
   field_slip_job_no_tracker: No Field Slip Tracker found
   field_slip_keep_obs: Save with Current Observation

--- a/test/components/form/errors_test.rb
+++ b/test/components/form/errors_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FormErrorsTest < ComponentTestCase
+  def test_renders_nothing_when_no_errors
+    html = render(Components::Form::Errors.new(model: GlossaryTerm.new))
+
+    assert_equal("", html)
+  end
+
+  def test_renders_error_count_and_messages
+    term = GlossaryTerm.new
+    term.errors.add(:name, "can't be blank")
+    html = render(Components::Form::Errors.new(model: term))
+
+    assert_html(html, "#error_explanation.alert-danger")
+    assert_html(html, "#error_explanation h2")
+    assert_html(html, "#error_explanation ul li")
+    error_text = Nokogiri::HTML(html).at_css("#error_explanation").text
+    assert_includes(error_text, "1 #{:error.t}")
+    assert_includes(
+      error_text, :errors_prohibited_save.t(type: term.type_tag.ti)
+    )
+    assert_match(/Name can.{1,6}t be blank/, error_text)
+  end
+
+  def test_pluralizes_error_count_for_multiple_errors
+    term = GlossaryTerm.new
+    term.errors.add(:name, "can't be blank")
+    term.errors.add(:base, "second problem")
+    html = render(Components::Form::Errors.new(model: term))
+
+    error_text = Nokogiri::HTML(html).at_css("#error_explanation").text
+    assert_includes(error_text, "2 #{:errors.t}")
+  end
+end

--- a/test/views/controllers/visual_models/form_test.rb
+++ b/test/views/controllers/visual_models/form_test.rb
@@ -29,7 +29,10 @@ module Views::Controllers::VisualModels
       assert_html(html, "li")
       error_text = Nokogiri::HTML(html).at_css("#error_explanation").text
       assert_includes(error_text, "1 #{:error.t}")
-      assert_includes(error_text, :visual_model_errors.t)
+      assert_includes(
+        error_text,
+        :errors_prohibited_save.t(type: @visual_model.type_tag.ti)
+      )
       assert_match(/Name can.{1,6}t be blank/, error_text)
     end
 


### PR DESCRIPTION
## Summary

Consolidates MO's validation-error display layer. There are currently 3 separate paths doing the same job: showing an `AbstractModel`'s `errors` to a user. 

Fixes XSS-vulnerability gap found while consolidating flash display: some error messages interpolate user-editable free text, and flash renders unescaped.

- **Flash** (already mostly consolidated): `AbstractModel#formatted_errors` → `ApplicationController::FlashNotices#flash_object_errors`, with 44 call sites across 27 controllers — but a few stragglers bypass it: `licenses_controller.rb` (×2, hand-rolled `.errors.full_messages.each`), `glossary_terms_controller.rb` (legacy Hash-based `.errors.messages` API), `projects/aliases_controller.rb` (`.errors.each`), `observations/external_links_controller.rb` (already called `formatted_errors`, but wrapped it in its own single joined `flash_error(...strip_html)` call instead of the shared `flash_object_errors` wrapper).
- **5** independently-diverged Phlex `render_errors` methods: `field_slips/form.rb`, `visual_groups/form.rb`, `visual_models/form.rb`, `projects/aliases/form.rb` all hand-roll the same "N errors prohibited this X from being saved" alert, each slightly differently (h2 vs p, `:error.t` vs `:error.l`, hardcoded English string vs a per-model translation tag, `.full_messages` vs `.each`+`.full_message`).
- **Raw API rendering** (`publications_controller.rb`, `field_slips_controller.rb`) — out of scope, a different and riskier problem (API response-shape stability for existing consumers, not display duplication).

## Changes

- **New `Components::Form::Errors`** (`app/components/form/errors.rb`) replaces all 5 duplicated `render_errors`/`error_count_message` methods, unifying their diverged copy into one generic `:errors_prohibited_save.t(type:)` translation tag — replacing the two now-redundant per-model tags (`visual_model_errors`, `field_slip_errors`).
- **Migrated all 4 flash stragglers** onto the shared `formatted_errors`/`flash_object_errors` path — `licenses_controller.rb` keeps its `flash_warning` severity rather than silently upgrading to `flash_error`; `glossary_terms_controller.rb` drops its legacy Hash-API wrapper method entirely; `projects/aliases_controller.rb` and `observations/external_links_controller.rb` are one-line swaps. `external_links_controller.rb`'s dropped `.strip_html` wasn't protecting against anything specific to that controller: `flash_notice`/`flash_warning`/`flash_error` do zero HTML escaping anywhere (flash renders via `trusted_html`, confirmed in `app/views/layouts/app/flash_notices.rb`), and neither of `ExternalLink`'s own `errors.add` calls interpolates user input into its messages.
- **Escaped every user-controllable interpolation into a flash-facing `errors.add` tag.** A multi-line scan of all `errors.add` calls in `app/models/` that interpolate into `.t`/`.l`/`.ti`/`.tl` found 8 sites where the interpolated value is user-editable free text: `image.rb` (uploaded filename, GPS-strip processor message), `occurrence.rb` (FieldSlip codes), `user.rb` ×3 (`notes_template` parts), `name/validation.rb` ×2 (`citation`, `real_search_name`), `name/lifeform.rb` (`lifeform` words). Each is now wrapped in `ERB::Util.html_escape`, the existing convention (`app/extensions/array.rb`). Two sites were reviewed and left unchanged as non-risky: `image.rb`'s `runtime_image_process_failed` interpolates an integer id, and `location.rb`'s `validate_missing` interpolates a hardcoded `:name` symbol literal.

This also happens to be a necessary precursor for issue #4901's Phase 2 (switching the 84 `errors.add(:field, tag.t)` call sites in `app/models/` to bare deferred tags, plus the shared resolver that implies — `ActiveModel::Error#raw_type`/`#options` on Rails 7.2 already expose the unresolved tag + args cleanly): once a model does `errors.add(:field, :some_tag)` (bare symbol), `error.message` starts triggering Rails' own (wrong-scope) i18n resolution instead of returning an already-built string, so every display path needs to go through one shared resolver by then. Phase 2 is designed in the linked issue comment but not attempted here — 84 call sites is its own sweep, sized once this phase has landed and the resolver shape proves itself.

## Test plan

- [x] `bin/rails test` — new `test/components/form/errors_test.rb`, all 4 touched form test files (one updated for the removed `visual_model_errors` tag), all 4 touched controller test files, `test/classes/localization_files_test.rb` (confirms the 2 removed + 1 added translation tags are consistent), `test/models/user_test.rb`, `test/models/name_test.rb`, `test/models/image_test.rb`, `test/models/occurrence_test.rb` — 0 failures
- [x] `bundle exec rubocop` clean on every touched file
- [x] `bin/rails lang:update` run after editing `en.txt` (never hand-edited `en.yml`)

