### PR TITLE
MyCoPortal export job with improved selection and name fixes

### DIFF
--- a/app/classes/mycoportal/export_candidates.rb
+++ b/app/classes/mycoportal/export_candidates.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Mycoportal
+  # Decides which Observations belong in a MyCoPortal (MCP) export batch,
+  # independent of any admin-picked Query. Report::Mycoportal and
+  # Report::MycoportalImageList handle CSV formatting; this class only
+  # computes the candidate observation ids.
+  #
+  # Every filter here is a set-based ActiveRecord/Arel condition (join +
+  # where), not a per-observation Ruby loop, so the whole computation runs
+  # as a handful of indexed SQL queries regardless of table size. The one
+  # exception -- kingdom filtering -- necessarily runs Name#kingdom parsing
+  # in Ruby, but only once per *distinct* consensus Name among candidates,
+  # not once per Observation.
+  class ExportCandidates
+    # Observations already exported to MCP whose consensus/content has
+    # changed since the last export -- these need to be re-sent.
+    def updated_observation_ids
+      exported_observations.
+        where(Observation[:updated_at].gt(ExternalLink[:last_synced_at])).
+        distinct.pluck(:id)
+    end
+
+    # Observations never exported to MCP that are good enough to send.
+    def new_observation_ids
+      not_yet_exported.
+        where(Observation.confidence_lower_bound(
+                MO.mycoportal_min_observation_vote
+              )).
+        where.not(name_id: excluded_name_ids).
+        where.not(name_id: non_fungal_name_ids).
+        where.not(id: empty_observation_ids).
+        distinct.pluck(:id)
+    end
+
+    private
+
+    def exported_observations
+      Observation.joins(:external_links).
+        where(external_links: {
+                external_site_id: ExternalSite.mycoportal.id,
+                relationship: ExternalLink.relationships[:export]
+              })
+    end
+
+    def not_yet_exported
+      Observation.where.not(id: exported_observations.select(:id))
+    end
+
+    # Consensus name text_name matches one of the placeholder/junk names
+    # (Duplicate, Undetermined, Mixed collection, etc.) that never belong
+    # in MCP.
+    def excluded_name_ids
+      Name.where(text_name: MO.mycoportal_excluded_names).select(:id)
+    end
+
+    # Consensus name's kingdom isn't Fungi/Protozoa. Bounded by the number
+    # of *distinct* consensus names among not-yet-exported observations,
+    # not by the observation count.
+    def non_fungal_name_ids
+      candidate_name_ids = not_yet_exported.distinct.pluck(:name_id).compact
+      Name.where(id: candidate_name_ids).
+        select(&:non_fungal_kingdom?).map(&:id)
+    end
+
+    # No proposed name (or only proposal is Fungi), unknown location, no
+    # notes, no sequences, no images -- nothing worth sending.
+    def empty_observation_ids
+      Observation.has_name(false).
+        where(location_id: unknown_location_ids).
+        has_notes(false).
+        has_sequences(false).
+        has_images(false).
+        pluck(:id)
+    end
+
+    def unknown_location_ids
+      [nil, Location.unknown&.id].compact
+    end
+  end
+end

--- a/app/classes/report/mycoportal.rb
+++ b/app/classes/report/mycoportal.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "haversine"
-
 # Report (a TSV spreadsheet) for exporting Observations to MyCoPortal
 # https://mycoportal.org/
 # https://www.mycoportal.org/portal/api/v2/documentation
@@ -12,7 +10,6 @@ require "haversine"
 # https://github.com/Symbiota/Symbiota
 module Report
   class Mycoportal < CSV
-    CODE_NAME_QUALIFIER = "code name aff. species"
     GPS_HIDDEN_MESSAGE = "Coordinates obscured by observer"
 
     # MCP uses Symbiota, which is largely based on Darwin Core (DwC).
@@ -83,30 +80,20 @@ module Report
 
     # taxon name, without authority or qualification (such as "group")
     def sciname(row)
-      text_name = row.name_text_name
-      return text_name.split.first if code_name?(row)
-      # The last word in text_name could be Group or Complex
-      return text_name_without_last_word(text_name) if group?(row)
-
-      text_name
+      NameResolver.new(row).sciname
     end
 
     # Qualifies unpublished MO text_name.
-    # Examples: nom. prov., comb. prov., group, sensu lato, sensu auct.
+    # Examples: nom. prov., comb. prov., group, sensu lato, sensu auct.,
+    # aff. section, aff. <code name epithet>
     def identification_qualifier(row)
-      return nil unless unregistrable_name?(row)
-      return CODE_NAME_QUALIFIER if code_name?(row)
-      return group_token(row) if group?(row)
-      return prov_token(row) if provisional?(row)
-
-      row.name_author&.match(/sensu.*/)&.[](0)
+      NameResolver.new(row).identification_qualifier
     end
 
-    # Full name+author for code names, provisional names, and groups
+    # Full name+author for code names, provisional names, groups, and
+    # infrageneric ranks (section, subgenus, etc.)
     def taxon_remarks(row)
-      return unless code_name?(row) || provisional?(row) || group?(row)
-
-      "#{row.name_text_name} #{row.name_author}".strip
+      NameResolver.new(row).taxon_remarks
     end
 
     # collector's number
@@ -147,10 +134,13 @@ module Report
       if gps_hidden?(row)
         return unless public_lat(row) && public_lng(row)
 
-        box = loc_box(row)
-        max_distance_to_any_corner(public_lat(row), public_lng(row), box)
+        CoordinateUncertainty.max_distance_to_any_corner(
+          public_lat(row), public_lng(row), loc_box(row)
+        )
       elsif row.obs_lat.blank?
-        distance_from_center_to_farthest_corner(row)
+        CoordinateUncertainty.distance_from_center_to_farthest_corner(
+          loc_box(row)
+        )
       end
     end
 
@@ -176,6 +166,7 @@ module Report
       add_herbarium_accession_numbers!(rows, :herbarium_accession_numbers)
       add_sequence_ids!(rows, :sequence_ids)
       add_gps_hidden!(rows)
+      add_correct_spelling!(rows)
     end
 
     def collector_ids(row)
@@ -195,87 +186,97 @@ module Report
     end
 
     def sort_before(rows)
+      @included_observation_ids = rows.map(&:obs_id)
       rows.sort_by(&:obs_id)
+    end
+
+    # Records every Observation included in the most recent #body call as
+    # exported to MyCoPortal (creating or refreshing its ExternalLink), so
+    # a future run's "updated since last export" check has something to
+    # compare against. A separate step from #body -- not automatic -- so
+    # merely computing a CSV never has the side effect of marking
+    # observations as sent; only an explicit post-generation call does.
+    def mark_exported!
+      unless @included_observation_ids
+        raise("mark_exported! called before body")
+      end
+
+      export_observations!
     end
 
     ##########
 
     private
 
-    def group?(row)
-      row.name_text_name.match?(/(group|complex|clade)$/)
+    # Misspelled MO Names must never reach MCP under the wrong spelling --
+    # substitute the correctly-spelled Name's text_name/author/rank for
+    # every downstream calculation. Batched over the distinct Names in
+    # this batch of rows, not per-row.
+    def add_correct_spelling!(rows)
+      corrections = correct_spellings_by_name_id(rows)
+      rows.each do |row|
+        correction = corrections[row.name_id]
+        next unless correction
+
+        row.add_val(correction[:text_name], :corrected_text_name)
+        row.add_val(correction[:author], :corrected_author)
+        row.add_val(correction[:rank], :corrected_rank)
+      end
     end
 
-    def group_token(row)
-      row.name_text_name.match(/(group|complex|clade)$/)[0]
+    def correct_spellings_by_name_id(rows)
+      name_ids = rows.map(&:name_id).uniq
+      Name.where(id: name_ids).where.not(correct_spelling_id: nil).
+        includes(:correct_spelling).index_by(&:id).
+        transform_values { |name| correct_spelling_vals(name) }
     end
 
-    def text_name_without_last_word(text_name)
-      text_name.split[0...-1].join(" ")
+    def correct_spelling_vals(name)
+      correct = name.correct_spelling
+      { text_name: correct.text_name, author: correct.author,
+        rank: correct.rank }
     end
 
-    def unregistrable_name?(row)
-      group?(row) ||
-        sensu_non_stricto?(row) ||
-        provisional?(row) ||
-        code_name?(row)
+    # Bookkeeping only -- must never let a failure here (e.g. a missing
+    # ExternalSite row, a DB error) turn an already-computed, valid CSV
+    # into a 500. See Report::MycoportalImageList#export_images! for the
+    # same reasoning.
+    def export_observations!
+      site = ExternalSite.mycoportal
+      now = Time.current
+      @included_observation_ids.each do |obs_id|
+        upsert_export_link(site, obs_id, now)
+      end
+    rescue StandardError => e
+      Rails.logger.error(
+        "MyCoPortal export-tracking failed: #{e.class}: #{e.message}"
+      )
     end
 
-    def sensu_non_stricto?(row)
-      row.name_author.present? &&
-        row.name_author.match(/sensu(?!.*stricto)/)
-    end
-
-    def provisional?(row)
-      row.name_author&.match?(/\w+\. prov\./)
-    end
-
-    def prov_token(row)
-      row.name_author&.match(/\w+\. prov\./)&.[](0)
-    end
-
-    def code_name?(row)
-      row.name_text_name.match?(/'/)
-    end
-
-    def distance_from_center_to_farthest_corner(row)
-      center = loc_box(row).center
-      distance_to_farthest_corner(center.first, center.last, loc_box(row))
+    # Creates the Observation's export link on first export, or refreshes
+    # last_synced_at on a re-export -- unlike images (never re-sent),
+    # observations can be updated and re-exported.
+    def upsert_export_link(site, obs_id, synced_at)
+      link = ExternalLink.find_by(target_type: "Observation",
+                                  target_id: obs_id, external_site: site,
+                                  relationship: :export)
+      if link
+        link.update!(last_synced_at: synced_at)
+      else
+        ExternalLink.create!(user: User.admin, target_type: "Observation",
+                             target_id: obs_id, external_site: site,
+                             relationship: :export, last_synced_at: synced_at)
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.warn(
+        "MyCoPortal export link failed for Observation #{obs_id}: " \
+        "#{e.message}"
+      )
     end
 
     def loc_box(row)
       Mappable::Box.new(north: row.loc_north, south: row.loc_south,
                         east: row.loc_east, west: row.loc_west)
-    end
-
-    def distance_to_farthest_corner(lat, lng, box)
-      # east and west corners are equidistant from center because
-      # boxes are isoceles trapezoids with bases parallel to the equator
-      # farthest corner belongs to longest base
-      if lat.positive?
-        distance_to_se_corner(lat, lng, box)
-      else
-        distance_to_ne_corner(lat, lng, box)
-      end
-    end
-
-    def distance_to_ne_corner(lat, lng, box)
-      Haversine.distance(lat, lng, box.north, box.east).to_meters.round
-    end
-
-    def distance_to_se_corner(lat, lng, box)
-      Haversine.distance(lat, lng, box.south, box.east).to_meters.round
-    end
-
-    def max_distance_to_any_corner(lat, lng, box)
-      box_corners(box).map do |clat, clng|
-        Haversine.distance(lat, lng, clat, clng).to_meters
-      end.max.round
-    end
-
-    def box_corners(box)
-      [[box.north, box.east], [box.north, box.west],
-       [box.south, box.east], [box.south, box.west]]
     end
 
     def add_gps_hidden!(rows)

--- a/app/classes/report/mycoportal/coordinate_uncertainty.rb
+++ b/app/classes/report/mycoportal/coordinate_uncertainty.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "haversine"
+
+module Report
+  class Mycoportal
+    # Pure geometry for coordinateUncertaintyInMeters: farthest-corner
+    # distance calculations given a location's bounding box and a
+    # reference point (either the obscured/public lat-lng, or the box's
+    # own center when no point is available).
+    class CoordinateUncertainty
+      def self.max_distance_to_any_corner(lat, lng, box)
+        box_corners(box).map do |clat, clng|
+          Haversine.distance(lat, lng, clat, clng).to_meters
+        end.max.round
+      end
+
+      def self.distance_from_center_to_farthest_corner(box)
+        center = box.center
+        distance_to_farthest_corner(center.first, center.last, box)
+      end
+
+      def self.distance_to_farthest_corner(lat, lng, box)
+        # east and west corners are equidistant from center because
+        # boxes are isoceles trapezoids with bases parallel to the equator
+        # farthest corner belongs to longest base
+        if lat.positive?
+          distance_to_se_corner(lat, lng, box)
+        else
+          distance_to_ne_corner(lat, lng, box)
+        end
+      end
+
+      def self.distance_to_ne_corner(lat, lng, box)
+        Haversine.distance(lat, lng, box.north, box.east).to_meters.round
+      end
+
+      def self.distance_to_se_corner(lat, lng, box)
+        Haversine.distance(lat, lng, box.south, box.east).to_meters.round
+      end
+
+      def self.box_corners(box)
+        [[box.north, box.east], [box.north, box.west],
+         [box.south, box.east], [box.south, box.west]]
+      end
+    end
+  end
+end

--- a/app/classes/report/mycoportal/name_resolver.rb
+++ b/app/classes/report/mycoportal/name_resolver.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+module Report
+  class Mycoportal
+    # Resolves a Report::Row's Name into MCP's DwC-ish sciname /
+    # identificationQualifier / taxonRemarks trio. MCP (like GBIF) is
+    # species-focused, so anything MO can name more precisely than that --
+    # misspellings, code names, provisional/inedit names, groups/complexes,
+    # sensu non stricto, and infrageneric ranks (section, subgenus, etc.) --
+    # needs translating down to a bare genus plus a qualifier/remark MCP
+    # can actually store.
+    #
+    # Reads the row's `:corrected_text_name` / `:corrected_author` /
+    # `:corrected_rank` extension values, which Report::Mycoportal's
+    # #add_correct_spelling! populates via a batched Name lookup before
+    # any row reaches here -- this class never queries the database itself.
+    class NameResolver
+      CODE_NAME_QUALIFIER = "code name aff. species"
+      # Matches the epithet segment of a code name like 'flavorubellus-IN04'
+      # or 'acicula-PNW01' (epithet, dash, state/region abbreviation, digits).
+      CODE_EPITHET_PATTERN = /\A([a-z][a-z-]*)-[A-Za-z]{2,}\d+\z/
+
+      def initialize(row)
+        @row = row
+      end
+
+      # taxon name, without authority or qualification (such as "group")
+      def sciname
+        # Code names and infrageneric ranks (section, subgenus, etc.) can
+        # only be usefully exported to MCP as a bare genus.
+        return genus_only if code_name? || infrageneric_rank?
+        # The last word in text_name could be Group or Complex
+        return text_name_without_last_word if group?
+
+        normalized_text_name
+      end
+
+      # Qualifies unpublished MO text_name.
+      # Examples: nom. prov., comb. prov., group, sensu lato, sensu auct.,
+      # aff. section, aff. <code name epithet>
+      def identification_qualifier
+        return nil unless unregistrable_name?
+        return code_name_qualifier if code_name?
+        return group_token if group?
+        return infrageneric_qualifier if infrageneric_rank?
+        return prov_token if provisional?
+
+        sensu_token
+      end
+
+      # Full name+author for code names, provisional names, groups, and
+      # infrageneric ranks (section, subgenus, etc.)
+      def taxon_remarks
+        return unless code_name? || provisional? || group? ||
+                      infrageneric_rank?
+
+        "#{text_name} #{author}".strip
+      end
+
+      def self.infrageneric_ranks
+        @infrageneric_ranks ||=
+          (Name.ranks_above_species & Name.ranks_below_genus) - ["Group"]
+      end
+
+      private
+
+      attr_reader :row
+
+      def text_name
+        row.val(:corrected_text_name) || row.name_text_name
+      end
+
+      def author
+        row.val(:corrected_author) || row.name_author
+      end
+
+      def rank
+        row.val(:corrected_rank) || row.name_rank
+      end
+
+      # Strips a leading "Gen. " token off "Gen. 'Foo' sp. 'bar-ST01'"-style
+      # code names so they're treated as a bare code name.
+      def normalized_text_name
+        text_name.sub(/\AGen\.\s+/, "")
+      end
+
+      def genus_only
+        normalized_text_name.split.first.delete("'")
+      end
+
+      def text_name_without_last_word
+        normalized_text_name.split[0...-1].join(" ")
+      end
+
+      def unregistrable_name?
+        group? || infrageneric_rank? || sensu_non_stricto? ||
+          provisional? || code_name?
+      end
+
+      def group?
+        normalized_text_name.match?(/(group|complex|clade)$/)
+      end
+
+      def group_token
+        normalized_text_name.match(/(group|complex|clade)$/)[0]
+      end
+
+      def sensu_non_stricto?
+        author.present? && author.match(/sensu(?!.*stricto)/)
+      end
+
+      def sensu_token
+        author&.match(/sensu.*/)&.[](0)
+      end
+
+      def provisional?
+        author&.match?(/\w+\. (?:prov|ined(?:it)?)\.?/)
+      end
+
+      def prov_token
+        author&.match(/\w+\. (?:prov|ined(?:it)?)\.?/)&.[](0)
+      end
+
+      def code_name?
+        normalized_text_name.match?(/'/)
+      end
+
+      # Ranks strictly between Species and Genus that MCP can only take as
+      # a bare genus (Section, Subsection, Series, Stirps, Subgenus).
+      # "Group" is excluded -- it's handled by #group?/#group_token
+      # instead, since its text_name already carries a
+      # "group"/"complex"/"clade" suffix to strip.
+      def infrageneric_rank?
+        self.class.infrageneric_ranks.include?(rank)
+      end
+
+      def infrageneric_qualifier
+        "aff. #{rank.downcase}"
+      end
+
+      # Genus sp. 'epithet-STATEnn' code names get a qualifier naming the
+      # epithet (e.g. "aff. flavorubellus") instead of the generic
+      # CODE_NAME_QUALIFIER, when the quoted segment parses cleanly.
+      def code_name_qualifier
+        precise_code_name_qualifier || CODE_NAME_QUALIFIER
+      end
+
+      def precise_code_name_qualifier
+        epithet = code_epithet
+        return nil if epithet.blank?
+
+        "aff. #{epithet}"
+      end
+
+      # Scans every quoted segment (not just the first -- "Gen. 'Foo' sp.
+      # 'bar-ST01'" quotes the genus too) for the one that parses as an
+      # "epithet-STATEnn" code.
+      def code_epithet
+        normalized_text_name.scan(/'([^']+)'/).flatten.
+          filter_map { |quoted| quoted.match(CODE_EPITHET_PATTERN)&.[](1) }.
+          first
+      end
+    end
+  end
+end

--- a/app/jobs/mycoportal_export_job.rb
+++ b/app/jobs/mycoportal_export_job.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Generate the MyCoPortal (MCP) data + image CSVs for observations
+# to export/update. Writes
+# both CSVs to disk and alerts #alerts with their paths, since (unlike
+# the admin download form) there's no HTTP request to stream them into.
+#
+# USAGE:
+# From a Rails console:
+#   MycoportalExportJob.perform_now or
+#   MycoportalExportJob.perform_later
+# (Not yet wired to a schedule.)
+class MycoportalExportJob < ApplicationJob
+  queue_as(:maintenance)
+
+  EXPORT_DIR = Rails.root.join("tmp/mycoportal")
+
+  def perform
+    ids = observation_ids
+    return log("MyCoPortal export: no observations to export") if ids.empty?
+
+    query = Query.lookup(:Observation, id_in_set: ids)
+    data_path = write_report(Report::Mycoportal.new(query: query,
+                                                    user: User.admin),
+                             "mycoportal_data")
+    images_path = write_report(Report::MycoportalImageList.new(query: query),
+                               "mycoportal_images")
+
+    alert("MyCoPortal export ready: #{ids.size} observation(s) -> " \
+          "#{data_path}, #{images_path}")
+  end
+
+  private
+
+  def observation_ids
+    candidates = Mycoportal::ExportCandidates.new
+    candidates.updated_observation_ids + candidates.new_observation_ids
+  end
+
+  def write_report(report, basename)
+    body = report.body
+    report.mark_exported! if report.respond_to?(:mark_exported!)
+    path = export_path(basename)
+    File.write(path, body)
+    path
+  end
+
+  def export_path(basename)
+    FileUtils.mkdir_p(EXPORT_DIR)
+    EXPORT_DIR.join("#{basename}_#{Time.zone.today.iso8601}.csv")
+  end
+end

--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -75,11 +75,7 @@ module Name::Taxonomy
       # name includes quote marks, but limit this to below Order in order to
       # account for things like "Discomycetes", which is registered & quoted
       /"/ =~ text_name && rank >= "Class" ||
-      # Use kingdom: Protozoa as a rough proxy for slime molds
-      # Slime molds, which are Protozoa, are in fungal nomenclature registries.
-      # But most Protozoa are not slime molds and there's no efficient way
-      # for MO to tell the difference. So err on the side of registrability.
-      kingdom.present? && /(Fungi|Protozoa)/ !~ kingdom
+      non_fungal_kingdom?
   end
 
   # Name for which it makes sense to have links to search pages in fungal
@@ -90,9 +86,18 @@ module Name::Taxonomy
   end
 
   def unsearchable_in_registry?
-    kingdom.present? && /(Fungi|Protozoa)/ !~ kingdom ||
+    non_fungal_kingdom? ||
       rank == "Domain" ||
       /\bcrypt temp\b/i =~ author&.delete(".")
+  end
+
+  # Is this name's kingdom something other than Fungi/Protozoa?
+  # Use kingdom: Protozoa as a rough proxy for slime molds.
+  # Slime molds, which are Protozoa, are in fungal nomenclature registries.
+  # But most Protozoa are not slime molds and there's no efficient way
+  # for MO to tell the difference. So err on the side of registrability.
+  def non_fungal_kingdom?
+    kingdom.present? && /(Fungi|Protozoa)/ !~ kingdom
   end
 
   ################

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -312,6 +312,13 @@ MushroomObserver::Application.configure do
   config.eol_min_image_vote = 2
   config.eol_min_observation_vote = 2.4
 
+  # MyCoPortal export parameters.
+  config.mycoportal_min_observation_vote = 2.0
+  config.mycoportal_excluded_names = [
+    "Duplicate", "Undetermined", "Mixed collection", "Non-fungal",
+    "Slime-flux", "Eukarya", "Eukaryota"
+  ]
+
   # Default number of items for an RSS page
   config.default_layout_count = 12
 

--- a/test/classes/mycoportal/export_candidates_test.rb
+++ b/test/classes/mycoportal/export_candidates_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Mycoportal::ExportCandidatesTest < UnitTestCase
+  def test_new_observation_ids_includes_high_confidence_obs
+    obs = create_observation(vote_cache: 3.0)
+
+    assert_includes(candidates.new_observation_ids, obs.id)
+  end
+
+  def test_new_observation_ids_excludes_low_confidence_obs
+    obs = create_observation(vote_cache: 1.0)
+
+    assert_not_includes(candidates.new_observation_ids, obs.id)
+  end
+
+  def test_new_observation_ids_excludes_excluded_name
+    obs = create_observation(vote_cache: 3.0, name: excluded_name)
+
+    assert_not_includes(candidates.new_observation_ids, obs.id)
+  end
+
+  def test_new_observation_ids_excludes_non_fungal_kingdom
+    obs = create_observation(vote_cache: 3.0, name: plant_name)
+
+    assert_not_includes(candidates.new_observation_ids, obs.id)
+  end
+
+  def test_new_observation_ids_excludes_empty_observation
+    obs = create_observation(vote_cache: 3.0, name: names(:fungi),
+                             where: nil, location: nil)
+
+    assert_not_includes(candidates.new_observation_ids, obs.id)
+  end
+
+  def test_new_observation_ids_includes_unnamed_obs_with_content
+    # Empty except for notes -- not "empty" because it has content.
+    obs = create_observation(vote_cache: 3.0, name: names(:fungi),
+                             notes: { Other: "Found under oak" })
+
+    assert_includes(candidates.new_observation_ids, obs.id)
+  end
+
+  def test_new_observation_ids_excludes_already_exported_obs
+    obs = create_observation(vote_cache: 3.0)
+    export_obs!(obs, last_synced_at: 1.hour.ago)
+
+    assert_not_includes(candidates.new_observation_ids, obs.id)
+  end
+
+  def test_updated_observation_ids_includes_obs_changed_since_export
+    obs = create_observation(vote_cache: 3.0)
+    export_obs!(obs, last_synced_at: 1.hour.ago)
+
+    assert_includes(candidates.updated_observation_ids, obs.id)
+  end
+
+  def test_updated_observation_ids_excludes_obs_unchanged_since_export
+    obs = create_observation(vote_cache: 3.0)
+    export_obs!(obs, last_synced_at: 1.hour.from_now)
+
+    assert_not_includes(candidates.updated_observation_ids, obs.id)
+  end
+
+  private
+
+  def candidates
+    Mycoportal::ExportCandidates.new
+  end
+
+  def create_observation(vote_cache:, name: names(:coprinus_comatus),
+                         where: "anywhere", location: nil, notes: {})
+    Observation.create!(
+      user: rolf, when: Time.zone.today, where: where, location: location,
+      name_id: name.id, vote_cache: vote_cache, notes: notes
+    )
+  end
+
+  def export_obs!(obs, last_synced_at:)
+    ExternalLink.create!(
+      user: rolf, target_type: "Observation", target_id: obs.id,
+      external_site: ExternalSite.mycoportal, relationship: :export,
+      last_synced_at: last_synced_at
+    )
+  end
+
+  def excluded_name
+    @excluded_name ||= Name.create!(
+      user: rolf, rank: "Species", text_name: "Undetermined", author: "",
+      search_name: "Undetermined", display_name: "Undetermined"
+    )
+  end
+
+  def plant_name
+    @plant_name ||= Name.create!(
+      user: rolf, rank: "Species", text_name: "Zea mays", author: "L.",
+      search_name: "Zea mays L.", display_name: "**__Zea mays__** L.",
+      classification: "Domain: _Eukarya_\r\nKingdom: _Plantae_\r\n"
+    )
+  end
+end

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -592,7 +592,7 @@ class ReportTest < UnitTestCase
 
   # Code names: text_name contains a single-quote (e.g. sp. 'IN34')
   # sciname = genus only;
-  # identificationQualifier = Report::Mycoportal::CODE_NAME_QUALIFIER;
+  # identificationQualifier = Report::Mycoportal::NameResolver::CODE_NAME_QUALIFIER;
   # taxonRemarks = full text_name plus author
   def test_mycoportal_code_name_unauthored_no_qualifier
     obs = Observation.create!(
@@ -605,7 +605,8 @@ class ReportTest < UnitTestCase
 
     expect = hashed_expect(obs).merge(
       sciname: "Cortinarius",
-      identificationQualifier: Report::Mycoportal::CODE_NAME_QUALIFIER,
+      identificationQualifier:
+        Report::Mycoportal::NameResolver::CODE_NAME_QUALIFIER,
       taxonRemarks: "Cortinarius sp. 'IN34'"
     ).values
 
@@ -631,7 +632,8 @@ class ReportTest < UnitTestCase
 
     expect = hashed_expect(obs).merge(
       sciname: "Geoglossum",
-      identificationQualifier: Report::Mycoportal::CODE_NAME_QUALIFIER,
+      identificationQualifier:
+        Report::Mycoportal::NameResolver::CODE_NAME_QUALIFIER,
       taxonRemarks: "Geoglossum sp. 'MI01' S.D. Russell"
     ).values
 
@@ -742,6 +744,141 @@ class ReportTest < UnitTestCase
 
     expect = hashed_expect(obs).merge(
       identificationQualifier: "sensu lato"
+    ).values
+
+    do_csv_test(Report::Mycoportal, obs, expect, &:id)
+  end
+
+  def test_mycoportal_misspelled_name_resolves_to_correct_spelling
+    correct_name = Name.create!(
+      user: rolf, rank: "Species", text_name: "Amanita phalloides",
+      author: "(Vaill. ex Fr.) Link", search_name: "Amanita phalloides",
+      display_name: "**__Amanita__** **__phalloides__**"
+    )
+    misspelled_name = Name.create!(
+      user: rolf, rank: "Species", text_name: "Amanita phaloides",
+      author: "", search_name: "Amanita phaloides",
+      display_name: "**__Amanita__** **__phaloides__**",
+      correct_spelling: correct_name
+    )
+    obs = Observation.create!(user: rolf, when: Time.zone.now,
+                              location: locations(:burbank),
+                              where: locations(:burbank).name,
+                              name: misspelled_name)
+
+    expect = hashed_expect(obs).merge(sciname: correct_name.text_name).values
+
+    do_csv_test(Report::Mycoportal, obs, expect, &:id)
+  end
+
+  # Ranks strictly between Species and Genus (Section, Subsection, Series,
+  # Stirps, Subgenus): sciname = genus only; identificationQualifier =
+  # "aff. <rank>"; taxonRemarks = full text_name + author.
+  def test_mycoportal_infrageneric_section_rank
+    name = Name.create!(
+      user: rolf, rank: "Section", text_name: "Morchella sect. Distantes",
+      author: "", search_name: "Morchella sect. Distantes",
+      display_name: "**__Morchella__** sect. **__Distantes__**"
+    )
+    obs = Observation.create!(user: rolf, when: Time.zone.now,
+                              location: locations(:burbank),
+                              where: locations(:burbank).name,
+                              name: name)
+
+    expect = hashed_expect(obs).merge(
+      sciname: "Morchella",
+      identificationQualifier: "aff. section",
+      taxonRemarks: "Morchella sect. Distantes"
+    ).values
+
+    do_csv_test(Report::Mycoportal, obs, expect, &:id)
+  end
+
+  def test_mycoportal_provisional_nom_ined
+    name = Name.create!(
+      user: rolf, rank: "Species", text_name: "Cortinarius percomis",
+      author: "nom. ined.", search_name: "Cortinarius percomis nom. ined.",
+      display_name: "__Cortinarius__ __percomis__ nom. ined."
+    )
+    obs = Observation.create!(user: rolf, when: Time.zone.now,
+                              location: locations(:burbank),
+                              where: locations(:burbank).name,
+                              name: name)
+
+    expect = hashed_expect(obs).merge(
+      sciname: "Cortinarius percomis",
+      identificationQualifier: "nom. ined.",
+      taxonRemarks: "Cortinarius percomis nom. ined."
+    ).values
+
+    do_csv_test(Report::Mycoportal, obs, expect, &:id)
+  end
+
+  def test_mycoportal_provisional_comb_inedit
+    name = Name.create!(
+      user: rolf, rank: "Species", text_name: "Cortinarius percomis",
+      author: "(Fr.) auct. comb. inedit",
+      search_name: "Cortinarius percomis (Fr.) auct. comb. inedit",
+      display_name: "__Cortinarius__ __percomis__ (Fr.) auct. comb. inedit"
+    )
+    obs = Observation.create!(user: rolf, when: Time.zone.now,
+                              location: locations(:burbank),
+                              where: locations(:burbank).name,
+                              name: name)
+
+    expect = hashed_expect(obs).merge(
+      sciname: "Cortinarius percomis",
+      identificationQualifier: "comb. inedit",
+      taxonRemarks: "Cortinarius percomis (Fr.) auct. comb. inedit"
+    ).values
+
+    do_csv_test(Report::Mycoportal, obs, expect, &:id)
+  end
+
+  # "Genus sp. 'epithet-STATEnn'" code names get a qualifier naming the
+  # epithet instead of the generic CODE_NAME_QUALIFIER.
+  def test_mycoportal_code_name_precise_qualifier
+    name = Name.create!(
+      user: rolf, rank: "Species",
+      text_name: "Hortiboletus sp. 'flavorubellus-IN04'",
+      author: "S.D. Russell",
+      search_name: "Hortiboletus sp. 'flavorubellus-IN04' S.D. Russell",
+      display_name: "**__Hortiboletus__** sp. **__'flavorubellus-IN04'__** " \
+                    "S.D. Russell"
+    )
+    obs = Observation.create!(user: rolf, when: Time.zone.now,
+                              location: locations(:burbank),
+                              where: locations(:burbank).name,
+                              name: name)
+
+    expect = hashed_expect(obs).merge(
+      sciname: "Hortiboletus",
+      identificationQualifier: "aff. flavorubellus",
+      taxonRemarks: "Hortiboletus sp. 'flavorubellus-IN04' S.D. Russell"
+    ).values
+
+    do_csv_test(Report::Mycoportal, obs, expect, &:id)
+  end
+
+  # "Gen. 'Foo' sp. 'bar-ST01'" code names are treated as if they didn't
+  # have the "Gen." prefix.
+  def test_mycoportal_code_name_gen_prefix
+    name = Name.create!(
+      user: rolf, rank: "Species",
+      text_name: "Gen. 'Mycena' sp. 'acicula-PNW01'",
+      author: "",
+      search_name: "Gen. 'Mycena' sp. 'acicula-PNW01'",
+      display_name: "Gen. **__'Mycena'__** sp. **__'acicula-PNW01'__**"
+    )
+    obs = Observation.create!(user: rolf, when: Time.zone.now,
+                              location: locations(:burbank),
+                              where: locations(:burbank).name,
+                              name: name)
+
+    expect = hashed_expect(obs).merge(
+      sciname: "Mycena",
+      identificationQualifier: "aff. acicula",
+      taxonRemarks: "Gen. 'Mycena' sp. 'acicula-PNW01'"
     ).values
 
     do_csv_test(Report::Mycoportal, obs, expect, &:id)
@@ -995,6 +1132,108 @@ class ReportTest < UnitTestCase
 
   def test_mycoportal_image_list_mark_exported_survives_site_lookup_failure
     report = Report::MycoportalImageList.new(query: Query.lookup(:Observation))
+    report.body
+
+    site_lookup_fails = -> { raise(ActiveRecord::RecordNotFound) }
+    ExternalSite.stub(:mycoportal, site_lookup_fails) do
+      assert_nothing_raised do
+        report.mark_exported!
+      end
+    end
+  end
+
+  def test_mycoportal_mark_exported_creates_link
+    obs = observations(:detailed_unknown_obs)
+    site = ExternalSite.mycoportal
+    report =
+      Report::Mycoportal.new(query: Query.lookup(:Observation,
+                                                 id_in_set: [obs.id]))
+    report.body
+
+    report.mark_exported!
+
+    link = ExternalLink.find_by(target_type: "Observation",
+                                target_id: obs.id, external_site: site,
+                                relationship: :export)
+    assert_not_nil(link, "mark_exported! should create an export " \
+                         "ExternalLink for observation #{obs.id}")
+    assert_not_nil(link.last_synced_at)
+  end
+
+  def test_mycoportal_mark_exported_refreshes_last_synced_at_on_reexport
+    obs = observations(:detailed_unknown_obs)
+    site = ExternalSite.mycoportal
+    old_time = 1.day.ago
+    ExternalLink.create!(user: User.admin, target_type: "Observation",
+                         target_id: obs.id, external_site: site,
+                         relationship: :export, last_synced_at: old_time)
+
+    report =
+      Report::Mycoportal.new(query: Query.lookup(:Observation,
+                                                 id_in_set: [obs.id]))
+    report.body
+    report.mark_exported!
+
+    assert_equal(
+      1,
+      ExternalLink.where(target_type: "Observation", target_id: obs.id,
+                         external_site: site, relationship: :export).count,
+      "Re-exporting should update the existing link, not create a duplicate"
+    )
+    link = ExternalLink.find_by(target_type: "Observation",
+                                target_id: obs.id, external_site: site,
+                                relationship: :export)
+    assert_operator(link.last_synced_at, :>, old_time)
+  end
+
+  def test_mycoportal_mark_exported_before_body_raises
+    report = Report::Mycoportal.new(query: Query.lookup(:Observation))
+
+    assert_raises(RuntimeError) { report.mark_exported! }
+  end
+
+  def test_mycoportal_mark_exported_logs_on_invalid
+    obs = observations(:detailed_unknown_obs)
+    report =
+      Report::Mycoportal.new(query: Query.lookup(:Observation,
+                                                 id_in_set: [obs.id]))
+    report.body
+
+    warnings = []
+    stubbed_error = lambda do |*|
+      link = ExternalLink.new
+      link.errors.add(:base, "stubbed failure")
+      raise(ActiveRecord::RecordInvalid.new(link))
+    end
+
+    Rails.logger.stub(:warn, ->(msg) { warnings << msg }) do
+      ExternalLink.stub(:create!, stubbed_error) do
+        report.mark_exported!
+      end
+    end
+
+    assert(
+      warnings.any? do |msg|
+        msg.include?(
+          "MyCoPortal export link failed for Observation #{obs.id}"
+        )
+      end,
+      "mark_exported! should log a warning naming the failed observation " \
+      "when ExternalLink.create! raises RecordInvalid"
+    )
+    assert_not(
+      ExternalLink.exists?(target_type: "Observation", target_id: obs.id,
+                           external_site: ExternalSite.mycoportal,
+                           relationship: :export),
+      "No ExternalLink should be created when create! raises"
+    )
+  end
+
+  def test_mycoportal_mark_exported_survives_site_lookup_failure
+    obs = observations(:detailed_unknown_obs)
+    report =
+      Report::Mycoportal.new(query: Query.lookup(:Observation,
+                                                 id_in_set: [obs.id]))
     report.body
 
     site_lookup_fails = -> { raise(ActiveRecord::RecordNotFound) }

--- a/test/jobs/mycoportal_export_job_test.rb
+++ b/test/jobs/mycoportal_export_job_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class MycoportalExportJobTest < ActiveJob::TestCase
+  def teardown
+    FileUtils.rm_rf(MycoportalExportJob::EXPORT_DIR)
+    super
+  end
+
+  def test_no_alert_when_no_candidates
+    Mycoportal::ExportCandidates.stub(:new, mock_candidates([], [])) do
+      alerts = capture_alerts { MycoportalExportJob.perform_now }
+
+      assert_empty(alerts)
+    end
+    assert_empty(Dir.glob("#{MycoportalExportJob::EXPORT_DIR}/*"))
+  end
+
+  def test_writes_csvs_marks_exported_and_alerts
+    obs = create_observation(vote_cache: 3.0)
+
+    Mycoportal::ExportCandidates.stub(:new, mock_candidates([], [obs.id])) do
+      alerts = capture_alerts { MycoportalExportJob.perform_now }
+
+      assert_equal(1, alerts.size)
+      assert_includes(alerts.first.message, "1 observation(s)")
+    end
+
+    data_file = Dir.glob(
+      "#{MycoportalExportJob::EXPORT_DIR}/mycoportal_data_*.csv"
+    ).first
+    assert_not_nil(data_file, "Expected a mycoportal_data CSV to be written")
+    assert_includes(File.read(data_file), "MUOB #{obs.id}")
+
+    images_file = Dir.glob(
+      "#{MycoportalExportJob::EXPORT_DIR}/mycoportal_images_*.csv"
+    ).first
+    assert_not_nil(images_file,
+                   "Expected a mycoportal_images CSV to be written")
+
+    assert(
+      ExternalLink.exists?(target_type: "Observation", target_id: obs.id,
+                           external_site: ExternalSite.mycoportal,
+                           relationship: :export),
+      "perform should mark the observation as exported"
+    )
+  end
+
+  private
+
+  def mock_candidates(updated, new)
+    candidates = Object.new
+    candidates.define_singleton_method(:updated_observation_ids) { updated }
+    candidates.define_singleton_method(:new_observation_ids) { new }
+    candidates
+  end
+
+  def create_observation(vote_cache:)
+    Observation.create!(
+      user: users(:rolf), when: Time.zone.today, where: "anywhere",
+      name_id: names(:coprinus_comatus).id, vote_cache: vote_cache
+    )
+  end
+
+  # Records the exceptions handed to the #alerts pipeline while alerting is
+  # forced active, so tests can assert on what a run would post to Slack.
+  def capture_alerts(&block)
+    alerts = []
+    ExceptionNotifier.stub(:notifiers, [:slack]) do
+      ExceptionNotifier.stub(:notify_exception,
+                             lambda { |exception, **_o|
+                               alerts << exception
+                             }, &block)
+    end
+    alerts
+  end
+end


### PR DESCRIPTION
Adds a job which generates the observation and image CSV's to upload to MCP for a bulk update

- Mycoportal::ExportCandidates picks which observations belong in an MCP batch: never-exported observations meeting a confidence threshold, not on an exclusion-name list, in the Fungi/Protozoa kingdom, and not "empty"; plus already-exported observations updated since their last sync. All filtering is SQL-driven.
- Extract Name::Taxonomy#non_fungal_kingdom? out of #unregistrable? and #unsearchable_in_registry? so all three share one check.
- Report::Mycoportal: resolve misspelled names via Name#correct_spelling, generalize group/complex handling to rank-based infrageneric names (Section, Subgenus, etc.), extend provisional detection to nom./comb. ined(it), strip a leading "Gen. " token from code names, and give "Genus sp. 'epithet-STATEnn'" code names a precise "aff. <epithet>" qualifier. Extracted NameResolver and CoordinateUncertainty to keep the class under the length limit.
- Add Report::Mycoportal#mark_exported!, mirroring MycoportalImageList's existing pattern.
- Add MycoportalExportJob to generate both CSVs, mark exports, write them to tmp/mycoportal/, and alert with the paths. Not yet wired to a schedule or trigger.
- Add config.mycoportal_min_observation_vote and mycoportal_excluded_names.

## Manual Test Plan — `MycoportalExportJob` (MCP CSV generation)

Covers `app/jobs/mycoportal_export_job.rb`, `app/classes/mycoportal/export_candidates.rb`, and the `Report::Mycoportal` / `Report::MycoportalImageList` changes in `c23c051` (name-resolution, kingdom filtering, `mark_exported!`). Run via `bin/rails console` in dev against a copy of production-like data (see `db/download_checkpoint`), since the candidate logic depends on real vote/name/link state.

### Setup

- [ ] `FileUtils.rm_rf(MycoportalExportJob::EXPORT_DIR)` to start with a clean `tmp/mycoportal/` directory.
- [ ] Confirm `MO.mycoportal_min_observation_vote` (`2.0`) and `MO.mycoportal_excluded_names` are loaded as expected: `MO.mycoportal_min_observation_vote`, `MO.mycoportal_excluded_names`.

### 1. No candidates → no-op, no alert

- [ ] Pick/ensure there are currently zero observations that qualify (or temporarily raise `mycoportal_min_observation_vote` in the console to `99`).
- [ ] Run `MycoportalExportJob.perform_now`.
- [ ] Confirm no files were written to `tmp/mycoportal/`.
- [ ] Confirm no exception/alert was raised (check log for `"MyCoPortal export: no observations to export"`).

### 2. New (never-exported) observation qualifies

- [ ] Find or create an observation with `vote_cache >= 2.0`, a Fungi-kingdom consensus name, a location, and not on the excluded-name list.
- [ ] Run `MycoportalExportJob.perform_now`.
- [ ] Confirm two files appear: `tmp/mycoportal/mycoportal_data_<date>.csv` and `tmp/mycoportal/mycoportal_images_<date>.csv`.
- [ ] Open `mycoportal_data_*.csv` and confirm a row with `catalogNumber` = `MUOB <obs.id>` and `occurrenceID` = `https://mushroomobserver.org/obs/<obs.id>`.
- [ ] Confirm an `ExternalLink` was created: `ExternalLink.exists?(target_type: "Observation", target_id: obs.id, external_site: ExternalSite.mycoportal, relationship: :export)` → `true`.
- [ ] Confirm the alert message (check log/exception notifier) reads `"MyCoPortal export ready: 1 observation(s) -> ..."`.

### 3. Exclusion filters keep observations out

For each, confirm the observation does **not** appear in `Mycoportal::ExportCandidates.new.new_observation_ids` and is **not** in the generated CSV:

- [ ] **Low confidence** — observation with `vote_cache < 2.0`.
- [ ] **Excluded name** — observation whose consensus name's `text_name` is one of `MO.mycoportal_excluded_names` (e.g. "Undetermined", "Duplicate").
- [ ] **Non-fungal kingdom** — observation with a non-Fungi/Protozoa consensus name (e.g. a plant or animal name if present in the DB).
- [ ] **"Empty" observation** — no name proposal (or only "Fungi"), unknown/no location, no notes, no sequences, no images.

### 4. Already-exported observation, unchanged → not re-sent

- [ ] Take an observation already exported (has an `ExternalLink` with `relationship: :export` to MyCoPortal) with `last_synced_at` at or after `observation.updated_at`.
- [ ] Confirm it does **not** appear in `Mycoportal::ExportCandidates.new.updated_observation_ids`.
- [ ] Run the job and confirm this observation is absent from the new CSV.

### 5. Already-exported observation, updated since last sync → re-sent

- [ ] Take an exported observation and touch it (e.g. edit its notes) so `updated_at > last_synced_at` on its export `ExternalLink`.
- [ ] Confirm it appears in `Mycoportal::ExportCandidates.new.updated_observation_ids`.
- [ ] Run the job and confirm the observation appears in the new CSV.
- [ ] Confirm the existing `ExternalLink`'s `last_synced_at` was updated (not a duplicate link created).

### 6. Misspelled name resolution

- [ ] Find/create an observation whose consensus name has a `correct_spelling_id` set.
- [ ] Include it in a run and confirm the CSV row's `sciname` reflects the *corrected* spelling, author, and rank — not the misspelled name.

### 7. Infrageneric / group / provisional name handling

- [ ] Include an observation with a Section/Subgenus-rank (or similar infrageneric) name and confirm `identificationQualifier`/`sciname` render sensibly (not blank, not malformed).
- [ ] Include an observation with a provisional name (`nom. prov.`, `comb. ined`, `nom. ined`) and confirm `identificationQualifier` reflects the provisional status.
- [ ] Include an observation with a code name like `Genus sp. 'epithet-STATEnn'` and confirm the qualifier renders as `aff. <epithet>` with the leading `"Gen. "` stripped where applicable.

### 8. Image CSV

- [ ] Confirm `mycoportal_images_*.csv` has header `catalogNumber,imageId` and one row per image on the exported observations.
- [ ] Confirm image URLs/ids use the `https://mushroomobserver.org/images/1280/` permalink prefix (per `LARGE_IMG_PERMALINK_PREFIX`).
- [ ] Re-run the job on the same observation (with unchanged images) and confirm previously-exported images are not duplicated in the new run.

### 9. Idempotency / re-running the job

- [ ] Run `MycoportalExportJob.perform_now` twice in a row with no new/updated candidates in between.
- [ ] Confirm the second run finds zero candidates (logs the "no observations to export" message) and writes no new files.

### 10. Failure isolation (bookkeeping doesn't break CSV output)

- [ ] Temporarily break `ExternalSite.mycoportal` (e.g. rename/remove the fixture site in a throwaway console session) so `mark_exported!` raises internally.
- [ ] Confirm the CSV files are still written correctly and the job still alerts with the file paths — the `mark_exported!` failure should only log an error (`Rails.logger.error("MyCoPortal export-tracking failed: ...")`), not raise out of the job or corrupt the CSV.

### 11. Coordinates / privacy

- [ ] Include an observation with GPS hidden from the public (obscured coordinates) and confirm `decimalLatitude`/`decimalLongitude` show the obscured message (`"Coordinates obscured by observer"`) rather than real coordinates, and `coordinateUncertaintyInMeters` is populated per `CoordinateUncertainty`.

### 12. Not yet wired to a schedule

- [ ] Confirm `MycoportalExportJob` does **not** run automatically (check `config/schedule.rb` / Solid Queue recurring jobs config) — it should only be triggerable via `perform_now`/`perform_later` from the console, per the class comment.

