### PR TITLE
Fix doubled colons on `Form::Specimen`'s Fungarium Name and Accession Number labels

### DIFF
--- a/app/views/controllers/observations/form/specimen.rb
+++ b/app/views/controllers/observations/form/specimen.rb
@@ -102,12 +102,11 @@ class Views::Controllers::Observations::Form::Specimen < Views::Base
   end
 
   def render_herbarium_autocompleter(hr_ns)
-    label = "#{:herbarium_record_herbarium_name.l}:"
     help = :form_observations_herbarium_record_help.t
     render(hr_ns.field(:herbarium_name).autocompleter(
              type: :herbarium,
-             wrapper_options: { label: label, help: help,
-                                help_collapse: true },
+             wrapper_options: { label: :herbarium_record_herbarium_name,
+                                help: help, help_collapse: true },
              value: @herbarium_name,
              hidden_value: @herbarium_id,
              create_text: :create_herbarium.l,
@@ -117,9 +116,8 @@ class Views::Controllers::Observations::Form::Specimen < Views::Base
   end
 
   def render_accession_number(hr_ns)
-    label = "#{:herbarium_record_accession_number.l}:"
     render(hr_ns.field(:accession_number).text(
-             wrapper_options: { label: label },
+             wrapper_options: { label: :herbarium_record_accession_number },
              value: @accession_number,
              data: { action: "specimen#checkCheckbox" }
            ))

--- a/test/views/controllers/observations/form_test.rb
+++ b/test/views/controllers/observations/form_test.rb
@@ -53,6 +53,22 @@ module Views::Controllers::Observations
       assert_html(html, "input[type='file'][accept='image/*']")
     end
 
+    # #4687 moved colon-appending into the field helper, but these two
+    # labels were still being built with a trailing colon by hand, so they
+    # rendered "Fungarium Name::" / "Accession Number::".
+    def test_specimen_labels_have_a_single_colon
+      user = users(:rolf)
+      obs = Observation.new(when: Time.zone.today)
+
+      html = render_form(observation: obs, user: user, mode: :create)
+
+      [:herbarium_record_herbarium_name,
+       :herbarium_record_accession_number].each do |key|
+        assert_html(html, "label", text: "#{key.l}:")
+        assert_no_html(html, "label", text: "#{key.l}::")
+      end
+    end
+
     # --- Field Slip Code ---
 
     def test_new_form_shows_editable_field_slip_code


### PR DESCRIPTION
## Summary

The observation form's specimen section renders "Fungarium Name::" and "Accession Number::" — two colons each.

#4687 centralized colon-appending into the field helper: `FieldLabelRow#label_text` runs every resolved label through `Components::Localization#append_colon`. These two labels in `Views::Controllers::Observations::Form::Specimen` were still being built by hand with a trailing colon and were missed in that pass, so they picked up a second one. Their siblings in the same file — Collector's Name, Collector's Number, Notes — pass a bare Symbol and have always rendered correctly, which is why only these two doubled.

```ruby
# Before
label = "#{:herbarium_record_herbarium_name.l}:"
render(hr_ns.field(:herbarium_name).autocompleter(
         wrapper_options: { label: label, ... }))

# After
render(hr_ns.field(:herbarium_name).autocompleter(
         wrapper_options: { label: :herbarium_record_herbarium_name, ... }))
```

Passing the Symbol also drops the local variable and lets the helper do the `.t` resolution, which is how every other field in the file declares its label.

## Scope

I grepped the rest of `app/views` and `app/components` for the same pattern. Every other manually colon-suffixed string sits inside a raw `label` / `h3` / `strong` / `span` tag that never goes through `append_colon`, so this is isolated to these two fields. No other labels are affected.

## Test plan

1. Open Create Observation.
2. Expand **Specimen Available**.
3. Confirm **Fungarium Name:** and **Accession Number:** each show a single colon, and that the other fields in the section (Collector's Name, Collector's Number, Notes) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
