### PR TITLE
Show blank field-slip-extract fields

### DIFF
--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -66,6 +66,11 @@ class FieldSlip
     OTHER_CODES_FIELD = "Other Codes"
     INAT_CODE_RE = /\A\d+\z/
 
+    # These four are Notes checkbox fields where a blank carries no signal worth
+    # a reviewer's attention
+    HIDE_WHEN_BLANK_FIELDS = ["Odor/Taste", "Trees/Shrubs", "Substrate",
+                              "Habit"].freeze
+
     def self.inat_code?(value)
       value.to_s.strip.match?(INAT_CODE_RE)
     end

--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -66,8 +66,7 @@ class FieldSlip
     OTHER_CODES_FIELD = "Other Codes"
     INAT_CODE_RE = /\A\d+\z/
 
-    # These four are Notes checkbox fields where a blank carries no signal worth
-    # a reviewer's attention
+    # Notes checkbox fields where a blank carries no signal worth reviewing
     HIDE_WHEN_BLANK_FIELDS = ["Odor/Taste", "Trees/Shrubs", "Substrate",
                               "Habit"].freeze
 

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -96,7 +96,7 @@ class FormObject::FieldSlipReview < FormObject::Base
     observation.send(target == :place_name ? :where : target)
   end
 
-  def rows_to_show = rows.compact_blank.reject(&:own_section?)
+  def rows_to_show = rows.reject(&:own_section?)
 
   def name_row = rows.find(&:name_row?)
   def location_row = rows.find(&:location_row?)

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -42,6 +42,11 @@ class FormObject::FieldSlipReview < FormObject::Base
     # autocompleter only renders its dropdown and hidden id field when
     # it has a real label.
     def own_section? = name_row? || location_row?
+
+    # Note fields carry no signal when blank
+    def hide_when_blank?
+      FieldSlip::Extractor::HIDE_WHEN_BLANK_FIELDS.include?(field)
+    end
   end
 
   attribute :rows, default: -> { [] }
@@ -96,7 +101,11 @@ class FormObject::FieldSlipReview < FormObject::Base
     observation.send(target == :place_name ? :where : target)
   end
 
-  def rows_to_show = rows.reject(&:own_section?)
+  def rows_to_show
+    rows.reject(&:own_section?).reject do |row|
+      row.hide_when_blank? && row.blank?
+    end
+  end
 
   def name_row = rows.find(&:name_row?)
   def location_row = rows.find(&:location_row?)

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -75,6 +75,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     # and overridable rather than silent, since the box is free text and
     # someone will eventually write a herbarium number in it.
     def render_inat_flag(row)
+      return if row.blank?
       return unless row.field == ::FieldSlip::Extractor::OTHER_CODES_FIELD
 
       checkbox_field("inat", checked: @review.inat_code,
@@ -82,7 +83,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     end
 
     def render_confidence(row)
-      return if row.confidence == "high"
+      return if row.blank? || row.confidence == "high"
 
       div do
         small do
@@ -125,7 +126,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     # what the slip actually read.
     def render_location_section
       row = @review.location_row
-      return if row.nil? || row.blank?
+      return if row.nil?
 
       panel = Components::Panel.new(panel_id: "field_slip_extract_location")
       render(panel) do |p|
@@ -157,7 +158,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     # writing an attribute.
     def render_name_section
       row = @review.name_row
-      return if row.nil? || row.blank?
+      return if row.nil?
 
       # `with_body`, not a bare block: Panel is slot-based, and content
       # passed straight to it is discarded rather than rendered.

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -31,7 +31,7 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
     assert_equal(FieldSlip::Extractor::FIELDS.keys, review.rows.map(&:field))
   end
 
-  # A reviewer needs the ability to complete fields the model found nothing for
+  # Reviewer must be able to complete fields the model found nothing for
   def test_rows_to_show_includes_blank_rows
     review = build(fields: { "Collector" => "Scott Shapiro" })
 

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -31,16 +31,30 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
     assert_equal(FieldSlip::Extractor::FIELDS.keys, review.rows.map(&:field))
   end
 
-  # A reviewer needs to see which fields the model found nothing for,
-  # not just the ones it read -- so blank rows stay in the table
-  # rather than disappearing.
+  # A reviewer needs the ability to complete fields the model found nothing for
   def test_rows_to_show_includes_blank_rows
     review = build(fields: { "Collector" => "Scott Shapiro" })
 
     assert_equal(FieldSlip::Extractor::FIELDS.keys -
                  [FieldSlip::Extractor::NAME_FIELD,
-                  FieldSlip::Extractor::LOCATION_FIELD],
+                  FieldSlip::Extractor::LOCATION_FIELD] -
+                 FieldSlip::Extractor::HIDE_WHEN_BLANK_FIELDS,
                  review.rows_to_show.map(&:field))
+  end
+
+  # Note checkbox fields stay hidden until the model actually reads them.
+  def test_rows_to_show_drops_blank_checkbox_grid_fields
+    review = build(fields: { "Collector" => "Scott Shapiro" })
+
+    FieldSlip::Extractor::HIDE_WHEN_BLANK_FIELDS.each do |field|
+      assert_not_includes(review.rows_to_show.map(&:field), field)
+    end
+  end
+
+  def test_rows_to_show_includes_a_read_checkbox_grid_field
+    review = build(fields: { "Substrate" => "wood" })
+
+    assert_includes(review.rows_to_show.map(&:field), "Substrate")
   end
 
   # The ID needs a real label to render its autocompleter, which a table

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -31,11 +31,16 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
     assert_equal(FieldSlip::Extractor::FIELDS.keys, review.rows.map(&:field))
   end
 
-  # Nothing read means nothing to review, so the table stays short.
-  def test_rows_to_show_drops_blank_rows
+  # A reviewer needs to see which fields the model found nothing for,
+  # not just the ones it read -- so blank rows stay in the table
+  # rather than disappearing.
+  def test_rows_to_show_includes_blank_rows
     review = build(fields: { "Collector" => "Scott Shapiro" })
 
-    assert_equal(["Collector"], review.rows_to_show.map(&:field))
+    assert_equal(FieldSlip::Extractor::FIELDS.keys -
+                 [FieldSlip::Extractor::NAME_FIELD,
+                  FieldSlip::Extractor::LOCATION_FIELD],
+                 review.rows_to_show.map(&:field))
   end
 
   # The ID needs a real label to render its autocompleter, which a table
@@ -47,6 +52,16 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
     assert_not_includes(review.rows_to_show.map(&:field),
                         FieldSlip::Extractor::NAME_FIELD)
     assert_equal(FieldSlip::Extractor::NAME_FIELD, review.name_row.field)
+  end
+
+  # The name and location sections render even when the model read
+  # nothing for them -- a reviewer still needs to be able to fill
+  # them in by hand.
+  def test_name_and_location_rows_present_even_when_blank
+    review = build(fields: { "Collector" => "Scott Shapiro" })
+
+    assert_predicate(review.name_row, :blank?)
+    assert_predicate(review.location_row, :blank?)
   end
 
   def test_name_row_is_editable_but_not_savable

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -42,7 +42,16 @@ module Views::Controllers::Images::FieldSlipExtracts
     def test_shows_fields_the_model_read_nothing_for
       html = render_page(fields: { "Collector" => "Scott Shapiro" })
 
-      assert_html(html, "input[name='value[Substrate]']")
+      assert_html(html, "input[name='value[Date]']")
+    end
+
+    def test_hides_blank_checkbox_grid_fields
+      html = render_page(fields: { "Collector" => "Scott Shapiro" })
+
+      assert_no_html(html, "input[name='value[Odor/Taste]']")
+      assert_no_html(html, "input[name='value[Trees/Shrubs]']")
+      assert_no_html(html, "input[name='value[Substrate]']")
+      assert_no_html(html, "input[name='value[Habit]']")
     end
 
     # The name gets an autocompleter, which only renders its dropdown

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -37,10 +37,12 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_html(html, "input[name='use[Collector]']")
     end
 
-    def test_omits_fields_the_model_read_nothing_for
+    # A reviewer needs to see which fields the model found nothing
+    # for, not just the ones it read.
+    def test_shows_fields_the_model_read_nothing_for
       html = render_page(fields: { "Collector" => "Scott Shapiro" })
 
-      assert_no_html(html, "input[name='value[Substrate]']")
+      assert_html(html, "input[name='value[Substrate]']")
     end
 
     # The name gets an autocompleter, which only renders its dropdown
@@ -85,10 +87,21 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_html(html, "select[name='vote'] option[selected]", count: 1)
     end
 
-    def test_no_name_section_when_nothing_was_read_for_it
+    # The reviewer needs to be able to add an ID by hand even when the
+    # model read nothing, so the section still renders (empty).
+    def test_name_section_renders_when_nothing_was_read_for_it
       html = render_page(fields: { "Collector" => "Scott Shapiro" })
 
-      assert_no_html(html, "#field_slip_extract_name")
+      assert_html(html, "#field_slip_extract_name")
+      assert_html(html, "[name='value[ID]']")
+    end
+
+    # Same reasoning as the name section: a reviewer needs to be able
+    # to fill in Locality by hand even when the model read nothing.
+    def test_location_section_renders_when_nothing_was_read_for_it
+      html = render_page(fields: { "Collector" => "Scott Shapiro" })
+
+      assert_html(html, "#field_slip_extract_location")
     end
 
     # Marked, but still ticked -- see `Row#default_use?`.


### PR DESCRIPTION
### Manual Test

Using a 20260801 db dumb, read and complete Field Slip for 

ID By 657566,
Date 657567
Other Codes 657567
Location 657279

Expected result. The blank fields:
- should appear on the Read Field Slip form
- should populate the Observaiton/Field slip when filled in on that form.