### PR TITLE
Hide Nomenclature registration column for code names

### DIFF
--- a/app/models/name/taxonomy.rb
+++ b/app/models/name/taxonomy.rb
@@ -57,6 +57,11 @@ module Name::Taxonomy
 
   # ----------------------------------------------------------------------------
 
+  # Is this an informal "code name"? Ex:  Cortinarius sp. 'IN34'
+  def code_name?
+    / sp(\.) '/.match?(text_name)
+  end
+
   # Is the Name (potentially) registrable in a fungal nomenclature repository?
   # This and #unregistrable are used in the views to determine whether
   # to display the ICN identifier, links to nomenclature records or searches

--- a/app/views/controllers/names/show/nomenclature.rb
+++ b/app/views/controllers/names/show/nomenclature.rb
@@ -149,6 +149,8 @@ class Views::Controllers::Names::Show::Nomenclature < Views::Base
   # --- Right column -------------------------------------------------
 
   def render_right_column
+    return if @name.code_name?
+
     Column(xs: 12, sm: 6) do
       ul(class: "list-unstyled") do
         if @name.icn_id?

--- a/test/models/name/taxonomy_test.rb
+++ b/test/models/name/taxonomy_test.rb
@@ -688,6 +688,23 @@ class Name::TaxonomyTest < UnitTestCase
            "Non-group, non-domain kingdom-less names should be registrable")
   end
 
+  def test_code_name
+    name = Name.new(text_name: "Cortinarius sp. 'IN34'", rank: "Species")
+    assert(name.code_name?, "'sp. ' + quote should be a code name")
+
+    name = names(:coprinus_comatus)
+    assert_not(name.code_name?,
+               "Ordinary binomial names should not be code names")
+
+    name = Name.new(text_name: "Cortinarius sp-IN34", rank: "Species")
+    assert_not(name.code_name?,
+               "'sp' without a period should not be a code name")
+
+    name = Name.new(text_name: 'Cortinarius "quoted"', rank: "Species")
+    assert_not(name.code_name?,
+               "A quoted name without 'sp. ' should not be a code name")
+  end
+
   def test_searchability_in_registry
     name = Name.new(text_name: "Eukaryota", rank: "Domain")
     assert(name.unsearchable_in_registry?, "Domains should be unsearchable")

--- a/test/views/controllers/names/show/nomenclature_test.rb
+++ b/test/views/controllers/names/show/nomenclature_test.rb
@@ -83,6 +83,18 @@ class Views::Controllers::Names::Show::NomenclatureTest < ComponentTestCase
     assert_html(html, "li.hanging-indent", text: :deprecated.ti.as_displayed)
   end
 
+  # Code names (informal provisional names) have no ICN registration,
+  # so the right column's registration/search links should be omitted.
+  def test_code_name_omits_right_column
+    name = names(:coprinus_comatus)
+    name.text_name = "Coprinus sp. 'IN34'"
+
+    html = render_nomenclature(name: name)
+
+    assert_no_html(html, "a[href*='indexfungorum']")
+    assert_no_html(html, "a[href*='mycobank']")
+  end
+
   def routes
     Rails.application.routes.url_helpers
   end


### PR DESCRIPTION
Resolves #4107 

<!-- changelog -->
article: yes
Hide Nomenclature registration section for code names
<!-- /changelog -->