### PR TITLE
Make name authors non-breaking wherever they render (`String#small_author`)

### DIFF
--- a/app/extensions/string.rb
+++ b/app/extensions/string.rb
@@ -587,7 +587,7 @@ class String
     return self if !ind || !offset || (length <= (ind + offset))
 
     insert(length, "</small>".html_safe)
-    insert(ind + offset, "<small>".html_safe)
+    insert(ind + offset, '<small class="text-nowrap">'.html_safe)
   end
 
   # Strip leading and trailing spaces, and squeeze embedded spaces.

--- a/test/classes/string_extensions_test.rb
+++ b/test/classes/string_extensions_test.rb
@@ -99,4 +99,21 @@ class StringExtensionsTest < UnitTestCase
     assert_false(str.valid_encoding?)
     assert_true(str.fix_utf8.valid_encoding?)
   end
+
+  def test_small_author
+    str = "<b><i>Abeliella xanthoconium</i></b> Lehman-Haupt nom. prov."
+    expected = "<b><i>Abeliella xanthoconium</i></b>" \
+               '<small class="text-nowrap"> Lehman-Haupt nom. prov.</small>'
+    assert_equal(expected, str.dup.small_author)
+  end
+
+  def test_small_author_no_matching_tag
+    str = "Plain text with no formatting"
+    assert_equal(str, str.dup.small_author)
+  end
+
+  def test_small_author_tag_at_end_with_nothing_after
+    str = "<b><i>Abeliella xanthoconium</i></b>"
+    assert_equal(str, str.dup.small_author)
+  end
 end


### PR DESCRIPTION
Fixes #4930

## Summary

`String#small_author` wraps the author portion of a formatted name in `<small>` — the single shared method behind every place a name+author renders (observation titles, matrix box titles, lightbox titles, `Title::Name`/`Title::Image`, namings rows, the votes modal). Adds `text-nowrap` (Bootstrap-style utility already defined in `_utilities.scss`, used ~20 places elsewhere) to that `<small>` tag, so a long author no longer breaks mid-word.

Fixed at this one shared method rather than just the observation title, since every other call site has the same problem.

## Test plan

- [x] `bin/rails test test/classes/string_extensions_test.rb` — new coverage for `small_author`, which had none before
- [x] `bin/rails test test/classes/title/name_test.rb test/classes/title/image_test.rb test/components/matrix/box/render_data_test.rb test/views/controllers/observations/consensus_name_link_test.rb test/views/controllers/observations/show/namings/header_test.rb` — every other consumer of `small_author`, 0 failures
- [x] `bundle exec rubocop` clean on both touched files
- [x] Verified rendered output against a real fixture name with an author via `bin/rails runner`
