### PR TITLE
Note the two-config maintenance of the GCS archive cutoff in `config/etc/nginx.conf`

### DIFF
--- a/config/etc/nginx.conf
+++ b/config/etc/nginx.conf
@@ -247,7 +247,13 @@ http {
     location @images {
       add_header Cache-Control "no-store" always;
 
-      # serve old originals from google object store
+      # serve old originals from google object store.
+      # The archived-id cutoff in this regex is hand-maintained in TWO
+      # configs: here and the images server's own nginx.conf (its
+      # orig/ -> bucket rewrite). Whenever the archived range advances
+      # (rclone_originals.sh), bump both -- they have drifted apart
+      # before, leaving a range that redirected on one server and
+      # 404ed on the other.
       if ($uri ~ "^/images/orig/((\d{1,6}|1[012345]\d\d\d\d\d)\.\w+)$") {
         return 302 https://storage.googleapis.com/mo-image-archive-bucket/orig/$1;
       }


### PR DESCRIPTION
Documentation-only follow-up to #4986. The GCS archive cutoff regex (which original ids redirect to the `mo-image-archive-bucket`) is hand-maintained in two configs on two servers: the web server's `@images` fallback (`config/etc/nginx.conf`, tracked here) and the images server's own nginx config (untracked). They had drifted - the web server redirected origs through 1,599,999 while the images server only covered through 1,199,999, leaving a 400k-id range that 404ed when requested from the images server directly. Caught and fixed on the images server while deploying #4986.

This adds a comment at the web server's redirect noting the twin and that both must be bumped together whenever `rclone_originals.sh` advances the archived range. The mirror note is in the images server's config (applied alongside the #4986 changes).

## Test plan

Comment-only; `nginx -t` passes unchanged on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
