### PR TITLE
Add the `su mo mo` directive logrotate needs to rotate `mo`-owned app logs

### DIFF
--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -356,14 +356,15 @@ mo> ssh images.mushroomobserver.org echo hello world
 # was never released without a restart, which is how the postrotate
 # escalated to a full restart in the first place.
 mo> exit
-# `su mo mo` is required: log/ is owned by mo and group-writable, and
-# logrotate refuses to rotate as root inside a directory a non-root
-# user can write to (symlink-attack guard) -- without it every log is
-# skipped with "parent directory has insecure permissions" and rotation
-# silently never happens. The directory must also not be world-writable
-# (su only vouches for the named user/group):
-root> chown mo:mo /var/web/mushroom-observer/log
-root> chmod 0755 /var/web/mushroom-observer/log
+# `su mo mo`: nightly runs go through /etc/logrotate.conf, whose global
+# `su root adm` (Ubuntu default) already satisfies logrotate's guard
+# against rotating as root in a non-root-writable directory -- rotation
+# works without any su here. But a standalone check of just this file
+# (`logrotate -d /etc/logrotate.d/puma`) lacks the global directive and
+# skips every log with "parent directory has insecure permissions"
+# (log/ is mo-owned and group-writable). Declaring `su mo mo` makes the
+# stanza self-sufficient, and rotated copies come out mo-owned instead
+# of root:adm.
 root> vi /etc/logrotate.d/puma
   /var/web/mushroom-observer/log/*.log {
     su mo mo

--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -356,8 +356,17 @@ mo> ssh images.mushroomobserver.org echo hello world
 # was never released without a restart, which is how the postrotate
 # escalated to a full restart in the first place.
 mo> exit
+# `su mo mo` is required: log/ is owned by mo and group-writable, and
+# logrotate refuses to rotate as root inside a directory a non-root
+# user can write to (symlink-attack guard) -- without it every log is
+# skipped with "parent directory has insecure permissions" and rotation
+# silently never happens. The directory must also not be world-writable
+# (su only vouches for the named user/group):
+root> chown mo:mo /var/web/mushroom-observer/log
+root> chmod 0755 /var/web/mushroom-observer/log
 root> vi /etc/logrotate.d/puma
   /var/web/mushroom-observer/log/*.log {
+    su mo mo
     daily
     missingok
     rotate 7


### PR DESCRIPTION
Follow-up to #4977 (fix 2 of #4974), surfaced by the `logrotate -d /etc/logrotate.d/puma` sanity check while deploying: run standalone, that check skips every log under `/var/web/mushroom-observer/log` with `parent directory has insecure permissions`, because the directory is `mo`-owned and group-writable and logrotate refuses to rotate as root inside a directory a non-root user can write to (symlink-attack guard).

Nightly rotation was never actually affected: the real runs go through `/etc/logrotate.conf`, whose global `su root adm` (Ubuntu default) satisfies the guard - a full-config dry run shows `switching euid from 0 to 0 and egid from 0 to 4`, and `/var/lib/logrotate/status` shows the app logs rotating daily. The failure only appears when the fragment is tested (or ever run) on its own, because nothing in the fragment itself declares the `su` credentials it needs.

This adds `su mo mo` to the documented stanza in `README_PRODUCTION_INSTALL` so it is self-sufficient rather than silently dependent on the distro's global directive - and as a side benefit, rotated copies come out `mo`-owned instead of `root:adm`.

## Test plan

On the web server, after adding `su mo mo` to `/etc/logrotate.d/puma`: `logrotate -d /etc/logrotate.d/puma` standalone should now consider each log with no `insecure permissions` errors (previously they all skipped), and the next nightly rotation should behave as before, with new rotated files owned by `mo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
