### PR TITLE
Fix `MatrixBox` heading/badge display

### DIFF
--- a/app/assets/stylesheets/mo/_matrix_box.scss
+++ b/app/assets/stylesheets/mo/_matrix_box.scss
@@ -46,11 +46,25 @@
 
 // To make way for floating ID
 .rss-heading {
-  @extend .d-flex, .justify-content-between, .align-items-start;
+  @extend .d-flex, .justify-content-between, .align-items-start, .gap-3;
 
-  .rss-name {
-    margin-right: 7.5rem;
+  // Flex items don't shrink below their content's min-content width by
+  // default -- without this, a long nowrap author line below (see the
+  // `.rss-name small.text-nowrap` override) forces this whole row,
+  // badge included, past the box's edge instead of wrapping.
+  > a {
+    min-width: 0;
   }
+}
+
+// `.text-nowrap` (`String#small_author`, see app/extensions/string.rb)
+// keeps an author citation from splitting mid-phrase when it shares a
+// line with the name elsewhere in the app. In a matrix box,
+// `String#break_name` already forces the author onto its own line
+// below the name -- so here the citation itself needs to be free to
+// wrap across multiple lines, or a long one overflows the box.
+.rss-name small.text-nowrap {
+  white-space: normal !important;
 }
 
 h5.rss-heading {

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -774,6 +774,10 @@
   gap: 0.5rem !important;
 }
 
+.gap-3 {
+  gap: 1rem !important;
+}
+
 //
 // larger devices
 // --------------------------------------------------

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -136,10 +136,10 @@ class Components::Matrix::Box < Components::Base
 
     div(class: "rss-what") do
       h5(class: class_names(%w[mt-0 rss-heading], h_style)) do
-        a(href: url_for(@data[:what].show_link_args)) do
-          render_title
-        end
-        render_id_badge(@data[:what])
+        Link(type: :get, name: @data[:name],
+             target: @data[:what].show_link_args) { render_title }
+        whitespace
+        IDBadge(object: @data[:what], size: :md, extra_class: nil)
       end
 
       render_identify_ui if @identify
@@ -152,11 +152,6 @@ class Components::Matrix::Box < Components::Base
              name: @data[:name],
              type: @data[:type]
            ))
-  end
-
-  def render_id_badge(obj)
-    whitespace
-    IDBadge(object: obj, size: :md, extra_class: nil)
   end
 
   def render_occurrence_link

--- a/app/components/matrix/box/title.rb
+++ b/app/components/matrix/box/title.rb
@@ -26,7 +26,7 @@ class Components::Matrix::Box::Title < Components::Base
 
   def view_template
     span(
-      class: ["rss-name", title_weight].join(" "),
+      class: class_names("rss-name", title_weight),
       id: "box_title_#{@id}"
     ) { @name }
   end
@@ -34,10 +34,6 @@ class Components::Matrix::Box::Title < Components::Base
   private
 
   def title_weight
-    if [:observation, :name].include?(@type)
-      ""
-    else
-      "font-weight-bold"
-    end
+    "font-weight-bold" unless [:observation, :name].include?(@type)
   end
 end


### PR DESCRIPTION
## Summary

`.rss-heading` (the matrix-box title link + `IDBadge`) is a flex row. Two problems compounded on long name+author combos like "Hemileccinum aenigmaticum":

<img width="1328" height="1336" alt="Screenshot 2026-08-03 at 11 57 15 AM" src="https://github.com/user-attachments/assets/df4187fe-3769-415e-983e-18a1b40c0361" />

- The title link's fixed `7.5rem` `margin-right` was either excessive whitespace on short titles or, on long ones, not enough to keep the badge from crowding the text.
- The author citation is forced onto its own line below the name by `String#break_name` (a hard `<br/>`), but kept as one unbreakable run by `String#small_author`'s `.text-nowrap`. A long citation could push the whole row past the box edge and shove the badge out with it, since flex items don't shrink below their content's min-content width by default.

## Fix

- `.rss-heading` uses a real flex `gap` (new `.gap-3` utility in `_utilities.scss`, `1rem`, alongside the existing `.gap-2`) instead of a per-child `margin-right` hack.
- `.rss-heading > a` gets `min-width: 0` so the flex item can actually shrink to the row's available width.
- `.rss-name small.text-nowrap` is overridden back to `white-space: normal` in this context -- the name/author split is already guaranteed by `break_name`'s hard line break, so the citation itself just needs to be free to wrap across lines instead of overflowing.

## Test plan

- [x] View a matrix box (e.g. RSS log / observation index) with a long name + long author citation (e.g. "Hemileccinum aenigmaticum") -- author wraps within the box, badge stays inside the box.
- [x] View a matrix box with a short name (e.g. "Aureoboletus betula") -- badge sits to the right of the name with a consistent gap, no excess whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
