### PR TITLE
Render field help outside `.form-group`, fixing autocompleter dropdown positioning (alt. to #4911)

### DIFF
--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -310,14 +310,3 @@ form {
     }
   }
 }
-
-// .help-block now renders as a sibling after .form-group (#4911)
-// instead of as its last child. .form-group's own margin-bottom
-// ($form-group-margin-bottom, 15px) used to apply *after* the help
-// text (between the whole field box and whatever follows); now it
-// collapses against .help-block's margin-top (5px) and lands between
-// the field and its own help text instead, widening that specific gap
-// by 10px. Pull it back down to match the pre-#4911 spacing.
-.form-group + .help-block {
-  margin-top: -10px;
-}

--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -295,6 +295,10 @@ form {
 .panel-body {
   .row:last-child .form-group,
   > .autocompleter:last-child .form-group.dropdown:last-child,
+  // Help now renders as a sibling after .form-group (#4911), so an
+  // autocompleter with help text has .help-block, not .form-group, as
+  // its actual last child.
+  > .autocompleter:last-child .help-block:last-child,
   > .form-group:last-child
   {
     margin-bottom: 0.25rem;
@@ -305,4 +309,15 @@ form {
       padding-top: 0 !important;
     }
   }
+}
+
+// .help-block now renders as a sibling after .form-group (#4911)
+// instead of as its last child. .form-group's own margin-bottom
+// ($form-group-margin-bottom, 15px) used to apply *after* the help
+// text (between the whole field box and whatever follows); now it
+// collapses against .help-block's margin-top (5px) and lands between
+// the field and its own help text instead, widening that specific gap
+// by 10px. Pull it back down to match the pre-#4911 spacing.
+.form-group + .help-block {
+  margin-top: -10px;
 }

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -249,10 +249,6 @@
   margin-right: 0.5rem !important;
 }
 
-.m-10px {
-  margin: 10px !important;
-}
-
 .m-3 {
   margin: 1rem !important;
 }
@@ -363,11 +359,6 @@
   margin-left: 0 !important;
 }
 
-.mx-10px {
-  margin-right: 10px !important;
-  margin-left: 10px !important;
-}
-
 .mx-3 {
   margin-right: 1rem !important;
   margin-left: 1rem !important;
@@ -379,10 +370,6 @@
 
 .mr-2 {
   margin-right: 0.5rem !important;
-}
-
-.mr-10px {
-  margin-right: 10px !important;
 }
 
 .mr-3 {
@@ -399,10 +386,6 @@
 
 .ml-0 {
   margin-left: 0 !important;
-}
-
-.ml-10px {
-  margin-left: 10px !important;
 }
 
 .ml-1 {
@@ -449,23 +432,9 @@
   padding: 3rem !important;
 }
 
-.p-5px {
-  padding: 5px !important;
-}
-
 .py-0 {
   padding-top: 0 !important;
   padding-bottom: 0 !important;
-}
-
-.py-5px {
-  padding-top: 5px !important;
-  padding-bottom: 5px !important;
-}
-
-.py-10px {
-  padding-top: 10px !important;
-  padding-bottom: 10px !important;
 }
 
 .py-2 {
@@ -480,10 +449,6 @@
 
 .pt-0 {
   padding-top: 0 !important;
-}
-
-.pt-10px {
-  padding-top: 10px !important;
 }
 
 .pt-2 {
@@ -560,10 +525,6 @@
 
 .pr-0 {
   padding-right: 0 !important;
-}
-
-.pr-10px {
-  padding-right: 10px !important;
 }
 
 .pr-3 {

--- a/app/components/application_form/field_wrapper_rendering.rb
+++ b/app/components/application_form/field_wrapper_rendering.rb
@@ -32,6 +32,11 @@ class Components::ApplicationForm < Superform::Rails::Form
       classes = base
       classes += " form-inline" if inline && base == "form-group"
       classes += " #{wrap_class}" if wrap_class.present?
+      # Help renders as a sibling right after this div, not inside it
+      # (see below) -- .help-block's own top margin already spaces it
+      # from the field, so drop this div's own bottom margin to avoid
+      # doubling up.
+      classes += " mb-0" if help_present?
       classes
     end
 
@@ -41,6 +46,10 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     def append_present?
       respond_to?(:append_slot) && append_slot
+    end
+
+    def help_present?
+      respond_to?(:help_slot) && help_slot
     end
 
     def render_with_wrapper

--- a/app/components/application_form/field_wrapper_rendering.rb
+++ b/app/components/application_form/field_wrapper_rendering.rb
@@ -48,8 +48,14 @@ class Components::ApplicationForm < Superform::Rails::Form
       respond_to?(:append_slot) && append_slot
     end
 
+    # Only plain help renders an always-visible .help-block sibling
+    # right after this div (what mb-0, above, is compensating for).
+    # help_collapse: true renders a Collapsible that's hidden by
+    # default -- dropping this div's own bottom margin there would
+    # shrink the gap to whatever field comes next, with no visible
+    # help-block to justify it.
     def help_present?
-      respond_to?(:help_slot) && help_slot
+      respond_to?(:help_slot) && help_slot && !wrapper_options[:help_collapse]
     end
 
     def render_with_wrapper

--- a/app/components/application_form/field_wrapper_rendering.rb
+++ b/app/components/application_form/field_wrapper_rendering.rb
@@ -48,9 +48,9 @@ class Components::ApplicationForm < Superform::Rails::Form
         render_label_row(label_text, inline?) if show_label?
         render(prepend_slot) if prepend_present?
         yield
-        render_help_after_field
         render(append_slot) if append_present?
       end
+      render_help_after_field
     end
   end
 end

--- a/app/components/application_form/select_range_field.rb
+++ b/app/components/application_form/select_range_field.rb
@@ -17,6 +17,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   #   end
   class SelectRangeField < Components::Base
     include Phlex::Slotable
+    include FieldWithHelp
 
     prop :form, ::Components::ApplicationForm
     prop :field_name, Symbol
@@ -45,18 +46,37 @@ class Components::ApplicationForm < Superform::Rails::Form
           @form.select_field(@field_name, @options,
                              label: @label,
                              inline: true,
-                             selected: @value) do |f|
-            f.with_help { render(help_slot) } if help_slot
-          end
+                             selected: @value,
+                             wrap_class: "mb-0")
         end
         div(class: "d-inline-block") do
           @form.select_field(:"#{@field_name}_range", @options,
                              label: :to,
                              label_colon: false,
                              inline: true,
-                             selected: @range_value)
+                             selected: @range_value,
+                             wrap_class: "mb-0")
         end
       end
+      render_help_after_field
+    end
+
+    private
+
+    # FieldWithHelp#help_id wants the single field it's attached to --
+    # use the first (non-range) select, matching where help rendered
+    # before this class threaded its own help_slot into that field
+    # directly.
+    def field
+      @form.field(@field_name)
+    end
+
+    # FieldWithHelp#render_help_after_field checks
+    # wrapper_options[:help_collapse] -- this class doesn't support
+    # collapsible help (no caller has ever needed it), so a plain
+    # empty hash always takes the plain-help branch.
+    def wrapper_options
+      {}
     end
   end
 end

--- a/app/components/button/collapse_content.rb
+++ b/app/components/button/collapse_content.rb
@@ -17,9 +17,19 @@ module Components::Button::CollapseContent
                title: @icon_title || @open_text || @closed_text
              ))
     end
-    span(class: "collapse-toggle-open") { plain(@open_text) } if @open_text
+    if @open_text
+      span(class: text_span_class("collapse-toggle-open")) { plain(@open_text) }
+    end
     return unless @closed_text
 
-    span(class: "collapse-toggle-closed") { plain(@closed_text) }
+    span(class: text_span_class("collapse-toggle-closed")) do
+      plain(@closed_text)
+    end
+  end
+
+  # `icon-text-gap` (see Components::IconWithText, _icons.scss) --
+  # only needed when an icon glyph precedes the text.
+  def text_span_class(base)
+    class_names(base, "icon-text-gap" => @icon)
   end
 end

--- a/app/views/controllers/images/show.rb
+++ b/app/views/controllers/images/show.rb
@@ -81,7 +81,7 @@ module Views::Controllers::Images
         div do
           ImageFragment(type: :copyright, user: current_user, image: @image)
         end
-        div(class: "py-5px mb-3") do
+        div(class: "py-2 mb-3") do
           LicenseBadge(license: @image.license)
         end
       end

--- a/app/views/controllers/names/eol_data/expanded_review/show.rb
+++ b/app/views/controllers/names/eol_data/expanded_review/show.rb
@@ -45,7 +45,7 @@ class Views::Controllers::Names::EolData::ExpandedReview::Show <
   end
 
   def render_name_row(name, odd_or_even)
-    div(class: "ListLine#{odd_or_even} py-10px") do
+    div(class: "ListLine#{odd_or_even} py-3") do
       plain(name.display_name(current_user))
       br
       render_image_count_line(name.id) if @data.has_images?(name.id)

--- a/app/views/controllers/names/eol_data/preview/show.rb
+++ b/app/views/controllers/names/eol_data/preview/show.rb
@@ -19,7 +19,7 @@ class Views::Controllers::Names::EolData::Preview::Show < Views::FullPageBase
     odd_or_even = 0
     @names.select(&:ok_for_export).each do |name|
       odd_or_even = 1 - odd_or_even
-      div(class: "ListLine#{odd_or_even} py-10px") do
+      div(class: "ListLine#{odd_or_even} py-3") do
         # Preserve textile-rendered italics/bold for scientific
         # names — `display_name.t` emits HTML, so trusted_html is
         # required (plain text would double-escape the tags).

--- a/app/views/layouts/sidebar.rb
+++ b/app/views/layouts/sidebar.rb
@@ -72,7 +72,7 @@ class Views::Layouts::Sidebar < Views::Base
   def render_logo
     a(id: "logo_link", href: logo_href) do
       img(
-        class: "logo-trim img-responsive py-10px",
+        class: "logo-trim img-responsive py-3",
         alt: "Mushroom Observer Logo",
         src: "/logo-trim.png"
       )

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -782,6 +782,63 @@ class ApplicationFormTest < ComponentTestCase
     assert_no_html(form, "span.form-between")
   end
 
+  # Help renders as a sibling after .form-group, not inside it (#4911)
+  # -- .form-group gets mb-0 so its own bottom margin doesn't double up
+  # with .help-block's own top margin.
+  def test_form_group_has_mb_0_when_field_has_help
+    form = render_form do
+      text_field(:name, label: "Name:", help: "Help text")
+    end
+
+    assert_html(form, "div.form-group.mb-0")
+    assert_html(form, "div.form-group + div.help-block")
+  end
+
+  def test_form_group_has_no_mb_0_without_help
+    form = render_form do
+      text_field(:name, label: "Name:")
+    end
+
+    assert_html(form, "div.form-group")
+    assert_no_html(form, "div.form-group.mb-0")
+  end
+
+  # Regression: SelectRangeField's two select fields sit in separate
+  # d-inline-block columns meant to stay on one line (e.g. the
+  # observation search form's Confidence range). Help used to render
+  # nested inside the first field's own .form-group; after #4911 it
+  # renders as a sibling instead, and if left inside the first
+  # d-inline-block column, that block-level .help-block forces a
+  # line-break within that column and pushes the second column
+  # ("to" + second select) onto its own line. Help must render outside
+  # both columns, and both .form-groups need mb-0 explicitly (neither
+  # carries its own help_slot anymore for the automatic mb-0 in
+  # FieldWrapperRendering to key off).
+  def test_select_range_field_help_renders_outside_both_columns
+    form = render_form do
+      render(Components::ApplicationForm::SelectRangeField.new(
+               form: self, field_name: :confidence,
+               options: [["", nil], ["Sure", 3]],
+               value: nil, range_value: nil,
+               label: "Confidence"
+             )) do |f|
+        f.with_help { plain("Confidence is in this range.") }
+      end
+    end
+
+    assert_no_html(form, ".d-inline-block .help-block")
+    assert_html(form, ".d-inline-block .form-group.mb-0", count: 2)
+
+    # .help-block is a sibling of the div wrapping both columns, not
+    # nested inside either one.
+    columns_row = Nokogiri::HTML5.fragment(form).at_css(".d-inline-block").
+                  parent
+    assert_equal("help-block",
+                 columns_row.next_element["class"],
+                 "help-block should immediately follow the row " \
+                 "containing both d-inline-block columns")
+  end
+
   def test_submit_with_custom_data_attributes
     form = render_form do
       submit("Save", data: { confirm: "Are you sure?" })

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -803,6 +803,19 @@ class ApplicationFormTest < ComponentTestCase
     assert_no_html(form, "div.form-group.mb-0")
   end
 
+  # Regression (Copilot review on #4922): help_collapse: true renders
+  # a Collapsible that's hidden by default, not an always-visible
+  # .help-block sibling -- mb-0 must not fire for it, or the gap to
+  # whatever field comes next shrinks with nothing visible to justify it.
+  def test_form_group_has_no_mb_0_with_collapsed_help
+    form = render_form do
+      text_field(:name, label: "Name:", help: "Help text",
+                        help_collapse: true)
+    end
+
+    assert_no_html(form, "div.form-group.mb-0")
+  end
+
   # Regression: SelectRangeField's two select fields sit in separate
   # d-inline-block columns meant to stay on one line (e.g. the
   # observation search form's Confidence range). Help used to render

--- a/test/components/button_test.rb
+++ b/test/components/button_test.rb
@@ -292,6 +292,36 @@ class Components::ButtonDispatcherTest < ComponentTestCase
                 "button span.collapse-toggle-closed", text: "Open map")
   end
 
+  # Regression: the map-toggle button's icon rendered flush against its
+  # text with no gap (icon-text-gap was only wired up in
+  # Components::IconWithText's own render_icon_text, never in
+  # CollapseContent's spans).
+  def test_type_collapse_toggle_with_icon_has_text_gap
+    html = render(Components::Button.new(
+                    type: :collapse_toggle,
+                    target_id: "map_div",
+                    open_text: "Hide map",
+                    closed_text: "Show map",
+                    icon: :globe,
+                    collapsed: true
+                  ))
+
+    assert_html(html, "button span.collapse-toggle-open.icon-text-gap")
+    assert_html(html, "button span.collapse-toggle-closed.icon-text-gap")
+  end
+
+  def test_type_collapse_toggle_without_icon_has_no_text_gap
+    html = render(Components::Button.new(
+                    type: :collapse_toggle,
+                    target_id: "map_div",
+                    open_text: "Hide map",
+                    closed_text: "Show map",
+                    collapsed: true
+                  ))
+
+    assert_no_html(html, ".icon-text-gap")
+  end
+
   # ---- type: :project --------------------------------------------------
 
   def test_type_project_dispatches_to_project_with_lg_size


### PR DESCRIPTION
Fixes #4909
Closes #4911

## Summary

- Autocompleter dropdown menus (e.g. Locality) no longer render below the help text - the dropdown now opens directly under the input.
- Field help text spacing is now consistent whether help is always visible or behind a collapse toggle.
- Range fields (e.g. Confidence on the observation search form) no longer wrap their second input onto its own line. 
<img width="1180" height="870" alt="Screenshot 2026-07-27 at 11 36 20 AM" src="https://github.com/user-attachments/assets/62d8323a-92fd-4aae-9f37-bf25525855a4" />

- The map "Show map" toggle button's icon no longer renders flush against its label text.
<img width="532" height="122" alt="Screenshot 2026-07-27 at 11 53 15 AM" src="https://github.com/user-attachments/assets/bf78f89e-3ccc-4446-b1bb-66b7753c7e9f" />

Also purges a handful of non-Bootstrap "bridge" utility classes (`.py-5px`, `.py-10px`, etc.) in favor of the existing Bootstrap-compatible rem scale (`.py-2`, `.py-3`), ahead of Bootstrap 4 prep.

## Test plan

- [x] `bin/rails test test/components/application_form_test.rb test/components/form/` — 0 failures
- [x] `bin/rails test test/views/controllers/locations/form_test.rb test/views/controllers/inat_imports/form_test.rb test/views/controllers/articles/form_test.rb` — 0 failures
- [x] `bin/rails test test/components/button_test.rb` — 0 failures
- [x] `bundle exec rubocop` clean on every touched file
- [x] Browser verification (autocompleter dropdown position, confidence range layout, help-block spacing)
