### PR TITLE
Fix carousel vote-button tooltip clipping; scope `.glyphicon` `top` offset to `.btn`

### DIFF
--- a/app/assets/stylesheets/mo/_carousel.scss
+++ b/app/assets/stylesheets/mo/_carousel.scss
@@ -25,6 +25,11 @@
       position: absolute;
       bottom: 0;
       left: 0;
+      // Bootstrap's own .carousel-caption base rule sets right: 15%.
+      // left/width alone already win it out under CSS's over-
+      // constrained resolution, but pin it explicitly rather than
+      // rely on that.
+      right: 0;
       width: 100%;
       height: auto;
       // Bootstrap's own .carousel-caption base rule sets 20-30px of

--- a/app/assets/stylesheets/mo/_carousel.scss
+++ b/app/assets/stylesheets/mo/_carousel.scss
@@ -22,16 +22,31 @@
     margin-right: -100%;
 
     .carousel-caption {
-      @extend .bg-legible, .py-2;
       position: absolute;
       bottom: 0;
-      left: 50%;
-      right: auto;
-      transform: translateX(-50%);
-      width: auto;
+      left: 0;
+      width: 100%;
       height: auto;
+      // Bootstrap's own .carousel-caption base rule sets 20-30px of
+      // padding-top/bottom -- MO's .py-2 used to live here and
+      // override it as a side effect; now that it moved to
+      // .caption-content below, this needs to cancel Bootstrap's
+      // default explicitly or the caption floats well above bottom:0.
+      padding: 0;
+      text-align: center;
       opacity: 0;
       transition: opacity 0.2s ease;
+
+      // Full-width so the vote-button tooltip container
+      // (VoteInterface#context == :carousel) has the whole image's
+      // width to lay out in, not just the caption's own content
+      // width. The visible dark backdrop moved to .caption-content
+      // (shrink-wrapped, centered by the text-align above) so it
+      // doesn't stretch full-width along with the positioning box.
+      .caption-content {
+        @extend .bg-legible, .py-2;
+        display: inline-block;
+      }
 
       .vote-section {
         background: transparent;

--- a/app/assets/stylesheets/mo/_icons.scss
+++ b/app/assets/stylesheets/mo/_icons.scss
@@ -173,13 +173,23 @@ tbody.collapse.in {
 }
 
 .glyphicon {
-  top: 3px;
+  // Cancels Bootstrap's own .glyphicon { top: 1px; } base rule --
+  // MO's default (outside a .btn, see below) is flush, not offset.
+  top: 0;
   font-size: 112%;
 
   // &.link-icon {
   //   background-color: white;
   //   border-radius: 50%;
   // }
+}
+
+// top: 3px is a .btn-specific baseline correction, not a general
+// glyphicon offset -- scoped here instead of on the bare .glyphicon
+// selector above so it doesn't push every non-button icon (inline
+// links, standalone icons, etc.) down by 3px too.
+.btn > .glyphicon {
+  top: 3px;
 }
 
 .spinner-right {

--- a/app/components/carousel/item.rb
+++ b/app/components/carousel/item.rb
@@ -83,9 +83,18 @@ class Components::Carousel::Item < Components::Image::Base
 
   def render_carousel_caption
     div(class: "carousel-caption") do
-      render_image_vote_section
-      render_image_info_section if image_info_visible?
+      div(class: "caption-content") do
+        render_image_vote_section
+        render_image_info_section if image_info_visible?
+      end
     end
+  end
+
+  # See Image::Base#vote_context -- every carousel slide (show-page
+  # gallery, matrix-box mini-carousel) shares this caption layout, so
+  # both need the :carousel tooltip treatment, not just :matrix.
+  def vote_context
+    :carousel
   end
 
   # Side-effect-free predicate. The earlier shape was

--- a/app/components/image/base.rb
+++ b/app/components/image/base.rb
@@ -229,7 +229,16 @@ class Components::Image::Base < Components::Base
   def render_image_vote_section
     return unless @votes && @img_instance
 
-    ImageFragment(type: :lazy_vote_interface, image: @img_instance)
+    ImageFragment(type: :lazy_vote_interface, image: @img_instance,
+                  context: vote_context)
+  end
+
+  # Which VoteInterface surface this is -- :matrix by default (a
+  # single-image hover overlay, InteractiveImage); Carousel::Item
+  # overrides to :carousel (per-slide caption, different tooltip
+  # placement/container needs -- see VoteInterface#context doc).
+  def vote_context
+    :matrix
   end
 
   # Render original filename if applicable

--- a/app/components/image_fragment/lazy_vote_interface.rb
+++ b/app/components/image_fragment/lazy_vote_interface.rb
@@ -12,10 +12,10 @@
 # many matrix boxes doesn't fire a request per box on load. See #4895.
 #
 # @example
-#   ImageFragment(type: :lazy_vote_interface, image: @image, context: :overlay)
+#   ImageFragment(type: :lazy_vote_interface, image: @image, context: :matrix)
 class Components::ImageFragment::LazyVoteInterface < Components::Base
   prop :image, ::Image
-  prop :context, Symbol, default: :overlay
+  prop :context, Symbol, default: :matrix
 
   def view_template
     turbo_frame_tag(

--- a/app/components/image_fragment/lightbox_caption.rb
+++ b/app/components/image_fragment/lightbox_caption.rb
@@ -102,7 +102,7 @@ class Components::ImageFragment::LightboxCaption < Components::Base
   end
 
   # `context: :lightbox` -- plain always-visible styling (no
-  # `.image-sizer` hover ancestor here to reveal a `:overlay`), and
+  # `.image-sizer` hover ancestor here to reveal a `:matrix`), and
   # every id this emits gets prefixed so it can't collide with the
   # in-page vote section that's also live in the DOM once the
   # lightbox is open. See `Components::ImageFragment::VoteInterface`.

--- a/app/components/image_fragment/vote_interface.rb
+++ b/app/components/image_fragment/vote_interface.rb
@@ -14,45 +14,34 @@
 #   ImageFragment(type: :vote_interface, user: @user, image: @image,
 #                 votes: true)
 #
-# @example Lightbox caption (always visible, no hover ancestor, and a
-# second live copy can coexist in the DOM alongside the in-page one)
+# @example Show-page / matrix-box carousel
+#   ImageFragment(type: :vote_interface, user: @user, image: @image,
+#                 votes: true, context: :carousel)
+#
+# @example Lightbox caption (a second live copy can coexist in the DOM
+# alongside the in-page one)
 #   ImageFragment(type: :vote_interface, user: @user, image: @image,
 #                 votes: true, context: :lightbox)
 class Components::ImageFragment::VoteInterface < Components::Base
   prop :user, _Nilable(::User)
   prop :image, ::Image
   prop :votes, _Boolean, default: true
-  # Where this is being rendered -- two independent concerns hang off
-  # it, deliberately not conflated:
-  #
-  # Styling: `:overlay` (the default) gets the absolutely positioned,
-  # hover-revealed treatment (`.vote-section`, see mo/_images.scss)
-  # meant for sitting on top of a thumbnail inside an `.image-sizer`
-  # ancestor (InteractiveImage/matrix-box). `:lightbox` gets the same
-  # dark background/link colors via `.vote-section-lightbox`, minus
-  # the absolute positioning -- always visible, not hover-revealed.
-  # Any other context falls back to `.vote-section-inline`, which has
-  # no styling yet -- a future non-lightbox inline caller (the image
-  # show page has been mentioned) that isn't designed yet.
-  #
-  # Element ids: only `:lightbox` gets every id this component emits
-  # (`vote_html_id`) prefixed. That's not a styling concern -- it's
-  # because the lightbox is the one context where a *second* live copy
-  # of the same image's vote UI can end up in the DOM simultaneously
-  # (opening the lightbox injects its caption's copy alongside the
-  # original in-page one), which would otherwise collide on id. A
-  # future inline-but-not-lightbox context with only ever one copy on
-  # the page doesn't need the prefix. `Images::VotesController#update`'s
-  # turbo-stream response updates both the plain and `lightbox_`-
-  # prefixed ids after a vote so both copies stay in sync.
-  prop :context, Symbol, default: :overlay
+  # Which surface this renders on -- governs styling class, tooltip
+  # direction, and id prefixing. `:matrix`/`:carousel` are both
+  # overlay-styled (`.vote-section`) but `:carousel` points tooltips
+  # up: a carousel's tooltip opens right above the show-page's
+  # thumbnail-indicator strip, which paints over a downward one.
+  # `:lightbox` gets `.vote-section-lightbox` and is the only context
+  # whose ids get `lightbox_`-prefixed, since it's the only one where
+  # a second live copy can coexist in the DOM.
+  prop :context, Symbol, default: :matrix
 
   # The root element's own id -- also what a lazy-loading Turbo Frame
   # wrapper (see #4895) must be given so Turbo can find and swap this
   # component's response out of it. Single source of truth for both
   # `#vote_html_id("image_vote")` below and any external caller that
   # needs the id before the component itself has rendered.
-  def self.frame_id(image_id:, context: :overlay)
+  def self.frame_id(image_id:, context: :matrix)
     prefix = context == :lightbox ? "lightbox_" : ""
     "#{prefix}image_vote_#{image_id}"
   end
@@ -73,7 +62,7 @@ class Components::ImageFragment::VoteInterface < Components::Base
   def section_classes
     class_names(
       case @context
-      when :overlay then "vote-section"
+      when :matrix, :carousel then "vote-section"
       when :lightbox then "vote-section-lightbox"
       else "vote-section-inline"
       end,
@@ -174,8 +163,17 @@ class Components::ImageFragment::VoteInterface < Components::Base
       class: "image-vote-link",
       target: image_vote_path(image_id: @image.id, value: vote),
       title: image_vote_as_help_string(vote),
-      data: { image_id: @image.id, value: vote, placement: "bottom",
-              tooltip_container: ".vote-section, .vote-section-lightbox" }
+      data: { image_id: @image.id, value: vote,
+              placement: @context == :carousel ? "top" : "bottom",
+              tooltip_container: tooltip_container }
     )
+  end
+
+  def tooltip_container
+    case @context
+    when :carousel then ".carousel-caption"
+    when :lightbox then ".vote-section-lightbox"
+    else ".vote-section"
+    end
   end
 end

--- a/app/components/image_fragment/vote_interface.rb
+++ b/app/components/image_fragment/vote_interface.rb
@@ -27,13 +27,16 @@ class Components::ImageFragment::VoteInterface < Components::Base
   prop :image, ::Image
   prop :votes, _Boolean, default: true
   # Which surface this renders on -- governs styling class, tooltip
-  # direction, and id prefixing. `:matrix`/`:carousel` are both
-  # overlay-styled (`.vote-section`) but `:carousel` points tooltips
-  # up: a carousel's tooltip opens right above the show-page's
-  # thumbnail-indicator strip, which paints over a downward one.
-  # `:lightbox` gets `.vote-section-lightbox` and is the only context
-  # whose ids get `lightbox_`-prefixed, since it's the only one where
-  # a second live copy can coexist in the DOM.
+  # container, and id prefixing. `:matrix`/`:carousel` are both
+  # overlay-styled (`.vote-section`) and both point tooltips up; only
+  # the container differs -- `:carousel` targets the full-width
+  # `.carousel-caption` instead of `.vote-section` itself, since a
+  # carousel's `.vote-section` is narrower (auto-width, centered) and
+  # would crowd a wide tooltip at the edges. `:lightbox` gets
+  # `.vote-section-lightbox`, keeps the downward tooltip (nothing
+  # below it to collide with), and is the only context whose ids get
+  # `lightbox_`-prefixed, since it's the only one where a second live
+  # copy can coexist in the DOM.
   prop :context, Symbol, default: :matrix
 
   # The root element's own id -- also what a lazy-loading Turbo Frame
@@ -161,10 +164,11 @@ class Components::ImageFragment::VoteInterface < Components::Base
       icon: (:x if vote.zero?),
       name: vote.zero? ? :clear.ti : image_vote_as_short_string(vote),
       class: "image-vote-link",
-      target: image_vote_path(image_id: @image.id, value: vote),
+      target: image_vote_path(image_id: @image.id, value: vote,
+                              context: @context),
       title: image_vote_as_help_string(vote),
       data: { image_id: @image.id, value: vote,
-              placement: @context == :carousel ? "top" : "bottom",
+              placement: @context == :lightbox ? "bottom" : "top",
               tooltip_container: tooltip_container }
     )
   end

--- a/app/components/image_fragment/vote_interface_streams.rb
+++ b/app/components/image_fragment/vote_interface_streams.rb
@@ -22,7 +22,7 @@ class Components::ImageFragment::VoteInterfaceStreams < Components::Base
 
     preload_votes(images)
     images.each do |image|
-      stream_for(image, :overlay)
+      stream_for(image, :matrix)
       stream_for(image, :lightbox)
     end
   end

--- a/app/controllers/images/votes_controller.rb
+++ b/app/controllers/images/votes_controller.rb
@@ -22,7 +22,7 @@ module Images
       @image = Image.find_by(id: params[:image_id])
       return head(:not_found) unless @image
 
-      @context = params[:context]&.to_sym || :overlay
+      @context = params[:context]&.to_sym || :matrix
       render(Views::Controllers::Images::Votes::Show.new(
                image: @image, user: @user, context: @context
              ), layout: false)
@@ -88,7 +88,7 @@ module Images
       ]
     end
 
-    def vote_interface(context: :overlay)
+    def vote_interface(context: :matrix)
       ::Components::ImageFragment.new(
         type: :vote_interface,
         user: @user, image: @image, votes: true, context: context

--- a/app/controllers/images/votes_controller.rb
+++ b/app/controllers/images/votes_controller.rb
@@ -22,7 +22,7 @@ module Images
       @image = Image.find_by(id: params[:image_id])
       return head(:not_found) unless @image
 
-      @context = params[:context]&.to_sym || :matrix
+      @context = normalized_context
       render(Views::Controllers::Images::Votes::Show.new(
                image: @image, user: @user, context: @context
              ), layout: false)
@@ -39,6 +39,7 @@ module Images
       @value = value == "0" ? nil : Image.validate_vote(value)
       anon = (@user.votes_anonymous == "yes")
       @image.change_vote(@user, @value, anon: anon)
+      @context = normalized_context
 
       respond_to do |format|
         # Change user's vote (on anyone's image) and go to next image.
@@ -82,7 +83,7 @@ module Images
     def vote_interface_streams
       [
         turbo_stream.replace("image_vote_#{@image.id}",
-                             vote_interface),
+                             vote_interface(context: @context)),
         turbo_stream.replace("lightbox_image_vote_#{@image.id}",
                              vote_interface(context: :lightbox))
       ]
@@ -93,6 +94,16 @@ module Images
         type: :vote_interface,
         user: @user, image: @image, votes: true, context: context
       )
+    end
+
+    # `:overlay` was VoteInterface's context name before it was
+    # renamed to `:matrix` -- mapped here so an old cached
+    # LazyVoteInterface turbo-frame (whose src= URL still has
+    # `context=overlay` baked in) doesn't 404 or fall into the
+    # unstyled `vote-section-inline` branch.
+    def normalized_context
+      value = params[:context]&.to_sym
+      value == :overlay ? :matrix : (value || :matrix)
     end
   end
 end

--- a/app/views/controllers/images/votes/show.rb
+++ b/app/views/controllers/images/votes/show.rb
@@ -11,7 +11,7 @@ module Views::Controllers::Images
     class Show < Views::Base
       prop :image, ::Image
       prop :user, _Nilable(::User)
-      prop :context, Symbol, default: :overlay
+      prop :context, Symbol, default: :matrix
 
       def view_template
         turbo_frame_tag(frame_id) do

--- a/test/components/image_fragment/lazy_vote_interface_test.rb
+++ b/test/components/image_fragment/lazy_vote_interface_test.rb
@@ -8,7 +8,7 @@ class ImageFragmentLazyVoteInterfaceTest < ComponentTestCase
     @image = images(:connected_coprinus_comatus_image)
   end
 
-  def test_renders_lazy_turbo_frame_for_overlay_context
+  def test_renders_lazy_turbo_frame_for_matrix_context
     html = render(Components::ImageFragment::LazyVoteInterface.new(
                     image: @image
                   ))
@@ -17,7 +17,7 @@ class ImageFragmentLazyVoteInterfaceTest < ComponentTestCase
                       "[loading='lazy'][src]")
     frame_src = Nokogiri::HTML5.fragment(html).at_css("turbo-frame")["src"]
     assert_includes(frame_src, "/images/#{@image.id}/vote")
-    assert_includes(frame_src, "context=overlay")
+    assert_includes(frame_src, "context=matrix")
   end
 
   def test_renders_lazy_turbo_frame_for_lightbox_context

--- a/test/components/image_fragment/vote_interface_test.rb
+++ b/test/components/image_fragment/vote_interface_test.rb
@@ -25,8 +25,7 @@ class ImageFragmentVoteInterfaceTest < ComponentTestCase
 
   # :matrix (default) -- the absolutely-positioned, hover-revealed
   # thumbnail treatment, plain (unprefixed) element ids, tooltips
-  # below the button (room below a matrix-box overlay; nothing to
-  # collide with).
+  # above the button.
   def test_matrix_context_is_the_default
     html = render_component
 
@@ -34,16 +33,16 @@ class ImageFragmentVoteInterfaceTest < ComponentTestCase
     assert_no_html(html, ".vote-section-lightbox")
     assert_html(html, "#vote_meter_bar_#{@image.id}")
     assert_html(html, "#image_vote_links_#{@image.id}")
-    assert_html(html, "button[data-placement='bottom']" \
+    assert_html(html, "button[data-placement='top']" \
                       "[data-tooltip-container='.vote-section']")
   end
 
-  # :carousel -- same overlay styling and unprefixed ids as :matrix
-  # (both are legitimately "overlay" treatments, see the `context`
-  # prop doc), but tooltips point up at the full-width `.carousel-
-  # caption` instead of down at the narrower, auto-width `.vote-
-  # section` -- a downward tooltip there gets painted over by the
-  # show-page thumbnail-indicator strip below it.
+  # :carousel -- same overlay styling, unprefixed ids, and upward
+  # tooltip as :matrix (both are legitimately "overlay" treatments,
+  # see the `context` prop doc), but the tooltip container is the
+  # full-width `.carousel-caption` instead of the narrower, auto-width
+  # `.vote-section` -- room for a wide tooltip without crowding at
+  # the carousel's edges.
   def test_carousel_context_points_tooltip_up_at_carousel_caption
     html = render_component(context: :carousel)
 

--- a/test/components/image_fragment/vote_interface_test.rb
+++ b/test/components/image_fragment/vote_interface_test.rb
@@ -23,22 +23,41 @@ class ImageFragmentVoteInterfaceTest < ComponentTestCase
     assert_equal("", html)
   end
 
-  # :overlay (default) -- the absolutely-positioned, hover-revealed
-  # thumbnail treatment, plain (unprefixed) element ids.
-  def test_overlay_context_is_the_default
+  # :matrix (default) -- the absolutely-positioned, hover-revealed
+  # thumbnail treatment, plain (unprefixed) element ids, tooltips
+  # below the button (room below a matrix-box overlay; nothing to
+  # collide with).
+  def test_matrix_context_is_the_default
     html = render_component
 
     assert_html(html, ".vote-section#image_vote_#{@image.id}")
     assert_no_html(html, ".vote-section-lightbox")
     assert_html(html, "#vote_meter_bar_#{@image.id}")
     assert_html(html, "#image_vote_links_#{@image.id}")
+    assert_html(html, "button[data-placement='bottom']" \
+                      "[data-tooltip-container='.vote-section']")
   end
 
-  # :lightbox -- same dark background/link treatment as :overlay,
+  # :carousel -- same overlay styling and unprefixed ids as :matrix
+  # (both are legitimately "overlay" treatments, see the `context`
+  # prop doc), but tooltips point up at the full-width `.carousel-
+  # caption` instead of down at the narrower, auto-width `.vote-
+  # section` -- a downward tooltip there gets painted over by the
+  # show-page thumbnail-indicator strip below it.
+  def test_carousel_context_points_tooltip_up_at_carousel_caption
+    html = render_component(context: :carousel)
+
+    assert_html(html, ".vote-section#image_vote_#{@image.id}")
+    assert_no_html(html, ".vote-section-lightbox")
+    assert_html(html, "button[data-placement='top']" \
+                      "[data-tooltip-container='.carousel-caption']")
+  end
+
+  # :lightbox -- same dark background/link treatment as :matrix,
   # minus the absolute positioning; always visible. Every id is
-  # prefixed so a live in-page :overlay copy and this :lightbox copy
-  # of the same image's vote UI can coexist in the DOM without
-  # colliding.
+  # prefixed so a live in-page :matrix/:carousel copy and this
+  # :lightbox copy of the same image's vote UI can coexist in the DOM
+  # without colliding.
   def test_lightbox_context_uses_lightbox_styling_and_prefixed_ids
     html = render_component(context: :lightbox)
 
@@ -47,6 +66,8 @@ class ImageFragmentVoteInterfaceTest < ComponentTestCase
     assert_no_html(html, ".vote-section")
     assert_html(html, "#lightbox_vote_meter_bar_#{@image.id}")
     assert_html(html, "#lightbox_image_vote_links_#{@image.id}")
+    assert_html(html, "button[data-placement='bottom']" \
+                      "[data-tooltip-container='.vote-section-lightbox']")
   end
 
   # `.frame_id` is the single source of truth `LazyVoteInterface`'s
@@ -54,20 +75,20 @@ class ImageFragmentVoteInterfaceTest < ComponentTestCase
   # and swap it -- pins it against the id `#view_template` actually
   # renders (via `#vote_html_id`).
   def test_frame_id_matches_rendered_root_id
-    overlay_id = Components::ImageFragment::VoteInterface.frame_id(
+    matrix_id = Components::ImageFragment::VoteInterface.frame_id(
       image_id: @image.id
     )
     lightbox_id = Components::ImageFragment::VoteInterface.frame_id(
       image_id: @image.id, context: :lightbox
     )
 
-    assert_html(render_component, "##{overlay_id}")
+    assert_html(render_component, "##{matrix_id}")
     assert_html(render_component(context: :lightbox), "##{lightbox_id}")
   end
 
   private
 
-  def render_component(votes: true, context: :overlay)
+  def render_component(votes: true, context: :matrix)
     render(Components::ImageFragment::VoteInterface.new(
              user: @user,
              image: @image,

--- a/test/controllers/images/votes_controller_test.rb
+++ b/test/controllers/images/votes_controller_test.rb
@@ -58,7 +58,7 @@ module Images
     end
 
     # Two turbo-stream targets, not one: the in-page vote section
-    # (:overlay context) and the lightbox caption's copy (:lightbox
+    # (:matrix context) and the lightbox caption's copy (:lightbox
     # context, a `lightbox_`-prefixed id) -- both can be live in the
     # DOM at once once the lightbox is open. See
     # Components::ImageFragment::VoteInterface#vote_html_id.


### PR DESCRIPTION
## Summary

Vote-button tooltips on the observation-show carousel (and matrix-box mini-carousels) were getting painted over by the show-page thumbnail-indicator strip below them — the tooltip box itself wasn't clipped (rounded corners intact), it was a z-index/stacking conflict from `bottom` placement having nowhere to render into. Matrix boxes never showed this since nothing sits below their vote overlay.

## Changes

- `Components::ImageFragment::VoteInterface#context` renamed `:overlay` → `:matrix` and gained a new `:carousel` value. Both `:matrix` and `:carousel` get the same `.vote-section` overlay styling (they're both legitimately "overlay" treatments — see the prop doc), but `:carousel` points the vote-button tooltip up instead of down, and targets the full-width `.carousel-caption` as its container instead of the narrower, auto-width `.vote-section`.
- `Components::Carousel::Item#vote_context` overrides `Image::Base`'s `:matrix` default to `:carousel`, so both the show-page gallery (`Components::ImageGallery::Item`) and matrix-box mini-carousels (`Components::Matrix::Carousel::Item`) — both subclass `Carousel::Item` — get the fix.
- `.carousel-caption` goes full-width instead of auto-width-centered-via-transform, so the tooltip container has the whole image's width to lay out in, not just the caption's own content width. The visible dark backdrop moved to a new `.caption-content` wrapper (shrink-wrapped, centered by `text-align`) so it doesn't stretch full-width too — needed its own explicit `padding: 0` to cancel Bootstrap's base `.carousel-caption` padding that MO's old rule was overriding as a side effect of also supplying the (now-relocated) background.
- `.glyphicon`'s `top: 3px` was a `.btn`-specific baseline correction applied globally, pushing every non-button icon (inline links, the progress-spinner modal) down 3px too. Scoped to `.btn > .glyphicon`; the bare `.glyphicon` default is now `top: 0`, explicitly canceling Bootstrap's own `top: 1px` base rule.

## Test plan

- [ ] Hover a vote button on the observation-show carousel: tooltip opens upward, fully visible, not painted over by the thumbnail strip.
- [ ] Hover a vote button on a matrix-box thumbnail (single image, no mini-carousel): tooltip still opens downward as before.
- [ ] Hover a vote button on a matrix-box mini-carousel (multi-image box): tooltip opens upward, matches the show-page carousel behavior.
- [ ] Check a button icon (e.g. the top-nav "Add" button) still has correct vertical glyph alignment.
- [ ] Check a non-button icon (inline link icon, progress-spinner modal) isn't pushed down anymore.
