### PR TITLE
Fix 500 deleting an external link on an occurrence-member observation (`siblings` relation vs typed prop)

### DIFF
--- a/app/controllers/observations/external_links_controller/show.rb
+++ b/app/controllers/observations/external_links_controller/show.rb
@@ -46,8 +46,10 @@ module Observations::ExternalLinksController::Show
   def load_siblings_with_external_links(obs)
     return [] unless obs.occurrence
 
+    # .to_a: render_external_links_section_update hands this to the
+    # panel's typed _Array(Observation) prop, which rejects a relation.
     obs.occurrence.observations.where.not(id: obs.id).
-      includes(external_links: show_link_includes)
+      includes(external_links: show_link_includes).to_a
   end
 
   # Sorted by relationship_date, matching the pre-badge external-links

--- a/test/controllers/observations/external_links_controller_test.rb
+++ b/test/controllers/observations/external_links_controller_test.rb
@@ -472,6 +472,27 @@ module Observations
       assert_select("turbo-stream[target='observation_external_links']")
     end
 
+    # Same, but the observation belongs to an occurrence: the sibling
+    # list handed to the re-rendered panel must be a real Array — a raw
+    # AssociationRelation trips the panel's typed prop and 500s the
+    # delete (seen in prod-data testing on #4853).
+    def test_remove_external_link_turbo_on_occurrence_member
+      link = external_links(:coprinus_comatus_obs_inaturalist_link)
+      obs = link.observation
+      sibling = observations(:detailed_unknown_obs)
+      [obs, sibling].each { |o| o.update_column(:occurrence_id, nil) }
+      occ = Occurrence.create!(user: obs.user, primary_observation: obs)
+      obs.update!(occurrence: occ)
+      sibling.update!(occurrence: occ)
+
+      login("mary")
+      delete(:destroy, params: { id: link.id }, format: :turbo_stream)
+
+      assert_response(:success)
+      assert_nil(ExternalLink.safe_find(link.id))
+      assert_select("turbo-stream[target='observation_external_links']")
+    end
+
     def test_remove_external_link_not_logged_in
       # obs owned by rolf, mary created link and is member of site's project
       link = external_links(:coprinus_comatus_obs_inaturalist_link)


### PR DESCRIPTION
## Summary

Deleting (or adding/editing) an external link on any observation that belongs to an occurrence 500s with `Literal::TypeError`. The turbo_stream panel re-render (`render_external_links_section_update` in `app/controllers/observations/external_links_controller/show.rb`) hands `load_siblings_with_external_links`' raw `AssociationRelation` to `Details::ExternalLinks`' typed `_Array(::Observation)` `siblings:` prop, which rejects relations. Observations without an occurrence return a literal `[]` from the early guard, which is why the existing turbo destroy test never caught it.

This has been live since the props were typed in `929459f46d` (2026-06-17). The observation show controller's own sibling load already ends in `.to_a`; this path missed it. Fix is the same `.to_a`.

Found while testing #4853 with production data (deleting a link on an occurrence member — `Literal::TypeError in Observations::ExternalLinksController#destroy`), but the bug is on `main` and is independent of that branch.

## Tests

New `test_remove_external_link_turbo_on_occurrence_member` — the existing turbo destroy test with the observation grouped into an occurrence. It reproduces the exact `Literal::TypeError` without the one-line fix and passes with it. Full `external_links_controller_test.rb` (35 tests) green.

## Test plan

1. On an observation that belongs to an occurrence (has sibling observations), add an external link, then delete it with the red X.
2. Both actions should update the panel in place instead of returning a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
