### PR TITLE
Fix lingering gray thumbnails: batch vote-interface streams, raise Puma concurrency, HTTP/2, stable `updated_at` on votes (#4984)

### DIFF
--- a/app/components/image_fragment.rb
+++ b/app/components/image_fragment.rb
@@ -16,7 +16,8 @@ class Components::ImageFragment < Components::Base
     lightbox_caption: :LightboxCaption,
     original_link: :OriginalLink,
     reuse_form: :ReuseForm,
-    vote_interface: :VoteInterface
+    vote_interface: :VoteInterface,
+    vote_interface_streams: :VoteInterfaceStreams
   }.freeze
 
   def self.new(**kwargs, &block)

--- a/app/components/image_fragment/vote_interface_streams.rb
+++ b/app/components/image_fragment/vote_interface_streams.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Inline `<turbo-stream>` backfill for a page of lazy vote-interface
+# frames. Turbo executes stream elements wherever they appear in the
+# document, so one replace per image/context rendered after a matrix
+# grid fills every frame in the same response — no per-frame `src`
+# fetch ever fires. Must render outside any fragment cache: the
+# content is viewer-specific (`Image#users_vote`), which is why the
+# cached boxes hold only empty frames (see `LazyVoteInterface`).
+#
+# A stream whose target frame isn't in the document (an image rendered
+# with `votes: false`, or a duplicate thumb) is a silent no-op.
+class Components::ImageFragment::VoteInterfaceStreams < Components::Base
+  register_element :turbo_stream
+
+  prop :images, _Array(::Image)
+  prop :user, _Nilable(::User), default: nil
+
+  def view_template
+    images = @images.uniq
+    return if images.empty?
+
+    preload_votes(images)
+    images.each do |image|
+      stream_for(image, :overlay)
+      stream_for(image, :lightbox)
+    end
+  end
+
+  private
+
+  # One query for the whole page — `Image#vote_hash` walks the
+  # `image_votes` association per image.
+  def preload_votes(images)
+    ActiveRecord::Associations::Preloader.new(
+      records: images, associations: :image_votes
+    ).call
+  end
+
+  def stream_for(image, context)
+    turbo_stream(
+      action: "replace",
+      target: Components::ImageFragment::VoteInterface.frame_id(
+        image_id: image.id, context: context
+      )
+    ) do
+      template do
+        ImageFragment(type: :vote_interface, user: @user, image: image,
+                      votes: true, context: context)
+      end
+    end
+  end
+end

--- a/app/components/matrix/table.rb
+++ b/app/components/matrix/table.rb
@@ -108,6 +108,7 @@ class Components::Matrix::Table < Components::Base
       end
     end
 
+    render_vote_interface_streams if !block && @objects
     div(class: "clearfix")
   end
 
@@ -184,5 +185,20 @@ class Components::Matrix::Table < Components::Base
                identify: @identify, project: @project
              ))
     end
+  end
+
+  # Fills every box's empty vote-interface frame in one uncached pass —
+  # viewer-specific content that must stay out of the shared box
+  # fragments, but shouldn't cost one frame-src request per image
+  # either. RssLog boxes have no thumb_image accessor; their frames
+  # keep the per-frame lazy fetch.
+  def render_vote_interface_streams
+    images = @objects.filter_map do |object|
+      object.is_a?(::Image) ? object : object.try(:thumb_image)
+    end
+    return if images.empty?
+
+    ImageFragment(type: :vote_interface_streams, images: images,
+                  user: @user)
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1147,12 +1147,14 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     # we don't need to do it twice).  vote_cache is derived data: keep
     # updated_at (and the cache-busting URL token derived from it, which
     # would invalidate every browser's cached renditions) stable.
+    # Suppressed on this instance only -- the class-level flag is shared
+    # across threads and would leak into unrelated concurrent saves.
     if save_changes
       begin
-        self.class.record_timestamps = false
+        self.record_timestamps = false
         save_without_our_callbacks
       ensure
-        self.class.record_timestamps = true
+        self.record_timestamps = true
       end
     end
     # update +updated_at+ for any associated observations, in order to update

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1144,10 +1144,17 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
 
     # Save changes unless there were already pending changes to be saved
     # (meaning the caller is presumably about to save the changes anyway so
-    # we don't need to do it twice).  No need to update +updated_at+ or do any
-    # of the other callbacks, either, since this doesn't result in emails,
-    # contribution changes, or rss log entries.
-    save_without_our_callbacks if save_changes
+    # we don't need to do it twice).  vote_cache is derived data: keep
+    # updated_at (and the cache-busting URL token derived from it, which
+    # would invalidate every browser's cached renditions) stable.
+    if save_changes
+      begin
+        self.class.record_timestamps = false
+        save_without_our_callbacks
+      ensure
+        self.class.record_timestamps = true
+      end
+    end
     # update +updated_at+ for any associated observations, in order to update
     # the cached interactive_image in the matrix_box (contrast with the above)
     observations&.touch_all

--- a/config/etc/nginx.conf
+++ b/config/etc/nginx.conf
@@ -119,7 +119,7 @@ http {
     listen [::]:80; # managed by Certbot
 
     # (add "http2" after "ssl" in the following line)
-    listen 443 ssl; # managed by Certbot
+    listen 443 ssl http2; # managed by Certbot
     ssl_certificate /etc/letsencrypt/live/mushroomobserver.org/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/mushroomobserver.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
@@ -142,7 +142,7 @@ http {
 
   server {
     # add "http2" after "ssl" below
-    listen 443 ssl;
+    listen 443 ssl http2;
     server_name mushroomobserver.org;
 
     # See map statement above for definition of $bad_user_agent.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,8 +15,13 @@ when "test"
 when "production"
   app_path = "/var/web/mushroom-observer"
   bind("unix://#{app_path}/tmp/sockets/puma.sock")
-  workers(3)
-  threads(1, 1)
+  # Total concurrency = workers x threads. Workers are the safe lever:
+  # the app has always run single-threaded in production, so raise
+  # RAILS_MAX_THREADS only as a deliberate, tested change (and size
+  # database.yml's pool to match).
+  workers(Integer(ENV.fetch("WEB_CONCURRENCY", 6)))
+  max_threads = Integer(ENV.fetch("RAILS_MAX_THREADS", 1))
+  threads(max_threads, max_threads)
   stdout_redirect("#{app_path}/log/puma.stdout.log",
                   "#{app_path}/log/puma.stderr.log", true)
 end

--- a/test/components/image_fragment/vote_interface_streams_test.rb
+++ b/test/components/image_fragment/vote_interface_streams_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# See test/components/matrix/table_test.rb for the render-site coverage
+# (streams emitted after the boxes) and
+# test/components/image_fragment/lazy_vote_interface_test.rb for the
+# per-frame fallback these streams replace.
+class VoteInterfaceStreamsTest < ComponentTestCase
+  def setup
+    super
+    @user = users(:rolf)
+    @image = images(:in_situ_image)
+  end
+
+  def test_renders_replace_streams_for_both_contexts
+    html = render_streams(images: [@image])
+
+    assert_html(
+      html,
+      "turbo-stream[action='replace'][target='image_vote_#{@image.id}']"
+    )
+    assert_html(
+      html,
+      "turbo-stream[action='replace']" \
+      "[target='lightbox_image_vote_#{@image.id}']"
+    )
+    # The stream payload is the full VoteInterface, wrapped in the
+    # <template> Turbo requires.
+    assert_html(
+      html,
+      "turbo-stream template div#image_vote_#{@image.id}.vote-section"
+    )
+    assert_html(
+      html,
+      "turbo-stream template " \
+      "div#lightbox_image_vote_#{@image.id}.vote-section-lightbox"
+    )
+  end
+
+  def test_deduplicates_images
+    html = render_streams(images: [@image, @image])
+
+    doc = Nokogiri::HTML.fragment(html)
+    assert_equal(
+      1,
+      doc.css("turbo-stream[target='image_vote_#{@image.id}']").size
+    )
+  end
+
+  def test_renders_nothing_for_empty_images
+    assert_equal("", render_streams(images: []))
+  end
+
+  def test_renders_for_anonymous_viewer
+    html = render_streams(images: [@image], user: nil)
+
+    assert_html(
+      html,
+      "turbo-stream[target='image_vote_#{@image.id}'] .require-user"
+    )
+  end
+
+  private
+
+  def render_streams(images:, user: @user)
+    render(Components::ImageFragment.new(
+             type: :vote_interface_streams, images: images, user: user
+           ))
+  end
+end

--- a/test/components/matrix/table_test.rb
+++ b/test/components/matrix/table_test.rb
@@ -279,6 +279,47 @@ class MatrixTableTest < ComponentTestCase
     assert_includes(html, "Custom content")
   end
 
+  # The boxes' cached fragments hold only empty vote-interface frames;
+  # the table must follow them with viewer-specific replace streams so
+  # the whole page needs zero per-frame fetches.
+  def test_renders_vote_interface_streams_after_boxes
+    obs = observations(:coprinus_comatus_obs)
+    html = render(Components::Matrix::Table.new(
+                    objects: [obs], user: @user, cached: false
+                  ))
+
+    image_id = obs.thumb_image.id
+    assert_html(
+      html,
+      "turbo-stream[action='replace'][target='image_vote_#{image_id}']"
+    )
+    assert_html(
+      html,
+      "turbo-stream[target='lightbox_image_vote_#{image_id}']"
+    )
+  end
+
+  def test_no_vote_interface_streams_for_objects_without_thumb_images
+    obs = observations(:coprinus_comatus_obs)
+    obs.stub(:thumb_image, nil) do
+      html = render(Components::Matrix::Table.new(
+                      objects: [obs], user: @user, cached: false
+                    ))
+
+      assert_no_html(html, "turbo-stream")
+    end
+  end
+
+  def test_no_vote_interface_streams_in_block_form
+    html = render(Components::Matrix::Table.new) do |table|
+      table.render(Components::Matrix::Box.new(id: 456) do
+        view_context.tag.div { "Block content" }
+      end)
+    end
+
+    assert_no_html(html, "turbo-stream")
+  end
+
   def test_cache_key_includes_locale
     obs = observations(:coprinus_comatus_obs)
     obs.thumb_image.stub(:transferred, true) do

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -79,8 +79,10 @@ class ImageTest < UnitTestCase
 
     assert_equal(3, img.reload.users_vote(mary))
     assert_equal(original.to_i, img.updated_at.to_i)
+    assert(img.record_timestamps,
+           "instance record_timestamps must be restored after the vote")
     assert(Image.record_timestamps,
-           "record_timestamps must be restored after the vote")
+           "class-level record_timestamps must never be touched")
   end
 
   def test_copyright_logging

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -68,6 +68,21 @@ class ImageTest < UnitTestCase
     assert_nil(img.users_vote(rolf))
   end
 
+  # updated_at feeds the cache-busting URL token: a vote must not flip
+  # it, or every browser's cached renditions of the image die.
+  def test_change_vote_does_not_bump_updated_at
+    img = images(:in_situ_image)
+    img.update_columns(updated_at: 1.week.ago)
+    original = img.reload.updated_at
+
+    img.change_vote(mary, 3)
+
+    assert_equal(3, img.reload.users_vote(mary))
+    assert_equal(original.to_i, img.updated_at.to_i)
+    assert(Image.record_timestamps,
+           "record_timestamps must be restored after the vote")
+  end
+
   def test_copyright_logging
     license_one = licenses(:ccnc25)
     license_two = licenses(:ccwiki30)


### PR DESCRIPTION
Implements fixes 1, 2, 3, and 6 from #4984 (the gray-thumbnails HAR analysis). Fixes #4983.

## 1. Vote-interface fan-out -> zero requests (`Components::ImageFragment::VoteInterfaceStreams`)

`Matrix::Table` now renders inline `<turbo-stream action="replace">` elements immediately after its boxes, one per image per context (overlay + lightbox), each carrying the viewer-specific `VoteInterface` in a `<template>`. Turbo executes stream elements wherever they appear in the document, so every lazy vote frame on an index page is filled by the page response itself - the 65-per-page `/images/<id>/vote_interface` fetches from the #4984 HAR never fire.

Why this shape:

- The #4895 constraint still holds: `Matrix::Box` fragments are cached without a user component, so viewer-specific vote state must stay out of them. The cached boxes still contain only empty frames; the streams render per-request, outside the cache.
- `LazyVoteInterface`, the `GET /images/:image_id/vote` route, and the frames' `src` are all unchanged, and still serve the callers the batch can't: standalone `Matrix::Box` uses (forms mostly pass `votes: false` anyway), the user-less `Image#broadcast_processed_update` render, and RssLog boxes (no `thumb_image` accessor). A stream whose target frame is missing is a silent Turbo no-op, and a frame the streams already replaced drops any racing frame response harmlessly.
- `VoteInterfaceStreams` preloads `image_votes` for the whole page in one query (`Image#vote_hash` otherwise walks the association per image).

## 2. Puma concurrency

Production had `workers(3), threads(1, 1)` - three concurrent requests for the whole app, which is what turned the request flood into ~6s queueing for everyone. Now `workers(Integer(ENV.fetch("WEB_CONCURRENCY", 6)))`, and threads become tunable via `RAILS_MAX_THREADS` (default still 1 - the app has always run single-threaded workers in production, so going multithreaded should be a deliberate, tested change, not a side effect of this PR). If 6 workers is too much RAM for the box, set `WEB_CONCURRENCY` in the service environment rather than editing the file.

## 3. HTTP/2 on the web server

Both `listen 443 ssl` directives in `config/etc/nginx.conf` gain `http2`, so a page's many small same-origin requests multiplex over one connection instead of queueing six-wide. (Server-side apply: copy the config and reload nginx, same flow as #4977's unit change.)

## 6. `Image#change_vote` no longer bumps `updated_at` (fixes #4983)

The save now runs with `record_timestamps` off (same pattern as `AbstractModel#update_view_stats`), matching the method's own long-standing comment. Since #4808 made `updated_at` the cache-busting URL token, every vote was invalidating every browser's cached renditions of that image. The `observations&.touch_all` for matrix-box fragment invalidation is untouched.

## Not in this PR

- Fix 4 (long-lived `Cache-Control` on the images server's renditions) - images-server nginx, not in this repo. Suggested stanza: `expires 1y; add_header Cache-Control "public, max-age=31536000, immutable";` for the size directories, safe because #4808 tokens change the URL whenever content changes.
- Fix 5 (re-scoping PR #4982's proxy) - stays on that PR.

## Test plan

- [ ] Load `/observations?by_user=1` logged in with DevTools Network open: the `vote?context=overlay` flood should be gone (zero `vote_interface` requests on a matrix index), vote overlays and lightbox captions still show your own vote state, and voting still updates both copies.
- [ ] Vote on an image, then confirm its thumbnail URL token (`?<updated_at>`) is unchanged on reload.
- [ ] After deploying the nginx config: `curl -s -o /dev/null -w "%{http_version}\n" https://mushroomobserver.org/` returns 2.
- [ ] After restarting Puma: `ps -ef | grep puma` shows 6 workers.

Note: `test/system/help_identify_system_test.rb` has 2 failures locally, but they fail identically on unmodified `main` - pre-existing, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
