### PR TITLE
Make observation `SpecimenPanel` collapsible

### DIFF
--- a/app/views/controllers/observations/show/specimen_panel.rb
+++ b/app/views/controllers/observations/show/specimen_panel.rb
@@ -28,9 +28,14 @@ class Views::Controllers::Observations::Show::SpecimenPanel < Views::Base
     @obs.occurrence&.has_specimen || @obs.specimen
   end
 
+  # Own records or a sibling's -- render_collection_numbers/
+  # render_herbarium_records/render_sequences all render sibling rows
+  # too, so the default expanded/collapsed state has to account for
+  # them as well, not just @obs's own associations.
   def specimen_records?
-    @obs.collection_numbers.any? || @obs.herbarium_records.any? ||
-      @obs.sequences.any?
+    [:collection_numbers, :herbarium_records, :sequences].any? do |assoc|
+      @obs.send(assoc).any? || sibling_has?(assoc)
+    end
   end
 
   def render_heading

--- a/app/views/controllers/observations/show/specimen_panel.rb
+++ b/app/views/controllers/observations/show/specimen_panel.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 # "Specimen" panel on the observation show page (and the naming
-# propose/edit pages) — specimen-available status, plus the
-# collection-numbers / herbarium-records / sequences sections. The
-# first line of the body says whether a specimen is actually
-# recorded. Renders right below the Details panel.
+# propose/edit pages) — the heading says whether a specimen is
+# actually recorded; the body holds the collection-numbers /
+# herbarium-records / sequences sections, collapsed by default when
+# none of those exist yet. Renders right below the Details panel.
 class Views::Controllers::Observations::Show::SpecimenPanel < Views::Base
   include SiblingRecords
 
@@ -13,9 +13,12 @@ class Views::Controllers::Observations::Show::SpecimenPanel < Views::Base
   prop :siblings, _Array(::Observation), default: -> { [] }
 
   def view_template
-    Panel(panel_id: "observation_specimen") do |panel|
-      panel.with_heading { :specimen.ti }
-      panel.with_body { render_body }
+    Panel(panel_id: "observation_specimen",
+          collapsible: true,
+          collapse_target: "#observation_specimen_body",
+          expanded: specimen_records?) do |panel|
+      panel.with_heading { render_heading }
+      panel.with_body(collapse: true) { render_body }
     end
   end
 
@@ -25,21 +28,23 @@ class Views::Controllers::Observations::Show::SpecimenPanel < Views::Base
     @obs.occurrence&.has_specimen || @obs.specimen
   end
 
+  def specimen_records?
+    @obs.collection_numbers.any? || @obs.herbarium_records.any? ||
+      @obs.sequences.any?
+  end
+
+  def render_heading
+    if specimen?
+      plain(:show_observation_specimen_available.t)
+    else
+      plain(:show_observation_specimen_not_available.t)
+    end
+  end
+
   def render_body
-    render_specimen_line
     render_collection_numbers
     render_herbarium_records
     render_sequences
-  end
-
-  def render_specimen_line
-    p(class: "obs-specimen", id: "observation_specimen_available") do
-      if specimen?
-        plain(:show_observation_specimen_available.t)
-      else
-        plain(:show_observation_specimen_not_available.t)
-      end
-    end
   end
 
   def render_collection_numbers

--- a/test/views/controllers/observations/show/specimen_panel_test.rb
+++ b/test/views/controllers/observations/show/specimen_panel_test.rb
@@ -63,6 +63,20 @@ class Views::Controllers::Observations::Show::SpecimenPanelTest <
     assert_html(html, "a.panel-collapse-trigger[aria-expanded='false']")
   end
 
+  def test_expanded_when_no_own_records_but_sibling_has_records
+    obs = observations(:imageless_unvouchered_obs)
+    assert_empty(obs.collection_numbers)
+    assert_empty(obs.herbarium_records)
+    assert_empty(obs.sequences)
+
+    sibling = sequences(:deposited_sequence).observation
+    assert_not_empty(sibling.sequences)
+
+    html = render(panel_with(obs, siblings: [sibling]))
+
+    assert_html(html, "a.panel-collapse-trigger[aria-expanded='true']")
+  end
+
   # Sibling records: when a sibling carries a Sequence with a
   # deposit URL, the panel renders the sibling sequence row +
   # the `[archive]` link from `SiblingRecords`. Covers the

--- a/test/views/controllers/observations/show/specimen_panel_test.rb
+++ b/test/views/controllers/observations/show/specimen_panel_test.rb
@@ -16,24 +16,42 @@ class Views::Controllers::Observations::Show::SpecimenPanelTest <
     assert_html(html, "#observation_specimen")
   end
 
-  def test_title_and_body_when_specimen_present
+  def test_heading_when_specimen_present
     @obs.specimen = true
 
     html = render(panel_with(@obs))
 
-    assert_html(html, "#observation_specimen .panel-title", text: :specimen.ti)
-    assert_html(html, "#observation_specimen_available",
+    assert_html(html, "#observation_specimen .panel-title",
                 text: :show_observation_specimen_available.t)
   end
 
-  def test_title_and_body_when_no_specimen
+  def test_heading_when_no_specimen
     @obs.specimen = false
 
     html = render(panel_with(@obs))
 
-    assert_html(html, "#observation_specimen .panel-title", text: :specimen.ti)
-    assert_html(html, "#observation_specimen_available",
+    assert_html(html, "#observation_specimen .panel-title",
                 text: :show_observation_specimen_not_available.t)
+  end
+
+  def test_expanded_when_records_present
+    # detailed_unknown_obs has collection numbers and herbarium
+    # records fixtures attached.
+    html = render(panel_with(@obs))
+
+    assert_html(html, "a.panel-collapse-trigger[aria-expanded='true']")
+  end
+
+  def test_collapsed_when_no_records_regardless_of_specimen_flag
+    obs = observations(:imageless_unvouchered_obs)
+    assert_empty(obs.collection_numbers)
+    assert_empty(obs.herbarium_records)
+    assert_empty(obs.sequences)
+
+    obs.specimen = true
+    html = render(panel_with(obs))
+
+    assert_html(html, "a.panel-collapse-trigger[aria-expanded='false']")
   end
 
   # Sibling records: when a sibling carries a Sequence with a

--- a/test/views/controllers/observations/show/specimen_panel_test.rb
+++ b/test/views/controllers/observations/show/specimen_panel_test.rb
@@ -42,6 +42,15 @@ class Views::Controllers::Observations::Show::SpecimenPanelTest <
     assert_html(html, "a.panel-collapse-trigger[aria-expanded='true']")
   end
 
+  def test_expanded_when_records_present_even_without_specimen_flag
+    assert_not_empty(@obs.collection_numbers)
+    @obs.specimen = false
+
+    html = render(panel_with(@obs))
+
+    assert_html(html, "a.panel-collapse-trigger[aria-expanded='true']")
+  end
+
   def test_collapsed_when_no_records_regardless_of_specimen_flag
     obs = observations(:imageless_unvouchered_obs)
     assert_empty(obs.collection_numbers)


### PR DESCRIPTION
Fixes #4928

## Summary

The specimen panel's heading now reads "Specimen available" / "No specimen available" (state-dependent, reusing the existing `show_observation_specimen_available`/`_not_available` tags — previously only used for a separate line inside the body) instead of the static "specimen" title. That in-body line is removed as redundant now that its text lives in the heading.

The panel is now collapsible. Expanded by default when the observation has any collection numbers, herbarium records, or sequences; collapsed when it has none of the three — independent of the `specimen` boolean flag itself.

## Test plan

- [x] `bin/rails test test/views/controllers/observations/show/specimen_panel_test.rb` — 0 failures, including new coverage for the heading text and collapse-default behavior
- [x] `bundle exec rubocop` clean on both touched files
