### PR TITLE
Fix glyphicon misalignment on carousel controls and the lightbox theater button

### DIFF
--- a/app/assets/stylesheets/mo/_icons.scss
+++ b/app/assets/stylesheets/mo/_icons.scss
@@ -187,9 +187,20 @@ tbody.collapse.in {
 // top: 3px is a .btn-specific baseline correction, not a general
 // glyphicon offset -- scoped here instead of on the bare .glyphicon
 // selector above so it doesn't push every non-button icon (inline
-// links, standalone icons, etc.) down by 3px too.
-.btn > .glyphicon {
+// links, standalone icons, etc.) down by 3px too. Two exclusions:
+// .carousel-control's .btn wrapper, since Bootstrap positions those
+// chevron icons itself (top: 50%, centered) and this nudge would
+// fight that default; and .btn-overlay, an icon-only overlay button
+// with no adjacent visible text to baseline-align against.
+.btn:not(.carousel-control .btn):not(.btn-overlay) > .glyphicon {
   top: 3px;
+}
+
+// `.theater-btn`'s icon needs its own baseline nudge -- not the
+// button-text +3px above (no adjacent visible text to align to
+// here), and not flush like a bare icon either.
+.theater-btn > .glyphicon {
+  top: 2px;
 }
 
 .spinner-right {

--- a/app/assets/stylesheets/mo/_images.scss
+++ b/app/assets/stylesheets/mo/_images.scss
@@ -35,19 +35,30 @@ svg.placeholder {
 .theater-btn {
   z-index: 2;
   opacity: 0;
+  transition: opacity 0.3s ease-out;
+}
+
+.vote-section {
   background: rgba(0,0,0, 0.8);
   // border-radius: $border-radius-sm;
   color: white;
-  transition: opacity 0.3s ease-out;
 }
 
 .theater-btn {
   @extend .top-right, .text-center, .mr-2, .mt-2;
-  padding: 0.125em;
-  // `.theater-btn` is a `div` now, not an `a` (#4894 -- an `a` can't
-  // legally contain the caption's interactive content nested inside
-  // it), so the pointer cursor needs to be explicit.
-  cursor: pointer;
+}
+
+// Dark, borderless button styling for a `.btn` overlaying an image --
+// pair with `.btn` on the element. No cursor/display/position/reveal
+// framing of its own; `.theater-btn` (the lightbox toggle) supplies
+// those for its specific placement and hover-reveal behavior, so
+// `.btn-overlay` alone stays usable for a non-hover overlay button
+// too.
+.btn-overlay {
+  @extend .p-1;
+  border: none;
+  background-color: $black;
+  color: $white;
 
   &:hover {
     color: rgba(white, 0.75);

--- a/app/components/image/base.rb
+++ b/app/components/image/base.rb
@@ -188,7 +188,7 @@ class Components::Image::Base < Components::Base
 
     div(
       href: lightbox_data[:url],
-      class: "theater-btn",
+      class: "theater-btn btn btn-overlay",
       role: "button",
       tabindex: "0",
       data: { sub_html: ".lightbox-caption" }


### PR DESCRIPTION
## Summary

`#4991` scoped a `+3px` baseline nudge to `.btn > .glyphicon` to fix vote-button icon alignment, but that blanket rule also caught two other `.btn`-classed elements it wasn't meant for:

- The carousel prev/next chevrons (`Components::Carousel::Controls`) wrap their icon in a `.btn` div. Bootstrap already centers those chevrons itself (`top: 50%`), so the `+3px` nudge fought that default and pushed the arrows off-center. Fixed by excluding `.carousel-control .btn` from the rule directly, rather than patching over it with a downstream override in `_carousel.scss`.
- The lightbox theater-toggle button had no `.btn` class at all, so its icon sat flush (`top: 0`) instead of getting any nudge. Gave it real `.btn` framing plus a new `.btn-overlay` variant class (dark, borderless, white icon, `.p-1` padding) for any future image-overlay button, excluded it from the generic `+3px` nudge (it has no adjacent visible text to baseline-align to), and gave it its own `top: 2px` correction.

`.theater-btn` is now a bare identifier class only (the `lightgallery_controller.js` JS hook still targets it) — `.btn-overlay` carries the visual look, `.theater-btn` carries the lightbox-specific corner placement and hover-reveal behavior.

## Test plan

- [x] `bin/rails test test/components/interactive_image_test.rb`
- [x] `bin/rails test test/components/image_gallery_test.rb`
- [x] `bundle exec rubocop app/components/image/base.rb`
- [x] Reviewed live via the sass watcher: carousel prev/next arrows centered, lightbox theater-button icon aligned
