### PR TITLE
Default the navbar search type to Observations on the Activity Log

### DIFF
--- a/app/components/form/pattern_search.rb
+++ b/app/components/form/pattern_search.rb
@@ -31,6 +31,11 @@ class Components::Form::PatternSearch < Components::ApplicationForm
     [:app_search_google, :google]
   ].freeze
 
+  # The selectable `type` values — the set a stored
+  # `session[:search_type]` must belong to for the select to be able
+  # to show it (see `Views::Layouts::TopNav::SearchBar`).
+  TYPE_VALUES = SEARCH_TYPE_OPTIONS.map(&:last).freeze
+
   FORM_CLASS = "flex-bar flex-grow-1 #{Components::Navbar::FORM_CLASS} " \
                "px-0 gap-2".freeze
 

--- a/app/views/layouts/top_nav/search_bar.rb
+++ b/app/views/layouts/top_nav/search_bar.rb
@@ -106,9 +106,17 @@ class Views::Layouts::TopNav::SearchBar < Views::Base
   # `SearchController#pattern` (after it pluralizes the submitted
   # form value) or by `ApplicationController::Queries` (which
   # stores `Query#search_type`, already plural from the
-  # controller's module name).
+  # controller's module name). The latter stores it for EVERY
+  # query-backed index — including types the select has no option
+  # for (e.g. `:rss_logs` from the Activity Log). An unselectable
+  # value would leave the browser showing the first alphabetical
+  # option ("Comments"), so those fall back to :observations
+  # (#4969).
   def default_search_type
-    controller.session[:search_type]&.to_sym || :observations
+    type = controller.session[:search_type]&.to_sym
+    return type if Components::Form::PatternSearch::TYPE_VALUES.include?(type)
+
+    :observations
   end
 
   def help_visible?

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -20,6 +20,18 @@ class RssLogsControllerTest < FunctionalTestCase
     assert_select("body.rss_logs__show")
   end
 
+  # The index stores `search_type: :rss_logs` in the session (like
+  # every query-backed index), but the navbar search select has no
+  # rss_logs option -- without a fallback the browser would display
+  # the first alphabetical option, "Comments" (#4969).
+  def test_search_bar_type_defaults_to_observations
+    login
+    get(:index)
+
+    assert_select("select[name='pattern_search[type]'] " \
+                  "option[selected][value='observations']")
+  end
+
   def test_rss_with_article_in_feed
     login("rolf")
     article = Article.create!(title: "Really _Neat_ Feature!",

--- a/test/views/layouts/top_nav/search_bar_test.rb
+++ b/test/views/layouts/top_nav/search_bar_test.rb
@@ -9,7 +9,11 @@ class Views::Layouts::TopNav
       @user = users(:rolf)
       viewer = @user
       controller.define_singleton_method(:current_user) { viewer }
-      session = { search_type: "observations" }
+      stub_session(search_type: "observations")
+    end
+
+    def stub_session(search_type:)
+      session = { search_type: search_type }
       controller.define_singleton_method(:session) { session }
     end
 
@@ -71,6 +75,28 @@ class Views::Layouts::TopNav
       assert_html(html,
                   "a[data-toggle='collapse']" \
                   "[data-search-type-target='formToggle'].d-none")
+    end
+
+    # `session[:search_type]` from a query-backed index can hold a
+    # type the select has no option for (e.g. `rss_logs` from the
+    # Activity Log) -- without a fallback the browser would display
+    # the first alphabetical option, "Comments" (#4969).
+    def test_type_select_falls_back_to_observations_for_unselectable_type
+      stub_session(search_type: "rss_logs")
+
+      html = render_bar
+
+      assert_html(html, "select[name='pattern_search[type]'] " \
+                        "option[selected][value='observations']")
+    end
+
+    def test_type_select_keeps_selectable_stored_type
+      stub_session(search_type: "comments")
+
+      html = render_bar
+
+      assert_html(html, "select[name='pattern_search[type]'] " \
+                        "option[selected][value='comments']")
     end
 
     def test_renders_login_reminder_when_no_user


### PR DESCRIPTION
## Summary

Fixes #4969. Another feature request from an in-person conversation with Igor at NEMF.

On the Activity Log the navbar search type showed **Comments** by default. Root cause: every query-backed index stores its `Query#search_type` in `session[:search_type]` (via `ApplicationController::Queries#store_query_in_session`), including types the search select has no option for — the Activity Log stores `:rss_logs`. `Views::Layouts::TopNav::SearchBar` then rendered the select with a value no `<option>` matches, so the browser fell back to displaying the first option in the alphabetically-sorted list, which is "Comments".

`SearchBar#default_search_type` now falls back to `:observations` unless the stored type is one of the select's actual options (new `Components::Form::PatternSearch::TYPE_VALUES`). This also fixes the same latent mis-display on every other non-searchable index (images, field slips, articles, etc.), and the help/advanced-form toggles — which key off the same method — stay consistent with what the select shows. A selectable stored type (e.g. a real comments search) is preserved as before.

## Test plan

- [ ] Log in and visit the Activity Log (`/activity_logs`): the navbar search type select shows **Observations**.
- [ ] Run a Comments search from the navbar, then browse a comments index: the select still shows **Comments** (valid stored types are kept).
- [ ] Visit an images or field-slips index: the select shows **Observations**, not Comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
