### PR TITLE
Tick every field slip row by default, and mark the disagreements

### DIFF
--- a/app/classes/field_slip/extractor/name_proposer.rb
+++ b/app/classes/field_slip/extractor/name_proposer.rb
@@ -12,6 +12,12 @@ class FieldSlip
     # created exactly as it would there, including the confirmation step
     # rather than silently minting a Name from a machine reading.
     class NameProposer
+      # "Promising": a slip's ID is the collector's determination,
+      # worth more than a guess and less than the reviewer's own
+      # certainty. Matches the form's default; this is the fallback for
+      # a submission that carries no vote at all.
+      DEFAULT_VOTE = Vote::NEXT_BEST_VOTE
+
       # :none    nothing to propose
       # :needs_approval  resolver wants a confirmation round-trip
       # :proposed        naming + vote created
@@ -78,6 +84,7 @@ class FieldSlip
       # Attributed to the reviewer, not the observation's owner: an
       # admin reading someone else's slip is stating their own reading
       # of it, and the vote weight should be theirs to own.
+      #
       # `Vote.validate_value` runs `to_f` first, so it answers 0.0 -- not
       # nil -- for a missing or unparseable value. 0 is DELETE_VOTE, and
       # `change_vote` reads it as "remove this vote", so relying on `||`
@@ -87,7 +94,7 @@ class FieldSlip
       # offers it.
       def cast_vote(naming)
         value = Vote.validate_value(@vote)
-        value = Vote::MIN_POS_VOTE if value.nil? || value == Vote::DELETE_VOTE
+        value = DEFAULT_VOTE if value.nil? || value == Vote::DELETE_VOTE
         Observation::NamingConsensus.new(@observation).
           change_vote(naming, value, @user)
       end

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -16,16 +16,24 @@ class FormObject::FieldSlipReview < FormObject::Base
     # Nothing to decide when the model read nothing.
     def blank? = extracted.to_s.strip.empty?
 
-    # A real disagreement -- both sides present and different. This is
-    # what makes the row default to OFF: applying it would overwrite
-    # something a person already entered.
+    # Both sides present and different. Marked in the table so the eye
+    # lands on it, but NOT unticked -- see `default_use?`.
     def conflict?
       return false if blank? || current.to_s.strip.empty?
 
       current.to_s.strip != extracted.to_s.strip
     end
 
-    def default_use? = savable && present? && !conflict?
+    # Everything the model read ticks. Conflicts used to start clear, on
+    # the reasoning that applying the form shouldn't overwrite what a
+    # person entered -- but on the observations this exists for, the
+    # "existing" values are the form's own defaults: today's date, the
+    # owner's name as collector, the project's catch-all location (289
+    # of project 404's 401 observations sit on it). Guarding those made
+    # the common case three clicks per slip to undo defaults nobody
+    # chose. Reviewers read every row anyway, and both values stay on
+    # screen, so the decision is still in front of them.
+    def default_use? = savable && present?
 
     def name_row? = field == FieldSlip::Extractor::NAME_FIELD
     def location_row? = field == FieldSlip::Extractor::LOCATION_FIELD

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -95,10 +95,18 @@ module Views::Controllers::Images::FieldSlipExtracts
       end
     end
 
+    # Every row ticks by default, so a real disagreement is marked here
+    # instead of being signalled by an empty box -- it is the one place
+    # a reviewer skimming the table needs to slow down.
     def render_current_cell(row)
       current = row.current.to_s
       if current.blank?
         small { plain(:field_slip_extract_empty.l) }
+      elsif row.conflict?
+        div(class: "field-slip-extract-conflict") do
+          plain(current)
+          div { small { plain(:field_slip_extract_replacing.l) } }
+        end
       else
         plain(current)
       end

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -191,10 +191,17 @@ module Views::Controllers::Images::FieldSlipExtracts
 
     # Defaults to the weakest positive value: relaying what a slip says
     # is not asserting the reviewer's own determination.
+    # "Promising" -- a slip's ID is the collector's determination, worth
+    # more than a guess and less than the reviewer's own certainty.
+    #
+    # `to_f` is load-bearing: `Vote.confidence_menu`'s values are Floats
+    # ("2.0"), so passing the Integer constant matched no option and the
+    # browser fell back to the FIRST one -- "I'd Call It That", the
+    # strongest vote and the opposite of the intended default.
     def render_vote_field
       select_field("vote", Vote.confidence_menu,
                    label: :field_slip_extract_vote.l,
-                   value: Vote::MIN_POS_VOTE)
+                   value: Vote::NEXT_BEST_VOTE.to_f)
     end
   end
 end

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -2,12 +2,8 @@
 
 # Review form for a machine-read field slip: one row per field the
 # model read, showing what it read next to what the observation already
-# holds, with a tick box deciding whether to apply it.
-#
-# Rows default to ticked only where there is nothing to lose -- a field
-# the observation has no value for. Where the two disagree the box
-# starts clear, so applying the whole form can never silently overwrite
-# something a person entered; the reviewer has to say so.
+# holds, with a tick box deciding whether to apply it. Ticking defaults
+# live in `FormObject::FieldSlipReview::Row`.
 module Views::Controllers::Images::FieldSlipExtracts
   class Form < ::Components::ApplicationForm
     # Superform wants the form's data object as the first positional
@@ -95,9 +91,9 @@ module Views::Controllers::Images::FieldSlipExtracts
       end
     end
 
-    # Every row ticks by default, so a real disagreement is marked here
-    # instead of being signalled by an empty box -- it is the one place
-    # a reviewer skimming the table needs to slow down.
+    # Every row ticks by default (see `FieldSlipReview::Row#default_use?`
+    # for why), so a disagreement is marked here rather than signalled by
+    # an empty box.
     def render_current_cell(row)
       current = row.current.to_s
       if current.blank?
@@ -189,8 +185,6 @@ module Views::Controllers::Images::FieldSlipExtracts
                                           label: :field_slip_extract_propose.l)
     end
 
-    # Defaults to the weakest positive value: relaying what a slip says
-    # is not asserting the reviewer's own determination.
     # "Promising" -- a slip's ID is the collector's determination, worth
     # more than a guess and less than the reviewer's own certainty.
     #

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2583,6 +2583,7 @@
   field_slip_extract_current: Currently on observation
   field_slip_extract_use: Save
   field_slip_extract_empty: (empty)
+  field_slip_extract_replacing: will be replaced
   field_slip_extract_check_only: cross-check only
   field_slip_extract_vote: Confidence for the proposed name
   field_slip_extract_id: ID written on the slip

--- a/test/classes/field_slip/extractor/name_proposer_test.rb
+++ b/test/classes/field_slip/extractor/name_proposer_test.rb
@@ -55,20 +55,22 @@ class FieldSlip::Extractor::NameProposerTest < UnitTestCase
     assert_equal(Vote::MAXIMUM_VOTE, vote.value)
   end
 
-  # Relaying what a slip says is not asserting a determination, so the
-  # weakest positive value is the default.
-  def test_vote_defaults_to_the_weakest_positive_value
+  # "Promising": a slip's ID is the collector's determination, worth
+  # more than a guess and less than the reviewer's own certainty.
+  def test_vote_defaults_to_promising
     outcome = propose("Coprinus comatus")
     vote = Vote.find_by(naming: outcome.naming, user: rolf)
 
-    assert_equal(Vote::MIN_POS_VOTE, vote.value)
+    assert_equal(FieldSlip::Extractor::NameProposer::DEFAULT_VOTE,
+                 vote.value)
   end
 
   def test_unusable_vote_falls_back_to_the_default
     outcome = propose("Coprinus comatus", vote: "not a number")
     vote = Vote.find_by(naming: outcome.naming, user: rolf)
 
-    assert_equal(Vote::MIN_POS_VOTE, vote.value)
+    assert_equal(FieldSlip::Extractor::NameProposer::DEFAULT_VOTE,
+                 vote.value)
   end
 
   # ---------- a name MO does not hold ----------

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -90,9 +90,7 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
 
   # ---------- conflict and the tick default ----------
 
-  # A conflict is marked in the table but still ticks: on the
-  # observations this exists for, the "existing" value is the form's own
-  # default rather than anything a person chose.
+  # Marked, but still ticked -- see `Row#default_use?`.
   def test_conflict_is_flagged_but_still_ticks
     @obs.update!(collector: "Someone Else")
     row = row_for(build(fields: { "Collector" => "Scott Shapiro" }),

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -90,13 +90,16 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
 
   # ---------- conflict and the tick default ----------
 
-  def test_conflict_when_both_sides_differ
+  # A conflict is marked in the table but still ticks: on the
+  # observations this exists for, the "existing" value is the form's own
+  # default rather than anything a person chose.
+  def test_conflict_is_flagged_but_still_ticks
     @obs.update!(collector: "Someone Else")
     row = row_for(build(fields: { "Collector" => "Scott Shapiro" }),
                   "Collector")
 
     assert_predicate(row, :conflict?)
-    assert_not(row.default_use?, "a conflict must not tick itself")
+    assert(row.default_use?)
   end
 
   def test_no_conflict_when_the_observation_is_empty

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -86,15 +86,26 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_no_html(html, "#field_slip_extract_name")
     end
 
-    # A field the observation already has starts unticked, so applying
-    # the form cannot silently overwrite a person's entry.
-    def test_conflicting_row_starts_unticked
+    # Everything ticks, including a row that disagrees with what the
+    # observation holds -- but the disagreement is marked, since that is
+    # the one place a reviewer skimming the table needs to slow down.
+    def test_conflicting_row_ticks_but_is_marked
       @obs.update!(collector: "Someone Else")
 
       html = render_page(fields: { "Collector" => "Scott Shapiro" })
 
-      assert_no_html(html, "input[name='use[Collector]'][checked]")
+      assert_html(html, "input[name='use[Collector]'][checked]")
+      assert_html(html, ".field-slip-extract-conflict")
       assert_includes(html, "Someone Else")
+    end
+
+    def test_agreeing_row_is_not_marked_as_a_conflict
+      @obs.update!(collector: "Scott Shapiro")
+
+      html = render_page(fields: { "Collector" => "Scott Shapiro" })
+
+      assert_html(html, "input[name='use[Collector]'][checked]")
+      assert_no_html(html, ".field-slip-extract-conflict")
     end
 
     def test_empty_current_value_ticks_by_default

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -73,10 +73,8 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_no_html(html, "input[name='use[ID]'][checked]")
     end
 
-    # The menu's values are Floats, so an Integer default matched no
-    # option and the browser silently fell back to the first one --
-    # "I'd Call It That", the strongest vote. Pin the selection, not
-    # just the menu's presence.
+    # Pins the SELECTED option, not just the menu's presence: a
+    # type mismatch once left none selected (see `render_vote_field`).
     def test_name_section_defaults_the_vote_to_promising
       html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
                                    "Coprinus comatus" })
@@ -93,9 +91,7 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_no_html(html, "#field_slip_extract_name")
     end
 
-    # Everything ticks, including a row that disagrees with what the
-    # observation holds -- but the disagreement is marked, since that is
-    # the one place a reviewer skimming the table needs to slow down.
+    # Marked, but still ticked -- see `Row#default_use?`.
     def test_conflicting_row_ticks_but_is_marked
       @obs.update!(collector: "Someone Else")
 

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -73,11 +73,18 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_no_html(html, "input[name='use[ID]'][checked]")
     end
 
-    def test_name_section_offers_a_confidence_menu
+    # The menu's values are Floats, so an Integer default matched no
+    # option and the browser silently fell back to the first one --
+    # "I'd Call It That", the strongest vote. Pin the selection, not
+    # just the menu's presence.
+    def test_name_section_defaults_the_vote_to_promising
       html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
                                    "Coprinus comatus" })
 
       assert_html(html, "select[name='vote']")
+      assert_html(html,
+                  "select[name='vote'] option[selected][value='2.0']")
+      assert_html(html, "select[name='vote'] option[selected]", count: 1)
     end
 
     def test_no_name_section_when_nothing_was_read_for_it


### PR DESCRIPTION
Follow-up to #4951. Every row the model read now ticks by default, and a disagreement with the observation is marked in the Current column rather than signalled by an empty box.

## Why the old rule was wrong

A row whose value disagreed with what the observation held started unticked, so applying the form couldn't silently overwrite something a person had entered. Sound in general — but on the observations this feature exists for, those "existing" values aren't choices. They're what the form fills in when someone creates a placeholder.

Observation 657299 (image 2048485) is typical:

| field | current value | what it actually is |
|---|---|---|
| `when` | 2026-07-31 | the day the observation was created |
| `collector` | `DThomas (BDThomas)` | the owner's own legal name |
| `location` | `NEMF 2026, Pennsylvania, USA` | the project's catch-all — **289 of project 404's 401 observations sit on it** |

So the guard was protecting defaults nobody made, and it cost three clicks per slip to undo them — on exactly the population the reader was built for.

## What replaces it

The disagreement is still shown, and now marked, in the Current column. That's a better place for it than an empty checkbox: it's the one spot a reviewer skimming the table needs to slow down, and both values were already on screen either way.

The safety argument for the old default rested on the reviewer not reading carefully. They do — reading every row is the entire step.

## Test plan

1. Open a placeholder observation's slip photo — one on the project's catch-all location, created the same day — and press **Read Field Slip**. Date, Collector and Locality should all arrive ticked. Saving without touching anything should apply all three.
2. On an observation with a genuinely hand-entered value that the slip disagrees with, confirm the Current column marks it as "will be replaced" and the row is still ticked. Untick it and confirm the value survives the save.
3. Confirm an agreeing row is not marked.
