### PR TITLE
Add dry-run/apply convention rule: `--apply` for runner scripts, `APPLY=1` for rake tasks

### DIFF
--- a/.claude/rules/dry_run_scripts.md
+++ b/.claude/rules/dry_run_scripts.md
@@ -1,0 +1,58 @@
+# Dry-run vs. apply convention for scripts and rake tasks
+
+Every script that can change data runs as a **dry run by default** and
+requires an explicit opt-in to write. The opt-in spelling depends on the
+invocation style — do not mix them:
+
+## `bin/rails runner` scripts (backfills, one-offs): trailing `--apply`
+
+```bash
+# Dry run (default — reports what WOULD change, writes nothing):
+bin/rails runner script/fix_whatever.rb
+
+# Live run:
+bin/rails runner script/fix_whatever.rb --apply
+```
+
+Requirements for the script:
+
+1. **Dry-run is the default.** `--apply` is the only way to write.
+2. **Reject unknown argv with a non-zero exit.** A typo (`--aply`) must
+   abort loudly, never silently degrade to a dry run — the operator
+   would believe they applied.
+3. **Dry-run output says so**, states that nothing was written, and
+   echoes the exact command to apply:
+   `Dry run - nothing written. To apply: bin/rails runner script/fix_whatever.rb --apply`
+
+Why a flag and not an env var here: a flag is per-invocation by
+construction (no `export` can leave it armed for a later script), a
+typo'd flag is detectable while a typo'd env var never is, it shows up
+in the usage line and `ps` output, and the natural promotion workflow
+is up-arrow + append ` --apply`.
+
+Use `--apply`, not `--commit` (collides with git vocabulary) and not
+`--force`/`--go`.
+
+## Rake tasks: inline `APPLY=1` prefix
+
+```bash
+# Dry run:
+bin/rails some:task
+
+# Live run:
+APPLY=1 bin/rails some:task
+```
+
+Rake's argv passthrough (`rake foo -- --apply`) is clumsy, and env vars
+are the established rake convention (`VERSION=`, `COUNT=`). Same
+semantics: absent → dry run; the task's `desc` documents `APPLY=1`.
+
+**Always write `APPLY=1` inline on the command line, never `export` it**
+— an exported APPLY silently arms every later task in the shell that
+honors the same variable.
+
+## Scope
+
+This covers the dry-run/apply toggle only. The rest of the backfill
+conventions (idempotent, ID-level reporting, periodic stderr progress)
+are unchanged.


### PR DESCRIPTION
## Summary

Adds `.claude/rules/dry_run_scripts.md`, pinning one dry-run/apply convention per invocation style for data-changing scripts. Different Claude sessions had been improvising between two idioms (`APPLY=1` env prefix vs. a trailing `--apply`/`--commit` flag); files under `.claude/rules/` are auto-loaded into every session, so this makes the choice stick.

**The convention:**

- **`bin/rails runner` scripts** (backfills, one-offs): trailing `--apply` flag. Dry-run is the default; the script rejects unknown argv with a non-zero exit (a typo like `--aply` aborts loudly instead of silently degrading to a dry run); dry-run output states nothing was written and echoes the exact apply command.
- **Rake tasks**: inline `APPLY=1` prefix (rake's `-- --flag` argv passthrough is clumsy, and env vars are rake's established style — `VERSION=`, `COUNT=`). Always inline on the command, never `export`ed, so a lingering variable can't silently arm a later task.

**Why a flag for runner scripts:** per-invocation by construction (no export can leave it switched on), typos are detectable while env-var typos never are, it shows in the usage line and `ps` output, and the natural promotion workflow is up-arrow + append ` --apply`. `--apply` specifically, rather than `--commit` (git vocabulary collision) or `--force`.

This covers only the dry-run/apply toggle; the other backfill conventions (idempotent, ID-level reporting, periodic progress output) are unchanged.

## Test plan

Documentation only — no code paths affected. Review the rule text for anything the team disagrees with; the convention applies to new scripts, with no requirement to retrofit existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
