### PR TITLE
Store field slip "Id by" as a user link, and stop the prompt expanding initials

### DIFF
--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -15,8 +15,15 @@ class FieldSlip
     PROVIDERS = { gemini: "FieldSlip::Extractor::Gemini" }.freeze
 
     # Bump when the prompt changes in a way that could change results.
-    # Stored on the extract so a stale read is identifiable later.
-    PROMPT_VERSION = "1"
+    # Stored on the extract so a stale read is identifiable later --
+    # which only works if this actually moves, so treat editing
+    # `Prompt` and bumping this as one act.
+    #
+    #   1  initial
+    #   2  user aliases transcribed rather than expanded, so "dcs" stays
+    #      resolvable to a User (extracts at v1 may hold an expanded
+    #      display name that resolves to nobody)
+    PROMPT_VERSION = "2"
 
     # The slip's fields, in the order they appear on the printed form,
     # mapped to where each one lands on the Observation. `nil` means the

--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -11,6 +11,8 @@ class FieldSlip
     # becomes a proposed naming, which is a different act with its own
     # name-creation and voting rules, so it is left to the caller.
     class Applier
+      ID_BY_KEY = :Field_Slip_ID_By
+
       # `chosen` is {slip field => edited value} for the ticked fields.
       # `inat_code` says whether "Other Codes" holds an iNaturalist
       # observation id, which is stored as a link rather than as the
@@ -62,11 +64,25 @@ class FieldSlip
         patch = targets.filter_map do |target, value|
           next unless target.to_s.start_with?("notes.")
 
-          [target.to_s.delete_prefix("notes.").to_sym, value]
+          key = target.to_s.delete_prefix("notes.").to_sym
+          [key, note_value(key, value)]
         end.to_h
         return if patch.empty?
 
         @observation.notes = @observation.notes.to_h.merge(patch)
+      end
+
+      # "Id by" names a person, and MO stores that as a textile user
+      # link rather than as bare text -- the same shape
+      # `ObservationsController::ProjectAliases#resolve_id_by_note`
+      # writes, so an observation reads back the same whichever route
+      # entered it. Unmatched text is kept verbatim: whoever identified
+      # a collection is not always an MO user.
+      def note_value(key, value)
+        return value unless key == ID_BY_KEY
+
+        user = resolved_user(value) || User.lookup_unique_text_name(value)
+        user.is_a?(User) ? user.textile_name : value
       end
 
       def assign_collector(value)

--- a/app/classes/field_slip/extractor/prompt.rb
+++ b/app/classes/field_slip/extractor/prompt.rb
@@ -73,14 +73,20 @@ class FieldSlip
       # Initials for Collector / ID By. Same reasoning: return the
       # abbreviation verbatim when it is not in the table, so the
       # reviewer sees an unknown one rather than a plausible wrong name.
+      # The table is a reading aid, not a substitution rule. Expanding
+      # "dcs" to "Dorothy Smullen" destroys the value: the initials
+      # resolve to a User two ways (this alias table, and a login
+      # lookup) while the expanded display name resolves neither, so MO
+      # can no longer link the note to the person. Transcribe; MO
+      # expands.
       def user_table
         rows = alias_rows("User")
         return nil if rows.empty?
 
         "\"Collector\" and \"ID By\" are often initials. This project " \
           "uses:\n#{rows}\n" \
-          "Expand an entry that appears in the table. Return anything " \
-          "else verbatim."
+          "Use the table only to read the handwriting. Return what is " \
+          "WRITTEN -- the initials, not the expanded name."
       end
 
       def alias_rows(target_type)

--- a/test/classes/field_slip/extractor/applier_test.rb
+++ b/test/classes/field_slip/extractor/applier_test.rb
@@ -61,6 +61,30 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
     assert_equal("Scott Shapiro", @obs.collector)
   end
 
+  # "Id by" names a person, and MO stores that as a textile user link,
+  # not bare text -- the same shape the observation form writes, so an
+  # observation reads back the same whichever route entered it.
+  def test_id_by_resolves_a_project_alias_to_a_user_link
+    fixture = project_aliases(:one) # "RS" -> rolf
+
+    apply_fields({ "ID By" => fixture.name })
+
+    assert_equal(rolf.textile_name, @obs.notes[:Field_Slip_ID_By])
+  end
+
+  def test_id_by_resolves_a_login
+    apply_fields({ "ID By" => rolf.login })
+
+    assert_equal(rolf.textile_name, @obs.notes[:Field_Slip_ID_By])
+  end
+
+  # Whoever identified a collection is not always an MO user.
+  def test_id_by_keeps_unmatched_text_verbatim
+    apply_fields({ "ID By" => "Some Visiting Expert" })
+
+    assert_equal("Some Visiting Expert", @obs.notes[:Field_Slip_ID_By])
+  end
+
   # A collector naming a project alias resolves to that user, so the
   # observation gets the link rather than initials as free text.
   def test_collector_resolves_through_a_project_alias

--- a/test/classes/field_slip/extractor/prompt_test.rb
+++ b/test/classes/field_slip/extractor/prompt_test.rb
@@ -47,6 +47,16 @@ class FieldSlip::Extractor::PromptTest < UnitTestCase
     assert_includes(text, "#{fixture.name} = ")
   end
 
+  # The user table is a reading aid, not a substitution rule. Expanding
+  # "dcs" to "Dorothy Smullen" destroys the value: the initials resolve
+  # to a User two ways, the expanded display name resolves neither.
+  def test_asks_for_initials_verbatim_not_expanded
+    text = prompt
+
+    assert_match(/Return what is WRITTEN/, text)
+    assert_no_match(/Expand an entry/, text)
+  end
+
   # An abbreviation the project hasn't defined must come back verbatim
   # rather than guessed at -- that is what surfaces it for an admin to
   # add, instead of silently resolving to a plausible wrong site.

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -99,6 +99,10 @@ module Images
 
       assert_equal("Scott Shapiro", extract.value_for("Collector"))
       assert_equal("gemini-3.6-flash", extract.model)
+      # Stamped from the constant, not a literal: a read is only
+      # attributable to the prompt that produced it if these agree.
+      assert_equal(FieldSlip::Extractor::PROMPT_VERSION,
+                   extract.prompt_version)
     end
 
     # A provider failure has to land as a flash, not a 500 -- the button


### PR DESCRIPTION
Reported against [observation 657376](https://mushroomobserver.org/obs/657376): the slip reads `dcs`, and it was stored as the bare text `Dorothy Smullen`. It should be `Dorothy Smullen (_user dcs_)` — what the observation form writes, and what renders as a link to the person.

## The prompt was throwing the link away

It told the model to expand any alias it recognized. Expanding destroys the only thing that can produce the link:

| what arrives | resolves to |
|---|---|
| `dcs` | `Dorothy Smullen (_user dcs_)` |
| `DCS` | `Dorothy Smullen (_user dcs_)` |
| `Dorothy Smullen` | *no match* |

The initials resolve to a `User` two ways — the project's own alias table and a login lookup — while the expanded display name resolves neither. So the table is now a reading aid rather than a substitution rule: transcribe what is written, and let MO expand it.

## And nothing was resolving it anyway

Even with `dcs` arriving intact, the applier wrote notes fields verbatim. `Field_Slip_ID_By` now goes through the project aliases, then `User.lookup_unique_text_name`, and is stored as `textile_name` — the same shape `ObservationsController::ProjectAliases#resolve_id_by_note` writes, so an observation reads back the same whichever route entered it.

Unmatched text is kept verbatim: whoever identified a collection is not always an MO user.

## Test plan

1. Read a slip whose "ID By" holds initials the project defines an alias for. Confirm the review page shows the **initials** (not an expanded name), and that saving stores the linked form — the observation's Notes should render "Id by" as a link to that user.
2. Read one whose "ID By" holds a login. Same result.
3. Read one naming somebody who is not an MO user. The text should survive unchanged.
