### PR TITLE
Alert on image-processing failures, classify stale files, and retry failed transfers (#4974)

### DIFF
--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -347,6 +347,14 @@ mo> ssh-keygen -t rsa
 mo> ssh images.mushroomobserver.org echo hello world
 
 # Set up logrotate to archive puma and rails logs.
+# copytruncate, NOT a puma signal/restart: puma and rails keep their log
+# file descriptors, so no restart is needed to release the files, and a
+# rotation can never kill an in-flight request (#4974: a daily
+# `service puma restart` here SIGTERMed an image resize mid-`convert`,
+# stranding a half-processed image). The old `kill -HUP` variant only
+# reopened puma's own stdout/stderr logs anyway -- rails' production.log
+# was never released without a restart, which is how the postrotate
+# escalated to a full restart in the first place.
 mo> exit
 root> vi /etc/logrotate.d/puma
   /var/web/mushroom-observer/log/*.log {
@@ -356,9 +364,9 @@ root> vi /etc/logrotate.d/puma
     dateext
     compress
     delaycompress
+    copytruncate
     sharedscripts
     postrotate
-      kill -HUP `cat /var/web/mushroom-observer/tmp/pids/puma.pid`
       mv /var/web/mushroom-observer/log/*.gz /var/web/mushroom-observer/log/old/
     endscript
   }

--- a/app/jobs/image_gap_detector_job.rb
+++ b/app/jobs/image_gap_detector_job.rb
@@ -11,15 +11,32 @@ class ImageGapDetectorJob < ApplicationJob
 
   def perform
     result = Image::Processor.detect_gaps { |msg| log(msg) }
-    log("Found #{result[:gaps].size} gap(s), " \
-        "regenerated #{result[:regenerated].size} image(s), " \
-        "#{result[:unregenerable].size} unregenerable")
+    log(summary(result))
+    alert_unchecked(result[:unchecked])
     return if result[:gaps].empty?
 
     alert(gap_alert_message(result))
   end
 
   private
+
+  def summary(result)
+    "Found #{result[:gaps].size} gap(s), " \
+      "regenerated #{result[:regenerated].size} image(s), " \
+      "#{result[:unregenerable].size} unregenerable, " \
+      "#{result[:unchecked].size} unchecked"
+  end
+
+  # A remote listing that failed outright (#4974) means those images
+  # were skipped, not verified -- say so rather than reporting a
+  # falsely-clean run. The held checkpoint re-examines them next run.
+  def alert_unchecked(unchecked)
+    return if unchecked.empty?
+
+    alert("Could not check #{unchecked.size} image(s) - remote listing " \
+          "failed; they will be re-examined next run - image ids: " \
+          "#{unchecked}")
+  end
 
   def gap_alert_message(result)
     affected_ids = result[:gaps].map(&:first).uniq

--- a/app/jobs/stale_image_files_job.rb
+++ b/app/jobs/stale_image_files_job.rb
@@ -3,37 +3,87 @@
 # Safety net for the image transfer pipeline (see #4791's target design):
 # scans local disk for image files that have sat around longer than they
 # should -- a sign TransferImagesJob never ran for them, or ran and
-# didn't finish. Never restarts a transfer itself; alerts to #alerts with
-# the exact command an admin can run to retry. Deliberately not scoped to
-# the DB's `transferred` column -- once a file is confirmed synced
-# everywhere it's supposed to be, Verifier deletes it immediately, so any
-# file still on disk past the threshold is, by construction, not yet
-# fully transferred.
+# didn't finish. Never restarts a transfer itself; classifies what it
+# finds (#4974) and alerts to #alerts with the remediation that can
+# actually work for each state. Deliberately not scoped to the DB's
+# `transferred` column -- once a file is confirmed synced everywhere
+# it's supposed to be, Verifier deletes it immediately, so any file
+# still on disk past the threshold is, by construction, not yet fully
+# transferred.
 class StaleImageFilesJob < ApplicationJob
   queue_as(:maintenance)
 
   STALE_THRESHOLD = 1.hour
 
   def perform
-    ids = stale_image_ids
-    return log("No stale image files found") if ids.empty?
+    files_by_id = stale_files_by_id
+    return log("No stale image files found") if files_by_id.empty?
 
-    alert("#{ids.size} image(s) have local files older than " \
-          "#{STALE_THRESHOLD.inspect}, still not transferred - retry " \
-          "with: TransferImagesJob.perform_now(image_ids: #{ids})")
+    orphaned, unprocessed, untransferred = classify(files_by_id)
+    alert_orphaned(orphaned, files_by_id)
+    alert_unprocessed(unprocessed)
+    alert_untransferred(untransferred)
   end
 
   private
 
-  def stale_image_ids
+  # The three states want different remedies (#4974): a file with no
+  # Image row can only be deleted; an image whose derivative sizes were
+  # never generated needs reprocessing (retrying the transfer does
+  # nothing -- Verifier skips images with missing local sizes); only a
+  # complete local set is a genuine transfer straggler that the retry
+  # command can fix.
+  def classify(files_by_id)
+    images = Image.where(id: files_by_id.keys).index_by(&:id)
+    orphaned = files_by_id.keys - images.keys
+    unprocessed, untransferred = images.values.partition do |image|
+      missing_local_sizes?(image)
+    end
+    [orphaned, unprocessed.map(&:id), untransferred.map(&:id)]
+  end
+
+  def missing_local_sizes?(image)
+    Image::Processor.expected_paths(image).any? do |path|
+      !File.exist?("#{Image::Processor.local_images_path}/#{path}")
+    end
+  end
+
+  def alert_orphaned(ids, files_by_id)
+    return if ids.empty?
+
+    files = ids.flat_map { |id| files_by_id[id] }.sort
+    alert("#{ids.size} stale image file id(s) have no Image row - " \
+          "orphaned files; delete with: FileUtils.rm_f(#{files.inspect})")
+  end
+
+  def alert_unprocessed(ids)
+    return if ids.empty?
+
+    alert("#{ids.size} image(s) have local files older than " \
+          "#{STALE_THRESHOLD.inspect} with derivative sizes missing - " \
+          "processing died? Reprocess with: " \
+          "#{Image::Processor.reprocess_command(ids)}")
+  end
+
+  def alert_untransferred(ids)
+    return if ids.empty?
+
+    alert("#{ids.size} image(s) have local files older than " \
+          "#{STALE_THRESHOLD.inspect}, still not transferred - retry " \
+          "with: #{TransferImagesJob.retry_command(ids)}")
+  end
+
+  # Every stale local file eligible for transfer, keyed by the image id
+  # parsed from its filename.
+  def stale_files_by_id
     kept_locally = Image::URL::SUBDIRECTORIES.values_at(
       *MO.keep_these_image_sizes_local
     )
-    stale_subdirs.flat_map do |subdir|
-      next [] if kept_locally.include?(File.basename(subdir))
+    stale_subdirs.each_with_object({}) do |subdir, files_by_id|
+      next if kept_locally.include?(File.basename(subdir))
 
-      stale_ids_in(subdir)
-    end.uniq
+      collect_stale_files(subdir, files_by_id)
+    end
   end
 
   def stale_subdirs
@@ -42,11 +92,12 @@ class StaleImageFilesJob < ApplicationJob
     end
   end
 
-  def stale_ids_in(subdir)
-    Dir.glob("#{subdir}/*").filter_map do |file|
+  def collect_stale_files(subdir, files_by_id)
+    Dir.glob("#{subdir}/*").each do |file|
       next unless File.file?(file) && stale?(file)
+      next unless (id = File.basename(file)[/\A\d+/]&.to_i)
 
-      File.basename(file)[/\A\d+/]&.to_i
+      (files_by_id[id] ||= []) << file
     end
   end
 

--- a/app/jobs/transfer_images_job.rb
+++ b/app/jobs/transfer_images_job.rb
@@ -7,6 +7,10 @@
 # delete/mark-transferred logic. Idempotent -- safe to re-run for the same
 # ids, since it only uploads what isn't already confirmed present.
 class TransferImagesJob < ApplicationJob
+  # Raised (and retried) when any file's upload or remote check failed
+  # this run. Never leaves the job -- retry_on either requeues or alerts.
+  class UploadFailure < StandardError; end
+
   queue_as(:default)
 
   # Each image's transfer serializes on its row lock with the writers
@@ -16,15 +20,53 @@ class TransferImagesJob < ApplicationJob
   # instead of failing the transfer permanently.
   retry_on ActiveRecord::LockWaitTimeout, wait: 30.seconds, attempts: 5
 
+  # A transient rsync/ssh failure is precisely what retry-with-backoff
+  # exists for -- the old behavior alerted a human whose whole remedy
+  # was to run the same job again (#4974). Eight polynomially-spaced
+  # attempts span ~80 minutes, sized to outlast the longest observed
+  # sshd connection storm (~30 minutes) before waking anyone up.
+  retry_on UploadFailure, wait: :polynomially_longer,
+                          attempts: 8 do |job, error|
+    job.alert("#{error.message} after #{job.executions} attempts - " \
+              "retry with: " \
+              "#{retry_command(job.arguments.first[:image_ids])}")
+  end
+
+  # The pasteable remediation for a genuine transfer straggler; also
+  # advised by StaleImageFilesJob's hourly scan.
+  def self.retry_command(image_ids)
+    "TransferImagesJob.perform_now(image_ids: #{image_ids})"
+  end
+
   def perform(image_ids:)
     result = Image::Processor.transfer_images(image_ids) { |msg| log(msg) }
-    log("Uploaded #{result[:uploaded].size}, " \
-        "deleted #{result[:deleted].size}, " \
-        "completed #{result[:completed].size}, " \
-        "failed #{result[:failed].size}")
+    log(summary(result))
+    alert_stuck(result[:stuck])
     return if result[:failed].empty?
 
-    alert("Transfer failed for #{result[:failed].size} file(s) - retry with: " \
-          "TransferImagesJob.perform_now(image_ids: #{image_ids})")
+    raise(UploadFailure.new("Transfer failed for " \
+                            "#{result[:failed].size} file(s)"))
+  end
+
+  private
+
+  def summary(result)
+    "Uploaded #{result[:uploaded].size}, " \
+      "deleted #{result[:deleted].size}, " \
+      "completed #{result[:completed].size}, " \
+      "failed #{result[:failed].size}, " \
+      "stuck #{result[:stuck].size}"
+  end
+
+  # Retrying the transfer can't help a stuck image -- its derivative
+  # sizes were never generated (processing died mid-#process, #4974) --
+  # so don't raise UploadFailure for it; advise reprocessing instead.
+  def alert_stuck(stuck)
+    return if stuck.blank?
+
+    alert("#{stuck.size} image(s) have missing local sizes past " \
+          "#{StaleImageFilesJob::STALE_THRESHOLD.inspect} - processing " \
+          "died? Reprocess with: " \
+          "#{Image::Processor.reprocess_command(stuck)}")
   end
 end

--- a/app/jobs/transfer_images_job.rb
+++ b/app/jobs/transfer_images_job.rb
@@ -61,8 +61,11 @@ class TransferImagesJob < ApplicationJob
   # Retrying the transfer can't help a stuck image -- its derivative
   # sizes were never generated (processing died mid-#process, #4974) --
   # so don't raise UploadFailure for it; advise reprocessing instead.
+  # First execution only: UploadFailure retries re-run the whole job,
+  # and the stuck state can't change between retries, so re-alerting
+  # on each of the 8 attempts would just spam #alerts.
   def alert_stuck(stuck)
-    return if stuck.blank?
+    return if stuck.blank? || executions > 1
 
     alert("#{stuck.size} image(s) have missing local sizes past " \
           "#{StaleImageFilesJob::STALE_THRESHOLD.inspect} - processing " \

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -861,7 +861,21 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   rescue StandardError => e
     Rails.logger.error("Image::Processor failed for image #{id}: " \
                        "#{e.full_message(highlight: false)}")
+    notify_image_process_failure(e)
     fail_image_process
+  end
+
+  # Same Slack routing (and gating) job failures get via ApplicationJob's
+  # rescue_from. Processing runs synchronously in the web request and its
+  # failure is rescued into a validation error above, so without this the
+  # exception never reaches exception_notification's middleware and
+  # nothing but production.log records it (#4974) -- while every
+  # neighbouring pipeline step (TransferImagesJob, StaleImageFilesJob,
+  # GpsLeakDetectorJob) alerts on failure.
+  def notify_image_process_failure(error)
+    return unless ExceptionNotifier.notifiers.any?
+
+    ExceptionNotifier.notify_exception(error, data: { image: id })
   end
 
   def fail_image_process # rubocop:disable Naming/PredicateMethod

--- a/app/models/image/processor.rb
+++ b/app/models/image/processor.rb
@@ -65,6 +65,30 @@ class Image
       image_server_data.keys - [:local]
     end
 
+    # Every file (relative path) a fully-processed image is expected to
+    # have: the six jpg renditions, plus the raw original when the upload
+    # wasn't a jpg. Shared by Verifier (are they all here to transfer?)
+    # and StaleImageFilesJob (did processing ever finish? -- #4974).
+    def self.expected_paths(image)
+      paths = Image::URL::SUBDIRECTORIES.values.map do |subdir|
+        "#{subdir}/#{image.id}.jpg"
+      end
+      ext = image.original_extension
+      paths << "orig/#{image.id}.#{ext}" if ext != "jpg"
+      paths
+    end
+
+    # Console command an admin can paste to regenerate images whose
+    # processing died before the derivative sizes were produced (#4974).
+    # Retrying the transfer alone can't help those -- there is nothing
+    # to transfer until the sizes exist again.
+    def self.reprocess_command(ids)
+      "Image.where(id: #{ids.inspect}).find_each { |i| " \
+        "i.current_user = i.user; " \
+        "Image::Processor.new(image: i, set_size: false).process }; " \
+        "TransferImagesJob.perform_now(image_ids: #{ids.inspect})"
+    end
+
     def initialize(image:, user: nil, ext: nil, set_size: false)
       @image = image
       raise("Image::Processor needs an image.") unless @image

--- a/app/models/image/processor/gap_detector.rb
+++ b/app/models/image/processor/gap_detector.rb
@@ -35,6 +35,7 @@ class Image
         @gaps = []
         @regenerated = []
         @unregenerable = []
+        @unchecked = []
         @image_server_data = Processor.image_server_data
         @image_servers = @image_server_data.keys - [:local]
       end
@@ -49,7 +50,7 @@ class Image
         end
         advance_checkpoint(scope) if images.nil?
         { gaps: @gaps, regenerated: @regenerated,
-          unregenerable: @unregenerable }
+          unregenerable: @unregenerable, unchecked: @unchecked }
       end
 
       private
@@ -71,18 +72,39 @@ class Image
       end
 
       def gaps_on_server(server, images)
-        image_for = {}
-        images.each do |image|
+        image_for = image_by_path(server, images)
+        image_for.keys.each_slice(REMOTE_CHECK_BATCH).flat_map do |chunk|
+          chunk_gaps(server, chunk, image_for)
+        end
+      end
+
+      def image_by_path(server, images)
+        images.each_with_object({}) do |image, image_for|
           paths_for_server(server, paths_for(image)).each do |path|
             image_for[path] = image
           end
         end
-        image_for.keys.each_slice(REMOTE_CHECK_BATCH).flat_map do |chunk|
-          remote = remote_sizes_for(server, chunk)
-          chunk.filter_map do |path|
-            [image_for[path], server, path] if remote[path].nil?
-          end
+      end
+
+      def chunk_gaps(server, chunk, image_for)
+        remote = remote_sizes_for(server, chunk)
+        # nil: the check itself failed (see RemoteFiles) -- reporting
+        # every path in the chunk as a gap would trigger a mass
+        # regeneration + re-upload of files that are actually fine
+        # (#4974). Record the images as unchecked instead; the held
+        # checkpoint re-examines them next run.
+        return record_unchecked(server, chunk, image_for) if remote.nil?
+
+        chunk.filter_map do |path|
+          [image_for[path], server, path] if remote[path].nil?
         end
+      end
+
+      def record_unchecked(server, chunk, image_for)
+        ids = chunk.map { |path| image_for[path].id }.uniq
+        @unchecked |= ids
+        log("Could not check #{server} - skipping #{ids.size} image(s)")
+        []
       end
 
       def paths_for(image)
@@ -125,13 +147,15 @@ class Image
       end
 
       # Advance the mark past everything examined and verified/regenerated,
-      # but hold below the lowest image we couldn't repair so it keeps
-      # being re-checked (and re-alerted) next run.
+      # but hold below the lowest image we couldn't repair -- or couldn't
+      # even check -- so it keeps being re-checked (and re-alerted) next
+      # run.
       def advance_checkpoint(scope)
         max_id = scope.maximum(:id)
         return unless max_id
 
-        ceiling = @unregenerable.min ? @unregenerable.min - 1 : max_id
+        blocked = (@unregenerable + @unchecked).min
+        ceiling = blocked ? blocked - 1 : max_id
         ImageGapCheckpoint.advance_to(ceiling)
       end
 

--- a/app/models/image/processor/remote_files.rb
+++ b/app/models/image/processor/remote_files.rb
@@ -14,6 +14,10 @@ class Image
 
       # Byte sizes of the given paths that exist on the server; a missing
       # path is absent (ssh) or nil (file), so callers check `[path].nil?`.
+      # Returns nil (not {}) when the check itself failed (#4974): "I
+      # could not ask the server" must stay distinguishable from "the
+      # server has nothing", or every path reads as missing and gets
+      # re-uploaded / re-generated needlessly.
       def remote_sizes_for(server, paths)
         return {} if paths.empty?
 
@@ -51,6 +55,7 @@ class Image
         )
         if connection_failed?(status, error)
           log("Failed to check #{host} for #{server}: #{error}")
+          return nil
         end
         parse_find_output(output, root)
       end

--- a/app/models/image/processor/verifier.rb
+++ b/app/models/image/processor/verifier.rb
@@ -36,6 +36,7 @@ class Image
         @deleted = []
         @completed = []
         @failed = []
+        @stuck = []
         # Fetched once per run (not cached at the class level -- see the
         # comment on Image::Processor.local_images_path).
         @image_server_data = Processor.image_server_data
@@ -45,7 +46,7 @@ class Image
       def transfer(images)
         images.find_each { |image| transfer_image(image) }
         { uploaded: @uploaded, deleted: @deleted, completed: @completed,
-          failed: @failed }
+          failed: @failed, stuck: @stuck }
       end
 
       private
@@ -66,13 +67,9 @@ class Image
       end
 
       def locked_transfer_image(image)
-        paths = paths_for(image)
+        paths = Processor.expected_paths(image)
         local_sizes = paths.index_with { |path| local_size(path) }
-        # Still mid-#process (a size hasn't been generated locally yet) --
-        # nothing to verify or transfer until it exists. Not an error: this
-        # is the normal in-progress window between upload and job
-        # completion, exactly the window #4791's race used to exploit.
-        return if local_sizes.value?(nil)
+        return handle_missing_sizes(image) if local_sizes.value?(nil)
 
         remote_sizes = remote_snapshot(paths)
         # Re-read the servers after uploading: a file just pushed here must
@@ -89,19 +86,27 @@ class Image
         mark_transferred(image)
       end
 
+      # A size missing locally normally means the image is still
+      # mid-#process -- nothing to verify or transfer until it exists.
+      # Not an error: that's the normal in-progress window between upload
+      # and job completion, exactly the window #4791's race used to
+      # exploit. But without a timeout, "still being worked on" is
+      # indistinguishable from "processing died" (#4974: a Puma restart
+      # killed the resize) -- forever, and a retried transfer silently
+      # does nothing. Past the stale threshold, nothing is still working
+      # on it: report it stuck so the caller can advise reprocessing.
+      def handle_missing_sizes(image)
+        return if image.updated_at > StaleImageFilesJob::STALE_THRESHOLD.ago
+
+        @stuck << image.id
+        log("Image #{image.id} has missing local sizes and hasn't been " \
+            "touched since #{image.updated_at} - processing died?")
+      end
+
       def remote_snapshot(paths)
         @image_servers.index_with do |server|
           remote_sizes_for(server, paths_for_server(server, paths))
         end
-      end
-
-      def paths_for(image)
-        paths = Image::URL::SUBDIRECTORIES.values.map do |subdir|
-          "#{subdir}/#{image.id}.jpg"
-        end
-        ext = image.original_extension
-        paths << "orig/#{image.id}.#{ext}" if ext != "jpg"
-        paths
       end
 
       def local_size(path)
@@ -115,6 +120,16 @@ class Image
       def upload_mismatches(image, paths, local_sizes, remote_sizes)
         attempted = false
         @image_servers.each do |server|
+          # A nil snapshot means the remote check itself failed (see
+          # RemoteFiles#remote_sizes_for) -- uploading against it would
+          # blindly re-send files that are mostly already there (#4974's
+          # ssh connection storm). Record the failure instead, so
+          # TransferImagesJob retries once the server answers again.
+          if remote_sizes[server].nil?
+            @failed << [image.id, server, "remote check failed"]
+            next
+          end
+
           paths_for_server(server, paths).each do |path|
             next if remote_sizes[server][path] == local_sizes[path]
 
@@ -159,6 +174,10 @@ class Image
         return false if @image_servers.empty?
 
         @image_servers.all? do |server|
+          # nil snapshot: the check failed, so nothing is confirmed --
+          # never treat "could not ask" as "fully synced" (#4974).
+          next false if remote_sizes[server].nil?
+
           paths_for_server(server, paths).all? do |path|
             remote_sizes[server][path] == local_sizes[path]
           end

--- a/config/etc/puma.service
+++ b/config/etc/puma.service
@@ -24,7 +24,7 @@ User=mo
 # Example /home/username/myapp
 WorkingDirectory=/var/web/mo
 
-PIDFile=/var/web/mo/tmp/puma.pid
+PIDFile=/var/web/mo/tmp/pids/puma.pid
 Environment=RAILS_ENV=production
 Environment=RUBY_MANAGER=chruby
 # Helpful for debugging socket activation, etc.
@@ -43,8 +43,24 @@ Environment=RUBY_MANAGER=chruby
 # ExecStart=/<FULLPATH>/puma -b tcp://0.0.0.0:9292 -b ssl://0.0.0.0:9293?key=key.pem&cert=cert.pem
 
 ExecStart=/var/web/mo/bin/run bundle exec puma -e production -C ./config/puma.rb config.ru
-ExecReload=/bin/kill -s $MAINPID
-ExecStop=/bin/kill -s QUIT $MAINPID
+
+# Hot restart (USR2): re-execs Puma while keeping the listening socket,
+# so `systemctl reload puma` picks up new code without dropping
+# connections.
+ExecReload=/bin/kill -s SIGUSR2 $MAINPID
+
+# Gentle stop/restart (#4974 fix 2): image resizing runs synchronously
+# inside the request (deliberately -- users are waiting on it), shelling
+# out to `convert`. The old ExecStop sent QUIT, which Puma does not trap
+# (instant, ungraceful death), and the default KillMode=control-group
+# then SIGTERMed every process in the cgroup -- including an in-flight
+# `convert`, stranding a half-processed image. Instead: TERM only the
+# master (Puma's graceful shutdown -- workers finish their in-flight
+# requests, so `convert` children run to completion), and only SIGKILL
+# whatever is still alive after TimeoutStopSec.
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=60
 
 Restart=always
 

--- a/test/jobs/image_gap_detector_job_test.rb
+++ b/test/jobs/image_gap_detector_job_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 class ImageGapDetectorJobTest < ActiveJob::TestCase
   def test_no_alert_when_no_gaps_found
-    result = { gaps: [], regenerated: [], unregenerable: [] }
+    result = { gaps: [], regenerated: [], unregenerable: [], unchecked: [] }
 
     Image::Processor.stub(:detect_gaps, result) do
       alerts = capture_alerts { ImageGapDetectorJob.perform_now }
@@ -17,7 +17,8 @@ class ImageGapDetectorJobTest < ActiveJob::TestCase
       gaps: [[1, :remote1, "960/1.jpg"], [1, :remote2, "640/1.jpg"],
              [2, :remote1, "orig/2.jpg"]],
       regenerated: [1],
-      unregenerable: [2]
+      unregenerable: [2],
+      unchecked: []
     }
 
     Image::Processor.stub(:detect_gaps, result) do
@@ -29,6 +30,21 @@ class ImageGapDetectorJobTest < ActiveJob::TestCase
       assert_includes(alerts.first.message, "1 regenerated")
       assert_includes(alerts.first.message, "1 could not be regenerated")
       assert_includes(alerts.first.message, "[1, 2]")
+    end
+  end
+
+  # A run that could not list a server verified nothing for those images
+  # -- it must say so (#4974), not read as a clean run.
+  def test_alerts_when_images_could_not_be_checked
+    result = { gaps: [], regenerated: [], unregenerable: [],
+               unchecked: [3, 4] }
+
+    Image::Processor.stub(:detect_gaps, result) do
+      alerts = capture_alerts { ImageGapDetectorJob.perform_now }
+
+      assert_equal(1, alerts.size)
+      assert_includes(alerts.first.message, "Could not check 2 image(s)")
+      assert_includes(alerts.first.message, "[3, 4]")
     end
   end
 

--- a/test/jobs/stale_image_files_job_test.rb
+++ b/test/jobs/stale_image_files_job_test.rb
@@ -4,7 +4,8 @@ require("test_helper")
 
 class StaleImageFilesJobTest < ActiveJob::TestCase
   # Large, deliberately out-of-range ids so this test's stray files can
-  # never collide with a real fixture image id.
+  # never collide with a real fixture image id -- and, having no Image
+  # row, they classify as orphaned files (#4974).
   FAKE_IDS = (999_900_001..999_900_004).to_a.freeze
 
   def local_root
@@ -12,6 +13,7 @@ class StaleImageFilesJobTest < ActiveJob::TestCase
   end
 
   def setup
+    @written = []
     Image::URL::SUBDIRECTORIES.each_value do |dir|
       FileUtils.mkpath("#{local_root}/#{dir}")
     end
@@ -19,11 +21,7 @@ class StaleImageFilesJobTest < ActiveJob::TestCase
   end
 
   def teardown
-    Image::URL::SUBDIRECTORIES.each_value do |dir|
-      FAKE_IDS.each do |id|
-        FileUtils.rm_f("#{local_root}/#{dir}/#{id}.jpg")
-      end
-    end
+    @written.each { |path| FileUtils.rm_f(path) }
     super
   end
 
@@ -35,41 +33,81 @@ class StaleImageFilesJobTest < ActiveJob::TestCase
     assert_empty(alerts)
   end
 
-  def test_alerts_with_remediation_command_for_stale_files
-    write_file("640", FAKE_IDS[1], age: 2.hours)
+  # A stale file with no Image row can't be transferred or reprocessed --
+  # the only remedy is deleting it, and the alert must say so instead of
+  # advising a retry that cannot work (#4974).
+  def test_orphaned_files_get_delete_advice
+    file1 = write_file("640", FAKE_IDS[1], age: 2.hours)
+    file2 = write_file("960", FAKE_IDS[1], age: 2.hours)
 
     alerts = capture_alerts { StaleImageFilesJob.perform_now }
 
     assert_equal(1, alerts.size)
     assert_instance_of(JobAlert, alerts.first)
-    assert_includes(alerts.first.message, "1 image(s)")
-    assert_includes(
-      alerts.first.message,
-      "TransferImagesJob.perform_now(image_ids: [#{FAKE_IDS[1]}])"
-    )
+    assert_includes(alerts.first.message, "no Image row")
+    assert_includes(alerts.first.message, "FileUtils.rm_f")
+    assert_includes(alerts.first.message, file1)
+    assert_includes(alerts.first.message, file2)
+    assert_not_includes(alerts.first.message, "TransferImagesJob")
+  end
+
+  # An image whose derivative sizes were never generated (processing
+  # died mid-#process, #4974) needs reprocessing -- retrying the
+  # transfer would do nothing, since Verifier skips images with missing
+  # local sizes.
+  def test_unprocessed_image_gets_reprocess_advice
+    image = images(:turned_over_image)
+    write_file("orig", image.id, age: 2.hours)
+
+    alerts = capture_alerts { StaleImageFilesJob.perform_now }
+
+    assert_equal(1, alerts.size)
+    assert_includes(alerts.first.message, "processing died?")
+    assert_includes(alerts.first.message,
+                    Image::Processor.reprocess_command([image.id]))
+  end
+
+  # A complete set of local files is a genuine transfer straggler -- the
+  # one state where retrying TransferImagesJob is the right advice.
+  def test_untransferred_image_gets_retry_advice
+    image = images(:turned_over_image)
+    Image::URL::SUBDIRECTORIES.each_value do |dir|
+      write_file(dir, image.id, age: 2.hours)
+    end
+
+    alerts = capture_alerts { StaleImageFilesJob.perform_now }
+
+    assert_equal(1, alerts.size)
+    assert_includes(alerts.first.message,
+                    TransferImagesJob.retry_command([image.id]))
+    assert_not_includes(alerts.first.message, "Reprocess")
+  end
+
+  # Each classification alerts independently, so mixed findings arrive
+  # as separate, correctly-advised messages.
+  def test_mixed_states_alert_separately
+    write_file("640", FAKE_IDS[2], age: 2.hours)
+    image = images(:turned_over_image)
+    write_file("orig", image.id, age: 2.hours)
+
+    alerts = capture_alerts { StaleImageFilesJob.perform_now }
+
+    assert_equal(2, alerts.size)
+    messages = alerts.map(&:message)
+    assert(messages.any? { |msg| msg.include?("no Image row") })
+    assert(messages.any? do |msg|
+      msg.include?(Image::Processor.reprocess_command([image.id]))
+    end)
   end
 
   def test_does_not_flag_sizes_kept_local
     MO.stub(:keep_these_image_sizes_local, [:medium]) do
-      write_file("640", FAKE_IDS[2], age: 2.hours)
+      write_file("640", FAKE_IDS[3], age: 2.hours)
 
       alerts = capture_alerts { StaleImageFilesJob.perform_now }
 
       assert_empty(alerts)
     end
-  end
-
-  def test_deduplicates_ids_across_subdirs
-    write_file("640", FAKE_IDS[3], age: 2.hours)
-    write_file("960", FAKE_IDS[3], age: 2.hours)
-
-    alerts = capture_alerts { StaleImageFilesJob.perform_now }
-
-    assert_equal(1, alerts.size)
-    assert_includes(
-      alerts.first.message,
-      "TransferImagesJob.perform_now(image_ids: [#{FAKE_IDS[3]}])"
-    )
   end
 
   private
@@ -81,6 +119,8 @@ class StaleImageFilesJobTest < ActiveJob::TestCase
     # Rails/TimeZone is correct here, not a style violation to fix.
     time = Time.at((Time.zone.now - age).to_f) # rubocop:disable Rails/TimeZone
     File.utime(time, time, path)
+    @written << path
+    path
   end
 
   # Records the exceptions handed to the #alerts pipeline while alerting is

--- a/test/jobs/transfer_images_job_test.rb
+++ b/test/jobs/transfer_images_job_test.rb
@@ -77,6 +77,29 @@ class TransferImagesJobTest < ActiveJob::TestCase
     end
   end
 
+  # When a run has both stuck and failed entries, the UploadFailure
+  # retries re-run the whole job -- but the stuck state can't change
+  # between retries, so only the first execution alerts it (Copilot
+  # review on PR #4977).
+  def test_does_not_re_alert_stuck_images_on_retry_executions
+    result = { uploaded: [], deleted: [], completed: [],
+               failed: [[1, :remote1, "640/1.jpg"]], stuck: [5] }
+
+    Image::Processor.stub(:transfer_images, result) do
+      first_run_alerts = capture_alerts do
+        TransferImagesJob.perform_now(image_ids: [1, 5])
+      end
+      assert_equal(1, first_run_alerts.size,
+                   "first execution should alert the stuck image")
+      assert_includes(first_run_alerts.first.message, "processing died?")
+
+      retry_run = TransferImagesJob.new(image_ids: [1, 5])
+      retry_run.executions = 1 # perform_now increments to 2 (a retry)
+      retry_alerts = capture_alerts { retry_run.perform_now }
+      assert_empty(retry_alerts, "retries must not re-emit the stuck alert")
+    end
+  end
+
   private
 
   # Records the exceptions handed to the #alerts pipeline while alerting is

--- a/test/jobs/transfer_images_job_test.rb
+++ b/test/jobs/transfer_images_job_test.rb
@@ -5,29 +5,75 @@ require("test_helper")
 class TransferImagesJobTest < ActiveJob::TestCase
   def test_calls_processor_transfer_images_and_logs_summary
     result = { uploaded: ["320/1.jpg"], deleted: ["960/1.jpg"],
-               completed: [1], failed: [] }
+               completed: [1], failed: [], stuck: [] }
 
     Image::Processor.stub(:transfer_images, result) do
       alerts = capture_alerts do
         TransferImagesJob.perform_now(image_ids: [1])
       end
       assert_empty(alerts, "no alert expected when nothing failed")
+      assert_no_enqueued_jobs(only: TransferImagesJob)
     end
   end
 
-  def test_alerts_with_retry_command_when_a_file_fails
+  # A transient upload failure retries itself with backoff (#4974)
+  # instead of immediately alerting a human whose remedy would be to run
+  # the same job again.
+  def test_failed_upload_requeues_itself_instead_of_alerting
     result = { uploaded: [], deleted: [], completed: [],
-               failed: [[1, :remote1, "640/1.jpg"]] }
+               failed: [[1, :remote1, "640/1.jpg"]], stuck: [] }
 
     Image::Processor.stub(:transfer_images, result) do
       alerts = capture_alerts do
         TransferImagesJob.perform_now(image_ids: [1])
       end
 
+      assert_empty(alerts, "first failure should retry, not alert")
+      assert_enqueued_with(job: TransferImagesJob,
+                           args: [{ image_ids: [1] }])
+    end
+  end
+
+  def test_alerts_with_retry_command_once_attempts_are_exhausted
+    result = { uploaded: [], deleted: [], completed: [],
+               failed: [[1, :remote1, "640/1.jpg"]], stuck: [] }
+    job = TransferImagesJob.new(image_ids: [1])
+    # Simulate the 8th (last) attempt: retry_on counts per-exception
+    # executions in exception_executions (incremented on rescue), while
+    # the alert message reports the overall executions counter.
+    job.executions = 7 # perform_now increments to 8
+    job.exception_executions = { "[TransferImagesJob::UploadFailure]" => 7 }
+
+    Image::Processor.stub(:transfer_images, result) do
+      alerts = capture_alerts { job.perform_now }
+
       assert_equal(1, alerts.size)
       assert_instance_of(JobAlert, alerts.first)
       assert_includes(alerts.first.message,
+                      "Transfer failed for 1 file(s) after 8 attempts")
+      assert_includes(alerts.first.message,
                       "TransferImagesJob.perform_now(image_ids: [1])")
+      assert_no_enqueued_jobs(only: TransferImagesJob)
+    end
+  end
+
+  # A stuck image (derivative sizes never generated -- processing died,
+  # #4974) is not retried: another transfer attempt can't help it. It is
+  # alerted with the reprocess remedy instead.
+  def test_alerts_with_reprocess_command_for_stuck_images
+    result = { uploaded: [], deleted: [], completed: [],
+               failed: [], stuck: [5] }
+
+    Image::Processor.stub(:transfer_images, result) do
+      alerts = capture_alerts do
+        TransferImagesJob.perform_now(image_ids: [5])
+      end
+
+      assert_equal(1, alerts.size)
+      assert_includes(alerts.first.message, "processing died?")
+      assert_includes(alerts.first.message,
+                      Image::Processor.reprocess_command([5]))
+      assert_no_enqueued_jobs(only: TransferImagesJob)
     end
   end
 

--- a/test/models/image/processor/gap_detector_test.rb
+++ b/test/models/image/processor/gap_detector_test.rb
@@ -114,6 +114,39 @@ class Image::Processor::GapDetectorTest < UnitTestCase
                  "regeneration should only be attempted once per image")
   end
 
+  # A remote listing that failed outright (#4974) verified nothing --
+  # treating every path in the chunk as missing would trigger a mass
+  # regeneration + re-upload of files that are actually fine. The images
+  # are recorded as unchecked instead, and nothing is regenerated.
+  def test_failed_remote_check_records_unchecked_instead_of_gaps
+    image = images(:turned_over_image)
+    image.update_columns(transferred: true)
+    messages = []
+    detector = Image::Processor::GapDetector.new { |msg| messages << msg }
+
+    result = detector.stub(:remote_sizes_for, nil) do
+      detector.run(Image.where(id: image.id))
+    end
+
+    assert_empty(result[:gaps])
+    assert_empty(result[:regenerated])
+    assert_equal([image.id], result[:unchecked])
+    assert(messages.any? { |msg| msg.include?("Could not check") })
+  end
+
+  # Unchecked images hold the mark just like unregenerable ones, so they
+  # are re-examined next run instead of being skipped forever.
+  def test_checkpoint_holds_below_the_lowest_unchecked_image
+    detector = Image::Processor::GapDetector.new
+    detector.instance_variable_set(:@unchecked, [40])
+    ImageGapCheckpoint.reset_to(0)
+
+    detector.send(:advance_checkpoint,
+                  Image.where(id: images(:turned_over_image).id))
+
+    assert_equal(39, ImageGapCheckpoint.last_verified_image_id)
+  end
+
   # The default (scheduled) scope only examines transferred images.
   def test_default_scope_only_includes_transferred_images
     ImageGapCheckpoint.reset_to(0)

--- a/test/models/image/processor/verifier_test.rb
+++ b/test/models/image/processor/verifier_test.rb
@@ -138,10 +138,11 @@ class Image::Processor::VerifierTest < UnitTestCase
   # A local file that hasn't been generated yet (still mid-#process) means
   # nothing to verify or transfer until it exists -- this is the normal
   # in-progress window between upload and job completion, exactly the
-  # window #4791's blind rsync used to race.
+  # window #4791's blind rsync used to race. A recently-touched image is
+  # in that window, not stuck.
   def test_skips_image_still_being_processed
     image = images(:turned_over_image)
-    image.update_columns(transferred: false)
+    image.update_columns(transferred: false, updated_at: Time.zone.now)
     # Only "orig" exists locally -- the rest haven't been generated yet.
     File.write("#{local_root}/orig/#{image.id}.jpg", "orig-only")
 
@@ -149,9 +150,58 @@ class Image::Processor::VerifierTest < UnitTestCase
 
     assert_empty(result[:uploaded])
     assert_empty(result[:completed])
+    assert_empty(result[:stuck],
+                 "a recently-touched image is mid-process, not stuck")
     assert_not(image.reload.transferred)
     assert_path_exists("#{local_root}/orig/#{image.id}.jpg",
                        "not deleted -- still mid-processing")
+  end
+
+  # Past the stale threshold, nothing is still generating the missing
+  # sizes -- processing died (#4974: a restart killed the resize
+  # mid-flight). Without the timeout this state was indistinguishable
+  # from "in progress" forever, so a retried transfer silently did
+  # nothing. It must be reported as stuck instead.
+  def test_reports_image_with_missing_sizes_past_threshold_as_stuck
+    image = images(:turned_over_image)
+    image.update_columns(transferred: false, updated_at: 2.hours.ago)
+    File.write("#{local_root}/orig/#{image.id}.jpg", "orig-only")
+    messages = []
+    verifier = Image::Processor::Verifier.new { |msg| messages << msg }
+
+    result = verifier.transfer(Image.where(id: image.id))
+
+    assert_equal([image.id], result[:stuck])
+    assert_empty(result[:uploaded])
+    assert_not(image.reload.transferred)
+    assert_path_exists("#{local_root}/orig/#{image.id}.jpg")
+    assert(messages.any? { |msg| msg.include?("processing died?") })
+  end
+
+  # "Could not ask the server" is not "the server has nothing" (#4974):
+  # a failed remote check must not blind-upload every size (they are
+  # mostly already there), must not confirm anything, and must surface
+  # as a failure so TransferImagesJob retries later.
+  def test_failed_remote_check_records_failure_instead_of_reuploading
+    image = images(:turned_over_image)
+    seed_locally_complete(image)
+    verifier = Image::Processor::Verifier.new
+
+    result = verifier.stub(:remote_sizes_for, nil) do
+      verifier.transfer(Image.where(id: image.id))
+    end
+
+    assert_empty(result[:uploaded],
+                 "must not re-upload against a failed check")
+    assert_empty(result[:completed])
+    assert_equal([[image.id, :remote1, "remote check failed"],
+                  [image.id, :remote2, "remote check failed"]],
+                 result[:failed])
+    assert_not(image.reload.transferred)
+    SUBDIRS.each do |dir|
+      assert_path_exists("#{local_root}/#{dir}/#{image.id}.jpg",
+                         "#{dir} must survive an unverifiable run")
+    end
   end
 
   # A non-jpg original also expects its raw orig/<id>.<ext> file (in
@@ -281,7 +331,9 @@ class Image::Processor::VerifierTest < UnitTestCase
     assert_empty(messages)
   end
 
-  def test_ssh_sizes_logs_and_returns_empty_on_real_failure
+  # nil, not {} -- "could not ask" must stay distinguishable from "the
+  # server has nothing" (#4974).
+  def test_ssh_sizes_logs_and_returns_nil_on_real_failure
     messages = []
     verifier = Image::Processor::Verifier.new { |msg| messages << msg }
     stderr = "ssh: Could not resolve hostname example.test\n"
@@ -289,7 +341,7 @@ class Image::Processor::VerifierTest < UnitTestCase
     Open3.stub(:capture3, ["", stderr, stub_status(false)]) do
       result = verifier.send(:ssh_sizes, :ssh_server,
                              "mo@example.test:/data/mo", ["orig/1.jpg"])
-      assert_equal({}, result)
+      assert_nil(result)
     end
 
     assert(messages.any? do |msg|

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -437,11 +437,19 @@ class ImageTest < UnitTestCase
     # looking like a real failure. Capturing also pins the logging
     # contract itself, which the old passthrough never asserted.
     logged = nil
+    notified = []
     img.stub(:move_original, true) do
       Image::Processor.stub(:new, failing_processor) do
         Rails.env.stub(:test?, false) do
           Rails.logger.stub(:error, ->(msg) { logged = msg }) do
-            assert_not(img.process_image)
+            ExceptionNotifier.stub(:notifiers, [:slack]) do
+              ExceptionNotifier.stub(
+                :notify_exception,
+                ->(exception, **_o) { notified << exception }
+              ) do
+                assert_not(img.process_image)
+              end
+            end
           end
         end
       end
@@ -449,6 +457,10 @@ class ImageTest < UnitTestCase
     assert(img.errors[:image].any?)
     assert_includes(logged, "Image::Processor failed for image #{img.id}")
     assert_includes(logged, "boom")
+    # A processing failure happens while a user is watching, yet used to
+    # alert nobody (#4974) -- it must reach the same pipeline job
+    # failures do.
+    assert_equal(["boom"], notified.map(&:message))
   end
 
   # Transfer-to-image-server is no longer part of Image::Processor#process


### PR DESCRIPTION
Part of #4974 (code fixes 1, 3, 4, 5, and 8). Every one of these turned a recoverable hiccup into a silent or misleading dead end when image 2049573's resize was killed mid-flight, and again when the 2026-08-01 ssh connection storm stranded 48 uploads.

## Fix 1 - a processing failure now alerts

`Image#process_and_enqueue_jobs`'s rescue previously wrote one `Rails.logger.error` and returned false - the exception never reached exception_notification's middleware because the rescue swallowed it. It now hands the exception to `ExceptionNotifier` with the same gating `ApplicationJob`'s `rescue_from` uses, so a mid-request processing death lands in `#alerts` immediately instead of being reconstructed from `production.log` an afternoon later.

## Fix 3 - the transfer guard can now tell "died" from "in progress"

`Verifier#locked_transfer_image` bailed silently whenever any local size was missing, with no timeout - an image whose processing died was indistinguishable from one being actively worked on, forever, and the alert's suggested `TransferImagesJob.perform_now` retry returned having done nothing. Past `StaleImageFilesJob::STALE_THRESHOLD` (measured from `image.updated_at`), the image is now reported in a new `stuck:` result bucket, and `TransferImagesJob` alerts with the reprocess command instead of staying silent.

## Fix 4 - `StaleImageFilesJob` classifies before advising

The stale scan previously always suggested the same retry-transfer command with no check that it could achieve anything. It now buckets each stale id into the three distinguishable states from the issue table, each with the remedy that actually works:

| state | advice |
|---|---|
| no `Image` row | `FileUtils.rm_f([...])` with the orphaned file paths |
| row exists, derivative sizes missing | `Image::Processor.reprocess_command(ids)` |
| row exists, all sizes present | the existing `TransferImagesJob.perform_now` retry |

## Fix 5 - `TransferImagesJob` retries failed uploads itself

A failed upload now raises `TransferImagesJob::UploadFailure`, covered by `retry_on wait: :polynomially_longer, attempts: 8` (~80 minutes total, sized to outlast the ~30-minute connection storms observed on 2026-08-01). The alert - with the same retry command as before - fires only when attempts are exhausted. With this in place, all 48 storm-stranded images would have self-healed with no alert at all.

## Fix 8 - "could not ask" is no longer "the server has nothing"

`RemoteFiles#ssh_sizes` returned `{}` on a connection failure, so every path read as missing. Consequences fixed in both consumers:

- `Verifier` no longer blind-re-uploads every size against a failed snapshot (the `Uploaded 6` lines on images whose files were already present); it records a `remote check failed` failure, which feeds fix 5's retry loop, and `all_synced?` can never confirm-and-delete on an unverified snapshot.
- `GapDetector` no longer treats an unreachable server as "every image has gaps" (which would have mass-regenerated and re-uploaded fine files); unchecked images are reported and the `ImageGapCheckpoint` holds below them so they are re-examined next run. `ImageGapDetectorJob` alerts when a run couldn't check images rather than reading as clean.

## Fix 2 - gentler restarts, resize stays synchronous

Decision: resizing stays synchronous in the request - users are waiting on the result, so it is not moving behind a job. Instead the restart stops killing it, via the two tracked config artifacts:

- `README_PRODUCTION_INSTALL`'s logrotate stanza now uses `copytruncate` with no Puma signal at all - rotation never needed a restart, only a release of the log files, and `copytruncate` needs neither. This removes the daily trigger entirely. (The documented `kill -HUP` only ever reopened Puma's own `stdout_redirect` logs, never Rails' `production.log`, which is presumably how the server's postrotate escalated to `service puma restart`.)
- `config/etc/puma.service` now sets `KillMode=mixed` + `KillSignal=SIGTERM` + `TimeoutStopSec=60`, so a stop/restart TERMs only the Puma master and its graceful shutdown lets workers finish in-flight requests - including their `convert` children - before any SIGKILL sweep. The old unit sent `QUIT` (which Puma 8 does not trap - instant ungraceful death) and systemd's default `KillMode=control-group` then SIGTERMed every process in the cgroup, `convert` included; that combination is exactly the status-15 kill in the incident. Also fixes `ExecReload` (was missing its signal name; now `SIGUSR2` hot restart) and the `PIDFile` path.

To apply on the web server (not done by merging):

```bash
# as root
cp /var/web/mo/config/etc/puma.service /etc/systemd/system/puma.service
systemctl daemon-reload
# edit /etc/logrotate.d/ stanza for the app logs to match the README:
#   drop the puma restart from postrotate, add copytruncate
```

## Not in this PR

- Fixes 6 and 7 (ssh `ControlMaster`/`ControlPersist` for the `mo` user, `MaxStartups` on the images server) - server-side configuration only, no code change.

## Test plan

Console reproductions of the two incident shapes, in dev:

1. Stuck image (incident 1): pick an image with `transferred: false`, write only `orig/<id>.jpg` under `MO.local_image_files`, backdate it with `Image.find(<id>).update_columns(updated_at: 2.hours.ago)`, then run `TransferImagesJob.perform_now(image_ids: [<id>])`. `log/job.log` should show the "processing died?" line with the pasteable reprocess command, instead of silently doing nothing.
2. Stale scan classification: drop a stale file with a bogus id (e.g. `999900001.jpg`, `touch -t` it 2+ hours old) into a non-kept size dir and run `StaleImageFilesJob.perform_now`. The job log should advise deleting the file, not retrying a transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
