### PR TITLE
Read field slips from their photos with an LLM, for admin review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ public/test_images-*
 
 # iNat import audit (#4213) CSV outputs — data, not code
 inat_import_audit*.csv
+
+/config/credentials/development.key
+
+# Each developer keeps their own; the dev key is not shared, so a
+# committed dev credentials file would be undecryptable for everyone else.
+/config/credentials/development.yml.enc

--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -6,10 +6,11 @@ class FieldSlip
   # `Extractor.for(:gemini)` returns a provider adapter; every adapter
   # answers `#extract(image, context:)` with an `Extractor::Result`, so
   # swapping providers -- or A/B-ing a new one against Gemini -- touches
-  # nothing but this registry. Providers do the HTTP call and hand back
-  # whatever JSON they produced; turning that into MO fields is
-  # `Extractor::Normalizer`'s job, so a new provider never reimplements
-  # the mapping.
+  # nothing but this registry. An adapter owns its own request and
+  # response parsing, and is asked -- through the shared `Prompt` -- for
+  # values keyed by the `FIELDS` labels below. Where each label lands on
+  # the Observation is `FIELDS`' business and `Applier`'s, so a new
+  # provider never restates the mapping.
   module Extractor
     PROVIDERS = { gemini: "FieldSlip::Extractor::Gemini" }.freeze
 

--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  # Machine-reads a field slip photo into MO's own field set.
+  #
+  # `Extractor.for(:gemini)` returns a provider adapter; every adapter
+  # answers `#extract(image, context:)` with an `Extractor::Result`, so
+  # swapping providers -- or A/B-ing a new one against Gemini -- touches
+  # nothing but this registry. Providers do the HTTP call and hand back
+  # whatever JSON they produced; turning that into MO fields is
+  # `Extractor::Normalizer`'s job, so a new provider never reimplements
+  # the mapping.
+  module Extractor
+    PROVIDERS = { gemini: "FieldSlip::Extractor::Gemini" }.freeze
+
+    # Bump when the prompt changes in a way that could change results.
+    # Stored on the extract so a stale read is identifiable later.
+    PROMPT_VERSION = "1"
+
+    # The slip's fields, in the order they appear on the printed form,
+    # mapped to where each one lands on the Observation. `nil` means the
+    # value is reviewed but not saved directly: the code is a
+    # cross-check against the attached slip, and the ID becomes a
+    # proposed naming rather than a column.
+    FIELDS = {
+      "Field Slip Code" => nil,
+      "Collector" => :collector,
+      "Date" => :when,
+      "Location" => :place_name,
+      "Notes" => :"notes.Other",
+      "Odor/Taste" => :"notes.Odor/Taste",
+      "Trees/Shrubs" => :"notes.Trees/Shrubs",
+      "Substrate" => :"notes.Substrate",
+      "Habit" => :"notes.Habit",
+      "ID" => nil,
+      "ID By" => :"notes.Field_Slip_ID_By",
+      "Other Codes" => :"notes.Other_Codes",
+      "MycoMap Voucher Number" => :"notes.MycoMap_Voucher_Number"
+    }.freeze
+
+    CONFIDENCE_LEVELS = %w[high medium low].freeze
+
+    # What one provider run produced: the raw response (stored verbatim
+    # for provenance), the per-field values, and the per-field
+    # confidence the model reported.
+    Result = Data.define(:provider, :model, :raw, :fields, :confidence) do
+      def value_for(slip_field) = fields[slip_field]
+
+      def confidence_for(slip_field)
+        level = confidence[slip_field].to_s.downcase
+        CONFIDENCE_LEVELS.include?(level) ? level : "low"
+      end
+    end
+
+    def self.for(provider)
+      name = PROVIDERS[provider.to_sym] ||
+             raise(ArgumentError.new("Unknown extractor: #{provider}"))
+      name.constantize.new
+    end
+
+    def self.default = self.for(:gemini)
+  end
+end

--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -50,6 +50,18 @@ class FieldSlip
     # a location autocompleter, which needs a real label to work.
     LOCATION_FIELD = "Location"
 
+    # "Other Codes" is free text, but in practice a purely numeric one
+    # is an iNaturalist observation id -- that is what collectors write
+    # in that box. Numeric values therefore default to being stored as
+    # an iNat link, the same shape the field slip form writes, with the
+    # reviewer able to untick it.
+    OTHER_CODES_FIELD = "Other Codes"
+    INAT_CODE_RE = /\A\d+\z/
+
+    def self.inat_code?(value)
+      value.to_s.strip.match?(INAT_CODE_RE)
+    end
+
     CONFIDENCE_LEVELS = %w[high medium low].freeze
 
     # What one provider run produced: the raw response (stored verbatim

--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -46,6 +46,10 @@ class FieldSlip
     # to correct a misreading.
     NAME_FIELD = "ID"
 
+    # Also its own section, for the same reason: it is corrected through
+    # a location autocompleter, which needs a real label to work.
+    LOCATION_FIELD = "Location"
+
     CONFIDENCE_LEVELS = %w[high medium low].freeze
 
     # What one provider run produced: the raw response (stored verbatim

--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -38,6 +38,14 @@ class FieldSlip
       "MycoMap Voucher Number" => :"notes.MycoMap_Voucher_Number"
     }.freeze
 
+    # The slip's ID, which has no target column: it becomes a proposed
+    # naming, not an attribute. Editable all the same, and through a
+    # name autocompleter rather than a plain box -- what collectors
+    # write is often a common name ("Lumpy Bracket") or a genus, so the
+    # reviewer's job is to look up what it actually means rather than
+    # to correct a misreading.
+    NAME_FIELD = "ID"
+
     CONFIDENCE_LEVELS = %w[high medium low].freeze
 
     # What one provider run produced: the raw response (stored verbatim

--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -12,10 +12,14 @@ class FieldSlip
     # name-creation and voting rules, so it is left to the caller.
     class Applier
       # `chosen` is {slip field => edited value} for the ticked fields.
-      def initialize(observation:, chosen:, user:)
+      # `inat_code` says whether "Other Codes" holds an iNaturalist
+      # observation id, which is stored as a link rather than as the
+      # bare number.
+      def initialize(observation:, chosen:, user:, inat_code: false)
         @observation = observation
         @chosen = chosen
         @user = user
+        @inat_code = inat_code
       end
 
       def apply
@@ -30,8 +34,20 @@ class FieldSlip
       def targets
         @targets ||= @chosen.filter_map do |field, value|
           target = Extractor::FIELDS[field]
-          [target, value.to_s.strip] if target && value.present?
+          [target, value_for(field, value)] if target && value.present?
         end
+      end
+
+      # An iNat id is stored as the link the field slip form writes, so
+      # an observation reads back the same whichever route entered it.
+      # Already-linked values pass through rather than nesting.
+      def value_for(field, value)
+        text = value.to_s.strip
+        return text unless field == Extractor::OTHER_CODES_FIELD
+        return text unless @inat_code
+        return text if FieldSlipNotesBuilder.inat_link?(text)
+
+        FieldSlipNotesBuilder.inat_link(text)
       end
 
       def assign_columns

--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  module Extractor
+    # Writes a reviewed extract onto its observation.
+    #
+    # Only the fields the reviewer ticked are applied, and the values
+    # applied are the ones they left in the form, not the ones the model
+    # produced -- the extract is a starting point, the form is the
+    # decision. The ID is deliberately not written as an attribute: it
+    # becomes a proposed naming, which is a different act with its own
+    # name-creation and voting rules, so it is left to the caller.
+    class Applier
+      # `chosen` is {slip field => edited value} for the ticked fields.
+      def initialize(observation:, chosen:, user:)
+        @observation = observation
+        @chosen = chosen
+        @user = user
+      end
+
+      def apply
+        assign_columns
+        assign_notes
+        @observation.save!
+        @observation
+      end
+
+      private
+
+      def targets
+        @targets ||= @chosen.filter_map do |field, value|
+          target = Extractor::FIELDS[field]
+          [target, value.to_s.strip] if target && value.present?
+        end
+      end
+
+      def assign_columns
+        targets.each do |target, value|
+          next if target.to_s.start_with?("notes.")
+
+          send(:"assign_#{target}", value)
+        end
+      end
+
+      def assign_notes
+        patch = targets.filter_map do |target, value|
+          next unless target.to_s.start_with?("notes.")
+
+          [target.to_s.delete_prefix("notes.").to_sym, value]
+        end.to_h
+        return if patch.empty?
+
+        @observation.notes = @observation.notes.to_h.merge(patch)
+      end
+
+      def assign_collector(value)
+        attrs = Observation.collector_attrs(resolved_user(value) || value)
+        @observation.collector = attrs[:collector]
+        @observation.collector_user_id = attrs[:collector_user_id]
+      end
+
+      def assign_when(value)
+        parsed = Date.parse(value)
+        @observation.when = parsed
+      rescue Date::Error
+        nil # a date the reviewer left unparseable is skipped, not fatal
+      end
+
+      # A location the project aliases (or MO itself) know becomes a real
+      # Location; anything else is stored as free text, exactly as the
+      # observation form does with a place name it can't resolve.
+      def assign_place_name(value)
+        location = alias_location(value) || Location.find_by(name: value)
+        if location
+          @observation.location = location
+          @observation.where = location.name
+        else
+          @observation.location = nil
+          @observation.where = value
+        end
+      end
+
+      def alias_location(value)
+        project_alias(value, "Location")&.target
+      end
+
+      def resolved_user(value)
+        project_alias(value, "User")&.target
+      end
+
+      def project_alias(value, target_type)
+        ids = @observation.project_ids
+        return nil if ids.empty?
+
+        ProjectAlias.where(project_id: ids, name: value.to_s.strip,
+                           target_type: target_type).
+          includes(:target).order(updated_at: :desc).first
+      end
+    end
+  end
+end

--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -59,11 +59,16 @@ class FieldSlip
         @observation.collector_user_id = attrs[:collector_user_id]
       end
 
+      # ISO only, deliberately. `Date.parse` is far too permissive to
+      # trust here -- it reads "sometime in July" as July 1st of the
+      # current year and raises nothing, so a garbage value would
+      # silently set a wrong date rather than being skipped. The prompt
+      # asks for YYYY-MM-DD and the field is prefilled with it, so
+      # anything else is a typo and gets left alone.
       def assign_when(value)
-        parsed = Date.parse(value)
-        @observation.when = parsed
+        @observation.when = Date.strptime(value, "%Y-%m-%d")
       rescue Date::Error
-        nil # a date the reviewer left unparseable is skipped, not fatal
+        nil
       end
 
       # A location the project aliases (or MO itself) know becomes a real

--- a/app/classes/field_slip/extractor/context.rb
+++ b/app/classes/field_slip/extractor/context.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  module Extractor
+    # What the prompt needs to know about the observation an image
+    # belongs to: which project's aliases apply, what the event's dates
+    # were, and which slip code is already attached (so the model's
+    # reading of the printed code can be checked against it).
+    #
+    # An image can hang off several observations and an observation can
+    # be in several projects; both are rare, and taking the first is
+    # enough to build a prompt -- the reviewer sees every value before
+    # anything is saved.
+    class Context
+      def self.for_image(image)
+        new(observation: image.observations.first)
+      end
+
+      attr_reader :observation
+
+      def initialize(observation:)
+        @observation = observation
+      end
+
+      def project
+        @project ||= observation&.projects&.first
+      end
+
+      def field_slip_code
+        observation&.field_slip&.code
+      end
+
+      # [name, target-name] pairs for the project's aliases of one type,
+      # newest first so a corrected alias outranks a stale one when the
+      # list is truncated.
+      def aliases(target_type)
+        return [] unless project
+
+        ProjectAlias.where(project: project, target_type: target_type).
+          includes(:target).order(updated_at: :desc).
+          filter_map { |a| [a.name, alias_target_name(a)] if a.target }
+      end
+
+      def date_range
+        return nil unless project&.start_date && project.end_date
+
+        [project.start_date.to_s, project.end_date.to_s]
+      end
+
+      private
+
+      def alias_target_name(project_alias)
+        target = project_alias.target
+        case target
+        when Location then target.name
+        when User then target.legal_name.presence || target.login
+        else target.to_s
+        end
+      end
+    end
+  end
+end

--- a/app/classes/field_slip/extractor/gemini.rb
+++ b/app/classes/field_slip/extractor/gemini.rb
@@ -72,16 +72,40 @@ class FieldSlip
                               response_mime_type: "application/json" } }
       end
 
-      # Base64 of the served JPEG. Read over HTTP rather than off disk:
-      # originals live on the image server, and the size we want is a
-      # derivative that only exists there.
+      # Base64 of the JPEG, from disk when MO holds a copy. Production
+      # writes local files before transferring them, and development's
+      # image precedence puts `:local` first, so going over the network
+      # for a file already on disk would be both slower and a needless
+      # dependency -- this feature shouldn't need DNS to read an image
+      # MO already has.
       def image_data(image)
-        url = image.image_url(IMAGE_SIZE).url
-        Base64.strict_encode64(
-          RestClient::Request.execute(method: :get, url: url,
-                                      timeout: TIMEOUT,
-                                      raw_response: true).file.read
-        )
+        Base64.strict_encode64(image_bytes(image))
+      end
+
+      def image_bytes(image)
+        url = image.image_url(IMAGE_SIZE)
+        path = local_path(url)
+        return File.binread(path) if path
+
+        RestClient::Request.execute(method: :get, url: url.url,
+                                    timeout: TIMEOUT,
+                                    raw_response: true).file.read
+      end
+
+      # `Image::URL#url` resolves through `MO.image_precedence` and
+      # returns the local source as a ROOT-RELATIVE path ("/images/1280/
+      # 42.jpg?v") rather than a file:// URL -- the local source's
+      # `read` spec is a web path, and only its `test` spec is a
+      # filesystem one. So map the web prefix onto the local root rather
+      # than looking for a scheme that never appears.
+      def local_path(url)
+        resolved = url.url.sub(/\?\d+\z/, "")
+        prefix = MO.image_sources.dig(:local, :read).to_s
+        return nil if prefix.blank? || !resolved.start_with?("#{prefix}/")
+
+        path = File.join(MO.local_image_files,
+                         resolved.delete_prefix("#{prefix}/"))
+        File.exist?(path) ? path : nil
       end
 
       # The model is asked for JSON and told not to fence it, but a

--- a/app/classes/field_slip/extractor/gemini.rb
+++ b/app/classes/field_slip/extractor/gemini.rb
@@ -47,6 +47,13 @@ class FieldSlip
 
       class BadResponse < StandardError; end
 
+      # The image resolved to a local path MO doesn't actually hold.
+      class MissingImage < StandardError
+        def initialize(url)
+          super("No image file at #{url}")
+        end
+      end
+
       private
 
       def credentials
@@ -87,25 +94,43 @@ class FieldSlip
         path = local_path(url)
         return File.binread(path) if path
 
-        RestClient::Request.execute(method: :get, url: url.url,
+        resolved = url.url
+        # A file:// URL that got past `local_path` means the file MO
+        # expects is not there. Say so, rather than handing RestClient
+        # something it rejects with a bare "not an HTTP URI".
+        raise(MissingImage.new(resolved)) unless resolved.start_with?("http")
+
+        RestClient::Request.execute(method: :get, url: resolved,
                                     timeout: TIMEOUT,
                                     raw_response: true).file.read
       end
 
-      # `Image::URL#url` resolves through `MO.image_precedence` and
-      # returns the local source as a ROOT-RELATIVE path ("/images/1280/
-      # 42.jpg?v") rather than a file:// URL -- the local source's
-      # `read` spec is a web path, and only its `test` spec is a
-      # filesystem one. So map the web prefix onto the local root rather
-      # than looking for a scheme that never appears.
+      # A resolved image URL is on disk in two different shapes, and
+      # both have to be recognized or RestClient is handed something
+      # that isn't an HTTP URI and raises.
+      #
+      #   "/images/1280/42.jpg?v"   the local source's `read` spec is a
+      #                             WEB path, not a filesystem one, so
+      #                             it maps onto MO.local_image_files.
+      #   "file:///…/42.jpg?v"      other sources (the test env's
+      #                             `remote1`) do use a file:// URL.
       def local_path(url)
         resolved = url.url.sub(/\?\d+\z/, "")
+        path = file_url_path(resolved) || web_path_on_disk(resolved)
+        path if path && File.exist?(path)
+      end
+
+      def file_url_path(resolved)
+        return nil unless resolved.start_with?("file://")
+
+        resolved.delete_prefix("file://")
+      end
+
+      def web_path_on_disk(resolved)
         prefix = MO.image_sources.dig(:local, :read).to_s
         return nil if prefix.blank? || !resolved.start_with?("#{prefix}/")
 
-        path = File.join(MO.local_image_files,
-                         resolved.delete_prefix("#{prefix}/"))
-        File.exist?(path) ? path : nil
+        File.join(MO.local_image_files, resolved.delete_prefix("#{prefix}/"))
       end
 
       # The model is asked for JSON and told not to fence it, but a

--- a/app/classes/field_slip/extractor/gemini.rb
+++ b/app/classes/field_slip/extractor/gemini.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  module Extractor
+    # Google Gemini adapter. The only place in the app that talks to
+    # generativelanguage.googleapis.com -- same discipline as
+    # `Inat::APIRequest` (see .claude/rules/inat_import.md), so a swap
+    # to another provider is one new class beside this one.
+    class Gemini
+      API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+      # An alias rather than a pinned name: Google retires concrete
+      # models out from under callers -- `gemini-2.5-flash` already
+      # answers 404 with "no longer available to new users" -- and a
+      # pinned default would strand the feature until someone deployed.
+      # The response reports the concrete model it actually ran
+      # (`modelVersion`), which is what gets stored, so provenance
+      # survives the indirection. Overridable from credentials to pin a
+      # specific model without a deploy.
+      DEFAULT_MODEL = "gemini-flash-latest"
+      # Handwriting needs the pixels; :huge is 1280px on the long edge,
+      # the largest MO serves short of the untouched original.
+      IMAGE_SIZE = :huge
+      TIMEOUT = 60
+
+      # `credentials.gemini` is an OrderedOptions, i.e. a Hash -- so
+      # `.key` resolves to `Hash#key` and raises ArgumentError rather
+      # than returning the API key. Subscript, not dot.
+      def initialize(model: nil, api_key: nil)
+        @model = model || credentials[:model].presence || DEFAULT_MODEL
+        @api_key = api_key || credentials[:key]
+      end
+
+      def extract(image, context:)
+        raise(MissingKey) if @api_key.blank?
+
+        raw = post(Prompt.new(context).to_s, image_data(image))
+        payload = parse(raw)
+        Result.new(provider: "gemini",
+                   model: raw["modelVersion"].presence || @model, raw: raw,
+                   fields: payload["fields"] || {},
+                   confidence: payload["confidence"] || {})
+      end
+
+      class MissingKey < StandardError
+        def message = "No Gemini API key configured (credentials.gemini.key)"
+      end
+
+      class BadResponse < StandardError; end
+
+      private
+
+      def credentials
+        Rails.application.credentials.gemini || {}
+      end
+
+      def post(prompt, image)
+        response = RestClient::Request.execute(
+          method: :post, timeout: TIMEOUT,
+          url: "#{API_BASE}/models/#{@model}:generateContent",
+          payload: body(prompt, image).to_json,
+          headers: { content_type: :json, accept: :json,
+                     "x-goog-api-key": @api_key }
+        )
+        JSON.parse(response.body)
+      end
+
+      def body(prompt, image)
+        { contents: [{ parts: [{ text: prompt },
+                               { inline_data: { mime_type: "image/jpeg",
+                                                data: image } }] }],
+          generationConfig: { temperature: 0,
+                              response_mime_type: "application/json" } }
+      end
+
+      # Base64 of the served JPEG. Read over HTTP rather than off disk:
+      # originals live on the image server, and the size we want is a
+      # derivative that only exists there.
+      def image_data(image)
+        url = image.image_url(IMAGE_SIZE).url
+        Base64.strict_encode64(
+          RestClient::Request.execute(method: :get, url: url,
+                                      timeout: TIMEOUT,
+                                      raw_response: true).file.read
+        )
+      end
+
+      # The model is asked for JSON and told not to fence it, but a
+      # fenced answer is the classic failure, so unwrap before parsing.
+      def parse(raw)
+        text = raw.dig("candidates", 0, "content", "parts", 0, "text").to_s
+        JSON.parse(text.sub(/\A```(?:json)?\s*/, "").sub(/```\s*\z/, ""))
+      rescue JSON::ParserError => e
+        raise(BadResponse.new("Gemini did not return JSON: #{e.message}"))
+      end
+    end
+  end
+end

--- a/app/classes/field_slip/extractor/name_proposer.rb
+++ b/app/classes/field_slip/extractor/name_proposer.rb
@@ -71,8 +71,16 @@ class FieldSlip
       # Attributed to the reviewer, not the observation's owner: an
       # admin reading someone else's slip is stating their own reading
       # of it, and the vote weight should be theirs to own.
+      # `Vote.validate_value` runs `to_f` first, so it answers 0.0 -- not
+      # nil -- for a missing or unparseable value. 0 is DELETE_VOTE, and
+      # `change_vote` reads it as "remove this vote", so relying on `||`
+      # here left a proposed naming with no vote at all: present on the
+      # observation, supporting nothing. Treat anything that lands on
+      # DELETE_VOTE as absent, since the form's confidence menu never
+      # offers it.
       def cast_vote(naming)
-        value = Vote.validate_value(@vote) || Vote::MIN_POS_VOTE
+        value = Vote.validate_value(@vote)
+        value = Vote::MIN_POS_VOTE if value.nil? || value == Vote::DELETE_VOTE
         Observation::NamingConsensus.new(@observation).
           change_vote(naming, value, @user)
       end

--- a/app/classes/field_slip/extractor/name_proposer.rb
+++ b/app/classes/field_slip/extractor/name_proposer.rb
@@ -36,9 +36,16 @@ class FieldSlip
         return none if @given_name.blank?
 
         resolver = resolve
-        return needs_approval(resolver) unless resolver.success && resolver.name
+        # Three outcomes, not two. The resolver returns early on a
+        # placeholder like "unknown" -- success stays true and no name
+        # comes back -- which means there is nothing to propose, NOT
+        # that a name needs creating. Collapsing that into
+        # needs_approval sent the reviewer to a confirmation page whose
+        # feedback panel renders empty: a dead end with no way forward.
+        return propose_naming(resolver.name) if resolver.name
+        return none if resolver.success
 
-        propose_naming(resolver.name)
+        needs_approval(resolver)
       end
 
       private

--- a/app/classes/field_slip/extractor/name_proposer.rb
+++ b/app/classes/field_slip/extractor/name_proposer.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  module Extractor
+    # Turns the reviewed ID into a proposed naming on the observation.
+    #
+    # Not part of `Applier`: every other field is an attribute write,
+    # while this creates a Naming and a Vote attributed to the reviewer,
+    # and can need a second round-trip when the name is unrecognized or
+    # ambiguous. Routed through `Naming::NameResolver` -- the same
+    # resolver the observation form uses -- so an unrecognized name gets
+    # created exactly as it would there, including the confirmation step
+    # rather than silently minting a Name from a machine reading.
+    class NameProposer
+      # :none    nothing to propose
+      # :needs_approval  resolver wants a confirmation round-trip
+      # :proposed        naming + vote created
+      Outcome = Data.define(:status, :naming, :feedback) do
+        def needs_approval? = status == :needs_approval
+        def proposed? = status == :proposed
+      end
+
+      # `name_params` takes the same shape `Naming::NameResolver` does
+      # -- given_name / approved_name / chosen_name -- so the round-trip
+      # params pass straight through instead of being renamed twice.
+      def initialize(observation:, user:, name_params:, vote: nil)
+        @observation = observation
+        @user = user
+        @given_name = name_params[:given_name].to_s.strip
+        @approved_name = name_params[:approved_name].to_s
+        @chosen_name = name_params[:chosen_name].to_s
+        @vote = vote
+      end
+
+      def propose
+        return none if @given_name.blank?
+
+        resolver = resolve
+        return needs_approval(resolver) unless resolver.success && resolver.name
+
+        propose_naming(resolver.name)
+      end
+
+      private
+
+      def resolve
+        Naming::NameResolver.new(@user, given_name: @given_name,
+                                        approved_name: @approved_name,
+                                        chosen_name: @chosen_name)
+      end
+
+      def none = Outcome.new(status: :none, naming: nil, feedback: {})
+
+      # The resolver's own ivars are what the form needs to render its
+      # "create this name?" / "which of these?" feedback, so they are
+      # handed back whole rather than reinterpreted here.
+      def needs_approval(resolver)
+        Outcome.new(status: :needs_approval, naming: nil,
+                    feedback: resolver.results.except(:success))
+      end
+
+      def propose_naming(name)
+        naming = Naming.construct({}, @observation)
+        naming.name = name
+        naming.user = @user
+        naming.save!
+        cast_vote(naming)
+        Outcome.new(status: :proposed, naming: naming, feedback: {})
+      end
+
+      # Attributed to the reviewer, not the observation's owner: an
+      # admin reading someone else's slip is stating their own reading
+      # of it, and the vote weight should be theirs to own.
+      def cast_vote(naming)
+        value = Vote.validate_value(@vote) || Vote::MIN_POS_VOTE
+        Observation::NamingConsensus.new(@observation).
+          change_vote(naming, value, @user)
+      end
+    end
+  end
+end

--- a/app/classes/field_slip/extractor/prompt.rb
+++ b/app/classes/field_slip/extractor/prompt.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  module Extractor
+    # Builds the extraction instructions for one image.
+    #
+    # The abbreviation tables come from the project's own ProjectAliases
+    # rather than being written into the prompt: a foray's walk numbers
+    # and member initials already live there (see #4932), they change
+    # between forays, and every alias an admin adds while reviewing
+    # improves the next extraction. The 2025 script hardcoded the
+    # equivalent 2025 site list, which is why it could not be reused.
+    class Prompt
+      MAX_ALIASES = 60
+
+      def initialize(context)
+        @context = context
+      end
+
+      def to_s
+        [preamble, field_rules, location_table, user_table, date_rule,
+         output_format].compact.join("\n\n")
+      end
+
+      private
+
+      def preamble
+        "Extract the data written on this mushroom field slip. The slip " \
+          "is a printed form; most values are handwritten. Ignore the " \
+          "specimen photographed beside it -- do not identify the " \
+          "mushroom yourself, only transcribe what the slip says."
+      end
+
+      def field_rules
+        <<~RULES.strip
+          Fields to extract, using exactly these keys:
+          #{Extractor::FIELDS.keys.map { |f| "  - #{f}" }.join("\n")}
+
+          Rules:
+          - Transcribe what is written. Do not correct spelling or
+            expand a name you are unsure of.
+          - Use null for a field that is blank or unreadable.
+          - "Field Slip Code" is printed, not handwritten, and looks
+            like #{code_example}. It also appears in the QR code.
+          - "ID" is the name written by the collector. It may be a
+            scientific name, a common name, or a genus alone. Give it
+            verbatim.
+          - Substrate and Habit are often circled from a printed list
+            rather than written. Report the circled word(s).
+          - "MycoMap Voucher Number" is the PRINTED code in the slip's
+            top-right corner, like N26-0290. It is not handwritten and
+            is not the field slip code. Do not put it in "Other Codes";
+            "Other Codes" is only what a person wrote in that box.
+        RULES
+      end
+
+      def code_example
+        @context.field_slip_code.presence || "NEMF-10222"
+      end
+
+      # Walk numbers and site abbreviations, straight from the project.
+      def location_table
+        rows = alias_rows("Location")
+        return nil if rows.empty?
+
+        "\"Location\" is usually a walk number or site abbreviation. " \
+          "Map it to the full location name using this table, and " \
+          "return the FULL NAME:\n#{rows}\n" \
+          "If the written value is not in the table, return it " \
+          "verbatim -- do not guess which site was meant."
+      end
+
+      # Initials for Collector / ID By. Same reasoning: return the
+      # abbreviation verbatim when it is not in the table, so the
+      # reviewer sees an unknown one rather than a plausible wrong name.
+      def user_table
+        rows = alias_rows("User")
+        return nil if rows.empty?
+
+        "\"Collector\" and \"ID By\" are often initials. This project " \
+          "uses:\n#{rows}\n" \
+          "Expand an entry that appears in the table. Return anything " \
+          "else verbatim."
+      end
+
+      def alias_rows(target_type)
+        @context.aliases(target_type).first(MAX_ALIASES).map do |name, full|
+          "  #{name} = #{full}"
+        end.join("\n")
+      end
+
+      # The foray's own dates beat a hardcoded month: a slip dated
+      # outside them is far more likely misread than real.
+      def date_rule
+        range = @context.date_range
+        return "Return \"Date\" as YYYY-MM-DD." unless range
+
+        "Return \"Date\" as YYYY-MM-DD. This event ran " \
+          "#{range.first} to #{range.last}; a date outside that range " \
+          "is probably a misreading, so re-check it before answering. " \
+          "Slips often write only a month and day."
+      end
+
+      def output_format
+        <<~FORMAT.strip
+          Return ONLY a JSON object, with no markdown fence, of the form:
+
+          {
+            "fields": { <each key above>: <string or null> },
+            "confidence": { <each key above>: "high" | "medium" | "low" },
+            "notes": "anything about readability worth a reviewer knowing"
+          }
+        FORMAT
+      end
+    end
+  end
+end

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -27,22 +27,48 @@ class FormObject::FieldSlipReview < FormObject::Base
 
     def default_use? = savable && present? && !conflict?
 
-    # The name row is editable but carries no tick box: it isn't applied
-    # as an attribute, so there is nothing for one to decide.
-    def name_row? = editable && !savable
+    def name_row? = field == FieldSlip::Extractor::NAME_FIELD
+    def location_row? = field == FieldSlip::Extractor::LOCATION_FIELD
+
+    # Both get their own labelled section rather than a table cell: an
+    # autocompleter only renders its dropdown and hidden id field when
+    # it has a real label.
+    def own_section? = name_row? || location_row?
   end
 
   attribute :rows, default: -> { [] }
+  # Whether the ID as read already resolves to a Name MO holds. Drives
+  # the name tick box: a known name is safe to propose unreviewed, an
+  # unknown one is an explicit decision to create something.
+  attribute :name_known, default: false
+  # The Location the written abbreviation obviously means, when the
+  # project is already using exactly one that matches.
+  attribute :location_suggestion, default: nil
 
-  def self.build(extract:, observation:)
-    new(rows: FieldSlip::Extractor::FIELDS.map do |field, target|
-      Row.new(field: field, extracted: extract.value_for(field),
-              current: current_value(observation, target),
-              confidence: extract.confidence_for(field),
-              savable: !target.nil?,
-              editable: !target.nil? ||
-                        field == FieldSlip::Extractor::NAME_FIELD)
-    end)
+  def self.build(extract:, observation:, user: nil)
+    new(name_known: name_known?(extract, user),
+        location_suggestion: extract.location_suggestion,
+        rows: FieldSlip::Extractor::FIELDS.map do |field, target|
+          Row.new(field: field, extracted: extract.value_for(field),
+                  current: current_value(observation, target),
+                  confidence: extract.confidence_for(field),
+                  savable: !target.nil?,
+                  editable: !target.nil? ||
+                            field == FieldSlip::Extractor::NAME_FIELD)
+        end)
+  end
+
+  # Asks the resolver the same question saving will: would proposing
+  # this right now succeed without a create-the-name round-trip? Pure
+  # lookup -- the resolver only creates on an explicit approved_name.
+  def self.name_known?(extract, user)
+    return false unless user
+
+    given = extract.value_for(FieldSlip::Extractor::NAME_FIELD).to_s.strip
+    return false if given.blank?
+
+    resolver = Naming::NameResolver.new(user, given_name: given)
+    resolver.success && resolver.name.present?
   end
 
   # What the observation holds today for the column or notes key this
@@ -57,5 +83,15 @@ class FormObject::FieldSlipReview < FormObject::Base
     observation.send(target == :place_name ? :where : target)
   end
 
-  def rows_to_show = rows.compact_blank
+  def rows_to_show = rows.compact_blank.reject(&:own_section?)
+
+  def name_row = rows.find(&:name_row?)
+  def location_row = rows.find(&:location_row?)
+
+  # What to put in the Locality box: the suggested full name when there
+  # is one, since accepting it should cost nothing, but the reviewer
+  # still sees what the slip actually said in the flag above.
+  def location_value
+    location_suggestion&.name.presence || location_row&.extracted
+  end
 end

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# One reviewer's pass over a machine-read field slip (see
+# FieldSlipExtract). Each row pairs what the model read with what the
+# observation currently holds, so the form can show both and the
+# reviewer decides per field.
+#
+# `use`/`value` submit as top-level param hashes keyed by the slip's own
+# field labels rather than under this object's namespace: the labels are
+# the extract's keys ("Field Slip Code", "MycoMap Voucher Number"), not
+# attributes of anything, and keying the params by them keeps the
+# controller's read a straight lookup against `Extractor::FIELDS`.
+class FormObject::FieldSlipReview < FormObject::Base
+  Row = Data.define(:field, :extracted, :current, :confidence, :savable) do
+    # Nothing to decide when the model read nothing.
+    def blank? = extracted.to_s.strip.empty?
+
+    # A real disagreement -- both sides present and different. This is
+    # what makes the row default to OFF: applying it would overwrite
+    # something a person already entered.
+    def conflict?
+      return false if blank? || current.to_s.strip.empty?
+
+      current.to_s.strip != extracted.to_s.strip
+    end
+
+    def default_use? = savable && present? && !conflict?
+  end
+
+  attribute :rows, default: -> { [] }
+
+  def self.build(extract:, observation:)
+    new(rows: FieldSlip::Extractor::FIELDS.map do |field, target|
+      Row.new(field: field, extracted: extract.value_for(field),
+              current: current_value(observation, target),
+              confidence: extract.confidence_for(field),
+              savable: !target.nil?)
+    end)
+  end
+
+  # What the observation holds today for the column or notes key this
+  # slip field maps to. nil for the two review-only fields.
+  def self.current_value(observation, target)
+    return nil if target.nil?
+
+    key = target.to_s
+    return observation.notes.to_h[key.delete_prefix("notes.").to_sym] if
+      key.start_with?("notes.")
+
+    observation.send(target == :place_name ? :where : target)
+  end
+
+  def rows_to_show = rows.compact_blank
+end

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -44,10 +44,15 @@ class FormObject::FieldSlipReview < FormObject::Base
   # The Location the written abbreviation obviously means, when the
   # project is already using exactly one that matches.
   attribute :location_suggestion, default: nil
+  # Whether "Other Codes" looks like an iNaturalist observation id.
+  attribute :inat_code, default: false
 
   def self.build(extract:, observation:, user: nil)
     new(name_known: name_known?(extract, user),
         location_suggestion: extract.location_suggestion,
+        inat_code: FieldSlip::Extractor.inat_code?(
+          extract.value_for(FieldSlip::Extractor::OTHER_CODES_FIELD)
+        ),
         rows: FieldSlip::Extractor::FIELDS.map do |field, target|
           Row.new(field: field, extracted: extract.value_for(field),
                   current: current_value(observation, target),

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -11,7 +11,8 @@
 # attributes of anything, and keying the params by them keeps the
 # controller's read a straight lookup against `Extractor::FIELDS`.
 class FormObject::FieldSlipReview < FormObject::Base
-  Row = Data.define(:field, :extracted, :current, :confidence, :savable) do
+  Row = Data.define(:field, :extracted, :current, :confidence, :savable,
+                    :editable) do
     # Nothing to decide when the model read nothing.
     def blank? = extracted.to_s.strip.empty?
 
@@ -25,6 +26,10 @@ class FormObject::FieldSlipReview < FormObject::Base
     end
 
     def default_use? = savable && present? && !conflict?
+
+    # The name row is editable but carries no tick box: it isn't applied
+    # as an attribute, so there is nothing for one to decide.
+    def name_row? = editable && !savable
   end
 
   attribute :rows, default: -> { [] }
@@ -34,7 +39,9 @@ class FormObject::FieldSlipReview < FormObject::Base
       Row.new(field: field, extracted: extract.value_for(field),
               current: current_value(observation, target),
               confidence: extract.confidence_for(field),
-              savable: !target.nil?)
+              savable: !target.nil?,
+              editable: !target.nil? ||
+                        field == FieldSlip::Extractor::NAME_FIELD)
     end)
   end
 

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -139,7 +139,8 @@ module Images
 
     def apply_chosen_fields
       FieldSlip::Extractor::Applier.new(
-        observation: @observation, chosen: chosen_fields, user: @user
+        observation: @observation, chosen: chosen_fields, user: @user,
+        inat_code: params[:inat] == "1"
       ).apply
     end
 

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -5,15 +5,16 @@ module Images
   # result before any of it reaches the observation (see
   # FieldSlip::Extractor).
   #
-  # Admin-only for now, and not because of permissions: every call costs
-  # money and roughly a third of fields need correcting, so this wants a
-  # small number of people who know what a slip should say. `create`
-  # always re-reads -- extraction changes over time and a fresh read is
-  # the point of pressing the button again.
+  # Open to site admins and to admins of a project the image's
+  # observations belong to (see `FieldSlipExtract.permitted?`), not to
+  # everyone: each call costs money and roughly a third of fields need
+  # correcting, so this wants people who know what a slip should say.
+  # `create` always re-reads -- extraction changes over time and a fresh
+  # read is the point of pressing the button again.
   class FieldSlipExtractsController < ApplicationController
     before_action :login_required
-    before_action :admin_required
     before_action :find_image!
+    before_action :permission_required
 
     def create
       result = FieldSlip::Extractor.default.extract(@image, context: context)
@@ -57,18 +58,23 @@ module Images
 
     # No return value: a `before_action` halts the chain when it
     # redirects, so signalling with true/false would be decoration.
-    def admin_required
-      return if in_admin_mode?
+    # Runs after `find_image!` because the permission depends on the
+    # image's observations, not just on the user.
+    def permission_required
+      return unless @image
+      return if FieldSlipExtract.permitted?(image: @image, user: @user,
+                                            site_admin: in_admin_mode?)
 
       flash_error(:permission_denied.t)
-      redirect_to(image_path(params[:image_id]))
+      redirect_to(image_path(@image.id))
     end
 
     def find_image!
       @image = Image.safe_find(params[:image_id])
       return @image if @image
 
-      flash_error(:runtime_image_not_found.t(id: params[:image_id]))
+      flash_error(:runtime_object_not_found.t(type: :image,
+                                              id: params[:image_id]))
       redirect_to(images_path)
       nil
     end
@@ -89,7 +95,16 @@ module Images
       nil
     end
 
+    # Only when the reviewer ticked it. Unticked means "the slip says
+    # this, don't propose it" -- the box starts clear for a name MO
+    # doesn't hold, so creating one is always a deliberate choice.
     def propose_name
+      unless params.dig(:use, FieldSlip::Extractor::NAME_FIELD) == "1"
+        return FieldSlip::Extractor::NameProposer::Outcome.new(
+          status: :none, naming: nil, feedback: {}
+        )
+      end
+
       FieldSlip::Extractor::NameProposer.new(
         observation: @observation, user: @user, vote: params[:vote],
         name_params: {
@@ -134,7 +149,8 @@ module Images
     # a form submitted with nothing ticked arrives without `use` at all.
     def chosen_fields
       ticked = (params[:use]&.to_unsafe_h || {}).
-               select { |_k, v| v == "1" }.keys
+               select { |_k, v| v == "1" }.keys -
+               [FieldSlip::Extractor::NAME_FIELD]
       values = params[:value]&.to_unsafe_h || {}
       ticked.index_with { |field| values[field] }
     end

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Images
+  # Machine-reads a field slip photo and lets a site admin review the
+  # result before any of it reaches the observation (see
+  # FieldSlip::Extractor).
+  #
+  # Admin-only for now, and not because of permissions: every call costs
+  # money and roughly a third of fields need correcting, so this wants a
+  # small number of people who know what a slip should say. `create`
+  # always re-reads -- extraction changes over time and a fresh read is
+  # the point of pressing the button again.
+  class FieldSlipExtractsController < ApplicationController
+    before_action :login_required
+    before_action :admin_required
+    before_action :find_image!
+
+    def create
+      result = FieldSlip::Extractor.default.extract(@image, context: context)
+      FieldSlipExtract.record(
+        image: @image, user: @user, result: result,
+        prompt_version: FieldSlip::Extractor::PROMPT_VERSION
+      )
+      redirect_to(edit_image_field_slip_extract_path(@image.id))
+    rescue StandardError => e
+      flash_error(:field_slip_extract_failed.t(error: e.message))
+      redirect_to(image_path(@image.id))
+    end
+
+    def edit
+      return unless extract_or_redirect!
+
+      # No `layout:` option -- `Views::FullPageBase#around_template`
+      # picks the wrapping layout itself (see ApplicationController).
+      render(Views::Controllers::Images::FieldSlipExtracts::Edit.new(
+               extract: @extract, observation: @observation, user: @user
+             ))
+    end
+
+    def update
+      return unless extract_or_redirect!
+
+      apply_chosen_fields
+      flash_notice(:field_slip_extract_saved.t)
+      redirect_to(permanent_observation_path(@observation.id))
+    end
+
+    private
+
+    # No return value: a `before_action` halts the chain when it
+    # redirects, so signalling with true/false would be decoration.
+    def admin_required
+      return if in_admin_mode?
+
+      flash_error(:permission_denied.t)
+      redirect_to(image_path(params[:image_id]))
+    end
+
+    def find_image!
+      @image = Image.safe_find(params[:image_id])
+      return @image if @image
+
+      flash_error(:runtime_image_not_found.t(id: params[:image_id]))
+      redirect_to(images_path)
+      nil
+    end
+
+    def context
+      FieldSlip::Extractor::Context.for_image(@image)
+    end
+
+    # The extract and the observation it would be written to. Both have
+    # to exist: an image with no observation has nothing to review into.
+    def extract_or_redirect!
+      @extract = FieldSlipExtract.find_by(image_id: @image.id)
+      @observation = @extract&.observation
+      return @observation if @observation
+
+      flash_error(:field_slip_extract_missing.t)
+      redirect_to(image_path(@image.id))
+      nil
+    end
+
+    def apply_chosen_fields
+      FieldSlip::Extractor::Applier.new(
+        observation: @observation, chosen: chosen_fields, user: @user
+      ).apply
+    end
+
+    # Only the ticked rows, keyed by slip field, holding whatever text
+    # the reviewer left in the input.
+    def chosen_fields
+      ticked = params[:use].to_unsafe_h.select { |_k, v| v == "1" }.keys
+      values = params[:value]&.to_unsafe_h || {}
+      ticked.index_with { |field| values[field] }
+    end
+  end
+end

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -41,7 +41,15 @@ module Images
       return unless extract_or_redirect!
 
       apply_chosen_fields
-      flash_notice(:field_slip_extract_saved.t)
+      outcome = propose_name
+      # An unrecognized or ambiguous name needs the reviewer to confirm
+      # before a Name is created, so the page comes back with the
+      # resolver's feedback. The field writes above already landed --
+      # re-running them on the resubmit is a no-op, since the values are
+      # then identical.
+      return rerender_for_name_approval(outcome) if outcome.needs_approval?
+
+      flash_extract_saved(outcome)
       redirect_to(permanent_observation_path(@observation.id))
     end
 
@@ -81,6 +89,39 @@ module Images
       nil
     end
 
+    def propose_name
+      FieldSlip::Extractor::NameProposer.new(
+        observation: @observation, user: @user, vote: params[:vote],
+        name_params: {
+          given_name: params.dig(:value, FieldSlip::Extractor::NAME_FIELD),
+          approved_name: params[:approved_name],
+          chosen_name: params.dig(:chosen_name, :name_id)
+        }
+      ).propose
+    end
+
+    def flash_extract_saved(outcome)
+      flash_notice(:field_slip_extract_saved.t)
+      return unless outcome.proposed?
+
+      flash_notice(:field_slip_extract_name_proposed.t(
+                     name: outcome.naming.name.text_name
+                   ))
+    end
+
+    def rerender_for_name_approval(outcome)
+      outcome.feedback.each do |ivar, value|
+        instance_variable_set(:"@#{ivar}", value)
+      end
+      flash_warning(:field_slip_extract_name_needs_approval.t)
+      render(Views::Controllers::Images::FieldSlipExtracts::Edit.new(
+               extract: @extract, observation: @observation, user: @user,
+               name_feedback: outcome.feedback,
+               given_name: params.dig(:value,
+                                      FieldSlip::Extractor::NAME_FIELD).to_s
+             ))
+    end
+
     def apply_chosen_fields
       FieldSlip::Extractor::Applier.new(
         observation: @observation, chosen: chosen_fields, user: @user
@@ -89,8 +130,11 @@ module Images
 
     # Only the ticked rows, keyed by slip field, holding whatever text
     # the reviewer left in the input.
+    # Both hashes can be absent entirely -- Rails drops an empty one, so
+    # a form submitted with nothing ticked arrives without `use` at all.
     def chosen_fields
-      ticked = params[:use].to_unsafe_h.select { |_k, v| v == "1" }.keys
+      ticked = (params[:use]&.to_unsafe_h || {}).
+               select { |_k, v| v == "1" }.keys
       values = params[:value]&.to_unsafe_h || {}
       ticked.index_with { |field| values[field] }
     end

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -125,9 +125,6 @@ module Images
     end
 
     def rerender_for_name_approval(outcome)
-      outcome.feedback.each do |ivar, value|
-        instance_variable_set(:"@#{ivar}", value)
-      end
       flash_warning(:field_slip_extract_name_needs_approval.t)
       render(Views::Controllers::Images::FieldSlipExtracts::Edit.new(
                extract: @extract, observation: @observation, user: @user,

--- a/app/jobs/check_for_broken_references_job/checks.rb
+++ b/app/jobs/check_for_broken_references_job/checks.rb
@@ -52,6 +52,10 @@ class CheckForBrokenReferencesJob
       [ExternalSite,                 :project,              :alert],
       [FieldSlip,                    :project,              :nil],
       [FieldSlip,                    :user,                 :alert],
+      # An extract describes one image; without it there is nothing left
+      # to review, so it goes rather than lingering as an orphan.
+      [FieldSlipExtract,             :image,                :delete],
+      [FieldSlipExtract,             :user,                 :alert],
       [FieldSlipJobTracker,          :user,                 :alert],
       [GlossaryTerm,                 :rss_log,              :nil],
       [GlossaryTerm,                 :thumb_image,          :alert],

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -18,6 +18,24 @@ class FieldSlipExtract < AbstractModel
   validates :model, presence: true
   validates :image_id, uniqueness: true
 
+  # Who may read a slip and review the result: site admins, and the
+  # admins of any project the image's observations belong to. A foray's
+  # own organizers are exactly the people who can tell whether a slip
+  # was transcribed correctly, and they are already trusted with that
+  # project's data -- gating on site admin alone would put every foray's
+  # transcription through the same few people.
+  #
+  # Still not open to everyone: each read costs an API call, and a
+  # careless one writes to observations the reviewer may not own.
+  def self.permitted?(image:, user:, site_admin: false)
+    return false unless user
+    return true if site_admin
+
+    image.observations.any? do |obs|
+      obs.projects.any? { |project| project.is_admin?(user) }
+    end
+  end
+
   # Replaces any previous read of this image.
   def self.record(image:, user:, result:, prompt_version:)
     extract = find_or_initialize_by(image_id: image.id)
@@ -68,7 +86,48 @@ class FieldSlipExtract < AbstractModel
     written
   end
 
+  # The Location a written abbreviation obviously means, when the
+  # project is already using exactly one that matches -- "Fulton, Co"
+  # against a project whose observations sit in "Fulton Co.,
+  # Pennsylvania, USA". Slips are written by hand in the field, so the
+  # county or site is abbreviated far more often than not, and typing
+  # the full MO name back in is the slowest part of a review.
+  #
+  # Deliberately narrow: it matches only against locations THIS project
+  # already uses, and only when exactly one of them matches, so a guess
+  # can't quietly pick between two plausible sites.
+  def location_suggestion
+    written = value_for("Location").to_s.strip
+    return nil if written.blank?
+
+    matches = project_locations.select do |location|
+      normalize_place(location.name).start_with?(normalize_place(written))
+    end
+    matches.first if matches.one?
+  end
+
   private
+
+  # Punctuation and case are what differ between a hand-written
+  # abbreviation and MO's full name; word order and spelling are not.
+  def normalize_place(str)
+    str.to_s.downcase.gsub(/[^a-z0-9]+/, " ").squish
+  end
+
+  # Every location the project is already using -- its observations',
+  # its aliases' targets, and its own -- which is a much better
+  # candidate set than all of MO.
+  def project_locations
+    project = observation&.projects&.first
+    return [] unless project
+
+    from_observations = Location.joins(:observations).
+                        where(observations: { id: project.observations }).
+                        distinct.to_a
+    aliased = ProjectAlias.where(project: project, target_type: "Location").
+              includes(:target).filter_map(&:target)
+    (from_observations + aliased + [project.location]).compact.uniq
+  end
 
   def known_location_names
     context = FieldSlip::Extractor::Context.new(observation: observation)

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# The latest machine-read of one field slip photo (see
+# FieldSlip::Extractor). One row per image: re-extracting replaces the
+# previous read, because only the newest is ever reviewed and keeping a
+# history would just accumulate rows nobody looks at.
+#
+# `data` holds the provider's response verbatim alongside the values
+# pulled out of it. That is deliberately more than the review form
+# needs: stored beside `provider`/`model`/`prompt_version` it records
+# how a value was arrived at, which is the part that stays useful once
+# the extraction setup has moved on.
+class FieldSlipExtract < AbstractModel
+  belongs_to :image
+  belongs_to :user
+
+  validates :provider, presence: true
+  validates :model, presence: true
+  validates :image_id, uniqueness: true
+
+  # Replaces any previous read of this image.
+  def self.record(image:, user:, result:, prompt_version:)
+    extract = find_or_initialize_by(image_id: image.id)
+    extract.update!(
+      user: user, provider: result.provider, model: result.model,
+      prompt_version: prompt_version,
+      data: { "fields" => result.fields, "confidence" => result.confidence,
+              "raw" => result.raw }
+    )
+    extract
+  end
+
+  def fields = data.to_h["fields"] || {}
+  def confidence = data.to_h["confidence"] || {}
+
+  def value_for(slip_field) = fields[slip_field]
+
+  def confidence_for(slip_field)
+    level = confidence[slip_field].to_s.downcase
+    FieldSlip::Extractor::CONFIDENCE_LEVELS.include?(level) ? level : "low"
+  end
+
+  # The observation the reviewed values would be saved to. An image can
+  # hang off several; the review form works on one at a time.
+  def observation = image.observations.first
+
+  # The printed code the model read, when it disagrees with the slip
+  # actually attached to the observation -- the strongest signal that
+  # this image is not the slip for this observation. nil when they
+  # agree, when either is missing, or when there is no attached slip.
+  def code_mismatch
+    read = value_for("Field Slip Code").to_s.strip
+    attached = observation&.field_slip&.code.to_s.strip
+    return nil if read.blank? || attached.blank? || read == attached
+
+    [read, attached]
+  end
+
+  # Location values the project has no alias for -- "EB2" for "Early
+  # Bird 2" when the project only knows "2". Worth surfacing: adding the
+  # alias fixes this slip and every later one, since the prompt is built
+  # from the same table.
+  def unknown_location_alias
+    written = value_for("Location").to_s.strip
+    return nil if written.blank?
+    return nil if known_location_names.any? { |n| n.casecmp?(written) }
+
+    written
+  end
+
+  private
+
+  def known_location_names
+    context = FieldSlip::Extractor::Context.new(observation: observation)
+    context.aliases("Location").flatten +
+      [observation&.location&.name].compact
+  end
+end

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -81,6 +81,11 @@ class FieldSlipExtract < AbstractModel
   def unknown_location_alias
     written = value_for("Location").to_s.strip
     return nil if written.blank?
+    # A full MO location name is not an unknown abbreviation, whether or
+    # not the project happens to alias it -- warning about one and
+    # offering to define an alias would be telling the reviewer that
+    # something MO already knows is unrecognized.
+    return nil if Location.exists?(name: written)
     return nil if known_location_names.any? { |n| n.casecmp?(written) }
 
     written

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -231,6 +231,12 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   # glossary unused-image cleanup).
   has_many :external_links, as: :target, dependent: :delete_all
 
+  # The machine-read of a field slip photo (#4932) describes this image
+  # specifically, so it goes with it. delete_all for the same reason as
+  # external_links above: no destroy callbacks, and a bulk DELETE avoids
+  # loading the association under strict loading.
+  has_many :field_slip_extracts, dependent: :delete_all
+
   # The import ExternalLink for this image (its source photo), if any.
   def import_link
     if external_links.loaded?

--- a/app/views/controllers/images/field_slip_extracts/edit.rb
+++ b/app/views/controllers/images/field_slip_extracts/edit.rb
@@ -52,10 +52,17 @@ module Views::Controllers::Images::FieldSlipExtracts
       written = @extract.unknown_location_alias
       return unless written
 
+      suggestion = @extract.location_suggestion
       Alert(level: :warning) do
-        plain(:field_slip_extract_unknown_alias.t(name: written))
-        whitespace
-        render_alias_link
+        if suggestion
+          plain(:field_slip_extract_location_guess.t(
+                  written: written, suggestion: suggestion.name
+                ))
+        else
+          plain(:field_slip_extract_unknown_alias.t(name: written))
+          whitespace
+          render_alias_link
+        end
       end
     end
 
@@ -93,7 +100,8 @@ module Views::Controllers::Images::FieldSlipExtracts
       render(Form.new(image: @extract.image, extract: @extract,
                       approved_name: (@given_name if @name_feedback.present?),
                       review: FormObject::FieldSlipReview.build(
-                        extract: @extract, observation: @observation
+                        extract: @extract, observation: @observation,
+                        user: @user
                       )))
     end
 

--- a/app/views/controllers/images/field_slip_extracts/edit.rb
+++ b/app/views/controllers/images/field_slip_extracts/edit.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Review page for a machine-read field slip. Shows the slip photo beside
+# the values read off it, flags the two things worth a second look
+# before anything is saved, and hands the rest to the form.
+module Views::Controllers::Images::FieldSlipExtracts
+  class Edit < Views::FullPageBase
+    prop :extract, ::FieldSlipExtract
+    prop :observation, ::Observation
+    prop :user, ::User
+
+    def view_template
+      add_page_title(:field_slip_extract_title.t(id: @observation.id))
+      container_class(:full)
+
+      render_flags
+      Row do
+        Column(xs: 12, md: 5) { render_slip_photo }
+        Column(xs: 12, md: 7) { render_form }
+      end
+      render_provenance
+    end
+
+    private
+
+    # The strongest signal that this image is not this observation's
+    # slip: the printed code the model read is not the code attached.
+    def render_flags
+      render_code_mismatch
+      render_unknown_alias
+    end
+
+    def render_code_mismatch
+      read, attached = @extract.code_mismatch
+      return unless read
+
+      Alert(level: :danger) do
+        plain(:field_slip_extract_code_mismatch.t(read: read,
+                                                  attached: attached))
+      end
+    end
+
+    # An abbreviation nobody has defined -- "EB2" where the project only
+    # knows "2". Worth fixing at the source: the prompt is built from
+    # the same alias table, so defining it improves every later slip.
+    def render_unknown_alias
+      written = @extract.unknown_location_alias
+      return unless written
+
+      Alert(level: :warning) do
+        plain(:field_slip_extract_unknown_alias.t(name: written))
+        whitespace
+        render_alias_link
+      end
+    end
+
+    def render_alias_link
+      project = @observation.projects.first
+      return unless project
+
+      Link(type: :get, name: :field_slip_extract_add_alias.l,
+           target: new_project_alias_path(project_id: project.id))
+    end
+
+    def render_slip_photo
+      render(Components::InteractiveImage.new(
+               image: @extract.image, user: @user, votes: false
+             ))
+    end
+
+    def render_form
+      render(Form.new(image: @extract.image, extract: @extract,
+                      review: FormObject::FieldSlipReview.build(
+                        extract: @extract, observation: @observation
+                      )))
+    end
+
+    # Which setup produced these values -- the part that stays useful
+    # once extraction has moved on.
+    def render_provenance
+      small do
+        plain(:field_slip_extract_provenance.t(
+                provider: @extract.provider, model: @extract.model,
+                version: @extract.prompt_version.to_s,
+                time: @extract.updated_at.web_time
+              ))
+      end
+    end
+  end
+end

--- a/app/views/controllers/images/field_slip_extracts/edit.rb
+++ b/app/views/controllers/images/field_slip_extracts/edit.rb
@@ -8,12 +8,17 @@ module Views::Controllers::Images::FieldSlipExtracts
     prop :extract, ::FieldSlipExtract
     prop :observation, ::Observation
     prop :user, ::User
+    # Set only on the confirmation round-trip, when the reviewed ID
+    # needs a Name created or disambiguated before it can be proposed.
+    prop :name_feedback, _Nilable(Hash), default: nil
+    prop :given_name, _Nilable(String), default: nil
 
     def view_template
       add_page_title(:field_slip_extract_title.t(id: @observation.id))
       container_class(:full)
 
       render_flags
+      render_name_feedback if @name_feedback.present?
       Row do
         Column(xs: 12, md: 5) { render_slip_photo }
         Column(xs: 12, md: 7) { render_form }
@@ -62,6 +67,22 @@ module Views::Controllers::Images::FieldSlipExtracts
            target: new_project_alias_path(project_id: project.id))
     end
 
+    # The resolver's own feedback UI -- "create this name?", the
+    # ambiguous-author list, the deprecated-name alternatives -- reused
+    # rather than restated, so approving here behaves as it does on the
+    # observation form.
+    def render_name_feedback
+      render(Components::Form::NameFeedback.new(
+               button_name: :field_slip_extract_save.l,
+               given_name: @given_name.to_s,
+               names: @name_feedback[:names],
+               valid_names: @name_feedback[:valid_names],
+               suggest_corrections:
+                 @name_feedback[:suggest_corrections].present?,
+               parent_deprecated: @name_feedback[:parent_deprecated].presence
+             ))
+    end
+
     def render_slip_photo
       render(Components::InteractiveImage.new(
                image: @extract.image, user: @user, votes: false
@@ -70,6 +91,7 @@ module Views::Controllers::Images::FieldSlipExtracts
 
     def render_form
       render(Form.new(image: @extract.image, extract: @extract,
+                      approved_name: (@given_name if @name_feedback.present?),
                       review: FormObject::FieldSlipReview.build(
                         extract: @extract, observation: @observation
                       )))

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -13,10 +13,14 @@ module Views::Controllers::Images::FieldSlipExtracts
     # Superform wants the form's data object as the first positional
     # arg; the review IS that object, so it goes to `super` rather than
     # being held as a plain prop.
-    def initialize(image:, extract:, review:, **attrs)
+    # `approved_name` is set only on the confirmation round-trip: it is
+    # the name the reviewer is being asked to create, and carrying it
+    # back on the form action is what turns the resubmit into approval.
+    def initialize(image:, extract:, review:, approved_name: nil, **attrs)
       @image = image
       @extract = extract
       @review = review
+      @approved_name = approved_name
       super(review, **attrs)
     end
 
@@ -30,7 +34,10 @@ module Views::Controllers::Images::FieldSlipExtracts
     end
 
     def form_action
-      image_field_slip_extract_path(@image.id)
+      path = image_field_slip_extract_path(@image.id)
+      return path if @approved_name.blank?
+
+      "#{path}?#{{ approved_name: @approved_name }.to_query}"
     end
 
     private
@@ -55,9 +62,16 @@ module Views::Controllers::Images::FieldSlipExtracts
     end
 
     # Editable: the model's reading is a starting point, and a reviewer
-    # correcting a misread here is the whole point of the step.
+    # correcting it is the whole point of the step. The name row gets an
+    # autocompleter rather than a plain box -- a slip saying "Lumpy
+    # Bracket" is not a misreading to fix but a common name to look up,
+    # and that is a search, not a retype.
     def render_extracted_cell(row)
-      if row.savable
+      if row.name_row?
+        autocompleter_field("value[#{row.field}]", type: :name,
+                                                   value: row.extracted,
+                                                   label: false)
+      elsif row.editable
         text_field("value[#{row.field}]", value: row.extracted, label: false)
       else
         plain(row.extracted.to_s)
@@ -85,21 +99,27 @@ module Views::Controllers::Images::FieldSlipExtracts
     end
 
     def render_use_cell(row)
-      unless row.savable
-        small { plain(:field_slip_extract_review_only.l) }
-        return
+      if row.name_row?
+        small { plain(:field_slip_extract_name_only.l) }
+      elsif row.savable
+        checkbox_field("use[#{row.field}]", checked: row.default_use?,
+                                            label: false)
+      else
+        small { plain(:field_slip_extract_check_only.l) }
       end
-
-      checkbox_field("use[#{row.field}]", checked: row.default_use?,
-                                          label: false)
     end
 
-    # The ID is shown but never written here: proposing a name creates a
-    # naming and a vote, which is a different act with its own rules.
+    # The ID becomes a proposed naming rather than an attribute, so it
+    # needs a confidence to vote at. Defaults to the weakest positive
+    # value: the reviewer is relaying what a slip says, not asserting
+    # their own determination.
     def render_id_note
-      return if @extract.value_for("ID").blank?
+      return if @extract.value_for(::FieldSlip::Extractor::NAME_FIELD).blank?
 
       Help(content: :field_slip_extract_id_help.l)
+      select_field("vote", Vote.confidence_menu,
+                   label: :field_slip_extract_vote.l,
+                   value: Vote::MIN_POS_VOTE)
     end
   end
 end

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -28,7 +28,8 @@ module Views::Controllers::Images::FieldSlipExtracts
       super do
         hidden_field("_method", value: "patch")
         div(class: "table-responsive") { render_table }
-        render_id_note
+        render_location_section
+        render_name_section
         submit(:field_slip_extract_save.l)
       end
     end
@@ -62,16 +63,9 @@ module Views::Controllers::Images::FieldSlipExtracts
     end
 
     # Editable: the model's reading is a starting point, and a reviewer
-    # correcting it is the whole point of the step. The name row gets an
-    # autocompleter rather than a plain box -- a slip saying "Lumpy
-    # Bracket" is not a misreading to fix but a common name to look up,
-    # and that is a search, not a retype.
+    # correcting it is the whole point of the step.
     def render_extracted_cell(row)
-      if row.name_row?
-        autocompleter_field("value[#{row.field}]", type: :name,
-                                                   value: row.extracted,
-                                                   label: false)
-      elsif row.editable
+      if row.editable
         text_field("value[#{row.field}]", value: row.extracted, label: false)
       else
         plain(row.extracted.to_s)
@@ -99,9 +93,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     end
 
     def render_use_cell(row)
-      if row.name_row?
-        small { plain(:field_slip_extract_name_only.l) }
-      elsif row.savable
+      if row.savable
         checkbox_field("use[#{row.field}]", checked: row.default_use?,
                                             label: false)
       else
@@ -109,14 +101,77 @@ module Views::Controllers::Images::FieldSlipExtracts
       end
     end
 
-    # The ID becomes a proposed naming rather than an attribute, so it
-    # needs a confidence to vote at. Defaults to the weakest positive
-    # value: the reviewer is relaying what a slip says, not asserting
-    # their own determination.
-    def render_id_note
-      return if @extract.value_for(::FieldSlip::Extractor::NAME_FIELD).blank?
+    # Locality, like the ID, is corrected through an autocompleter and
+    # so needs a real label -- but unlike the ID it is an ordinary
+    # attribute write, so it keeps its tick box. The box is prefilled
+    # with the suggested full name when the project already uses a
+    # location the abbreviation obviously means; the flag above says
+    # what the slip actually read.
+    def render_location_section
+      row = @review.location_row
+      return if row.nil? || row.blank?
 
-      Help(content: :field_slip_extract_id_help.l)
+      panel = Components::Panel.new(panel_id: "field_slip_extract_location")
+      render(panel) do |p|
+        p.with_body do
+          autocompleter_field("value[#{row.field}]",
+                              type: :location, value: @review.location_value,
+                              label: :field_slip_extract_locality.l)
+          render_current_note(row)
+          checkbox_field("use[#{row.field}]",
+                         checked: row.default_use?,
+                         label: :field_slip_extract_apply.l)
+        end
+      end
+    end
+
+    def render_current_note(row)
+      return if row.current.to_s.blank?
+
+      div do
+        small { plain(:field_slip_extract_currently.l(value: row.current)) }
+      end
+    end
+
+    # The ID gets its own section rather than a table cell. Two reasons,
+    # both load-bearing: a name autocompleter only renders its dropdown
+    # and hidden id field when it has a real label (`label: false`
+    # silently drops the append slot they live in), and unlike every
+    # other field this one creates a Naming and a Vote rather than
+    # writing an attribute.
+    def render_name_section
+      row = @review.name_row
+      return if row.nil? || row.blank?
+
+      # `with_body`, not a bare block: Panel is slot-based, and content
+      # passed straight to it is discarded rather than rendered.
+      render(Components::Panel.new(panel_id: "field_slip_extract_name")) do |p|
+        p.with_body do
+          render_name_field(row)
+          render_name_use(row)
+          render_vote_field
+          Help(content: :field_slip_extract_id_help.l)
+        end
+      end
+    end
+
+    def render_name_field(row)
+      autocompleter_field("value[#{row.field}]",
+                          type: :name, value: row.extracted,
+                          label: :field_slip_extract_id.l)
+    end
+
+    # Ticked by default only when the ID already resolves to a name MO
+    # holds. An unrecognized one -- "Lumpy Bracket" -- starts clear, so
+    # creating a Name is always something the reviewer chose to do.
+    def render_name_use(row)
+      checkbox_field("use[#{row.field}]", checked: @review.name_known,
+                                          label: :field_slip_extract_propose.l)
+    end
+
+    # Defaults to the weakest positive value: relaying what a slip says
+    # is not asserting the reviewer's own determination.
+    def render_vote_field
       select_field("vote", Vote.confidence_menu,
                    label: :field_slip_extract_vote.l,
                    value: Vote::MIN_POS_VOTE)

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -70,7 +70,19 @@ module Views::Controllers::Images::FieldSlipExtracts
       else
         plain(row.extracted.to_s)
       end
+      render_inat_flag(row)
       render_confidence(row)
+    end
+
+    # A purely numeric "Other Codes" is an iNaturalist observation id in
+    # practice, so it ticks itself and gets stored as a link. Visible
+    # and overridable rather than silent, since the box is free text and
+    # someone will eventually write a herbarium number in it.
+    def render_inat_flag(row)
+      return unless row.field == ::FieldSlip::Extractor::OTHER_CODES_FIELD
+
+      checkbox_field("inat", checked: @review.inat_code,
+                             label: :field_slip_extract_inat.l)
     end
 
     def render_confidence(row)

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Review form for a machine-read field slip: one row per field the
+# model read, showing what it read next to what the observation already
+# holds, with a tick box deciding whether to apply it.
+#
+# Rows default to ticked only where there is nothing to lose -- a field
+# the observation has no value for. Where the two disagree the box
+# starts clear, so applying the whole form can never silently overwrite
+# something a person entered; the reviewer has to say so.
+module Views::Controllers::Images::FieldSlipExtracts
+  class Form < ::Components::ApplicationForm
+    # Superform wants the form's data object as the first positional
+    # arg; the review IS that object, so it goes to `super` rather than
+    # being held as a plain prop.
+    def initialize(image:, extract:, review:, **attrs)
+      @image = image
+      @extract = extract
+      @review = review
+      super(review, **attrs)
+    end
+
+    def view_template
+      super do
+        hidden_field("_method", value: "patch")
+        div(class: "table-responsive") { render_table }
+        render_id_note
+        submit(:field_slip_extract_save.l)
+      end
+    end
+
+    def form_action
+      image_field_slip_extract_path(@image.id)
+    end
+
+    private
+
+    def render_table
+      render(Components::Table.new(@review.rows_to_show)) do |t|
+        t.column(:field_slip_extract_field.l)
+        t.column(:field_slip_extract_read.l)
+        t.column(:field_slip_extract_current.l)
+        t.column(:field_slip_extract_use.l)
+        t.row { |row| render_row(row) }
+      end
+    end
+
+    def render_row(row)
+      tr do
+        td { plain(row.field) }
+        td { render_extracted_cell(row) }
+        td { render_current_cell(row) }
+        td { render_use_cell(row) }
+      end
+    end
+
+    # Editable: the model's reading is a starting point, and a reviewer
+    # correcting a misread here is the whole point of the step.
+    def render_extracted_cell(row)
+      if row.savable
+        text_field("value[#{row.field}]", value: row.extracted, label: false)
+      else
+        plain(row.extracted.to_s)
+      end
+      render_confidence(row)
+    end
+
+    def render_confidence(row)
+      return if row.confidence == "high"
+
+      div do
+        small do
+          plain(:field_slip_extract_confidence.l(level: row.confidence))
+        end
+      end
+    end
+
+    def render_current_cell(row)
+      current = row.current.to_s
+      if current.blank?
+        small { plain(:field_slip_extract_empty.l) }
+      else
+        plain(current)
+      end
+    end
+
+    def render_use_cell(row)
+      unless row.savable
+        small { plain(:field_slip_extract_review_only.l) }
+        return
+      end
+
+      checkbox_field("use[#{row.field}]", checked: row.default_use?,
+                                          label: false)
+    end
+
+    # The ID is shown but never written here: proposing a name creates a
+    # naming and a vote, which is a different act with its own rules.
+    def render_id_note
+      return if @extract.value_for("ID").blank?
+
+      Help(content: :field_slip_extract_id_help.l)
+    end
+  end
+end

--- a/app/views/controllers/images/show.rb
+++ b/app/views/controllers/images/show.rb
@@ -47,7 +47,7 @@ module Views::Controllers::Images
 
     def render_right_column
       render(InfoPanel.new(image: @image))
-      render_field_slip_extract_button if in_admin_mode?
+      render_field_slip_extract_button
       render_reviewer_export_controls if reviewer?
       div(id: "image_votes_container") do
         render(VotePanel.new(image: @image,
@@ -57,11 +57,13 @@ module Views::Controllers::Images
 
     # Offered on every image rather than only where a slip looks likely:
     # a plausibility test that guessed wrong would hide the button on
-    # exactly the slips someone wants to read (#4932 follow-up).
-    # Admin-only for now -- each press costs an API call and the result
-    # needs a human before it reaches the observation.
+    # exactly the slips someone wants to read (#4932 follow-up). Who may
+    # press it is `FieldSlipExtract.permitted?`, shared with the
+    # controller so the button and the endpoint can't disagree.
     def render_field_slip_extract_button
-      return if @image.observations.empty?
+      return unless ::FieldSlipExtract.permitted?(
+        image: @image, user: current_user, site_admin: in_admin_mode?
+      )
 
       div(class: "mb-3 text-center") do
         Button(type: :post, name: :field_slip_extract_button.l,

--- a/app/views/controllers/images/show.rb
+++ b/app/views/controllers/images/show.rb
@@ -47,10 +47,25 @@ module Views::Controllers::Images
 
     def render_right_column
       render(InfoPanel.new(image: @image))
+      render_field_slip_extract_button if in_admin_mode?
       render_reviewer_export_controls if reviewer?
       div(id: "image_votes_container") do
         render(VotePanel.new(image: @image,
                              size: @size, default_size: @default_size))
+      end
+    end
+
+    # Offered on every image rather than only where a slip looks likely:
+    # a plausibility test that guessed wrong would hide the button on
+    # exactly the slips someone wants to read (#4932 follow-up).
+    # Admin-only for now -- each press costs an API call and the result
+    # needs a human before it reaches the observation.
+    def render_field_slip_extract_button
+      return if @image.observations.empty?
+
+      div(class: "mb-3 text-center") do
+        Button(type: :post, name: :field_slip_extract_button.l,
+               target: image_field_slip_extract_path(@image.id))
       end
     end
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2576,6 +2576,24 @@
   field_slip_no_project: No Project found
   field_slip_nil_project: "(No Project)"
   field_slip_other_codes: Other Codes
+  field_slip_extract_button: Read Field Slip
+  field_slip_extract_title: "Field Slip Data for Observation [id]"
+  field_slip_extract_field: Field
+  field_slip_extract_read: Read from slip
+  field_slip_extract_current: Currently on observation
+  field_slip_extract_use: Save
+  field_slip_extract_empty: (empty)
+  field_slip_extract_review_only: review only
+  field_slip_extract_confidence: "[level] confidence"
+  field_slip_extract_save: Save to Observation
+  field_slip_extract_saved: Saved the selected field slip values.
+  field_slip_extract_missing: That image has no field slip data to review yet.
+  field_slip_extract_failed: "Could not read the field slip: [error]"
+  field_slip_extract_add_alias: Add this abbreviation
+  field_slip_extract_code_mismatch: "The slip in this photo reads [read], but the observation is attached to field slip [attached]. Check that this is the right photo before saving."
+  field_slip_extract_unknown_alias: "No project abbreviation is defined for [name], so the location was left as written."
+  field_slip_extract_id_help: The ID is shown for review but is not saved here. Propose it as a name on the observation itself.
+  field_slip_extract_provenance: "Read by [provider] [model], prompt v[version], [time]."
   field_slip_other_example: e.g., iNat ID
   field_slip_other_inat: Check if [:field_slip_other_codes] is an iNat ID
   field_slip_project_success: Field Slip will be associated with the [TITLE] Project

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2583,7 +2583,11 @@
   field_slip_extract_current: Currently on observation
   field_slip_extract_use: Save
   field_slip_extract_empty: (empty)
-  field_slip_extract_review_only: review only
+  field_slip_extract_check_only: cross-check only
+  field_slip_extract_name_only: not saved here
+  field_slip_extract_vote: Confidence for the proposed name
+  field_slip_extract_name_proposed: "Proposed [name] as a name for this observation."
+  field_slip_extract_name_needs_approval: The name needs confirming before it can be proposed. The other fields were saved.
   field_slip_extract_confidence: "[level] confidence"
   field_slip_extract_save: Save to Observation
   field_slip_extract_saved: Saved the selected field slip values.
@@ -2592,7 +2596,7 @@
   field_slip_extract_add_alias: Add this abbreviation
   field_slip_extract_code_mismatch: "The slip in this photo reads [read], but the observation is attached to field slip [attached]. Check that this is the right photo before saving."
   field_slip_extract_unknown_alias: "No project abbreviation is defined for [name], so the location was left as written."
-  field_slip_extract_id_help: The ID is shown for review but is not saved here. Propose it as a name on the observation itself.
+  field_slip_extract_id_help: The ID is what the collector wrote, often a common name. Look up the real name here; it is not saved with the other fields, because proposing a name creates a naming and a vote.
   field_slip_extract_provenance: "Read by [provider] [model], prompt v[version], [time]."
   field_slip_other_example: e.g., iNat ID
   field_slip_other_inat: Check if [:field_slip_other_codes] is an iNat ID

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2589,6 +2589,7 @@
   field_slip_extract_propose: Propose this as a name for the observation
   field_slip_extract_locality: Locality
   field_slip_extract_apply: Save this to the observation
+  field_slip_extract_inat: This is an iNaturalist observation id
   field_slip_extract_currently: "Currently: [value]"
   field_slip_extract_location_guess: "The slip reads [written]. This project already uses [suggestion], which is filled in below -- check it before saving."
   field_slip_extract_name_proposed: "Proposed [name] as a name for this observation."

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2584,8 +2584,13 @@
   field_slip_extract_use: Save
   field_slip_extract_empty: (empty)
   field_slip_extract_check_only: cross-check only
-  field_slip_extract_name_only: not saved here
   field_slip_extract_vote: Confidence for the proposed name
+  field_slip_extract_id: ID written on the slip
+  field_slip_extract_propose: Propose this as a name for the observation
+  field_slip_extract_locality: Locality
+  field_slip_extract_apply: Save this to the observation
+  field_slip_extract_currently: "Currently: [value]"
+  field_slip_extract_location_guess: "The slip reads [written]. This project already uses [suggestion], which is filled in below -- check it before saving."
   field_slip_extract_name_proposed: "Proposed [name] as a name for this observation."
   field_slip_extract_name_needs_approval: The name needs confirming before it can be proposed. The other fields were saved.
   field_slip_extract_confidence: "[level] confidence"
@@ -2596,7 +2601,7 @@
   field_slip_extract_add_alias: Add this abbreviation
   field_slip_extract_code_mismatch: "The slip in this photo reads [read], but the observation is attached to field slip [attached]. Check that this is the right photo before saving."
   field_slip_extract_unknown_alias: "No project abbreviation is defined for [name], so the location was left as written."
-  field_slip_extract_id_help: The ID is what the collector wrote, often a common name. Look up the real name here; it is not saved with the other fields, because proposing a name creates a naming and a vote.
+  field_slip_extract_id_help: Collectors often write a common name. Look up the scientific name here. Ticking the box proposes it, creating the name first if Mushroom Observer does not have it yet.
   field_slip_extract_provenance: "Read by [provider] [model], prompt v[version], [time]."
   field_slip_other_example: e.g., iNat ID
   field_slip_other_inat: Check if [:field_slip_other_codes] is an iNat ID

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -431,6 +431,9 @@ MushroomObserver::Application.routes.draw do
       post("emails", to: "images/emails#create",
                      as: "send_commercial_inquiry_for")
     end
+    # Singular: one field slip extract per image, replaced on re-run.
+    resource(:field_slip_extract, only: [:create, :edit, :update],
+                                  controller: "images/field_slip_extracts")
     put("/vote", to: "images/votes#update", as: "vote")
     get("/vote", to: "images/votes#show", as: "vote_interface")
   end

--- a/db/migrate/20260731120000_create_field_slip_extracts.rb
+++ b/db/migrate/20260731120000_create_field_slip_extracts.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# One machine-read of a field slip photo (see FieldSlipExtract /
+# FieldSlip::Extractor). Unique on image_id: re-running an extraction
+# replaces the previous read rather than accumulating versions, since
+# only the latest is reviewed. `provider`/`model`/`prompt_version` are
+# stored beside the data so a result can be attributed to the setup that
+# produced it -- extraction is expected to change over time.
+class CreateFieldSlipExtracts < ActiveRecord::Migration[7.2]
+  def change
+    create_table(:field_slip_extracts) do |t|
+      t.integer(:image_id, null: false)
+      t.integer(:user_id, null: false)
+      t.string(:provider, null: false)
+      t.string(:model, null: false)
+      t.string(:prompt_version)
+      t.json(:data)
+      t.timestamps
+    end
+    add_index(:field_slip_extracts, :image_id, unique: true)
+    add_index(:field_slip_extracts, :user_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_18_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_31_120000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -104,6 +104,19 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_18_120000) do
     t.text "description"
     t.datetime "last_successful_sync_at"
     t.string "url_template"
+  end
+
+  create_table "field_slip_extracts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "image_id", null: false
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "model", null: false
+    t.string "prompt_version"
+    t.json "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["image_id"], name: "index_field_slip_extracts_on_image_id", unique: true
+    t.index ["user_id"], name: "index_field_slip_extracts_on_user_id"
   end
 
   create_table "field_slip_job_trackers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/classes/field_slip/extractor/applier_test.rb
+++ b/test/classes/field_slip/extractor/applier_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlip::Extractor::ApplierTest < UnitTestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @project = projects(:eol_project)
+    @project.observations << @obs unless @project.observations.include?(@obs)
+  end
+
+  def apply_fields(chosen, user: rolf)
+    FieldSlip::Extractor::Applier.new(observation: @obs, chosen: chosen,
+                                      user: user).apply
+    @obs.reload
+  end
+
+  def test_applies_only_what_was_chosen
+    was = @obs.when
+    apply_fields({ "Collector" => "Scott Shapiro" })
+
+    assert_equal("Scott Shapiro", @obs.collector)
+    assert_equal(was, @obs.when, "an unchosen field is left alone")
+  end
+
+  def test_writes_notes_fields_under_their_keys
+    apply_fields({ "Substrate" => "wood",
+                   "MycoMap Voucher Number" => "N26-0290" })
+
+    assert_equal("wood", @obs.notes[:Substrate])
+    assert_equal("N26-0290", @obs.notes[:MycoMap_Voucher_Number])
+  end
+
+  # Several notes fields in one pass have to merge, not overwrite each
+  # other -- and must not drop notes the observation already had.
+  def test_notes_writes_merge_with_existing_notes
+    @obs.update!(notes: { Other: "keep me" })
+    apply_fields({ "Substrate" => "wood", "Habit" => "clustered" })
+
+    assert_equal("keep me", @obs.notes[:Other])
+    assert_equal("wood", @obs.notes[:Substrate])
+    assert_equal("clustered", @obs.notes[:Habit])
+  end
+
+  def test_parses_a_date
+    apply_fields({ "Date" => "2026-07-30" })
+
+    assert_equal(Date.parse("2026-07-30"), @obs.when)
+  end
+
+  # Prose dates are skipped, not guessed at: `Date.parse` would read
+  # "sometime in July" as July 1st of the current year without
+  # complaint, silently setting a wrong date.
+  def test_unparseable_date_is_skipped_not_fatal
+    was = @obs.when
+    apply_fields({ "Date" => "sometime in July",
+                   "Collector" => "Scott Shapiro" })
+
+    assert_equal(was, @obs.when)
+    assert_equal("Scott Shapiro", @obs.collector)
+  end
+
+  # A collector naming a project alias resolves to that user, so the
+  # observation gets the link rather than initials as free text.
+  def test_collector_resolves_through_a_project_alias
+    fixture = project_aliases(:one) # "RS" -> rolf
+
+    apply_fields({ "Collector" => fixture.name })
+
+    assert_equal(rolf.id, @obs.collector_user_id)
+  end
+
+  def test_collector_left_as_text_when_no_alias_matches
+    apply_fields({ "Collector" => "Some Stranger" })
+
+    assert_equal("Some Stranger", @obs.collector)
+    assert_nil(@obs.collector_user_id)
+  end
+
+  def test_location_resolves_through_a_project_alias
+    ProjectAlias.create!(project: @project, name: "EB2",
+                         target: locations(:albion))
+
+    apply_fields({ "Location" => "EB2" })
+
+    assert_equal(locations(:albion), @obs.location)
+    assert_equal(locations(:albion).name, @obs.where)
+  end
+
+  def test_location_resolves_a_real_location_name
+    apply_fields({ "Location" => locations(:burbank).name })
+
+    assert_equal(locations(:burbank), @obs.location)
+  end
+
+  # An unrecognized locality is kept as written rather than dropped: the
+  # observation form does the same, and a human can fix it later.
+  def test_unknown_location_is_kept_as_free_text
+    apply_fields({ "Location" => "Behind the barn" })
+
+    assert_nil(@obs.location)
+    assert_equal("Behind the barn", @obs.where)
+  end
+
+  def test_blank_values_are_not_applied
+    was = @obs.collector
+    apply_fields({ "Collector" => "   " })
+
+    assert_equal(was, @obs.collector)
+  end
+
+  # The two review-only fields have no target, so they can never be
+  # written even if they arrive in the chosen set.
+  def test_review_only_fields_are_never_written
+    namings_before = @obs.namings.count
+    slip_before = @obs.field_slip&.code
+
+    apply_fields({ "Field Slip Code" => "NEMF-99999",
+                   FieldSlip::Extractor::NAME_FIELD => "Coprinus comatus" })
+
+    assert_equal(slip_before, @obs.field_slip&.code)
+    assert_equal(namings_before, @obs.namings.count,
+                 "the ID is proposed elsewhere, never applied here")
+  end
+
+  def test_nothing_chosen_leaves_the_observation_alone
+    before = @obs.attributes.dup
+    apply_fields({})
+
+    assert_equal(before["collector"], @obs.collector)
+    assert_equal(before["when"], @obs.when)
+  end
+end

--- a/test/classes/field_slip/extractor/applier_test.rb
+++ b/test/classes/field_slip/extractor/applier_test.rb
@@ -9,9 +9,10 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
     @project.observations << @obs unless @project.observations.include?(@obs)
   end
 
-  def apply_fields(chosen, user: rolf)
+  def apply_fields(chosen, user: rolf, inat_code: false)
     FieldSlip::Extractor::Applier.new(observation: @obs, chosen: chosen,
-                                      user: user).apply
+                                      user: user,
+                                      inat_code: inat_code).apply
     @obs.reload
   end
 
@@ -100,6 +101,40 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
 
     assert_nil(@obs.location)
     assert_equal("Behind the barn", @obs.where)
+  end
+
+  # A numeric "Other Codes" is an iNat observation id in practice, and
+  # is stored as the link the field slip form writes, so an observation
+  # reads back the same whichever route entered it.
+  def test_numeric_other_codes_stored_as_an_inat_link
+    apply_fields({ "Other Codes" => "386717373" }, inat_code: true)
+
+    assert_equal(FieldSlipNotesBuilder.inat_link("386717373"),
+                 @obs.notes[:Other_Codes])
+  end
+
+  def test_other_codes_left_bare_when_not_flagged
+    apply_fields({ "Other Codes" => "386717373" })
+
+    assert_equal("386717373", @obs.notes[:Other_Codes])
+  end
+
+  # Editing a value that is already a link must not nest one link in
+  # another.
+  def test_an_existing_inat_link_is_not_wrapped_twice
+    already = FieldSlipNotesBuilder.inat_link("386717373")
+
+    apply_fields({ "Other Codes" => already }, inat_code: true)
+
+    assert_equal(already, @obs.notes[:Other_Codes])
+  end
+
+  # The flag is specific to Other Codes; a numeric value elsewhere is
+  # just a value.
+  def test_the_inat_flag_does_not_touch_other_fields
+    apply_fields({ "MycoMap Voucher Number" => "12345" }, inat_code: true)
+
+    assert_equal("12345", @obs.notes[:MycoMap_Voucher_Number])
   end
 
   def test_blank_values_are_not_applied

--- a/test/classes/field_slip/extractor/context_test.rb
+++ b/test/classes/field_slip/extractor/context_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlip::Extractor::ContextTest < UnitTestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @image = images(:in_situ_image)
+    @obs.images << @image unless @obs.images.include?(@image)
+    @project = projects(:eol_project)
+  end
+
+  def context_for(obs = @obs)
+    FieldSlip::Extractor::Context.new(observation: obs)
+  end
+
+  def join_project
+    @project.observations << @obs unless @project.observations.include?(@obs)
+  end
+
+  def test_for_image_uses_the_images_observation
+    context = FieldSlip::Extractor::Context.for_image(@image.reload)
+
+    assert_includes(@image.observations, context.observation)
+  end
+
+  def test_field_slip_code_comes_from_the_attached_slip
+    assert_equal(@obs.field_slip&.code, context_for.field_slip_code)
+  end
+
+  # The abbreviation table is the project's own aliases rather than
+  # anything written into the prompt -- that is what lets an alias added
+  # during review improve the next slip.
+  def test_aliases_pair_names_with_their_targets
+    join_project
+    ProjectAlias.create!(project: @project, name: "9",
+                         target: locations(:albion))
+
+    pairs = context_for.aliases("Location")
+
+    assert_includes(pairs, ["9", locations(:albion).name])
+  end
+
+  def test_user_aliases_use_the_legal_name
+    join_project
+    fixture = project_aliases(:one) # "RS" -> rolf, in eol_project
+
+    assert_equal(@project, fixture.project, "premise: alias is on this project")
+    assert_includes(context_for.aliases("User"),
+                    [fixture.name, rolf.legal_name.presence || rolf.login])
+  end
+
+  # Newest first, so a corrected alias outranks a stale one when the
+  # list is truncated for the prompt.
+  def test_aliases_are_newest_first
+    join_project
+    older = ProjectAlias.create!(project: @project, name: "AAA",
+                                 target: locations(:albion))
+    newer = ProjectAlias.create!(project: @project, name: "BBB",
+                                 target: locations(:burbank))
+    older.update_columns(updated_at: 2.days.ago)
+    newer.update_columns(updated_at: 1.hour.ago)
+
+    names = context_for.aliases("Location").map(&:first)
+
+    assert_operator(names.index("BBB"), :<, names.index("AAA"))
+  end
+
+  def test_aliases_empty_without_a_project
+    assert_empty(context_for.aliases("Location"))
+  end
+
+  # An alias whose target has been deleted would otherwise render as a
+  # blank row in the prompt, teaching the model nothing.
+  def test_aliases_skip_targetless_entries
+    join_project
+    orphan = ProjectAlias.create!(project: @project, name: "Gone",
+                                  target: locations(:albion))
+    orphan.update_columns(target_id: 0)
+
+    assert_not_includes(context_for.aliases("Location").map(&:first), "Gone")
+  end
+
+  # The event's own dates beat a hardcoded month: a slip dated outside
+  # them is far more likely misread than real.
+  def test_date_range_comes_from_the_project
+    join_project
+    @project.update!(start_date: Date.parse("2026-07-30"),
+                     end_date: Date.parse("2026-08-02"))
+
+    assert_equal(%w[2026-07-30 2026-08-02], context_for.date_range)
+  end
+
+  def test_date_range_nil_when_the_project_has_none
+    join_project
+    @project.update_columns(start_date: nil, end_date: nil)
+
+    assert_nil(context_for.date_range)
+  end
+
+  def test_no_observation_is_survivable
+    context = FieldSlip::Extractor::Context.new(observation: nil)
+
+    assert_nil(context.project)
+    assert_nil(context.field_slip_code)
+    assert_nil(context.date_range)
+    assert_empty(context.aliases("User"))
+  end
+end

--- a/test/classes/field_slip/extractor/gemini_test.rb
+++ b/test/classes/field_slip/extractor/gemini_test.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlip::Extractor::GeminiTest < UnitTestCase
+  API = %r{generativelanguage\.googleapis\.com/v1beta/models/}
+  KEY = "test-key"
+
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @image = images(:in_situ_image)
+    @obs.images << @image unless @obs.images.include?(@image)
+    @context = FieldSlip::Extractor::Context.new(observation: @obs)
+    stub_image_fetch
+    write_local_image
+  end
+
+  def teardown
+    FileUtils.rm_f(local_image_path)
+    super
+  end
+
+  def stub_image_fetch
+    stub_request(:get, /images\.mushroomobserver\.org/).
+      to_return(status: 200, body: "\xFF\xD8jpegbytes".b)
+  end
+
+  # The test environment resolves an image to a `file://` URL and the
+  # fixtures have nothing behind it, so put a file there. Reading from
+  # disk is also the production path whenever MO holds the file.
+  def write_local_image
+    FileUtils.mkdir_p(File.dirname(local_image_path))
+    File.binwrite(local_image_path, "\xFF\xD8localbytes".b)
+  end
+
+  def stub_gemini(payload, model_version: "gemini-3.6-flash", status: 200)
+    body = { "candidates" => [{ "content" => { "parts" =>
+               [{ "text" => payload }] } }],
+             "modelVersion" => model_version }
+    stub_request(:post, API).
+      with { |req| @request = req }.
+      to_return(status: status, body: body.to_json,
+                headers: { "Content-Type" => "application/json" })
+  end
+
+  def json_payload(fields: {}, confidence: {})
+    { fields: fields, confidence: confidence }.to_json
+  end
+
+  def extract(api_key: KEY, **)
+    FieldSlip::Extractor::Gemini.new(api_key: api_key, **).
+      extract(@image, context: @context)
+  end
+
+  def test_missing_key_raises_a_named_error
+    with_gemini_credentials(nil) do
+      error = assert_raises(FieldSlip::Extractor::Gemini::MissingKey) do
+        FieldSlip::Extractor::Gemini.new.extract(@image, context: @context)
+      end
+
+      assert_match(/credentials\.gemini\.key/, error.message)
+    end
+  end
+
+  def test_returns_fields_and_confidence
+    stub_gemini(json_payload(fields: { "Collector" => "Scott Shapiro" },
+                             confidence: { "Collector" => "high" }))
+
+    result = extract
+
+    assert_equal("Scott Shapiro", result.value_for("Collector"))
+    assert_equal("high", result.confidence_for("Collector"))
+    assert_equal("gemini", result.provider)
+  end
+
+  # The alias is what gets requested; the concrete model the API reports
+  # is what gets recorded, so provenance survives the indirection.
+  def test_records_the_model_the_api_actually_ran
+    stub_gemini(json_payload, model_version: "gemini-3.6-flash")
+
+    assert_equal("gemini-3.6-flash",
+                 extract(model: "gemini-flash-latest").model)
+  end
+
+  def test_falls_back_to_the_requested_model_when_none_reported
+    stub_gemini(json_payload, model_version: nil)
+
+    assert_equal("some-model", extract(model: "some-model").model)
+  end
+
+  def test_requests_the_configured_model
+    stub_gemini(json_payload)
+
+    extract(model: "gemini-3-flash-preview")
+
+    assert_requested(:post, %r{models/gemini-3-flash-preview:generateContent})
+  end
+
+  def test_sends_the_key_as_a_header_not_a_query_param
+    stub_gemini(json_payload)
+
+    extract
+
+    assert_equal(KEY, @request.headers["X-Goog-Api-Key"])
+    assert_not_includes(@request.uri.query.to_s, KEY)
+  end
+
+  def test_sends_the_prompt_and_the_image
+    stub_gemini(json_payload)
+
+    extract
+
+    parts = JSON.parse(@request.body).dig("contents", 0, "parts")
+
+    assert_includes(parts.first["text"], "Field Slip Code")
+    assert_equal("image/jpeg", parts.last.dig("inline_data", "mime_type"))
+    assert(parts.last.dig("inline_data", "data").present?)
+  end
+
+  # Asking for JSON doesn't stop a model fencing it; unwrapping is the
+  # difference between a working read and a hard failure.
+  def test_unwraps_a_fenced_json_response
+    stub_gemini("```json\n#{json_payload(fields: { "ID" => "Boletus" })}\n```")
+
+    assert_equal("Boletus", extract.value_for("ID"))
+  end
+
+  def test_non_json_response_raises_bad_response
+    stub_gemini("I'm afraid I can't do that")
+
+    assert_raises(FieldSlip::Extractor::Gemini::BadResponse) { extract }
+  end
+
+  def test_missing_fields_key_yields_an_empty_result
+    stub_gemini({ notes: "nothing legible" }.to_json)
+
+    result = extract
+
+    assert_nil(result.value_for("Collector"))
+    assert_equal("low", result.confidence_for("Collector"))
+  end
+
+  def test_http_error_propagates
+    stub_request(:post, API).to_return(status: 404, body: "{}")
+
+    assert_raises(RestClient::NotFound) { extract }
+  end
+
+  # Reading a file MO already holds beats going out to the network --
+  # faster, and it means this doesn't need DNS for a local image.
+  def test_reads_the_local_file_when_one_exists
+    stub_gemini(json_payload(fields: { "ID" => "Local" }))
+
+    assert_equal("Local", extract.value_for("ID"))
+    assert_not_requested(:get, /images\.mushroomobserver\.org/)
+  end
+
+  # A local path MO does not actually hold gets a named error rather
+  # than RestClient rejecting a file:// URL as "not an HTTP URI".
+  def test_missing_local_file_raises_a_named_error
+    stub_gemini(json_payload)
+    # A different fixture, deliberately: tests share a filesystem, so
+    # deleting the file THIS test's image resolves to would pull it out
+    # from under another test running in parallel.
+    other = images(:turned_over_image)
+
+    assert_raises(FieldSlip::Extractor::Gemini::MissingImage) do
+      FieldSlip::Extractor::Gemini.new(api_key: KEY).
+        extract(other, context: @context)
+    end
+  end
+
+  def test_fetches_remotely_when_the_url_is_http
+    stub_gemini(json_payload)
+    remote = Struct.new(:url).new(
+      "https://images.mushroomobserver.org/1280/#{@image.id}.jpg"
+    )
+
+    @image.stub(:image_url, remote) do
+      FieldSlip::Extractor::Gemini.new(api_key: KEY).
+        extract(@image, context: @context)
+    end
+
+    assert_requested(:get, /images\.mushroomobserver\.org/)
+  end
+
+  # Credentials supply both key and model when the caller passes neither.
+  def test_reads_key_and_model_from_credentials
+    stub_gemini(json_payload)
+    creds = ActiveSupport::OrderedOptions.new
+    creds[:key] = KEY
+    creds[:model] = "gemini-from-credentials"
+
+    with_gemini_credentials(creds) do
+      FieldSlip::Extractor::Gemini.new.extract(@image, context: @context)
+    end
+
+    assert_requested(:post, %r{models/gemini-from-credentials:generateContent})
+  end
+
+  private
+
+  # `Rails.application.credentials` answers `gemini` through
+  # method_missing, which Minitest's `stub` cannot alias, so define the
+  # singleton outright and take it away again.
+  def with_gemini_credentials(value)
+    creds = Rails.application.credentials
+    creds.define_singleton_method(:gemini) { value }
+    yield
+  ensure
+    creds.singleton_class.remove_method(:gemini)
+  end
+
+  # Wherever the environment's image precedence actually resolves to --
+  # `file://` in test, a root-relative web path in development -- mapped
+  # to disk the same way the adapter does it.
+  def local_image_path
+    resolved = @image.image_url(FieldSlip::Extractor::Gemini::IMAGE_SIZE).
+               url.sub(/\?\d+\z/, "")
+    return resolved.delete_prefix("file://") if resolved.start_with?("file://")
+
+    prefix = MO.image_sources.dig(:local, :read).to_s
+    File.join(MO.local_image_files, resolved.delete_prefix("#{prefix}/"))
+  end
+end

--- a/test/classes/field_slip/extractor/gemini_test.rb
+++ b/test/classes/field_slip/extractor/gemini_test.rb
@@ -5,6 +5,11 @@ require("test_helper")
 class FieldSlip::Extractor::GeminiTest < UnitTestCase
   API = %r{generativelanguage\.googleapis\.com/v1beta/models/}
   KEY = "test-key"
+  # Distinct payloads so a test can tell WHICH source the adapter read
+  # from by looking at what it sent, rather than asking WebMock whether
+  # a fetch happened -- see `assert_sent_image`.
+  REMOTE_BYTES = "\xFF\xD8jpegbytes".b
+  LOCAL_BYTES = "\xFF\xD8localbytes".b
 
   def setup
     @obs = observations(:minimal_unknown_obs)
@@ -22,7 +27,7 @@ class FieldSlip::Extractor::GeminiTest < UnitTestCase
 
   def stub_image_fetch
     stub_request(:get, /images\.mushroomobserver\.org/).
-      to_return(status: 200, body: "\xFF\xD8jpegbytes".b)
+      to_return(status: 200, body: REMOTE_BYTES)
   end
 
   # The test environment resolves an image to a `file://` URL and the
@@ -30,7 +35,7 @@ class FieldSlip::Extractor::GeminiTest < UnitTestCase
   # disk is also the production path whenever MO holds the file.
   def write_local_image
     FileUtils.mkdir_p(File.dirname(local_image_path))
-    File.binwrite(local_image_path, "\xFF\xD8localbytes".b)
+    File.binwrite(local_image_path, LOCAL_BYTES)
   end
 
   def stub_gemini(payload, model_version: "gemini-3.6-flash", status: 200)
@@ -93,7 +98,8 @@ class FieldSlip::Extractor::GeminiTest < UnitTestCase
 
     extract(model: "gemini-3-flash-preview")
 
-    assert_requested(:post, %r{models/gemini-3-flash-preview:generateContent})
+    assert_includes(@request.uri.to_s,
+                    "models/gemini-3-flash-preview:generateContent")
   end
 
   def test_sends_the_key_as_a_header_not_a_query_param
@@ -152,7 +158,7 @@ class FieldSlip::Extractor::GeminiTest < UnitTestCase
     stub_gemini(json_payload(fields: { "ID" => "Local" }))
 
     assert_equal("Local", extract.value_for("ID"))
-    assert_not_requested(:get, /images\.mushroomobserver\.org/)
+    assert_sent_image(LOCAL_BYTES)
   end
 
   # A local path MO does not actually hold gets a named error rather
@@ -181,7 +187,7 @@ class FieldSlip::Extractor::GeminiTest < UnitTestCase
         extract(@image, context: @context)
     end
 
-    assert_requested(:get, /images\.mushroomobserver\.org/)
+    assert_sent_image(REMOTE_BYTES)
   end
 
   # Credentials supply both key and model when the caller passes neither.
@@ -195,10 +201,23 @@ class FieldSlip::Extractor::GeminiTest < UnitTestCase
       FieldSlip::Extractor::Gemini.new.extract(@image, context: @context)
     end
 
-    assert_requested(:post, %r{models/gemini-from-credentials:generateContent})
+    assert_includes(@request.uri.to_s,
+                    "models/gemini-from-credentials:generateContent")
   end
 
   private
+
+  # Which bytes reached the provider, read off THIS test's captured
+  # request. WebMock's registry is never reset in this suite, so
+  # `assert_requested`/`assert_not_requested` answer "did any test in
+  # this process make that call?" -- which passed locally and failed on
+  # CI purely on test order.
+  def assert_sent_image(bytes)
+    sent = JSON.parse(@request.body).
+           dig("contents", 0, "parts", 1, "inline_data", "data")
+
+    assert_equal(Base64.strict_encode64(bytes), sent)
+  end
 
   # `Rails.application.credentials` answers `gemini` through
   # method_missing, which Minitest's `stub` cannot alias, so define the

--- a/test/classes/field_slip/extractor/name_proposer_test.rb
+++ b/test/classes/field_slip/extractor/name_proposer_test.rb
@@ -118,17 +118,19 @@ class FieldSlip::Extractor::NameProposerTest < UnitTestCase
     assert_equal(name, outcome.naming.name)
   end
 
-  # The resolver treats "unknown" as no opinion, so it neither resolves
-  # nor asks to create anything. Note "Fungi" is NOT one of these: it is
-  # a real Name and proposing it is legitimate, if uninformative.
+  # The resolver treats "unknown" as no opinion: it returns early with
+  # success and no name. That means nothing to propose -- NOT a name
+  # needing creation, which would send the reviewer to a confirmation
+  # page whose feedback panel renders empty. Note "Fungi" is not one of
+  # these: it is a real Name and proposing it is legitimate.
   def test_placeholder_names_propose_nothing
     names_before = Name.count
 
     Name.names_for_unknown.compact_blank.uniq.each do |placeholder|
       outcome = propose(placeholder)
 
-      assert_predicate(outcome, :needs_approval?,
-                       "#{placeholder.inspect} should not resolve")
+      assert_equal(:none, outcome.status,
+                   "#{placeholder.inspect} is no opinion, not a new name")
     end
     assert_equal(names_before, Name.count)
   end

--- a/test/classes/field_slip/extractor/name_proposer_test.rb
+++ b/test/classes/field_slip/extractor/name_proposer_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlip::Extractor::NameProposerTest < UnitTestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+  end
+
+  def propose(given, user: rolf, vote: nil, approved: nil, chosen: nil)
+    FieldSlip::Extractor::NameProposer.new(
+      observation: @obs, user: user, vote: vote,
+      name_params: { given_name: given, approved_name: approved,
+                     chosen_name: chosen }
+    ).propose
+  end
+
+  def test_nothing_to_propose_when_the_id_is_blank
+    before = @obs.namings.count
+
+    ["", "   ", nil].each do |blank|
+      outcome = propose(blank)
+
+      assert_equal(:none, outcome.status)
+    end
+    assert_equal(before, @obs.reload.namings.count)
+  end
+
+  # ---------- a name MO already holds ----------
+
+  def test_proposes_a_known_name
+    before = @obs.namings.count
+
+    outcome = propose("Coprinus comatus")
+
+    assert_predicate(outcome, :proposed?)
+    assert_equal(before + 1, @obs.reload.namings.count)
+    assert_equal("Coprinus comatus", outcome.naming.name.text_name)
+  end
+
+  # An admin reading someone else's slip is stating their own reading of
+  # it, so the naming and the vote are theirs, not the owner's.
+  def test_naming_is_attributed_to_the_reviewer
+    assert_not_equal(@obs.user, dick, "premise: reviewer is not the owner")
+
+    outcome = propose("Coprinus comatus", user: dick)
+
+    assert_equal(dick, outcome.naming.user)
+  end
+
+  def test_casts_the_requested_vote
+    outcome = propose("Coprinus comatus", vote: Vote::MAXIMUM_VOTE.to_s)
+    vote = Vote.find_by(naming: outcome.naming, user: rolf)
+
+    assert_equal(Vote::MAXIMUM_VOTE, vote.value)
+  end
+
+  # Relaying what a slip says is not asserting a determination, so the
+  # weakest positive value is the default.
+  def test_vote_defaults_to_the_weakest_positive_value
+    outcome = propose("Coprinus comatus")
+    vote = Vote.find_by(naming: outcome.naming, user: rolf)
+
+    assert_equal(Vote::MIN_POS_VOTE, vote.value)
+  end
+
+  def test_unusable_vote_falls_back_to_the_default
+    outcome = propose("Coprinus comatus", vote: "not a number")
+    vote = Vote.find_by(naming: outcome.naming, user: rolf)
+
+    assert_equal(Vote::MIN_POS_VOTE, vote.value)
+  end
+
+  # ---------- a name MO does not hold ----------
+
+  # The whole point of the round-trip: a machine reading never mints a
+  # Name on its own.
+  def test_unknown_name_asks_before_creating_anything
+    names_before = Name.count
+    namings_before = @obs.namings.count
+
+    outcome = propose("Lumpy Bracket")
+
+    assert_predicate(outcome, :needs_approval?)
+    assert_equal(names_before, Name.count)
+    assert_equal(namings_before, @obs.reload.namings.count)
+  end
+
+  # The resolver's own ivars drive the form's "create this name?" UI,
+  # so they have to survive the trip back.
+  def test_needs_approval_carries_the_resolvers_feedback
+    outcome = propose("Lumpysomething bracketii")
+
+    assert(outcome.feedback.key?(:names))
+    assert_not(outcome.feedback.key?(:success),
+               "success is the status, not feedback")
+  end
+
+  def test_approved_name_is_created_and_proposed
+    names_before = Name.count
+
+    outcome = propose("Lumpysomething bracketii",
+                      approved: "Lumpysomething bracketii")
+
+    assert_predicate(outcome, :proposed?)
+    assert_operator(Name.count, :>, names_before)
+    assert_equal("Lumpysomething bracketii", outcome.naming.name.text_name)
+  end
+
+  # Choosing among same-named authors goes through the same resolver
+  # path the observation form uses.
+  def test_chosen_name_resolves_to_that_record
+    name = names(:coprinus_comatus)
+
+    outcome = propose("anything at all", chosen: name.id.to_s)
+
+    assert_predicate(outcome, :proposed?)
+    assert_equal(name, outcome.naming.name)
+  end
+
+  # The resolver treats "unknown" as no opinion, so it neither resolves
+  # nor asks to create anything. Note "Fungi" is NOT one of these: it is
+  # a real Name and proposing it is legitimate, if uninformative.
+  def test_placeholder_names_propose_nothing
+    names_before = Name.count
+
+    Name.names_for_unknown.compact_blank.uniq.each do |placeholder|
+      outcome = propose(placeholder)
+
+      assert_predicate(outcome, :needs_approval?,
+                       "#{placeholder.inspect} should not resolve")
+    end
+    assert_equal(names_before, Name.count)
+  end
+end

--- a/test/classes/field_slip/extractor/prompt_test.rb
+++ b/test/classes/field_slip/extractor/prompt_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlip::Extractor::PromptTest < UnitTestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @project = projects(:eol_project)
+    @project.observations << @obs unless @project.observations.include?(@obs)
+  end
+
+  def prompt(obs = @obs)
+    context = FieldSlip::Extractor::Context.new(observation: obs)
+    FieldSlip::Extractor::Prompt.new(context).to_s
+  end
+
+  def test_asks_for_every_field_by_its_exact_key
+    text = prompt
+    FieldSlip::Extractor::FIELDS.each_key do |field|
+      assert_includes(text, field, "prompt must name #{field}")
+    end
+  end
+
+  def test_asks_for_json_with_confidence
+    text = prompt
+
+    assert_includes(text, "fields")
+    assert_includes(text, "confidence")
+    assert_includes(text, "JSON")
+  end
+
+  # The whole point of building the prompt from the database: the walk
+  # numbers a foray actually uses, not a list written into the code.
+  def test_includes_the_projects_location_aliases
+    ProjectAlias.create!(project: @project, name: "EB2",
+                         target: locations(:albion))
+
+    text = prompt
+
+    assert_includes(text, "EB2 = #{locations(:albion).name}")
+  end
+
+  def test_includes_the_projects_user_aliases
+    text = prompt
+    fixture = project_aliases(:one) # "RS" -> rolf
+
+    assert_includes(text, "#{fixture.name} = ")
+  end
+
+  # An abbreviation the project hasn't defined must come back verbatim
+  # rather than guessed at -- that is what surfaces it for an admin to
+  # add, instead of silently resolving to a plausible wrong site.
+  def test_instructs_verbatim_return_for_unknown_abbreviations
+    ProjectAlias.create!(project: @project, name: "EB2",
+                         target: locations(:albion))
+
+    assert_includes(prompt, "verbatim")
+  end
+
+  def test_includes_the_events_date_range
+    @project.update!(start_date: Date.parse("2026-07-30"),
+                     end_date: Date.parse("2026-08-02"))
+
+    text = prompt
+
+    assert_includes(text, "2026-07-30")
+    assert_includes(text, "2026-08-02")
+  end
+
+  def test_still_asks_for_iso_dates_without_a_range
+    @project.update_columns(start_date: nil, end_date: nil)
+
+    assert_includes(prompt, "YYYY-MM-DD")
+  end
+
+  # The MycoMap voucher is printed, not handwritten, and belongs in its
+  # own field -- left unsaid, the model files it under Other Codes.
+  def test_separates_the_printed_voucher_from_other_codes
+    text = prompt
+
+    assert_includes(text, "MycoMap Voucher Number")
+    assert_includes(text, "Other Codes")
+    assert_match(/printed/i, text)
+  end
+
+  def test_tells_the_model_not_to_identify_the_mushroom
+    assert_match(/do not identify/i, prompt)
+  end
+
+  # No project, no aliases: the prompt still has to be usable.
+  def test_survives_an_observation_with_no_project
+    @project.observations.delete(@obs)
+
+    text = prompt(@obs.reload)
+
+    assert_includes(text, "Field Slip Code")
+    assert_includes(text, "YYYY-MM-DD")
+  end
+
+  def test_uses_the_attached_slip_code_as_the_example
+    assert_includes(prompt, @obs.field_slip.code) if @obs.field_slip
+  end
+
+  # A foray can define more aliases than belong in one prompt; the cap
+  # keeps the request bounded rather than growing without limit.
+  def test_alias_list_is_capped
+    max = FieldSlip::Extractor::Prompt::MAX_ALIASES
+    (max + 5).times do |i|
+      ProjectAlias.create!(project: @project, name: "L#{i}",
+                           target: locations(:albion))
+    end
+
+    rows = prompt.scan(/^  L\d+ = /).size
+
+    assert_operator(rows, :<=, max)
+  end
+end

--- a/test/classes/field_slip/extractor_test.rb
+++ b/test/classes/field_slip/extractor_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlip::ExtractorTest < UnitTestCase
+  def test_for_returns_the_named_adapter
+    assert_instance_of(FieldSlip::Extractor::Gemini,
+                       FieldSlip::Extractor.for(:gemini))
+    assert_instance_of(FieldSlip::Extractor::Gemini,
+                       FieldSlip::Extractor.for("gemini"))
+  end
+
+  def test_for_rejects_an_unknown_provider
+    assert_raises(ArgumentError) { FieldSlip::Extractor.for(:tesseract) }
+  end
+
+  def test_default_is_gemini
+    assert_instance_of(FieldSlip::Extractor::Gemini,
+                       FieldSlip::Extractor.default)
+  end
+
+  # Every field either maps to somewhere on the Observation or is
+  # deliberately review-only. A new field with a typo'd target would
+  # otherwise fail silently at save time.
+  def test_field_targets_are_reachable
+    obs = observations(:minimal_unknown_obs)
+    FieldSlip::Extractor::FIELDS.each do |field, target|
+      next if target.nil?
+
+      key = target.to_s
+      if key.start_with?("notes.")
+        assert(key.delete_prefix("notes.").present?, "#{field}: empty key")
+      else
+        assert_respond_to(obs, target, "#{field}: no such attribute")
+      end
+    end
+  end
+
+  def test_name_field_is_review_only
+    assert_nil(FieldSlip::Extractor::FIELDS[FieldSlip::Extractor::NAME_FIELD],
+               "the ID becomes a naming, never an attribute write")
+  end
+
+  # ---------- Result ----------
+
+  def result(fields: {}, confidence: {})
+    FieldSlip::Extractor::Result.new(provider: "gemini", model: "m", raw: {},
+                                     fields: fields, confidence: confidence)
+  end
+
+  def test_result_reads_values_and_confidence
+    res = result(fields: { "Date" => "2026-07-30" },
+                 confidence: { "Date" => "medium" })
+
+    assert_equal("2026-07-30", res.value_for("Date"))
+    assert_equal("medium", res.confidence_for("Date"))
+  end
+
+  # An unrecognized level is treated as low rather than trusted: the
+  # confidence drives what a reviewer looks at first.
+  def test_result_confidence_falls_back_to_low
+    res = result(confidence: { "Date" => "pretty sure" })
+
+    assert_equal("low", res.confidence_for("Date"))
+    assert_equal("low", res.confidence_for("Missing"))
+  end
+end

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FormObject::FieldSlipReviewTest < UnitTestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @image = images(:in_situ_image)
+    @obs.images << @image unless @obs.images.include?(@image)
+  end
+
+  def build(fields: {}, confidence: {}, user: rolf)
+    extract = FieldSlipExtract.record(
+      image: @image, user: rolf, prompt_version: "1",
+      result: FieldSlip::Extractor::Result.new(
+        provider: "g", model: "m", raw: {}, fields: fields,
+        confidence: confidence
+      )
+    )
+    FormObject::FieldSlipReview.build(extract: extract, observation: @obs,
+                                      user: user)
+  end
+
+  def row_for(review, field)
+    review.rows.find { |row| row.field == field }
+  end
+
+  def test_builds_one_row_per_field
+    review = build
+
+    assert_equal(FieldSlip::Extractor::FIELDS.keys, review.rows.map(&:field))
+  end
+
+  # Nothing read means nothing to review, so the table stays short.
+  def test_rows_to_show_drops_blank_rows
+    review = build(fields: { "Collector" => "Scott Shapiro" })
+
+    assert_equal(["Collector"], review.rows_to_show.map(&:field))
+  end
+
+  # The ID needs a real label to render its autocompleter, which a table
+  # cell has no room for, so it is pulled out of the table.
+  def test_rows_to_show_excludes_the_name_row
+    review = build(fields: { FieldSlip::Extractor::NAME_FIELD => "Boletus",
+                             "Collector" => "Scott Shapiro" })
+
+    assert_not_includes(review.rows_to_show.map(&:field),
+                        FieldSlip::Extractor::NAME_FIELD)
+    assert_equal(FieldSlip::Extractor::NAME_FIELD, review.name_row.field)
+  end
+
+  def test_name_row_is_editable_but_not_savable
+    review = build(fields: { FieldSlip::Extractor::NAME_FIELD => "Boletus" })
+    row = review.name_row
+
+    assert(row.editable, "the reviewer looks the real name up here")
+    assert_not(row.savable, "it becomes a naming, not an attribute")
+  end
+
+  def test_review_only_rows_are_neither_editable_nor_savable
+    review = build(fields: { "Field Slip Code" => "NEMF-10222" })
+    row = row_for(review, "Field Slip Code")
+
+    assert_not(row.editable)
+    assert_not(row.savable)
+  end
+
+  # ---------- current values ----------
+
+  def test_current_value_reads_a_column
+    @obs.update!(collector: "Someone Else")
+    review = build(fields: { "Collector" => "Scott Shapiro" })
+
+    assert_equal("Someone Else", row_for(review, "Collector").current)
+  end
+
+  def test_current_value_reads_a_notes_key
+    @obs.update!(notes: { Substrate: "soil" })
+    review = build(fields: { "Substrate" => "wood" })
+
+    assert_equal("soil", row_for(review, "Substrate").current)
+  end
+
+  # Locality is stored as `where`, whatever the form calls it.
+  def test_current_value_for_locality_reads_where
+    review = build(fields: { "Location" => "EB2" })
+
+    assert_equal(@obs.where, row_for(review, "Location").current)
+  end
+
+  # ---------- conflict and the tick default ----------
+
+  def test_conflict_when_both_sides_differ
+    @obs.update!(collector: "Someone Else")
+    row = row_for(build(fields: { "Collector" => "Scott Shapiro" }),
+                  "Collector")
+
+    assert_predicate(row, :conflict?)
+    assert_not(row.default_use?, "a conflict must not tick itself")
+  end
+
+  def test_no_conflict_when_the_observation_is_empty
+    @obs.update!(collector: nil)
+    row = row_for(build(fields: { "Collector" => "Scott Shapiro" }),
+                  "Collector")
+
+    assert_not_predicate(row, :conflict?)
+    assert(row.default_use?, "nothing to lose, so it ticks")
+  end
+
+  def test_no_conflict_when_the_values_agree
+    @obs.update!(collector: "Scott Shapiro")
+    row = row_for(build(fields: { "Collector" => " Scott Shapiro " }),
+                  "Collector")
+
+    assert_not_predicate(row, :conflict?)
+  end
+
+  def test_blank_rows_never_tick
+    row = row_for(build(fields: { "Collector" => "" }), "Collector")
+
+    assert_not(row.default_use?)
+  end
+
+  # ---------- name_known ----------
+
+  # Ticked by default only when saving would succeed without a
+  # create-the-name round-trip.
+  def test_name_known_for_a_name_mo_holds
+    review = build(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                             "Coprinus comatus" })
+
+    assert(review.name_known)
+  end
+
+  def test_name_not_known_for_a_common_name
+    review = build(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                             "Lumpy Bracket" })
+
+    assert_not(review.name_known)
+  end
+
+  def test_name_not_known_when_blank_or_userless
+    assert_not(build(fields: {}).name_known)
+    assert_not(build(fields: { FieldSlip::Extractor::NAME_FIELD => "Boletus" },
+                     user: nil).name_known,
+               "no user means no resolver, so no default tick")
+  end
+
+  def test_confidence_rides_along_on_the_row
+    review = build(fields: { "Date" => "2026-07-30" },
+                   confidence: { "Date" => "low" })
+
+    assert_equal("low", row_for(review, "Date").confidence)
+  end
+end

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -190,6 +190,31 @@ module Images
       assert_redirected_to(permanent_observation_path(@obs.id))
     end
 
+    # The flag rides along as a top-level param, the same shape the
+    # observation form uses for the same decision.
+    def test_update_stores_a_flagged_code_as_an_inat_link
+      record_extract(fields: { "Other Codes" => "386717373" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id, inat: "1",
+                             use: { "Other Codes" => "1" },
+                             value: { "Other Codes" => "386717373" } })
+
+      assert_equal(FieldSlipNotesBuilder.inat_link("386717373"),
+                   @obs.reload.notes[:Other_Codes])
+    end
+
+    def test_update_stores_an_unflagged_code_verbatim
+      record_extract(fields: { "Other Codes" => "386717373" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id, inat: "0",
+                             use: { "Other Codes" => "1" },
+                             value: { "Other Codes" => "386717373" } })
+
+      assert_equal("386717373", @obs.reload.notes[:Other_Codes])
+    end
+
     def test_update_proposes_a_ticked_known_name
       record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
                                "Coprinus comatus" })

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -272,6 +272,20 @@ module Images
       assert_equal("Scott Shapiro", @obs.reload.collector)
     end
 
+    # A placeholder is no opinion, not a name to create: the save must
+    # complete rather than bouncing to a confirmation page whose
+    # feedback panel would render empty.
+    def test_update_completes_when_the_id_is_a_placeholder
+      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                               "unknown" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id, use: { "ID" => "1" },
+                             value: { "ID" => "unknown" } })
+
+      assert_redirected_to(permanent_observation_path(@obs.id))
+    end
+
     def test_update_creates_the_name_once_approved
       record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
                                "Lumpysomething bracketii" })

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -1,0 +1,288 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Images
+  class FieldSlipExtractsControllerTest < FunctionalTestCase
+    def setup
+      super
+      @obs = observations(:minimal_unknown_obs)
+      @image = images(:in_situ_image)
+      @obs.images << @image unless @obs.images.include?(@image)
+      @project = projects(:eol_project)
+    end
+
+    def record_extract(fields: {}, confidence: {})
+      FieldSlipExtract.record(
+        image: @image, user: rolf, prompt_version: "1",
+        result: FieldSlip::Extractor::Result.new(
+          provider: "g", model: "m", raw: {}, fields: fields,
+          confidence: confidence
+        )
+      )
+    end
+
+    def login_as_site_admin
+      login("rolf")
+      make_admin
+    end
+
+    def join_project_as_admin(user)
+      @project.observations << @obs unless @project.observations.include?(@obs)
+      login(user.login)
+    end
+
+    # ---------- permissions ----------
+
+    def test_edit_requires_login
+      record_extract(fields: { "Collector" => "A" })
+
+      get(:edit, params: { image_id: @image.id })
+
+      assert_redirected_to(new_account_login_path)
+    end
+
+    def test_edit_refused_for_an_ordinary_user
+      record_extract(fields: { "Collector" => "A" })
+      login("katrina")
+
+      get(:edit, params: { image_id: @image.id })
+
+      assert_redirected_to(image_path(@image.id))
+      assert_flash_error
+    end
+
+    def test_edit_allowed_for_a_site_admin
+      record_extract(fields: { "Collector" => "A" })
+      login_as_site_admin
+
+      get(:edit, params: { image_id: @image.id })
+
+      assert_response(:success)
+    end
+
+    # A foray's own organizers are the people who can tell whether a
+    # slip was transcribed right.
+    def test_edit_allowed_for_a_project_admin
+      record_extract(fields: { "Collector" => "A" })
+      join_project_as_admin(mary)
+
+      assert(@project.is_admin?(mary), "premise: mary administers it")
+      get(:edit, params: { image_id: @image.id })
+
+      assert_response(:success)
+    end
+
+    def test_create_refused_for_an_ordinary_user
+      login("katrina")
+
+      post(:create, params: { image_id: @image.id })
+
+      assert_redirected_to(image_path(@image.id))
+    end
+
+    # ---------- create ----------
+
+    def test_create_records_the_extract_and_redirects_to_review
+      login_as_site_admin
+      result = FieldSlip::Extractor::Result.new(
+        provider: "gemini", model: "gemini-3.6-flash", raw: { "x" => 1 },
+        fields: { "Collector" => "Scott Shapiro" }, confidence: {}
+      )
+
+      FieldSlip::Extractor.stub(:default, fake_extractor(result)) do
+        post(:create, params: { image_id: @image.id })
+      end
+
+      assert_redirected_to(edit_image_field_slip_extract_path(@image.id))
+      extract = FieldSlipExtract.find_by(image_id: @image.id)
+
+      assert_equal("Scott Shapiro", extract.value_for("Collector"))
+      assert_equal("gemini-3.6-flash", extract.model)
+    end
+
+    # A provider failure has to land as a flash, not a 500 -- the button
+    # is one click and the network is not reliable.
+    def test_create_reports_a_provider_failure
+      login_as_site_admin
+
+      FieldSlip::Extractor.stub(:default, failing_extractor) do
+        post(:create, params: { image_id: @image.id })
+      end
+
+      assert_redirected_to(image_path(@image.id))
+      assert_flash_error
+    end
+
+    def test_create_with_an_unknown_image_redirects
+      login_as_site_admin
+
+      post(:create, params: { image_id: -1 })
+
+      assert_redirected_to(images_path)
+      assert_flash_error
+    end
+
+    # ---------- edit ----------
+
+    def test_edit_without_an_extract_redirects
+      login_as_site_admin
+
+      get(:edit, params: { image_id: @image.id })
+
+      assert_redirected_to(image_path(@image.id))
+      assert_flash_error
+    end
+
+    def test_edit_renders_the_rows_and_the_name_section
+      record_extract(fields: { "Collector" => "Scott Shapiro",
+                               FieldSlip::Extractor::NAME_FIELD => "Boletus" })
+      login_as_site_admin
+
+      get(:edit, params: { image_id: @image.id })
+
+      assert_select("input[name='value[Collector]'][value='Scott Shapiro']")
+      assert_select("input[name='use[Collector]']")
+      assert_select("[name='value[ID]']")
+      assert_select("#field_slip_extract_name")
+    end
+
+    # ---------- update ----------
+
+    def test_update_applies_only_ticked_fields
+      record_extract(fields: { "Collector" => "Scott Shapiro",
+                               "Substrate" => "wood" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Collector" => "1", "Substrate" => "0" },
+                             value: { "Collector" => "Scott Shapiro",
+                                      "Substrate" => "wood" } })
+
+      @obs.reload
+
+      assert_equal("Scott Shapiro", @obs.collector)
+      assert_nil(@obs.notes[:Substrate])
+      assert_redirected_to(permanent_observation_path(@obs.id))
+    end
+
+    # The reviewer's edit wins over what the model read: the extract is
+    # a starting point, the form is the decision.
+    def test_update_saves_the_edited_value_not_the_extracted_one
+      record_extract(fields: { "Collector" => "Scott Shapior" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Collector" => "1" },
+                             value: { "Collector" => "Scott Shapiro" } })
+
+      assert_equal("Scott Shapiro", @obs.reload.collector)
+    end
+
+    def test_update_without_any_ticks_changes_nothing
+      record_extract(fields: { "Collector" => "Scott Shapiro" })
+      was = @obs.collector
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id })
+
+      assert_equal(was, @obs.reload.collector)
+      assert_redirected_to(permanent_observation_path(@obs.id))
+    end
+
+    def test_update_proposes_a_ticked_known_name
+      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                               "Coprinus comatus" })
+      before = @obs.namings.count
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id, use: { "ID" => "1" },
+                             value: { "ID" => "Coprinus comatus" } })
+
+      assert_equal(before + 1, @obs.reload.namings.count)
+      assert_redirected_to(permanent_observation_path(@obs.id))
+    end
+
+    def test_update_leaves_an_unticked_name_alone
+      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                               "Coprinus comatus" })
+      before = @obs.namings.count
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id, use: { "ID" => "0" },
+                             value: { "ID" => "Coprinus comatus" } })
+
+      assert_equal(before, @obs.reload.namings.count)
+    end
+
+    # An unrecognized name comes back for confirmation rather than being
+    # created off a machine reading.
+    def test_update_asks_before_creating_an_unknown_name
+      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                               "Lumpy Bracket" })
+      names_before = Name.count
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id, use: { "ID" => "1" },
+                             value: { "ID" => "Lumpy Bracket" } })
+
+      assert_response(:success)
+      assert_equal(names_before, Name.count)
+      assert_flash_warning
+    end
+
+    # The other fields land on the first pass, so confirming the name
+    # does not mean re-doing the rest.
+    def test_update_applies_fields_even_when_the_name_needs_approval
+      record_extract(fields: { "Collector" => "Scott Shapiro",
+                               FieldSlip::Extractor::NAME_FIELD =>
+                               "Lumpy Bracket" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Collector" => "1", "ID" => "1" },
+                             value: { "Collector" => "Scott Shapiro",
+                                      "ID" => "Lumpy Bracket" } })
+
+      assert_equal("Scott Shapiro", @obs.reload.collector)
+    end
+
+    def test_update_creates_the_name_once_approved
+      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                               "Lumpysomething bracketii" })
+      names_before = Name.count
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id, use: { "ID" => "1" },
+                             value: { "ID" => "Lumpysomething bracketii" },
+                             approved_name: "Lumpysomething bracketii" })
+
+      assert_operator(Name.count, :>, names_before)
+      assert_redirected_to(permanent_observation_path(@obs.id))
+    end
+
+    def test_update_without_an_extract_redirects
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id })
+
+      assert_redirected_to(image_path(@image.id))
+    end
+
+    private
+
+    def fake_extractor(result)
+      extractor = Object.new
+      extractor.define_singleton_method(:extract) { |_image, **| result }
+      extractor
+    end
+
+    def failing_extractor
+      extractor = Object.new
+      extractor.define_singleton_method(:extract) do |_image, **|
+        raise(FieldSlip::Extractor::Gemini::BadResponse.new("nope"))
+      end
+      extractor
+    end
+  end
+end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -150,6 +150,43 @@ class ImagesControllerTest < FunctionalTestCase
     end
   end
 
+  # The Read Field Slip button is offered on every image with an
+  # observation -- a plausibility test that guessed wrong would hide it
+  # on exactly the slips someone wants to read -- but only to people
+  # who may press it (FieldSlipExtract.permitted?).
+  def test_show_hides_field_slip_button_from_ordinary_users
+    image = images(:in_situ_image)
+    login("katrina")
+
+    get(:show, params: { id: image.id })
+
+    assert_select("form[action=?]",
+                  image_field_slip_extract_path(image.id), count: 0)
+  end
+
+  def test_show_offers_field_slip_button_to_site_admin
+    image = images(:in_situ_image)
+    login("rolf")
+    make_admin
+
+    get(:show, params: { id: image.id })
+
+    assert_select("form[action=?]", image_field_slip_extract_path(image.id))
+  end
+
+  def test_show_offers_field_slip_button_to_project_admin
+    image = images(:in_situ_image)
+    obs = image.observations.first
+    project = projects(:eol_project)
+    project.observations << obs unless project.observations.include?(obs)
+    login(mary.login)
+
+    assert(project.is_admin?(mary), "premise: mary administers it")
+    get(:show, params: { id: image.id })
+
+    assert_select("form[action=?]", image_field_slip_extract_path(image.id))
+  end
+
   def test_show_image_info_panel_heading
     image = images(:peltigera_image)
     login

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -132,6 +132,17 @@ class FieldSlipExtractTest < UnitTestCase
     assert_nil(record(fields: {}).unknown_location_alias)
   end
 
+  # A full MO location name is not an unknown abbreviation, alias or no
+  # alias -- warning about one would tell the reviewer that something MO
+  # already knows is unrecognized, and offer to define an alias for it.
+  def test_unknown_location_alias_nil_for_a_real_location_name
+    other = locations(:albion)
+
+    assert_not_equal(other, @obs.location, "premise: not this obs's location")
+    assert_nil(record(fields: { "Location" => other.name }).
+               unknown_location_alias)
+  end
+
   # ---------- location suggestion ----------
 
   # "Fulton, Co" against a project already sitting in "Fulton Co.,

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlipExtractTest < UnitTestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @image = images(:in_situ_image)
+    @obs.images << @image unless @obs.images.include?(@image)
+  end
+
+  def result(fields: {}, confidence: {}, provider: "gemini", model: "m")
+    FieldSlip::Extractor::Result.new(
+      provider: provider, model: model, raw: { "ok" => true },
+      fields: fields, confidence: confidence
+    )
+  end
+
+  def record(fields: {}, confidence: {}, **)
+    FieldSlipExtract.record(image: @image, user: rolf, prompt_version: "1",
+                            result: result(fields:, confidence:, **))
+  end
+
+  # One row per image: pressing the button again replaces the previous
+  # read rather than accumulating versions nobody reviews.
+  def test_record_replaces_rather_than_accumulates
+    first = record(fields: { "Collector" => "A" })
+    second = record(fields: { "Collector" => "B" })
+
+    assert_equal(first.id, second.id)
+    assert_equal(1, FieldSlipExtract.where(image_id: @image.id).count)
+    assert_equal("B", second.value_for("Collector"))
+  end
+
+  def test_record_stores_provenance_and_raw_response
+    extract = record(fields: { "Collector" => "A" }, model: "gemini-3.6-flash")
+
+    assert_equal("gemini", extract.provider)
+    assert_equal("gemini-3.6-flash", extract.model)
+    assert_equal("1", extract.prompt_version)
+    assert_equal({ "ok" => true }, extract.data["raw"])
+  end
+
+  def test_confidence_defaults_to_low_when_unusable
+    extract = record(fields: { "Collector" => "A" },
+                     confidence: { "Collector" => "wildly sure" })
+
+    assert_equal("low", extract.confidence_for("Collector"))
+    assert_equal("low", extract.confidence_for("Date"), "absent -> low")
+  end
+
+  def test_confidence_passes_through_known_levels
+    extract = record(fields: { "Date" => "2026-07-30" },
+                     confidence: { "Date" => "HIGH" })
+
+    assert_equal("high", extract.confidence_for("Date"))
+  end
+
+  # An extract describes one image, so it goes when the image does
+  # rather than lingering as an orphan for the integrity job to sweep.
+  def test_destroyed_with_its_image
+    record(fields: { "Collector" => "A" })
+    image = Image.find(@image.id)
+    image.current_user = image.user
+
+    assert_difference("FieldSlipExtract.count", -1) { image.destroy }
+  end
+
+  # ---------- code mismatch ----------
+
+  def test_code_mismatch_nil_when_codes_agree
+    slip = FieldSlip.create!(code: "NEMF-10222", user: @obs.user)
+    attach_slip(slip)
+    extract = record(fields: { "Field Slip Code" => "NEMF-10222" })
+
+    assert_nil(extract.code_mismatch)
+  end
+
+  # The strongest signal that this photo is not this observation's slip.
+  def test_code_mismatch_reports_both_codes
+    slip = FieldSlip.create!(code: "NEMF-10222", user: @obs.user)
+    attach_slip(slip)
+    extract = record(fields: { "Field Slip Code" => "NEMF-99999" })
+
+    assert_equal(%w[NEMF-99999 NEMF-10222], extract.code_mismatch)
+  end
+
+  def test_code_mismatch_nil_without_an_attached_slip
+    @obs.update!(occurrence: nil)
+
+    assert_nil(@obs.reload.field_slip, "premise: no slip attached")
+    extract = record(fields: { "Field Slip Code" => "NEMF-99999" })
+
+    assert_nil(extract.code_mismatch)
+  end
+
+  def test_code_mismatch_nil_when_nothing_was_read
+    slip = FieldSlip.create!(code: "NEMF-10222", user: @obs.user)
+    attach_slip(slip)
+
+    assert_nil(record(fields: { "Field Slip Code" => "" }).code_mismatch)
+  end
+
+  # ---------- unknown location alias ----------
+
+  # "EB2" for "Early Bird 2" where the project only defines "2": naming
+  # it is what lets an admin add the alias, which then improves every
+  # later slip, since the prompt is built from the same table.
+  def test_unknown_location_alias_names_an_undefined_abbreviation
+    extract = record(fields: { "Location" => "EB2" })
+
+    assert_equal("EB2", extract.unknown_location_alias)
+  end
+
+  def test_unknown_location_alias_nil_when_the_project_defines_it
+    project = projects(:eol_project)
+    project.observations << @obs unless project.observations.include?(@obs)
+    ProjectAlias.create!(project: project, name: "Walk 9",
+                         target: locations(:albion))
+    extract = record(fields: { "Location" => "Walk 9" })
+
+    assert_nil(extract.reload.unknown_location_alias)
+  end
+
+  def test_unknown_location_alias_nil_when_it_matches_the_location
+    extract = record(fields: { "Location" => @obs.location.name })
+
+    assert_nil(extract.unknown_location_alias)
+  end
+
+  def test_unknown_location_alias_nil_when_nothing_was_read
+    assert_nil(record(fields: {}).unknown_location_alias)
+  end
+
+  # ---------- location suggestion ----------
+
+  # "Fulton, Co" against a project already sitting in "Fulton Co.,
+  # Pennsylvania, USA": punctuation and case differ, the words do not.
+  def test_suggests_a_location_the_project_already_uses
+    target = project_using(locations(:albion))
+    written = target.name.split(",").first.downcase
+
+    extract = record(fields: { "Location" => written })
+
+    assert_equal(target, extract.location_suggestion)
+  end
+
+  def test_no_suggestion_when_nothing_matches
+    project_using(locations(:albion))
+
+    assert_nil(record(fields: { "Location" => "Zzz" }).location_suggestion)
+  end
+
+  # A guess must not pick between two plausible sites, so an ambiguous
+  # abbreviation suggests nothing at all. "Albion" prefixes both
+  # "Albion, California, USA" and the twin created here.
+  def test_no_suggestion_when_several_match
+    albion = locations(:albion)
+    project_using(albion)
+    add_to_project(observations(:coprinus_comatus_obs), twin_of(albion))
+    written = albion.name.split(",").first
+
+    assert_nil(record(fields: { "Location" => written }).location_suggestion)
+  end
+
+  # A full name still resolves when a longer sibling exists, because
+  # matching is a prefix test on the CANDIDATE: "Albion, California,
+  # USA" is not a prefix of "Albion Annex, California, USA".
+  def test_a_full_name_resolves_despite_a_longer_sibling
+    albion = locations(:albion)
+    project_using(albion)
+    add_to_project(observations(:coprinus_comatus_obs), twin_of(albion))
+
+    assert_equal(albion,
+                 record(fields: { "Location" => albion.name }).
+                 location_suggestion)
+  end
+
+  def test_no_suggestion_without_a_project
+    assert_nil(record(fields: { "Location" => "Anything" }).
+               location_suggestion)
+  end
+
+  def test_no_suggestion_when_nothing_was_read
+    project_using(locations(:albion))
+
+    assert_nil(record(fields: {}).location_suggestion)
+  end
+
+  # ---------- permitted? ----------
+
+  def test_permitted_for_site_admin
+    assert(FieldSlipExtract.permitted?(image: @image, user: dick,
+                                       site_admin: true))
+  end
+
+  # A foray's own organizers are the people who can tell whether a slip
+  # was transcribed right, so project admins get in too.
+  def test_permitted_for_admin_of_the_observations_project
+    project = projects(:eol_project)
+    project.observations << @obs unless project.observations.include?(@obs)
+
+    assert(project.is_admin?(rolf), "fixture must have rolf as admin")
+    assert(FieldSlipExtract.permitted?(image: @image.reload, user: rolf))
+  end
+
+  def test_not_permitted_for_a_plain_member
+    project = projects(:eol_project)
+    project.observations << @obs unless project.observations.include?(@obs)
+
+    assert_not(project.is_admin?(katrina))
+    assert_not(FieldSlipExtract.permitted?(image: @image.reload,
+                                           user: katrina))
+  end
+
+  # An image can carry several observations, and permission is granted
+  # by ANY of them -- `in_situ_image` also belongs to an observation in
+  # the Bolete Project, which is why the stranger here has to be someone
+  # who administers none of them.
+  def test_not_permitted_for_a_stranger
+    stranger = katrina
+    admin_of = @image.reload.observations.flat_map(&:projects).
+               select { |project| project.is_admin?(stranger) }
+
+    assert_empty(admin_of, "premise: stranger administers none of them")
+    assert_not(FieldSlipExtract.permitted?(image: @image, user: stranger))
+  end
+
+  def test_not_permitted_without_a_user_even_in_admin_mode
+    assert_not(FieldSlipExtract.permitted?(image: @image, user: nil,
+                                           site_admin: true))
+  end
+
+  # Permission comes from any of the image's observations, not only the
+  # one the review would write to.
+  def test_permitted_via_a_second_observation_on_the_same_image
+    other = @image.observations.find { |obs| obs.id != @obs.id }
+
+    assert(other, "premise: the image carries a second observation")
+    assert(other.projects.any? { |project| project.is_admin?(dick) })
+    assert(FieldSlipExtract.permitted?(image: @image, user: dick))
+  end
+
+  private
+
+  # Puts a second observation in the project at a known location, so a
+  # suggestion has something to match against.
+  def project_using(location)
+    project = projects(:eol_project)
+    project.observations << @obs unless project.observations.include?(@obs)
+    other = observations(:detailed_unknown_obs)
+    project.observations << other unless project.observations.include?(other)
+    other.update!(location: location)
+    location
+  end
+
+  def add_to_project(obs, location)
+    project = projects(:eol_project)
+    project.observations << obs unless project.observations.include?(obs)
+    obs.update!(location: location)
+    location
+  end
+
+  # A second Location whose name starts with the first's, so a written
+  # abbreviation matches both.
+  def twin_of(location)
+    head, tail = location.name.split(",", 2)
+    twin = Location.new(user: rolf, name: "#{head} Annex,#{tail}",
+                        north: location.north, south: location.south,
+                        east: location.east, west: location.west)
+    twin.current_user = rolf
+    twin.save!
+    twin
+  end
+
+  def attach_slip(slip)
+    occ = Occurrence.create!(user: @obs.user, primary_observation: @obs,
+                             field_slip: slip)
+    @obs.update!(occurrence: occ)
+  end
+end

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Views::Controllers::Images::FieldSlipExtracts
+  class EditTest < ComponentTestCase
+    def setup
+      super
+      @user = users(:rolf)
+      @obs = observations(:minimal_unknown_obs)
+      @image = images(:in_situ_image)
+      @obs.images << @image unless @obs.images.include?(@image)
+      @project = projects(:eol_project)
+    end
+
+    def extract_with(fields: {}, confidence: {})
+      FieldSlipExtract.record(
+        image: @image, user: @user, prompt_version: "1",
+        result: FieldSlip::Extractor::Result.new(
+          provider: "gemini", model: "gemini-3.6-flash", raw: {},
+          fields: fields, confidence: confidence
+        )
+      )
+    end
+
+    def render_page(**)
+      render(Edit.new(extract: extract_with(**), observation: @obs,
+                      user: @user))
+    end
+
+    def test_renders_a_row_per_field_read
+      html = render_page(fields: { "Collector" => "Scott Shapiro",
+                                   "Substrate" => "wood" })
+
+      assert_html(html, "input[name='value[Collector]'][value='Scott Shapiro']")
+      assert_html(html, "input[name='value[Substrate]'][value='wood']")
+      assert_html(html, "input[name='use[Collector]']")
+    end
+
+    def test_omits_fields_the_model_read_nothing_for
+      html = render_page(fields: { "Collector" => "Scott Shapiro" })
+
+      assert_no_html(html, "input[name='value[Substrate]']")
+    end
+
+    # The name gets an autocompleter, which only renders its dropdown
+    # and hidden id field when it has a real label -- `label: false`
+    # silently drops the append slot they live in.
+    def test_name_row_renders_a_live_autocompleter
+      html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                                   "Coprinus comatus" })
+
+      assert_html(html, "[data-controller='autocompleter--name']")
+      assert_html(html,
+                  "[data-controller='autocompleter--name'] input[type=hidden]")
+      assert_html(html, "label[for*='value_ID']")
+    end
+
+    # Ticked only when the ID already resolves to a name MO holds, so
+    # creating a Name is always a deliberate act.
+    def test_name_tick_defaults_on_for_a_known_name
+      html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                                   "Coprinus comatus" })
+
+      assert_html(html, "input[name='use[ID]'][checked]")
+    end
+
+    def test_name_tick_defaults_off_for_an_unknown_name
+      html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                                   "Lumpy Bracket" })
+
+      assert_html(html, "input[name='use[ID]']")
+      assert_no_html(html, "input[name='use[ID]'][checked]")
+    end
+
+    def test_name_section_offers_a_confidence_menu
+      html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
+                                   "Coprinus comatus" })
+
+      assert_html(html, "select[name='vote']")
+    end
+
+    def test_no_name_section_when_nothing_was_read_for_it
+      html = render_page(fields: { "Collector" => "Scott Shapiro" })
+
+      assert_no_html(html, "#field_slip_extract_name")
+    end
+
+    # A field the observation already has starts unticked, so applying
+    # the form cannot silently overwrite a person's entry.
+    def test_conflicting_row_starts_unticked
+      @obs.update!(collector: "Someone Else")
+
+      html = render_page(fields: { "Collector" => "Scott Shapiro" })
+
+      assert_no_html(html, "input[name='use[Collector]'][checked]")
+      assert_includes(html, "Someone Else")
+    end
+
+    def test_empty_current_value_ticks_by_default
+      @obs.update!(collector: nil)
+
+      html = render_page(fields: { "Collector" => "Scott Shapiro" })
+
+      assert_html(html, "input[name='use[Collector]'][checked]")
+    end
+
+    # ---------- flags ----------
+
+    def test_flags_a_code_that_disagrees_with_the_attached_slip
+      html = render_page(fields: { "Field Slip Code" => "NEMF-99999" })
+
+      assert_includes(html, "NEMF-99999")
+      assert_includes(html, @obs.field_slip.code)
+    end
+
+    def test_no_code_flag_when_they_agree
+      html = render_page(fields: { "Field Slip Code" => @obs.field_slip.code })
+
+      assert_no_html(html, ".alert-danger")
+    end
+
+    # Naming the undefined abbreviation is what lets an admin add it,
+    # which then improves every later slip.
+    def test_flags_an_undefined_location_abbreviation
+      @project.observations << @obs unless @project.observations.include?(@obs)
+
+      html = render_page(fields: { "Location" => "EB2" })
+
+      assert_includes(html, "EB2")
+      assert_html(html, "a[href*='aliases/new']")
+    end
+
+    def test_no_alias_flag_for_a_known_abbreviation
+      @project.observations << @obs unless @project.observations.include?(@obs)
+      ProjectAlias.create!(project: @project, name: "EB2",
+                           target: locations(:albion))
+
+      html = render_page(fields: { "Location" => "EB2" })
+
+      assert_no_html(html, "a[href*='aliases/new']")
+    end
+
+    # Which setup produced these values is the part that stays useful
+    # once extraction has moved on.
+    def test_shows_its_provenance
+      html = render_page(fields: { "Collector" => "A" })
+
+      assert_includes(html, "gemini")
+      assert_includes(html, "gemini-3.6-flash")
+    end
+
+    def test_low_confidence_is_called_out
+      html = render_page(fields: { "Date" => "2026-07-30" },
+                         confidence: { "Date" => "low" })
+
+      assert_includes(html, "low")
+    end
+
+    # ---------- locality ----------
+
+    # Corrected through an autocompleter, like the ID: a table cell has
+    # no room for the label one needs in order to work at all.
+    def test_locality_renders_a_live_autocompleter
+      html = render_page(fields: { "Location" => "Fulton, Co" })
+
+      assert_html(html, "[data-controller='autocompleter--location']")
+      assert_html(html, "#field_slip_extract_location")
+    end
+
+    # Unlike the ID, locality is an ordinary attribute write, so it
+    # keeps its tick box.
+    def test_locality_keeps_its_tick_box
+      html = render_page(fields: { "Location" => "Fulton, Co" })
+
+      assert_html(html, "input[name='use[Location]']")
+    end
+
+    # Typing a full MO location name back in is the slowest part of a
+    # review, so an abbreviation the project already resolves is filled
+    # in ready to accept -- with what the slip read shown above it.
+    def test_locality_prefills_a_suggestion_from_the_projects_locations
+      target = project_using(locations(:albion))
+
+      html = render_page(fields: { "Location" => target.name[0, 6] })
+
+      assert_html(html,
+                  "input[name='value[Location]'][value='#{target.name}']")
+    end
+
+    def test_locality_keeps_what_was_written_when_nothing_matches
+      html = render_page(fields: { "Location" => "Behind the barn" })
+
+      assert_html(html,
+                  "input[name='value[Location]'][value='Behind the barn']")
+    end
+
+    private
+
+    # Puts a second observation in the project at a known location, so
+    # the suggestion has something to match against.
+    def project_using(location)
+      @project.observations << @obs unless @project.observations.include?(@obs)
+      other = observations(:detailed_unknown_obs)
+      unless @project.observations.include?(other)
+        @project.observations << other
+      end
+      other.update!(location: location)
+      location
+    end
+  end
+end

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -157,6 +157,31 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_includes(html, "low")
     end
 
+    # ---------- other codes ----------
+
+    # A purely numeric Other Codes is an iNat observation id in
+    # practice, so the flag ticks itself.
+    def test_numeric_other_codes_ticks_the_inat_flag
+      html = render_page(fields: { "Other Codes" => "386717373" })
+
+      assert_html(html, "input[name='inat'][checked]")
+    end
+
+    # Free text goes in that box too, so the flag stays clear for
+    # anything that isn't a bare number.
+    def test_non_numeric_other_codes_leaves_the_flag_clear
+      html = render_page(fields: { "Other Codes" => "Herbarium 42-A" })
+
+      assert_html(html, "input[name='inat']")
+      assert_no_html(html, "input[name='inat'][checked]")
+    end
+
+    def test_no_inat_flag_without_other_codes
+      html = render_page(fields: { "Collector" => "Scott Shapiro" })
+
+      assert_no_html(html, "input[name='inat']")
+    end
+
     # ---------- locality ----------
 
     # Corrected through an autocompleter, like the ID: a table cell has


### PR DESCRIPTION
A site or project admin viewing an image can press **Read Field Slip** to have the photo machine-read into MO's own field set, then review every value before any of it reaches the observation. Nothing is written without a tick.

Groundwork for #4208-style automation, but useful on its own for the 2026 NEMF backlog: the placeholder observations identified only as "Fungi" are exactly the ones whose slips need reading.

## Why a review step, not an import

A 2025 pass over 1,770 NEMF slips (the Python work in `projects/nemf-photos`) left ~30% of dates and ~27% of locations null or low-confidence. The human step isn't a nicety, and the UI is built around it: every field shows what the model read next to what the observation already holds, with a tick box deciding whether to apply it. **A row whose values disagree starts unticked**, so applying the whole form can never silently overwrite something a person entered.

## The abbreviation tables come from the database

The 2025 script hardcoded that year's site list, which is why it couldn't be reused. `Extractor::Prompt` builds them from the project's own `ProjectAlias` records and the project's date range, so every alias an admin adds while reviewing improves the next slip.

Two flags surface on the review page. The printed code the model read is checked against the slip actually attached — a mismatch means the wrong photo. And a location abbreviation the project has no alias for is named, with a link to define it.

Locality goes further: when the project already uses exactly one location the written abbreviation obviously means, the full name is filled in ready to accept. Verified on image 2048695, whose slip reads `Fulton, Co` against a project sitting in `Fulton Co., Pennsylvania, USA`. Deliberately narrow — candidates come only from what *this* project already uses, and only an unambiguous single match is offered, so it can't quietly pick between two plausible sites.

## The ID becomes a naming, not an attribute

Collectors write common names — the slip on 2048698 says "Lumpy Bracket". So the ID gets a **name autocompleter** to look the real name up, and its own tick box, ticked by default only when the ID already resolves to a name MO holds. Saving routes through `Naming::NameResolver`, the same resolver the observation form uses, so an unrecognized name gets created exactly as it would there — including the confirmation round-trip. **A machine reading never mints a `Name` unasked.**

The naming and its vote are attributed to the reviewer: an admin reading someone else's slip is stating their own reading of it. The vote defaults to the weakest positive value, since relaying what a slip says isn't asserting a determination.

## Providers are swappable

`Extractor.for(:gemini)` returns an adapter answering one method; the field mapping lives outside it, so trying another OCR service is one new class. Gemini is the only adapter today.

Its model defaults to the `gemini-flash-latest` alias rather than a pinned name — Google retires concrete models out from under callers, and `gemini-2.5-flash` already 404s with "no longer available to new users". The response's own `modelVersion` is what gets stored, so provenance survives the indirection. `credentials.gemini.model` pins a specific model without a deploy.

Images are read from disk when MO holds them: production writes local files before transferring them, so this shouldn't need DNS to read an image MO already has.

## Who can press it

Site admins, and admins of any project the image's observations belong to. Gating on site admin alone would put every foray's transcription through the same few people, and a foray's own organizers are exactly who can tell whether a slip was read right. `FieldSlipExtract.permitted?` is shared by the controller and the button so they can't disagree.

Not open to everyone: each press costs an API call, and a careless review writes to observations the reviewer may not own.

## Storage

One row per image, replaced on re-run — only the newest is ever reviewed. `provider` / `model` / `prompt_version` sit beside the raw response so a value can be attributed to the setup that produced it, which is the part that stays useful once extraction has moved on.

## Bugs the tests caught

All four were in code that read correctly and had never been executed:

- `Vote.validate_value` runs `to_f`, so it answers `0.0` — not nil — for a missing value. `0` is `DELETE_VOTE`, so `|| MIN_POS_VOTE` never fired and every naming proposed without an explicit confidence got **no vote at all**: present on the observation, supporting nothing.
- `Date.parse("sometime in July")` returns July 1st of the current year rather than raising, so a garbage date was written instead of skipped. ISO only now.
- A `file://` image URL reached RestClient as "not an HTTP URI".
- `:runtime_image_not_found` was invented and doesn't exist in `en.txt`.

Plus two integrity gaps: every `belongs_to` must be registered in `CheckForBrokenReferencesJob::Checks`, and an extract should go with its image rather than lingering as an orphan.

## Setup

`credentials.gemini.key` — note `credentials.gemini` is an `OrderedOptions`, i.e. a Hash, so `.key` resolves to `Hash#key` and raises; the adapter subscripts, with a comment saying why. Development credentials are per-environment (`config/credentials/development.yml.enc`), now gitignored so each developer keeps their own.

## Test plan

Needs `credentials.gemini.key` set for the environment you're testing in.

1. **Permissions.** As an ordinary user, open any image show page — no "Read Field Slip" button. In admin mode, or as an admin of a project one of the image's observations belongs to, it appears.
2. **Read a slip.** On an image of a 2026 NEMF slip (e.g. image 2048698 on observation 657357), press it. Expect the review page in ~8 seconds with the printed code, collector, date, locality, ID and MycoMap voucher filled in.
3. **Conflicts.** A field the observation already has a different value for should show both and start unticked. Tick it, save, confirm it applied; leave another unticked and confirm it didn't.
4. **Locality.** On image 2048695 (slip reads "Fulton, Co"), the Locality box should be prefilled with "Fulton Co., Pennsylvania, USA" and the flag should say what the slip read. The autocompleter should offer suggestions as you type.
5. **Unknown abbreviation.** On a slip whose walk number the project has no alias for, expect the warning naming it and a link to add the alias.
6. **Name, known.** With an ID MO recognizes, the box is ticked; save and confirm a naming appears attributed to you.
7. **Name, unknown.** With something like "Lumpy Bracket", the box starts clear. Tick it and save: expect the create-this-name confirmation rather than a new Name, and confirm the other fields still saved. Confirm to create it.
8. **Re-run.** Press the button again on the same image — it re-reads and replaces the stored result rather than adding a second one.
