### PR TITLE
Silence and assert on expected-failure log noise in 2 tests

### DIFF
--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -998,11 +998,18 @@ class ReportTest < UnitTestCase
     report.body
 
     site_lookup_fails = -> { raise(ActiveRecord::RecordNotFound) }
-    ExternalSite.stub(:mycoportal, site_lookup_fails) do
-      assert_nothing_raised do
-        report.mark_exported!
+    log = with_captured_logger do
+      ExternalSite.stub(:mycoportal, site_lookup_fails) do
+        assert_nothing_raised do
+          report.mark_exported!
+        end
       end
     end
+
+    assert_includes(
+      log, "MyCoPortal export-tracking failed: ActiveRecord::RecordNotFound",
+      "mark_exported! should log the swallowed lookup failure"
+    )
   end
 
   def hashed_expect(obs)

--- a/test/general_extensions.rb
+++ b/test/general_extensions.rb
@@ -623,10 +623,18 @@ module GeneralExtensions
     str == template
   end
 
+  # ActiveJob::Base.logger holds its own reference, copied from
+  # Rails.logger once at boot -- it's not a live delegate, so a
+  # job's log output (e.g. ActiveJob::LogSubscriber's own
+  # retry-exhaustion/discard messages) wouldn't be captured by
+  # swapping Rails.logger alone.
   def with_captured_logger
     log_output = StringIO.new
+    new_logger = Logger.new(log_output)
     old_logger = Rails.logger
-    Rails.logger = Logger.new(log_output)
+    old_job_logger = ActiveJob::Base.logger
+    Rails.logger = new_logger
+    ActiveJob::Base.logger = new_logger
 
     yield
 
@@ -634,6 +642,7 @@ module GeneralExtensions
     log_output.string
   ensure
     Rails.logger = old_logger
+    ActiveJob::Base.logger = old_job_logger
   end
 
   # assert_equal raises a deprecation warning in Minitest 5 when the

--- a/test/general_extensions.rb
+++ b/test/general_extensions.rb
@@ -630,9 +630,11 @@ module GeneralExtensions
   # swapping Rails.logger alone.
   def with_captured_logger
     log_output = StringIO.new
-    new_logger = Logger.new(log_output)
     old_logger = Rails.logger
     old_job_logger = ActiveJob::Base.logger
+    new_logger = Logger.new(log_output)
+    new_logger.level = old_logger.level
+    new_logger.formatter = old_logger.formatter
     Rails.logger = new_logger
     ActiveJob::Base.logger = new_logger
 

--- a/test/general_extensions.rb
+++ b/test/general_extensions.rb
@@ -633,8 +633,6 @@ module GeneralExtensions
     old_logger = Rails.logger
     old_job_logger = ActiveJob::Base.logger
     new_logger = Logger.new(log_output)
-    new_logger.level = old_logger.level
-    new_logger.formatter = old_logger.formatter
     Rails.logger = new_logger
     ActiveJob::Base.logger = new_logger
 

--- a/test/jobs/transfer_images_job_test.rb
+++ b/test/jobs/transfer_images_job_test.rb
@@ -3,6 +3,8 @@
 require("test_helper")
 
 class TransferImagesJobTest < ActiveJob::TestCase
+  include GeneralExtensions
+
   def test_calls_processor_transfer_images_and_logs_summary
     result = { uploaded: ["320/1.jpg"], deleted: ["960/1.jpg"],
                completed: [1], failed: [], stuck: [] }
@@ -44,17 +46,21 @@ class TransferImagesJobTest < ActiveJob::TestCase
     job.executions = 7 # perform_now increments to 8
     job.exception_executions = { "[TransferImagesJob::UploadFailure]" => 7 }
 
-    Image::Processor.stub(:transfer_images, result) do
-      alerts = capture_alerts { job.perform_now }
-
-      assert_equal(1, alerts.size)
-      assert_instance_of(JobAlert, alerts.first)
-      assert_includes(alerts.first.message,
-                      "Transfer failed for 1 file(s) after 8 attempts")
-      assert_includes(alerts.first.message,
-                      "TransferImagesJob.perform_now(image_ids: [1])")
-      assert_no_enqueued_jobs(only: TransferImagesJob)
+    alerts = nil
+    log = with_captured_logger do
+      Image::Processor.stub(:transfer_images, result) do
+        alerts = capture_alerts { job.perform_now }
+      end
     end
+
+    assert_equal(1, alerts.size)
+    assert_instance_of(JobAlert, alerts.first)
+    assert_includes(alerts.first.message,
+                    "Transfer failed for 1 file(s) after 8 attempts")
+    assert_includes(alerts.first.message,
+                    "TransferImagesJob.perform_now(image_ids: [1])")
+    assert_includes(log, "Stopped retrying TransferImagesJob")
+    assert_no_enqueued_jobs(only: TransferImagesJob)
   end
 
   # A stuck image (derivative sizes never generated -- processing died,


### PR DESCRIPTION
## Summary

Two tests deliberately trigger a rescued error to verify resilience behavior, and the resulting `Rails.logger.error` call was leaking into the live test-runner console on every full-suite run:

- `test_mycoportal_image_list_mark_exported_survives_site_lookup_failure` stubs `ExternalSite.mycoportal` to raise `RecordNotFound`, verifying `Report::MycoportalImageList#export_images!` swallows it rather than turning an already-sent CSV download into a 500.
- `test_alerts_with_retry_command_once_attempts_are_exhausted` simulates `TransferImagesJob`'s final retry attempt, triggering ActiveJob's own built-in "Stopped retrying..." log line when `retry_on`'s attempts are exhausted.

Both are working as designed. Rather than just silencing the noise, each is now wrapped in `with_captured_logger` and asserts on the captured message -- the test actually verifies the log line now, instead of it being an unasserted side effect a reader has to trust is intentional.

## Changes

- `with_captured_logger` (`test/general_extensions.rb`) only swapped `Rails.logger`, which doesn't capture `ActiveJob::LogSubscriber` output -- `ActiveJob::Base.logger` is a separate reference copied from `Rails.logger` once at boot, not a live delegate, so it doesn't see a later `Rails.logger` reassignment. Swapped both in the helper (verified empirically: without this, the captured log string came back empty while the real message still printed to the console).
- `TransferImagesJobTest` is an `ActiveJob::TestCase`, which doesn't include `GeneralExtensions` automatically the way `UnitTestCase` (and its subclasses) do -- added the explicit include, matching the existing pattern in `field_slip_job_test.rb`, `image_loader_job_test.rb`, `inat_import_job_test.rb`, and `refresh_name_lister_cache_job_test.rb`.

## Test plan

- [x] `bundle exec rubocop` clean on all three files.
- [x] `bin/rails test test/jobs/transfer_images_job_test.rb` -- 5 tests, 31 assertions, 0 failures, no console log noise.
- [x] `bin/rails test test/classes/report_test.rb` -- 57 tests, 1138 assertions, 0 failures, no console log noise.
- [x] Full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
