### PR TITLE
Pre-check `specimen` on the observation form when arriving from a field slip

### DIFF
--- a/app/controllers/observations_controller/new.rb
+++ b/app/controllers/observations_controller/new.rb
@@ -53,6 +53,9 @@ module ObservationsController::New
     @good_images = []
     @field_code        = params[:field_code]
     @field_code_locked = @field_code.present?
+    # A field slip almost always means a physical specimen, and users
+    # coming from the slip form often miss the checkbox (#4916).
+    @observation.specimen = true if @field_code_locked
     init_specimen_vars
     init_project_vars_for_new
     init_list_vars

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -1491,12 +1491,14 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     login("rolf")
 
     get(:new, params: { field_code: "TEST-001" })
+    assert_response(:success)
     assert_select("input[type='checkbox'][name='observation[specimen]']" \
                   "[checked]", count: 1,
                                message: "field-slip path should pre-check " \
-                                         "the specimen checkbox")
+                                        "the specimen checkbox")
 
     get(:new)
+    assert_response(:success)
     assert_select("input[type='checkbox'][name='observation[specimen]']" \
                   "[checked]", count: 0,
                                message: "plain create form should leave " \

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -1484,6 +1484,25 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert_select("#name_messages", count: 0)
   end
 
+  # A field slip almost always means a physical specimen, so arriving
+  # from the slip form pre-checks the specimen checkbox (#4916); the
+  # plain create form leaves it unchecked.
+  def test_new_from_field_slip_checks_specimen_by_default
+    login("rolf")
+
+    get(:new, params: { field_code: "TEST-001" })
+    assert_select("input[type='checkbox'][name='observation[specimen]']" \
+                  "[checked]", count: 1,
+                               message: "field-slip path should pre-check " \
+                                         "the specimen checkbox")
+
+    get(:new)
+    assert_select("input[type='checkbox'][name='observation[specimen]']" \
+                  "[checked]", count: 0,
+                               message: "plain create form should leave " \
+                                        "the specimen checkbox unchecked")
+  end
+
   # Stub-based regression coverage for the
   # `validate_observation` / `validate_naming` / `validate_vote`
   # failure branches (`@any_errors = true; false`). Observation,


### PR DESCRIPTION
Fixes #4916

## What this does

Arriving at the new-observation form from a field slip now pre-checks the specimen checkbox. `ObservationsController::New#new` sets `@observation.specimen = true` whenever the request carries a `field_code` — which covers both field-slip entry points ("Add Images or Other Data" on the new slip form, and "Create Observation" on the edit slip form), since both redirect with `field_code`. The checkbox drives a `CheckboxCollapse`, so the specimen fields section (collector's name/number, herbarium, accession) also starts expanded.

The reasoning from the issue: a field slip almost always means a physical specimen, and users switching over from the slip form often miss the checkbox.

Two scoping notes:

- The default applies only to the fresh GET of the form. A validation-failure re-render rebuilds state from the submitted params, so a user who deliberately unchecks the box doesn't get it re-checked.
- Quick Create (which builds the observation directly, no form) is unchanged — the issue is about the form default, and silently changing saved data on that path wasn't asked for.

## Tests

`test_new_from_field_slip_checks_specimen_by_default` asserts the checkbox renders checked with `field_code` and unchecked on the plain create form. It fails without the one-line controller change.

## Test plan

1. On a field slip form, click "Add Images or Other Data" — the Create Observation page should arrive with "Specimen Available" checked and the specimen fields expanded.
2. Open the plain Create Observation page directly — the checkbox should still start unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
