### PR TITLE
Move observation source-credit line into `ObjectFooter`

### DIFF
--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -252,7 +252,8 @@ class Components::Matrix::Box < Components::Base
     if (link = target.import_link)
       render_external_credit_link(link)
     else
-      :"source_credit_#{target.source}".l.tpl
+      b { plain("#{:via.l} ") }
+      trusted_html(:"source_credit_#{target.source}".l.tl)
     end
   end
 

--- a/app/components/matrix/box.rb
+++ b/app/components/matrix/box.rb
@@ -244,7 +244,8 @@ class Components::Matrix::Box < Components::Base
 
   # External imports get a Phlex-rendered link so we can set
   # target="_blank" / rel="noopener" — textile has no syntax for
-  # those attributes. Enum credits keep going through .tpl.
+  # those attributes. Enum credits go through .tl (inline, no <div>
+  # wrapper -- needed to sit next to the bold "via" on one line).
   # `source_noteworthy?` (the caller's guard) guarantees `source` is
   # present whenever `import_link` isn't, so the enum branch is safe
   # without its own presence check.

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -130,7 +130,6 @@ module Views::Controllers::Observations
     def render_namings_and_comments
       render_namings if @user
       render_comments
-      render_source_credit if show_source_credit?
     end
 
     def render_namings
@@ -143,17 +142,6 @@ module Views::Controllers::Observations
                object: @observation, comments: @comments.to_a, user: @user,
                editable: @user.present?, limit: nil
              ))
-    end
-
-    def show_source_credit?
-      @observation.source_noteworthy? && !@observation.import_link
-    end
-
-    # show_source_credit? (above) guarantees no import_link, so
-    # @observation.source is guaranteed present here (source_noteworthy?
-    # requires import_link.present? || source.present?).
-    def render_source_credit
-      trusted_html(:"source_credit_#{@observation.source}".l.tpl)
     end
 
     def render_footer

--- a/app/views/layouts/object_footer.rb
+++ b/app/views/layouts/object_footer.rb
@@ -139,6 +139,24 @@ module Views::Layouts
 
       render_user_dated_line(:footer_created_by,
                              user: @obj.user, date: @obj.created_at)
+      render_source_credit if show_source_credit?
+    end
+
+    # Observation-only: which client created it (API, mobile app, ...),
+    # when noteworthy (i.e. not the website) and not already covered by
+    # its own import-provenance UI (Observation#source_noteworthy?,
+    # #import_link). Duck-typed since most models ObjectFooter renders
+    # for have no concept of "source" at all.
+    def show_source_credit?
+      @obj.respond_to?(:source_noteworthy?) && @obj.source_noteworthy? &&
+        !(@obj.respond_to?(:import_link) && @obj.import_link)
+    end
+
+    def render_source_credit
+      br
+      span(class: "source-credit") do
+        trusted_html(:"source_credit_#{@obj.source}".l.tpl)
+      end
     end
 
     # Renders creation and update info for non-versioned objects

--- a/app/views/layouts/object_footer.rb
+++ b/app/views/layouts/object_footer.rb
@@ -153,9 +153,11 @@ module Views::Layouts
     end
 
     def render_source_credit
-      br
       span(class: "source-credit") do
-        trusted_html(:"source_credit_#{@obj.source}".l.tpl)
+        plain(" ")
+        b { plain(:via.l) }
+        plain(" ")
+        trusted_html(:"source_credit_#{@obj.source}".l.tl)
       end
     end
 

--- a/app/views/layouts/object_footer.rb
+++ b/app/views/layouts/object_footer.rb
@@ -147,9 +147,14 @@ module Views::Layouts
     # its own import-provenance UI (Observation#source_noteworthy?,
     # #import_link). Duck-typed since most models ObjectFooter renders
     # for have no concept of "source" at all.
+    #
+    # Checks import_link before source_noteworthy? (which also reads
+    # import_link internally) so an imported observation short-circuits
+    # on one import_link lookup instead of two.
     def show_source_credit?
-      @obj.respond_to?(:source_noteworthy?) && @obj.source_noteworthy? &&
-        !(@obj.respond_to?(:import_link) && @obj.import_link)
+      return false if @obj.respond_to?(:import_link) && @obj.import_link
+
+      @obj.respond_to?(:source_noteworthy?) && @obj.source_noteworthy?
     end
 
     def render_source_credit

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1126,13 +1126,11 @@
   log_object_updated: "[:log_object_updated_by_user]"
   log_object_updated_at: "[:log_object_updated_by_user]"
 
-  source_credit_mo_website: Created via the Mushroom Observer website
-  source_credit_mo_android_app: Created via the "Mushroom Observer Android app":https://mushroomobserver.org/articles/34
-  source_credit_mo_iphone_app: Created via the "Mushroom Observer iPhone app":https://mushroomobserver.org/articles/34
-  source_credit_mo_api: Created via the "Mushroom Observer API":https://github.com/MushroomObserver/mushroom-observer/blob/main/README_API.md.
-  source_credit_external: '"Imported from [name]":[url]'
+  source_credit_mo_website: MO Web
+  source_credit_mo_api: '"MO API":https://github.com/MushroomObserver/mushroom-observer/blob/main/README_API.md'
   source_credit_external_text: Imported from [name]
   source_credit_help_link: About imported observations
+  via: via
   observation_reflection_read_only_note: Read-only reflection of its imported source. To change it, edit it at the source and resync.
   observation_resync_confirm: If you recently edited at the source, those changes may take up to 10 seconds to appear there. Ready to sync now, or would you rather wait?
   observation_resync_started: Syncing imported data from the source. This may take a moment.

--- a/test/components/matrix/box_test.rb
+++ b/test/components/matrix/box_test.rb
@@ -353,15 +353,17 @@ class MatrixBoxTest < ComponentTestCase
   # in app/components/matrix/box.rb#render_source_credit_inner.
   # mo_website specifically is excluded by source_noteworthy? (it's
   # the default, not worth calling out), so this needs a fixture with
-  # a different source -- mo_iphone_app.
+  # a different source. mo_iphone_app is a dead enum value (no
+  # observation uses it, no translation left for it) -- mo_api is the
+  # one other live, translated source, set directly since no fixture
+  # has it by default.
   def test_enum_source_credit_renders_credit_text
     obs = observations(:amateur_obs)
-    assert_equal("mo_iphone_app", obs.source)
+    obs.source = "mo_api"
     assert(obs.source_noteworthy?)
     component = Components::Matrix::Box.new(user: @user, object: obs)
     html = render(component)
 
-    assert_html(html, ".source-credit",
-                text: :source_credit_mo_iphone_app.l.tpl.as_displayed)
+    assert_html(html, ".source-credit", text: "#{:via.l} MO API")
   end
 end

--- a/test/components/matrix/box_test.rb
+++ b/test/components/matrix/box_test.rb
@@ -353,13 +353,9 @@ class MatrixBoxTest < ComponentTestCase
   # in app/components/matrix/box.rb#render_source_credit_inner.
   # mo_website specifically is excluded by source_noteworthy? (it's
   # the default, not worth calling out), so this needs a fixture with
-  # a different source. mo_iphone_app is a dead enum value (no
-  # observation uses it, no translation left for it) -- mo_api is the
-  # one other live, translated source, set directly since no fixture
-  # has it by default.
+  # a different source -- amateur_obs has mo_api.
   def test_enum_source_credit_renders_credit_text
     obs = observations(:amateur_obs)
-    obs.source = "mo_api"
     assert(obs.source_noteworthy?)
     component = Components::Matrix::Box.new(user: @user, object: obs)
     html = render(component)

--- a/test/fixtures/observations.yml
+++ b/test/fixtures/observations.yml
@@ -314,7 +314,7 @@ amateur_obs:
     :Other: "A friend showed me this."
   lat: 34.1622
   lng: -118.3521
-  source: <%= Observation.sources[:mo_iphone_app] %>
+  source: <%= Observation.sources[:mo_api] %>
 
 peltigera_obs:
   <<: *DEFAULTS

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -2151,7 +2151,7 @@ class ObservationTest < UnitTestCase
     assert_equal("mo_website", obs.source)
 
     obs = observations(:amateur_obs)
-    assert_equal("mo_iphone_app", obs.source)
+    assert_equal("mo_api", obs.source)
     assert(obs.source_noteworthy?)
 
     obs = observations(:imported_inat_obs)

--- a/test/views/layouts/object_footer_test.rb
+++ b/test/views/layouts/object_footer_test.rb
@@ -12,7 +12,7 @@ module Views::Layouts
     # views / rss chunks.
     def test_minimal_renders_dates_only
       obj = collection_numbers(:coprinus_comatus_coll_num)
-      html = render(ObjectFooter.new(obj: obj, minimal: true))
+      html = footer_for(obj, minimal: true)
 
       # `Created at: <date>` / `Updated at: <date>` inside the
       # padded wrapper.
@@ -35,6 +35,8 @@ module Views::Layouts
 
       def respond_to?(method, *)
         instance_variable_defined?("@#{method}") || super
+      rescue NameError
+        false
       end
 
       def old_last_viewed_by(_user)
@@ -57,11 +59,7 @@ module Views::Layouts
         updated_at: Time.zone.parse("2024-01-20 15:30:00")
       )
 
-      html = render_component(ObjectFooter.new(
-                                user: nil,
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj)
 
       assert_includes(html, "footer-view-stats")
       assert_includes(html, "2024-01-15")
@@ -75,11 +73,7 @@ module Views::Layouts
         user: creator
       )
 
-      html = render_component(ObjectFooter.new(
-                                user: users(:mary),
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj, user: users(:mary))
 
       assert_includes(html, creator.unique_text_name)
       assert_includes(html, "2024-01-15")
@@ -88,11 +82,7 @@ module Views::Layouts
     def test_non_versioned_object_without_timestamps
       obj = TestObject.new(created_at: nil, updated_at: nil)
 
-      html = render_component(ObjectFooter.new(
-                                user: nil,
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj)
 
       assert_includes(html, "footer-view-stats")
       # Should render the container but without dates
@@ -113,11 +103,7 @@ module Views::Layouts
       version3 = TestVersion.new(user_id: users(:katrina).id)
       versions = [version1, version2, version3]
 
-      html = render_component(ObjectFooter.new(
-                                user: user,
-                                obj: obj,
-                                versions: versions
-                              ))
+      html = footer_for(obj, user: user, versions: versions)
 
       assert_includes(html, "footer-view-stats")
       # Should show created by original user
@@ -140,11 +126,7 @@ module Views::Layouts
       version2 = TestVersion.new(user_id: nil) # No user_id
       versions = [version1, version2]
 
-      html = render_component(ObjectFooter.new(
-                                user: user,
-                                obj: obj,
-                                versions: versions
-                              ))
+      html = footer_for(obj, user: user, versions: versions)
 
       assert_includes(html, "footer-view-stats")
       # Should show created by
@@ -170,11 +152,7 @@ module Views::Layouts
       version3 = TestVersion.new(user_id: katrina.id)
       versions = [version1, version2, version3]
 
-      html = render_component(ObjectFooter.new(
-                                user: rolf,
-                                obj: obj,
-                                versions: versions
-                              ))
+      html = footer_for(obj, user: rolf, versions: versions)
 
       assert_includes(html, "footer-view-stats")
       # Should show version number
@@ -198,11 +176,7 @@ module Views::Layouts
         TestVersion.new(user_id: users(:dick).id)
       ]
 
-      html = render_component(ObjectFooter.new(
-                                user: user,
-                                obj: obj,
-                                versions: versions
-                              ))
+      html = footer_for(obj, user: user, versions: versions)
 
       assert_includes(html, "footer-view-stats")
       # Should show version number
@@ -221,11 +195,7 @@ module Views::Layouts
         num_views: 1
       )
 
-      html = render_component(ObjectFooter.new(
-                                user: user,
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj, user: user)
 
       assert_includes(html, "footer-view-stats")
       # Should show "once" for single view
@@ -243,11 +213,7 @@ module Views::Layouts
         num_views: 42
       )
 
-      html = render_component(ObjectFooter.new(
-                                user: user,
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj, user: user)
 
       assert_includes(html, "footer-view-stats")
       # Should show count for multiple views
@@ -262,11 +228,7 @@ module Views::Layouts
         last_viewed_by_time: Time.zone.parse("2024-01-18 12:00:00")
       )
 
-      html = render_component(ObjectFooter.new(
-                                user: user,
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj, user: user)
 
       assert_includes(html, "footer-view-stats")
       # Should show when user last viewed
@@ -281,11 +243,7 @@ module Views::Layouts
         last_viewed_by_time: nil
       )
 
-      html = render_component(ObjectFooter.new(
-                                user: user,
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj, user: user)
 
       assert_includes(html, "footer-view-stats")
       # Should show "never" when user hasn't viewed
@@ -298,11 +256,7 @@ module Views::Layouts
         rss_log_id: 123
       )
 
-      html = render_component(ObjectFooter.new(
-                                user: nil,
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj)
 
       assert_includes(html, "footer-view-stats")
       # Should include link to activity log
@@ -316,11 +270,7 @@ module Views::Layouts
         rss_log_id: nil
       )
 
-      html = render_component(ObjectFooter.new(
-                                user: nil,
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj)
 
       assert_includes(html, "footer-view-stats")
       # Should not include activity log link
@@ -331,11 +281,7 @@ module Views::Layouts
       name = names(:fungi)
       versions = name.versions.to_a
 
-      html = render_component(ObjectFooter.new(
-                                user: users(:rolf),
-                                obj: name,
-                                versions: versions
-                              ))
+      html = footer_for(name, user: users(:rolf), versions: versions)
 
       assert_includes(html, "footer-view-stats")
       # Should render without errors
@@ -346,11 +292,7 @@ module Views::Layouts
       location = locations(:albion)
       versions = location.versions.to_a
 
-      html = render_component(ObjectFooter.new(
-                                user: users(:rolf),
-                                obj: location,
-                                versions: versions
-                              ))
+      html = footer_for(location, user: users(:rolf), versions: versions)
 
       assert_includes(html, "footer-view-stats")
       assert_not_nil(html)
@@ -362,11 +304,7 @@ module Views::Layouts
         user: users(:rolf)
       )
 
-      html = render_component(ObjectFooter.new(
-                                user: users(:rolf),
-                                obj: obj,
-                                versions: []
-                              ))
+      html = footer_for(obj, user: users(:rolf))
 
       assert_includes(html, "footer-view-stats")
       # Should treat as non-versioned object
@@ -383,11 +321,7 @@ module Views::Layouts
       version1 = TestVersion.new(user_id: user.id)
       versions = [version1]
 
-      html = render_component(ObjectFooter.new(
-                                user: user,
-                                obj: obj,
-                                versions: versions
-                              ))
+      html = footer_for(obj, user: user, versions: versions)
 
       # Verify that "Created:" appears before the username
       # This is a regression test for the issue where user_link
@@ -399,6 +333,57 @@ module Views::Layouts
       assert_not_nil(user_index, "Should contain username")
       assert(created_index < user_index,
              "Created should appear before username, but got:\n#{html}")
+    end
+
+    def test_source_credit_shown_for_noteworthy_source
+      obs = observations(:detailed_unknown_obs)
+      obs.source = "mo_api"
+
+      html = footer_for(obs, user: users(:rolf))
+
+      assert_html(html, "span.source-credit")
+    end
+
+    def test_source_credit_hidden_for_website_source
+      obs = observations(:detailed_unknown_obs)
+      obs.source = "mo_website"
+
+      html = footer_for(obs, user: users(:rolf))
+
+      assert_no_html(html, "span.source-credit")
+    end
+
+    # Import-linked observations (e.g. iNat imports) have their own
+    # provenance UI elsewhere -- the footer must not also show a
+    # source credit for them, even though import provenance makes
+    # `source_noteworthy?` true on its own.
+    def test_source_credit_hidden_for_import_linked_observation
+      obs = observations(:imported_inat_obs)
+      assert(obs.import_link, "fixture should have an import link")
+
+      html = footer_for(obs, user: users(:rolf))
+
+      assert_no_html(html, "span.source-credit")
+    end
+
+    # TestObject has no concept of "source" at all -- confirms the
+    # duck-typed gate skips cleanly for models that don't implement
+    # source_noteworthy?, rather than raising NoMethodError.
+    def test_source_credit_skipped_for_object_without_source_concept
+      obj = TestObject.new(created_at: Time.zone.parse("2024-01-15 10:00:00"))
+
+      html = footer_for(obj)
+
+      assert_no_html(html, "span.source-credit")
+    end
+
+    private
+
+    def footer_for(obj, user: nil, versions: [], minimal: false)
+      render_component(ObjectFooter.new(
+                         user: user, obj: obj,
+                         versions: versions, minimal: minimal
+                       ))
     end
   end
 end


### PR DESCRIPTION
## Summary

On the observation show page, the "Created via the Mushroom Observer API" line rendered as a bare `trusted_html()` call between the comments and notes panels — no wrapping element (so no CSS class to hook), and disconnected from the Created/Updated metadata it's actually describing.

Moves it into `Views::Layouts::ObjectFooter`, right after the "Created by X on Y" line, wrapped in `span.source-credit`. Gated with a duck-typed check (`@obj.respond_to?(:source_noteworthy?)`) so every other model `ObjectFooter` renders for (Article, Image, Name, Sequence, etc.) is unaffected — only `Observation` implements `source_noteworthy?`/`import_link`. Import-linked observations (e.g. iNat imports) still don't get a source-credit line, since they have their own provenance UI elsewhere.

`app/views/controllers/observations/show.rb` loses its old `render_source_credit`/`show_source_credit?` methods and the call site entirely.

Also extracted a `footer_for(obj, user:, versions:, minimal:)` helper in `object_footer_test.rb` — every one of its ~18 existing tests was constructing `ObjectFooter.new(...)` inline.

## Test plan

- [ ] View an observation created via the API (`source: mo_api`): the credit line now appears in the footer, right after "Created by," not between comments and notes.
- [ ] View a normal website-created observation: no source-credit line.
- [ ] View an iNat-imported observation: no source-credit line (import provenance UI covers it separately).
- [ ] View a non-Observation show page (e.g. a Name or Image): footer renders normally, no error, no stray source-credit line.
