### PR TITLE
Derive API2 `external_link` url from `external_id`

### DIFF
--- a/app/views/controllers/api2/_external_link.json.jbuilder
+++ b/app/views/controllers/api2/_external_link.json.jbuilder
@@ -2,7 +2,8 @@
 
 json.id(object.id)
 json.type("external_link")
-json.url(object.url.to_s)
+json.url(object.link_url.to_s)
+json.external_id(object.external_id)
 json.created_at(object.created_at.try(&:utc))
 json.updated_at(object.updated_at.try(&:utc))
 json.observation_id(object.observation_id)

--- a/app/views/controllers/api2/_external_link.xml.builder
+++ b/app/views/controllers/api2/_external_link.xml.builder
@@ -6,7 +6,8 @@ xml.tag!(
   url: object.show_url,
   type: "external_link"
 ) do
-  xml_string(xml, :url, object.url)
+  xml_string(xml, :url, object.link_url)
+  xml_string(xml, :external_id, object.external_id)
   xml_datetime(xml, :created_at, object.created_at)
   xml_datetime(xml, :updated_at, object.updated_at)
   xml_minimal_object(xml, :observation, :observation, object.observation_id)

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -336,6 +336,45 @@ class API2ControllerTest < FunctionalTestCase
     assert_equal(expected, files)
   end
 
+  # A link identified by `external_id` stores no `url` -- the model's
+  # `normalize_external_id_and_url` deliberately drops it, and
+  # `ExternalSite#observation_url` is "the single source of truth for an
+  # ExternalLink's URL" (#4299/#4565). Serializing the raw `url` attribute
+  # therefore emitted "" for every materialized link, leaving API clients no
+  # way to learn what the link points to. Render `link_url` instead, and
+  # expose `external_id` so clients need not reverse-parse the URL.
+  def test_get_external_link_url_derived_from_external_id
+    link = ExternalLink.create!(
+      user: users(:rolf),
+      observation: observations(:agaricus_campestris_obs),
+      external_site: external_sites(:inaturalist),
+      relationship: :copy,
+      external_id: "4675274"
+    )
+    assert_nil(link.reload.url,
+               "an external_id-backed link must not store a url")
+
+    get(:external_links, params: { id: link.id, detail: :high, format: :json })
+
+    assert_no_api_errors
+    result = response.parsed_body["results"][0]
+    assert_equal("https://www.inaturalist.org/observations/4675274",
+                 result["url"])
+    assert_equal("4675274", result["external_id"])
+  end
+
+  # The url-column form must keep serializing exactly as before.
+  def test_get_external_link_url_from_url_column
+    link = external_links(:coprinus_comatus_obs_inaturalist_link)
+
+    get(:external_links, params: { id: link.id, detail: :high, format: :json })
+
+    assert_no_api_errors
+    result = response.parsed_body["results"][0]
+    assert_equal(link.url, result["url"])
+    assert_nil(result["external_id"])
+  end
+
   def test_post_corrupt_image
     setup_image_dirs
     count = Image.count


### PR DESCRIPTION
# API2: derive `external_link` url from `external_id`

## Problem

`GET /api2/external_links` returns `"url": ""` for every link identified by
`external_id` rather than by the `url` column — which is every link
`script/materialize_external_links.rb` created. The target is in the database
and the web UI displays it correctly; only the API can't see it.

Observation 2799, external_link 272867:

```
GET /api2/external_links?id=272867&detail=high&format=json
→ {"id":272867,"url":"","observation_id":2799,
   "owner":{"id":0,"login_name":"admin"},
   "external_site":{"id":2,"name":"iNaturalist"}}
```

while the page renders the target fine:

```
GET /external_links/272867   (Turbo-Frame: external_link_frame_272867)
→ <a href="https://www.inaturalist.org/observations/4675274">
     2016-12-01: Copied by iNaturalist</a>
```

Confirmed in production:

```
+--------+-------------------------------------------+-------------+--------------+---------+
| id     | url                                       | external_id | relationship | user_id |
+--------+-------------------------------------------+-------------+--------------+---------+
|   4934 | https://www.inaturalist.org/.../61261786  | NULL        |            0 |     123 |
| 272867 | NULL                                      |     4675274 |            4 |       0 |
+--------+-------------------------------------------+-------------+--------------+---------+
```

## Cause

`_external_link.json.jbuilder` serialized the raw attribute:

```ruby
json.url(object.url.to_s)
```

but `ExternalLink` deliberately nils `url` whenever `external_id` is present —
the XOR invariant from #4565 — and provides `link_url` for reading it back:

```ruby
def normalize_external_id_and_url
  self.external_id = nil if external_id.blank?
  self.url = nil if external_id.present?
end

def link_url
  url.presence || external_site&.observation_url(external_id)
end
```

`ExternalSite#observation_url` is documented as "the single source of truth for
an ExternalLink's URL — links store only `external_id`, not the full URL"
(#4299). The serializer was the one reader not going through it.
`_external_link.xml.builder` had the same issue.

## Change

- `json.url(object.link_url.to_s)` / `xml_string(xml, :url, object.link_url)`
- also serialize `external_id`, so clients don't have to reverse-parse the URL
  to recover the site's own identifier
- two controller tests: one for the `external_id` form, one pinning the
  `url`-column form so existing behavior stays fixed

The tests build the record with `ExternalLink.create!` rather than adding a
fixture, deliberately: fixtures skip `before_validation`, so a fixture with
both `external_id` and `url` set (as `imported_inat_obs_inat_link` has) does
not reproduce production rows. Going through the model exercises the invariant
that causes the bug.

## Scope / follow-up

Not fixed here, but same root cause and probably worth its own issue:
`Query::ExternalLinks`'s `url_has` searches `ExternalLink[:url]` directly, so
URL search never matches an `external_id`-backed link:

```
?url=https://www.inaturalist.org/observations/61261786   → 1 result
?url=https://www.inaturalist.org/observations/4675274    → 0 results
```

Fixing that means matching a derived value in SQL, which is a bigger design
call than this serializer change — happy to open a separate issue.

## Impact

There are ~11,273 of these rows on my account alone. To an API consumer each
one announces "this observation is linked to iNaturalist" while providing no
way to learn which observation, and it can't safely be ignored either, since
it's indistinguishable from a real link whose target failed to serialize.

## Testing

Style-checked against `.rubocop.yml` (all lines ≤ 80, methods well under the
30-line limit), but I have no Ruby/Rails/MySQL environment set up, so **I have
not been able to run the suite** — the two new tests need a real run before
merge.
