### PR TITLE
DRY component/view test render calls; add `MO/DryTestRenderHelper` cop to catch it going forward

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ plugins:
   - rubocop-rails
 
 require:
+  - ./lib/rubocop/cop/mo/dry_test_render_helper
   - ./lib/rubocop/cop/mo/lowercase_translation_tag
   - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
   - ./lib/rubocop/cop/mo/no_resolved_errors_add_type
@@ -40,6 +41,17 @@ AllCops:
 # ------------------------------------------------------------------------------
 
 ########### Individual cops for which MO uses a non-default configuration
+
+MO/DryTestRenderHelper:
+  Description: >-
+    render(SomeClass.new(...)) repeated inline across sibling test_*
+    methods must go through a private render_x helper instead -- see
+    lib/rubocop/cop/mo/dry_test_render_helper.rb and "Extract DRY
+    Render Helper" in .claude/rules/testing.md.
+  Enabled: true
+  Include:
+    - "test/components/**/*_test.rb"
+    - "test/views/**/*_test.rb"
 
 MO/LowercaseTranslationTag:
   Description: >-

--- a/lib/rubocop/cop/mo/dry_test_render_helper.rb
+++ b/lib/rubocop/cop/mo/dry_test_render_helper.rb
@@ -79,19 +79,28 @@ module RuboCop
         end
 
         def each_duplicate_render_group(test_defs)
-          renders_by_class = Hash.new { |h, k| h[k] = [] }
+          renders_by_class(test_defs).each_value do |pairs|
+            # Only a repeat across sibling test methods counts -- two
+            # calls to the same class within ONE test method (e.g.
+            # comparing two renders side by side) aren't the pattern
+            # this cop targets.
+            next if pairs.map(&:first).uniq.size < 2
+
+            yield(pairs.map(&:last))
+          end
+        end
+
+        def renders_by_class(test_defs)
+          grouped = Hash.new { |h, k| h[k] = [] }
           test_defs.each do |def_node|
             def_node.each_descendant(:send) do |send_node|
               next unless render_new_call?(send_node)
 
               key = send_node.first_argument.receiver.source
-              renders_by_class[key] << send_node
+              grouped[key] << [def_node, send_node]
             end
           end
-
-          renders_by_class.each_value do |nodes|
-            yield(nodes) if nodes.size > 1
-          end
+          grouped
         end
 
         def render_new_call?(node)

--- a/lib/rubocop/cop/mo/dry_test_render_helper.rb
+++ b/lib/rubocop/cop/mo/dry_test_render_helper.rb
@@ -9,12 +9,18 @@ module RuboCop
       # DRY Render Helper" in .claude/rules/testing.md.
       #
       # Only counts direct `render(<Const>.new(...))` calls where the
-      # receiver of `.new` is a constant. A call already routed through a
-      # local helper (`render_form(...)`, `render(build_table(...))`,
+      # receiver of `.new` is a constant AND `.new` takes at least one
+      # argument. A call already routed through a local helper
+      # (`render_form(...)`, `render(build_table(...))`,
       # `render(klass.new(...))` with `klass` a variable) never matches
       # this pattern, so files that already extracted a helper are silent
       # by construction -- this cop only needs to catch the case where no
-      # helper exists yet.
+      # helper exists yet. A bare `render(Page.new)` with no arguments is
+      # excluded even when repeated: the whole point of extracting a
+      # helper is to stop an argument list from drifting out of sync
+      # across call sites, and a zero-argument constructor has no
+      # argument list to drift -- extracting one there trades a
+      # single-line duplicate for a 3-line method that saves nothing.
       #
       # @example
       #   # bad
@@ -90,9 +96,14 @@ module RuboCop
 
         def render_new_call?(node)
           node.method?(:render) && node.receiver.nil? &&
-            node.arguments.size == 1 && node.first_argument.send_type? &&
-            node.first_argument.method?(:new) &&
-            node.first_argument.receiver&.const_type?
+            node.arguments.size == 1 && new_call_with_args?(node.first_argument)
+        end
+
+        # `SomeClass.new(...)` with a constant receiver and at least one
+        # argument -- a bare `SomeClass.new` has nothing to consolidate.
+        def new_call_with_args?(node)
+          node.send_type? && node.method?(:new) &&
+            node.receiver&.const_type? && node.arguments.any?
         end
 
         def message_for(node)

--- a/lib/rubocop/cop/mo/dry_test_render_helper.rb
+++ b/lib/rubocop/cop/mo/dry_test_render_helper.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Flags `render(SomeClass.new(...))` repeated inline across two or
+      # more sibling `test_*` methods in the same test class, instead of
+      # going through a single private `render_x` helper -- see "Extract
+      # DRY Render Helper" in .claude/rules/testing.md.
+      #
+      # Only counts direct `render(<Const>.new(...))` calls where the
+      # receiver of `.new` is a constant. A call already routed through a
+      # local helper (`render_form(...)`, `render(build_table(...))`,
+      # `render(klass.new(...))` with `klass` a variable) never matches
+      # this pattern, so files that already extracted a helper are silent
+      # by construction -- this cop only needs to catch the case where no
+      # helper exists yet.
+      #
+      # @example
+      #   # bad
+      #   def test_one
+      #     html = render(Components::Foo.new(bar: 1))
+      #   end
+      #
+      #   def test_two
+      #     html = render(Components::Foo.new(bar: 2))
+      #   end
+      #
+      #   # good
+      #   def test_one
+      #     html = render_foo(bar: 1)
+      #   end
+      #
+      #   def test_two
+      #     html = render_foo(bar: 2)
+      #   end
+      #
+      #   private
+      #
+      #   def render_foo(**opts)
+      #     render(Components::Foo.new(**opts))
+      #   end
+      class DryTestRenderHelper < Base
+        MSG = "Repeated `render(%<class>s.new(...))` across sibling " \
+              "test methods -- extract a private `render_x` helper " \
+              "instead (see 'Extract DRY Render Helper' in " \
+              ".claude/rules/testing.md)."
+
+        def on_class(class_node)
+          test_defs = class_node.each_descendant(:def).select do |def_node|
+            owned_by?(def_node, class_node) && test_method?(def_node)
+          end
+          return if test_defs.size < 2
+
+          each_duplicate_render_group(test_defs) do |nodes|
+            nodes.each { |node| add_offense(node, message: message_for(node)) }
+          end
+        end
+
+        private
+
+        # A `def` belongs to `class_node` only if `class_node` is its
+        # NEAREST enclosing class/sclass -- excludes `def`s that live
+        # inside a class nested within `class_node` (each_descendant
+        # would otherwise also pick those up, double-counting them
+        # under both the inner and outer class).
+        def owned_by?(def_node, class_node)
+          def_node.each_ancestor(:class, :sclass).first.equal?(class_node)
+        end
+
+        def test_method?(def_node)
+          def_node.method_name.to_s.start_with?("test_")
+        end
+
+        def each_duplicate_render_group(test_defs)
+          renders_by_class = Hash.new { |h, k| h[k] = [] }
+          test_defs.each do |def_node|
+            def_node.each_descendant(:send) do |send_node|
+              next unless render_new_call?(send_node)
+
+              key = send_node.first_argument.receiver.source
+              renders_by_class[key] << send_node
+            end
+          end
+
+          renders_by_class.each_value do |nodes|
+            yield(nodes) if nodes.size > 1
+          end
+        end
+
+        def render_new_call?(node)
+          node.method?(:render) && node.receiver.nil? &&
+            node.arguments.size == 1 && node.first_argument.send_type? &&
+            node.first_argument.method?(:new) &&
+            node.first_argument.receiver&.const_type?
+        end
+
+        def message_for(node)
+          format(MSG, class: node.first_argument.receiver.source)
+        end
+      end
+    end
+  end
+end

--- a/test/components/accordion_test.rb
+++ b/test/components/accordion_test.rb
@@ -46,32 +46,28 @@ class AccordionTest < ComponentTestCase
   end
 
   def test_slide_true_uses_bootstraps_default_transition
-    html = render(
-      Components::Accordion.new(id: "notes_42", slide: true)
-    ) { |a| a.with_pane(id: "p") { "x" } }
+    html = render_accordion(slide: true) { |a| a.with_pane(id: "p") { "x" } }
 
     assert_no_html(html, "#p.fade-not-slide")
   end
 
   def test_extra_class_merges_onto_inner_panel_div
-    html = render(
-      Components::Accordion.new(id: "notes_42", class: "m-0")
-    ) { |a| a.with_pane(id: "p") { "x" } }
+    html = render_accordion(class: "m-0") { |a| a.with_pane(id: "p") { "x" } }
 
     assert_html(html, "div.panel.border-none.bg-none.m-0")
   end
 
   def test_extra_data_attrs_merge_onto_inner_panel_div
-    html = render(
-      Components::Accordion.new(id: "notes_42", data: { foo: "bar" })
-    ) { |a| a.with_pane(id: "p") { "x" } }
+    html = render_accordion(data: { foo: "bar" }) do |a|
+      a.with_pane(id: "p") { "x" }
+    end
 
     assert_html(html, "#notes_42 div.panel[data-foo='bar']")
   end
 
   private
 
-  def render_accordion(&block)
-    render(Components::Accordion.new(id: "notes_42"), &block)
+  def render_accordion(**, &block)
+    render(Components::Accordion.new(id: "notes_42", **), &block)
   end
 end

--- a/test/components/alert/link_test.rb
+++ b/test/components/alert/link_test.rb
@@ -4,28 +4,28 @@ require("test_helper")
 
 class Components::Alert::LinkTest < ComponentTestCase
   def test_renders_link_with_alert_link_class
-    html = render(Components::Alert::Link.new("Set prefix",
-                                              "/projects/1/admin"))
+    html = render_link
 
     assert_html(html, "a.alert-link[href='/projects/1/admin']",
                 text: "Set prefix")
   end
 
   def test_merges_caller_class_with_alert_link
-    html = render(
-      Components::Alert::Link.new("Set prefix", "/projects/1/admin",
-                                  class: "my-class")
-    )
+    html = render_link(class: "my-class")
 
     assert_html(html, "a.alert-link.my-class[href='/projects/1/admin']")
   end
 
   def test_passes_extra_html_attrs_through
-    html = render(
-      Components::Alert::Link.new("Set prefix", "/projects/1/admin",
-                                  id: "prefix-link")
-    )
+    html = render_link(id: "prefix-link")
 
     assert_html(html, "a#prefix-link.alert-link")
+  end
+
+  private
+
+  def render_link(**)
+    render(Components::Alert::Link.new("Set prefix", "/projects/1/admin",
+                                       **))
   end
 end

--- a/test/components/application_form/button_style_checkbox_test.rb
+++ b/test/components/application_form/button_style_checkbox_test.rb
@@ -9,10 +9,9 @@ require("test_helper")
 # Field/FieldProxy) and has NO `.checkbox` div wrap.
 class ButtonStyleCheckboxTest < ComponentTestCase
   def test_renders_label_wrapping_checkbox_input
-    html = render(klass.new(
-                    name: "q[type][]", value: "observation",
-                    id: "type_observation"
-                  )) { "Observations" }
+    html = render_checkbox(
+      name: "q[type][]", value: "observation", id: "type_observation"
+    ) { "Observations" }
 
     # <label for="type_observation">
     #   <input type="checkbox" ...>Observations
@@ -27,44 +26,42 @@ class ButtonStyleCheckboxTest < ComponentTestCase
   end
 
   def test_checked_true_sets_input_attr
-    html = render(klass.new(
-                    name: "n[]", value: "1", id: "x", checked: true
-                  ))
+    html = render_checkbox(name: "n[]", value: "1", id: "x", checked: true)
 
     assert_html(html, "input[type='checkbox'][checked]")
   end
 
   def test_checked_default_false_omits_attr
-    html = render(klass.new(name: "n[]", value: "1", id: "x"))
+    html = render_checkbox(name: "n[]", value: "1", id: "x")
 
     assert_html(html, "input[type='checkbox']:not([checked])")
   end
 
   def test_variant_and_size_applied_to_label
-    html = render(klass.new(
-                    name: "n[]", value: "1", id: "x",
-                    variant: :outline, size: :sm,
-                    label: { class: "filter-checkbox",
-                             data: { action: "click->filter#toggle" } }
-                  ))
+    html = render_checkbox(
+      name: "n[]", value: "1", id: "x",
+      variant: :outline, size: :sm,
+      label: { class: "filter-checkbox",
+               data: { action: "click->filter#toggle" } }
+    )
 
     assert_html(html, "label[for='x']")
     assert_html(html, "label[data-action='click->filter#toggle']")
   end
 
   def test_input_attrs_passed_through_via_splat
-    html = render(klass.new(
-                    name: "n[]", value: "1", id: "x",
-                    class: "form-control",
-                    data: { filter_id: "1" }
-                  ))
+    html = render_checkbox(
+      name: "n[]", value: "1", id: "x",
+      class: "form-control",
+      data: { filter_id: "1" }
+    )
 
     assert_html(html, "input[type='checkbox'].form-control" \
                       "[data-filter-id='1']")
   end
 
   def test_renders_without_block_content
-    html = render(klass.new(name: "n[]", value: "1", id: "x"))
+    html = render_checkbox(name: "n[]", value: "1", id: "x")
 
     # Label exists, contains the input, no extra content.
     assert_html(html, "label[for='x'] > input[type='checkbox']")
@@ -74,8 +71,8 @@ class ButtonStyleCheckboxTest < ComponentTestCase
   # — that's the whole reason this component exists separately from
   # ButtonStyleRadio. Verify the name-array shape is preserved.
   def test_multiple_instances_share_name_array_shape
-    html_a = render(klass.new(name: "q[type][]", value: "a", id: "ta"))
-    html_b = render(klass.new(name: "q[type][]", value: "b", id: "tb"))
+    html_a = render_checkbox(name: "q[type][]", value: "a", id: "ta")
+    html_b = render_checkbox(name: "q[type][]", value: "b", id: "tb")
 
     assert_html(html_a, "input[name='q[type][]'][value='a']")
     assert_html(html_b, "input[name='q[type][]'][value='b']")
@@ -83,7 +80,8 @@ class ButtonStyleCheckboxTest < ComponentTestCase
 
   private
 
-  def klass
-    Components::ApplicationForm::ButtonStyleCheckbox
+  def render_checkbox(**, &block)
+    render(Components::ApplicationForm::ButtonStyleCheckbox.new(**),
+           &block)
   end
 end

--- a/test/components/application_form/button_style_radio_test.rb
+++ b/test/components/application_form/button_style_radio_test.rb
@@ -8,10 +8,9 @@ require("test_helper")
 # and has NO `.radio` div wrap.
 class ButtonStyleRadioTest < ComponentTestCase
   def test_renders_label_wrapping_radio_input
-    html = render(klass.new(
-                    name: "obs[thumb]", value: "42",
-                    id: "thumb_42"
-                  )) { "Pick this" }
+    html = render_radio(
+      name: "obs[thumb]", value: "42", id: "thumb_42"
+    ) { "Pick this" }
 
     # <label for="thumb_42"><input type="radio" ...>Pick this</label>
     assert_html(html, "label[for='thumb_42'] > input[type='radio']" \
@@ -22,43 +21,41 @@ class ButtonStyleRadioTest < ComponentTestCase
   end
 
   def test_checked_true_sets_input_attr
-    html = render(klass.new(
-                    name: "n", value: "1", id: "x", checked: true
-                  ))
+    html = render_radio(name: "n", value: "1", id: "x", checked: true)
 
     assert_html(html, "input[type='radio'][checked]")
   end
 
   def test_checked_default_false_omits_attr
-    html = render(klass.new(name: "n", value: "1", id: "x"))
+    html = render_radio(name: "n", value: "1", id: "x")
 
     assert_html(html, "input[type='radio']:not([checked])")
   end
 
   def test_label_attrs_passed_through
-    html = render(klass.new(
-                    name: "n", value: "1", id: "x",
-                    label: { class: "thumb_img_btn",
-                             data: { action: "click->form-images#set" } }
-                  ))
+    html = render_radio(
+      name: "n", value: "1", id: "x",
+      label: { class: "thumb_img_btn",
+               data: { action: "click->form-images#set" } }
+    )
 
     assert_html(html, "label.thumb_img_btn[for='x']")
     assert_html(html, "label[data-action='click->form-images#set']")
   end
 
   def test_input_attrs_passed_through_via_splat
-    html = render(klass.new(
-                    name: "n", value: "1", id: "x",
-                    class: "form-control",
-                    data: { thumb_id: "1" }
-                  ))
+    html = render_radio(
+      name: "n", value: "1", id: "x",
+      class: "form-control",
+      data: { thumb_id: "1" }
+    )
 
     assert_html(html, "input[type='radio'].form-control" \
                       "[data-thumb-id='1']")
   end
 
   def test_renders_without_block_content
-    html = render(klass.new(name: "n", value: "1", id: "x"))
+    html = render_radio(name: "n", value: "1", id: "x")
 
     # Label exists, contains the input, no extra content.
     assert_html(html, "label[for='x'] > input[type='radio']")
@@ -66,7 +63,7 @@ class ButtonStyleRadioTest < ComponentTestCase
 
   private
 
-  def klass
-    Components::ApplicationForm::ButtonStyleRadio
+  def render_radio(**, &block)
+    render(Components::ApplicationForm::ButtonStyleRadio.new(**), &block)
   end
 end

--- a/test/components/application_form_helper_parity_test.rb
+++ b/test/components/application_form_helper_parity_test.rb
@@ -80,7 +80,7 @@ class ApplicationFormHelperParityTest < ComponentTestCase
   # --- AutocompleterField: no outer `id` unless caller asks for one ------
 
   def test_autocompleter_field_omits_outer_id_by_default
-    html = render(AutocompleterNoIdForm.new(Comment.new, action: "/t"))
+    html = render_autocompleter_no_id_form
 
     wrap = Nokogiri::HTML5.fragment(html).at_css("div.autocompleter")
     assert_nil(wrap["id"],
@@ -137,7 +137,7 @@ class ApplicationFormHelperParityTest < ComponentTestCase
   # --- AutocompleterField: no d-flex when label_end is empty -------------
 
   def test_autocompleter_field_no_d_flex_when_no_create_text
-    html = render(AutocompleterNoIdForm.new(Comment.new, action: "/t"))
+    html = render_autocompleter_no_id_form
 
     # With no `create_text:`, AutocompleterField must not register an
     # empty `label_end` slot — otherwise FieldLabelRow forces the
@@ -248,6 +248,12 @@ class ApplicationFormHelperParityTest < ComponentTestCase
     assert_html(html,
                 "input[type='radio'][name='comment[target_id]']" \
                 "[value='1']:not([checked])")
+  end
+
+  private
+
+  def render_autocompleter_no_id_form
+    render(AutocompleterNoIdForm.new(Comment.new, action: "/t"))
   end
 end
 

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -1075,10 +1075,8 @@ class ApplicationFormTest < ComponentTestCase
     proxy = Components::ApplicationForm::FieldProxy.new(
       "chosen_name", :name_id
     )
-    html = render(Components::ApplicationForm::RadioField.new(
-                    proxy, [10, "Alpha"], [20, "Beta"],
-                    wrapper_options: { wrap_class: "ml-4" }
-                  ))
+    html = render_radio_field(proxy, [10, "Alpha"], [20, "Beta"],
+                              wrapper_options: { wrap_class: "ml-4" })
 
     assert_html(html, "div.radio.ml-4", count: 2)
     assert_html(html,
@@ -1094,9 +1092,7 @@ class ApplicationFormTest < ComponentTestCase
     proxy = Components::ApplicationForm::FieldProxy.new(
       "chosen_name", :name_id, "20"
     )
-    html = render(Components::ApplicationForm::RadioField.new(
-                    proxy, [10, "Alpha"], [20, "Beta"]
-                  ))
+    html = render_radio_field(proxy, [10, "Alpha"], [20, "Beta"])
 
     assert_html(html, "input[value='10']:not([checked])")
     assert_html(html, "input[value='20'][checked]")
@@ -1107,9 +1103,8 @@ class ApplicationFormTest < ComponentTestCase
     proxy = Components::ApplicationForm::FieldProxy.new(
       "chosen_name", :status, :active
     )
-    html = render(Components::ApplicationForm::RadioField.new(
-                    proxy, [:active, "Active"], [:inactive, "Inactive"]
-                  ))
+    html = render_radio_field(proxy, [:active, "Active"],
+                              [:inactive, "Inactive"])
 
     # Symbol values should be rendered as strings
     assert_html(html, "input[value='active']")
@@ -1265,6 +1260,12 @@ class ApplicationFormTest < ComponentTestCase
     form.field_block = block
 
     render(form)
+  end
+
+  def render_radio_field(proxy, *options, **field_opts)
+    render(Components::ApplicationForm::RadioField.new(
+             proxy, *options, **field_opts
+           ))
   end
 
   # Single reusable test form class to avoid duplicate view_template methods

--- a/test/components/base_test.rb
+++ b/test/components/base_test.rb
@@ -47,14 +47,6 @@ class BaseTest < ComponentTestCase
     end
   end
 
-  def render_current_user
-    render(CurrentUserReader.new)
-  end
-
-  def render_current_query
-    render(CurrentQueryReader.new)
-  end
-
   def test_trusted_html_with_plain_string
     html = render_component(TestComponent.new)
     doc = Nokogiri::HTML(html)
@@ -119,13 +111,13 @@ class BaseTest < ComponentTestCase
     user = users(:rolf)
     controller.instance_variable_set(:@user, user)
 
-    assert_equal(user.login, render_current_user)
+    assert_equal(user.login, render(CurrentUserReader.new))
   end
 
   def test_current_user_is_nil_when_no_one_logged_in
     controller.instance_variable_set(:@user, nil)
 
-    assert_equal("nobody", render_current_user)
+    assert_equal("nobody", render(CurrentUserReader.new))
   end
 
   # `current_query` is a `register_value_helper`'d alias for
@@ -136,13 +128,13 @@ class BaseTest < ComponentTestCase
     query = ::Query.lookup_and_save(:Observation)
     controller.instance_variable_set(:@query, query)
 
-    assert_equal(query.id.to_s, render_current_query)
+    assert_equal(query.id.to_s, render(CurrentQueryReader.new))
   end
 
   def test_current_query_is_nil_when_no_query_on_controller
     controller.instance_variable_set(:@query, nil)
 
-    assert_equal("no-query", render_current_query)
+    assert_equal("no-query", render(CurrentQueryReader.new))
   end
 
   # `viewer_aware_unique_format_name` passes the viewer straight

--- a/test/components/base_test.rb
+++ b/test/components/base_test.rb
@@ -47,6 +47,14 @@ class BaseTest < ComponentTestCase
     end
   end
 
+  def render_current_user
+    render(CurrentUserReader.new)
+  end
+
+  def render_current_query
+    render(CurrentQueryReader.new)
+  end
+
   def test_trusted_html_with_plain_string
     html = render_component(TestComponent.new)
     doc = Nokogiri::HTML(html)
@@ -111,13 +119,13 @@ class BaseTest < ComponentTestCase
     user = users(:rolf)
     controller.instance_variable_set(:@user, user)
 
-    assert_equal(user.login, render(CurrentUserReader.new))
+    assert_equal(user.login, render_current_user)
   end
 
   def test_current_user_is_nil_when_no_one_logged_in
     controller.instance_variable_set(:@user, nil)
 
-    assert_equal("nobody", render(CurrentUserReader.new))
+    assert_equal("nobody", render_current_user)
   end
 
   # `current_query` is a `register_value_helper`'d alias for
@@ -128,13 +136,13 @@ class BaseTest < ComponentTestCase
     query = ::Query.lookup_and_save(:Observation)
     controller.instance_variable_set(:@query, query)
 
-    assert_equal(query.id.to_s, render(CurrentQueryReader.new))
+    assert_equal(query.id.to_s, render_current_query)
   end
 
   def test_current_query_is_nil_when_no_query_on_controller
     controller.instance_variable_set(:@query, nil)
 
-    assert_equal("no-query", render(CurrentQueryReader.new))
+    assert_equal("no-query", render_current_query)
   end
 
   # `viewer_aware_unique_format_name` passes the viewer straight

--- a/test/components/button/crud_base_test.rb
+++ b/test/components/button/crud_base_test.rb
@@ -4,11 +4,8 @@ require("test_helper")
 
 class ButtonCRUDBaseTest < ComponentTestCase
   def test_basic_post_button
-    html = render(Components::Button::CRUDBase.new(
-                    name: "Submit",
-                    target: "/some/path",
-                    method: :post
-                  ))
+    html = render_crud_base(name: "Submit", target: "/some/path",
+                            method: :post)
 
     assert_html(html, "form[action='/some/path']")
     assert_html(html, "button", text: "Submit")
@@ -16,12 +13,8 @@ class ButtonCRUDBaseTest < ComponentTestCase
   end
 
   def test_patch_button_with_confirm
-    html = render(Components::Button::CRUDBase.new(
-                    name: "Remove",
-                    target: "/items/1/remove",
-                    method: :patch,
-                    confirm: "Are you sure?"
-                  ))
+    html = render_crud_base(name: "Remove", target: "/items/1/remove",
+                            method: :patch, confirm: "Are you sure?")
 
     assert_html(html, "form[action='/items/1/remove']")
     assert_html(html, "input[name='_method'][value='patch']")
@@ -31,13 +24,9 @@ class ButtonCRUDBaseTest < ComponentTestCase
 
   def test_delete_button_with_destroy_action
     herbarium = herbaria(:nybg_herbarium)
-    html = render(Components::Button::CRUDBase.new(
-                    name: "Destroy",
-                    target: herbarium,
-                    method: :delete,
-                    action: :destroy,
-                    confirm: "Are you sure?"
-                  ))
+    html = render_crud_base(name: "Destroy", target: herbarium,
+                            method: :delete, action: :destroy,
+                            confirm: "Are you sure?")
 
     # Should build path from model
     assert_html(html,
@@ -49,12 +38,8 @@ class ButtonCRUDBaseTest < ComponentTestCase
   end
 
   def test_button_with_icon
-    html = render(Components::Button::CRUDBase.new(
-                    name: "Remove",
-                    target: "/items/1",
-                    method: :patch,
-                    icon: :remove
-                  ))
+    html = render_crud_base(name: "Remove", target: "/items/1",
+                            method: :patch, icon: :remove)
 
     # Icon should be rendered
     assert_html(html, ".glyphicon")
@@ -64,22 +49,15 @@ class ButtonCRUDBaseTest < ComponentTestCase
 
   def test_raises_on_btn_class_in_class_kwarg
     assert_raises(ArgumentError) do
-      render(Components::Button::CRUDBase.new(
-               name: "Submit",
-               target: "/path",
-               method: :post,
-               class: "btn btn-primary"
-             ))
+      render_crud_base(name: "Submit", target: "/path", method: :post,
+                       class: "btn btn-primary")
     end
   end
 
   def test_button_with_model_target_builds_path_and_identifier
     herbarium = herbaria(:nybg_herbarium)
-    html = render(Components::Button::CRUDBase.new(
-                    name: "Update",
-                    target: herbarium,
-                    method: :patch
-                  ))
+    html = render_crud_base(name: "Update", target: herbarium,
+                            method: :patch)
 
     # Should build path: herbarium_path(herbarium.id) - method is separate
     assert_html(html,
@@ -89,17 +67,19 @@ class ButtonCRUDBaseTest < ComponentTestCase
   end
 
   def test_button_with_confirm_shows_title_and_button_name
-    html = render(Components::Button::CRUDBase.new(
-                    name: "Remove",
-                    target: "/items/1/remove",
-                    method: :patch,
-                    confirm: "Remove this item?"
-                  ))
+    html = render_crud_base(name: "Remove", target: "/items/1/remove",
+                            method: :patch, confirm: "Remove this item?")
 
     # confirm becomes both the turbo-confirm trigger and the dialog title
     assert_html(html, "[data-turbo-confirm]")
     assert_html(html, "[data-turbo-confirm-title]")
     assert_html(html, "[data-turbo-confirm-button='Remove']")
+  end
+
+  private
+
+  def render_crud_base(**)
+    render(Components::Button::CRUDBase.new(**))
   end
 end
 
@@ -122,9 +102,8 @@ class ButtonSubclassesTest < ComponentTestCase
 
   def test_delete_with_custom_name
     herbarium = herbaria(:nybg_herbarium)
-    html = render(
-      Components::Button::Delete.new(target: herbarium, name: "Delete it")
-    )
+    html = render_button(Components::Button::Delete,
+                         target: herbarium, name: "Delete it")
 
     assert_html(html, "button", text: "Delete it")
   end
@@ -133,7 +112,7 @@ class ButtonSubclassesTest < ComponentTestCase
   # renders the remove-circle glyphicon + sr-only label wrapper.
   def test_delete_default_icon
     herbarium = herbaria(:nybg_herbarium)
-    html = render(Components::Button::Delete.new(target: herbarium))
+    html = render_button(Components::Button::Delete, target: herbarium)
 
     assert_html(html, "button span.glyphicon-remove-circle")
     assert_html(html, "button span.sr-only")
@@ -143,9 +122,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # context-nav `[ DESTROY ]` text-link rendering path.
   def test_delete_icon_nil_opts_out
     herbarium = herbaria(:nybg_herbarium)
-    html = render(
-      Components::Button::Delete.new(target: herbarium, icon: nil)
-    )
+    html = render_button(Components::Button::Delete,
+                         target: herbarium, icon: nil)
 
     assert_no_html(html, "button span.glyphicon")
     assert_no_html(html, "button span.sr-only")
@@ -156,9 +134,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # Explicit icon override (e.g. `:remove`) wins over the default.
   def test_delete_icon_override
     herbarium = herbaria(:nybg_herbarium)
-    html = render(
-      Components::Button::Delete.new(target: herbarium, icon: :remove)
-    )
+    html = render_button(Components::Button::Delete,
+                         target: herbarium, icon: :remove)
 
     assert_html(html, "button span.glyphicon-remove-circle")
   end
@@ -166,7 +143,7 @@ class ButtonSubclassesTest < ComponentTestCase
   # Default renders the standard btn-default frame.
   def test_delete_default_btn_frame
     herbarium = herbaria(:nybg_herbarium)
-    html = render(Components::Button::Delete.new(target: herbarium))
+    html = render_button(Components::Button::Delete, target: herbarium)
 
     assert_html(html, "button.btn.btn-default")
     assert_html(html, "input[name='_method'][value='delete']")
@@ -177,9 +154,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # choice for CRUD index rows.
   def test_delete_outline_variant
     herbarium = herbaria(:nybg_herbarium)
-    html = render(
-      Components::Button::Delete.new(target: herbarium, variant: :outline)
-    )
+    html = render_button(Components::Button::Delete,
+                         target: herbarium, variant: :outline)
 
     assert_html(html, "button.btn.btn-outline-default")
   end
@@ -188,9 +164,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # dense table cells / list rows.
   def test_delete_strip_variant
     herbarium = herbaria(:nybg_herbarium)
-    html = render(
-      Components::Button::Delete.new(target: herbarium, variant: :strip)
-    )
+    html = render_button(Components::Button::Delete,
+                         target: herbarium, variant: :strip)
 
     assert_no_html(html, "button.btn-outline-default")
     assert_no_html(html, "button.btn")
@@ -203,9 +178,9 @@ class ButtonSubclassesTest < ComponentTestCase
   # delete button shape.
   def test_delete_size_kwarg
     herbarium = herbaria(:nybg_herbarium)
-    html = render(
-      Components::Button::Delete.new(target: herbarium,
-                                     variant: :outline, size: :sm)
+    html = render_button(
+      Components::Button::Delete, target: herbarium, variant: :outline,
+                                  size: :sm
     )
 
     assert_html(html, "button.btn.btn-outline-default.btn-sm")
@@ -216,9 +191,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # (text-danger, confirm, icon) still apply. `default_name` falls
   # back to `:destroy.ti` since there's no type to interpolate.
   def test_delete_with_string_target
-    html = render(
-      Components::Button::Delete.new(target: "/items/42", name: "Destroy")
-    )
+    html = render_button(Components::Button::Delete,
+                         target: "/items/42", name: "Destroy")
 
     assert_html(html, "form[action='/items/42']")
     assert_html(html, "input[name='_method'][value='delete']")
@@ -230,7 +204,7 @@ class ButtonSubclassesTest < ComponentTestCase
   # Edit default: GET + `edit_<type>_path` + icon `:edit`.
   def test_edit_with_model_target
     herbarium = herbaria(:nybg_herbarium)
-    html = render(Components::Button::Edit.new(target: herbarium))
+    html = render_button(Components::Button::Edit, target: herbarium)
 
     assert_html(html,
                 "a[href='#{routes.edit_herbarium_path(herbarium)}']")
@@ -245,9 +219,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # `icon: nil` opt-out for text-only edit links.
   def test_edit_icon_nil_opts_out
     herbarium = herbaria(:nybg_herbarium)
-    html = render(
-      Components::Button::Edit.new(target: herbarium, icon: nil)
-    )
+    html = render_button(Components::Button::Edit,
+                         target: herbarium, icon: nil)
 
     path = routes.edit_herbarium_path(herbarium)
     assert_html(html, "a[href='#{path}']",
@@ -260,7 +233,7 @@ class ButtonSubclassesTest < ComponentTestCase
   # Default renders the standard btn-default frame.
   def test_edit_default_btn_frame
     herbarium = herbaria(:nybg_herbarium)
-    html = render(Components::Button::Edit.new(target: herbarium))
+    html = render_button(Components::Button::Edit, target: herbarium)
 
     assert_html(html, "a.btn.btn-default")
   end
@@ -269,9 +242,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # choice for CRUD index rows.
   def test_edit_outline_variant
     herbarium = herbaria(:nybg_herbarium)
-    html = render(
-      Components::Button::Edit.new(target: herbarium, variant: :outline)
-    )
+    html = render_button(Components::Button::Edit,
+                         target: herbarium, variant: :outline)
 
     assert_html(html, "a.btn.btn-outline-default")
   end
@@ -279,9 +251,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # `variant: :strip` opt-out — icon-only inline edits in dense table rows.
   def test_edit_strip_variant
     herbarium = herbaria(:nybg_herbarium)
-    html = render(
-      Components::Button::Edit.new(target: herbarium, variant: :strip)
-    )
+    html = render_button(Components::Button::Edit,
+                         target: herbarium, variant: :strip)
 
     assert_no_html(html, "a.btn-outline-default")
     assert_no_html(html, "a.btn")
@@ -290,10 +261,9 @@ class ButtonSubclassesTest < ComponentTestCase
 
   # Edit with String target + explicit `class:` override.
   def test_edit_with_string_target_and_class
-    html = render(Components::Button::Edit.new(
-                    target: "/items/42/edit", name: "Edit it",
-                    variant: :link
-                  ))
+    html = render_button(Components::Button::Edit,
+                         target: "/items/42/edit", name: "Edit it",
+                         variant: :link)
 
     assert_html(html, "a.btn.btn-link[href='/items/42/edit']")
     assert_html(html, "a span.glyphicon-edit")
@@ -304,9 +274,7 @@ class ButtonSubclassesTest < ComponentTestCase
   # falls back to the generic `:edit.ti` instead of
   # `:edit_object.t(type: …)`.
   def test_edit_with_string_target_default_name
-    html = render(
-      Components::Button::Edit.new(target: "/items/42/edit")
-    )
+    html = render_button(Components::Button::Edit, target: "/items/42/edit")
 
     assert_html(html, "a span.sr-only", text: :edit.ti)
   end
@@ -318,10 +286,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # should pass an explicit `name:`.
   def test_new_with_string_target_and_icon
     path = routes.new_herbarium_path
-    html = render(Components::Button::New.new(
-                    target: path,
-                    name: :new_object.t(type: :herbarium)
-                  ))
+    html = render_button(Components::Button::New,
+                         target: path, name: :new_object.t(type: :herbarium))
 
     assert_html(html, "a[href='#{path}']")
     assert_no_html(html, "form")
@@ -334,11 +300,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # `icon: nil` opt-out: text-only new links.
   def test_new_icon_nil_opts_out
     path = routes.new_herbarium_path
-    html = render(
-      Components::Button::New.new(
-        target: path, name: "New Herbarium", icon: nil
-      )
-    )
+    html = render_button(Components::Button::New,
+                         target: path, name: "New Herbarium", icon: nil)
 
     assert_html(html, "a[href='#{path}']", text: "New Herbarium")
     assert_no_html(html, "a span.glyphicon")
@@ -348,30 +311,25 @@ class ButtonSubclassesTest < ComponentTestCase
 
   # Default renders the standard btn-default frame.
   def test_new_default_btn_frame
-    html = render(
-      Components::Button::New.new(target: routes.new_herbarium_path)
-    )
+    html = render_button(Components::Button::New,
+                         target: routes.new_herbarium_path)
 
     assert_html(html, "a.btn.btn-default")
   end
 
   # `variant: :outline` produces the outline button frame.
   def test_new_outline_variant
-    html = render(
-      Components::Button::New.new(
-        target: routes.new_herbarium_path,
-        variant: :outline
-      )
-    )
+    html = render_button(Components::Button::New,
+                         target: routes.new_herbarium_path,
+                         variant: :outline)
 
     assert_html(html, "a.btn.btn-outline-default")
   end
 
   # Generic `:add.ti` fallback when no `name:` is supplied.
   def test_new_default_name_add_l
-    html = render(
-      Components::Button::New.new(target: routes.new_herbarium_path)
-    )
+    html = render_button(Components::Button::New,
+                         target: routes.new_herbarium_path)
 
     assert_html(html, "a span.sr-only", text: :add.ti)
   end
@@ -386,7 +344,7 @@ class ButtonSubclassesTest < ComponentTestCase
   def test_download_with_explicit_path
     species_list = species_lists(:first_species_list)
     path = routes.new_download_species_list_path(id: species_list.id)
-    html = render(Components::Button::Download.new(target: path))
+    html = render_button(Components::Button::Download, target: path)
 
     assert_html(html, "a[href='#{path}']")
     assert_no_html(html, "form")
@@ -397,9 +355,8 @@ class ButtonSubclassesTest < ComponentTestCase
   # Post: form, no `_method` field (POST is default), no confirm,
   # button body is the name verbatim.
   def test_post
-    html = render(
-      Components::Button::Post.new(name: "Create", target: "/items")
-    )
+    html = render_button(Components::Button::Post,
+                         name: "Create", target: "/items")
 
     assert_html(html, "form[action='/items']")
     assert_no_html(html, "input[name='_method']")
@@ -410,9 +367,10 @@ class ButtonSubclassesTest < ComponentTestCase
   # Put + confirm: form action, `_method=put`, turbo-confirm title
   # and button data, body text.
   def test_put_with_confirm
-    html = render(Components::Button::Put.new(
-                    name: "Replace", target: "/items/1", confirm: "Sure?"
-                  ))
+    html = render_button(
+      Components::Button::Put, name: "Replace", target: "/items/1",
+                               confirm: "Sure?"
+    )
 
     assert_html(html, "form[action='/items/1']")
     assert_html(html, "input[name='_method'][value='put']")
@@ -424,18 +382,17 @@ class ButtonSubclassesTest < ComponentTestCase
 
   # Post defaults to `btn btn-default`.
   def test_post_default_btn_frame
-    html = render(
-      Components::Button::Post.new(name: "Submit", target: "/items")
-    )
+    html = render_button(Components::Button::Post,
+                         name: "Submit", target: "/items")
 
     assert_html(html, "button.btn.btn-default")
   end
 
   # Explicit `variant:` overrides the default.
   def test_post_variant_override
-    html = render(
-      Components::Button::Post.new(name: "Submit", target: "/items",
-                                   variant: :primary)
+    html = render_button(
+      Components::Button::Post, name: "Submit", target: "/items",
+                                variant: :primary
     )
 
     assert_html(html, "button.btn.btn-primary")
@@ -444,9 +401,9 @@ class ButtonSubclassesTest < ComponentTestCase
 
   # `variant: :strip` suppresses the frame entirely (icon-only inline buttons).
   def test_post_variant_nil_suppresses_frame
-    html = render(
-      Components::Button::Post.new(name: "Submit", target: "/items",
-                                   variant: :strip)
+    html = render_button(
+      Components::Button::Post, name: "Submit", target: "/items",
+                                variant: :strip
     )
 
     assert_no_html(html, "button.btn")
@@ -454,18 +411,17 @@ class ButtonSubclassesTest < ComponentTestCase
 
   # Patch defaults to `btn btn-default`.
   def test_patch_default_btn_frame
-    html = render(
-      Components::Button::Patch.new(name: "Update", target: "/items/1")
-    )
+    html = render_button(Components::Button::Patch,
+                         name: "Update", target: "/items/1")
 
     assert_html(html, "button.btn.btn-default")
   end
 
   # `variant: :strip` suppresses the frame (icon-only / inline patches).
   def test_patch_strip_suppresses_frame
-    html = render(
-      Components::Button::Patch.new(name: "Update", target: "/items/1",
-                                    variant: :strip)
+    html = render_button(
+      Components::Button::Patch, name: "Update", target: "/items/1",
+                                 variant: :strip
     )
 
     assert_no_html(html, "button.btn")
@@ -473,18 +429,17 @@ class ButtonSubclassesTest < ComponentTestCase
 
   # Put defaults to `btn btn-default`.
   def test_put_default_btn_frame
-    html = render(
-      Components::Button::Put.new(name: "Replace", target: "/items/1")
-    )
+    html = render_button(Components::Button::Put,
+                         name: "Replace", target: "/items/1")
 
     assert_html(html, "button.btn.btn-default")
   end
 
   # `variant: :strip` suppresses the frame (icon-only / inline puts).
   def test_put_strip_suppresses_frame
-    html = render(
-      Components::Button::Put.new(name: "Replace", target: "/items/1",
-                                  variant: :strip)
+    html = render_button(
+      Components::Button::Put, name: "Replace", target: "/items/1",
+                               variant: :strip
     )
 
     assert_no_html(html, "button.btn")
@@ -492,10 +447,10 @@ class ButtonSubclassesTest < ComponentTestCase
 
   # Patch with `variant:` override: form, `_method=patch`, variant applied.
   def test_patch_with_variant_override
-    html = render(Components::Button::Patch.new(
-                    name: "Update", target: "/items/1",
-                    variant: :primary
-                  ))
+    html = render_button(
+      Components::Button::Patch, name: "Update", target: "/items/1",
+                                 variant: :primary
+    )
 
     assert_html(html, "form[action='/items/1']")
     assert_html(html, "input[name='_method'][value='patch']")
@@ -507,10 +462,8 @@ class ButtonSubclassesTest < ComponentTestCase
 
   def test_get_button_renders_anchor_with_btn_default
     herbarium = herbaria(:nybg_herbarium)
-    html = render(Components::Button::Get.new(
-                    name: "View",
-                    target: herbarium
-                  ))
+    html = render_button(Components::Button::Get,
+                         name: "View", target: herbarium)
 
     expected_href = routes.herbarium_path(herbarium)
     assert_html(html, "a.btn.btn-default[href='#{expected_href}']",
@@ -519,11 +472,12 @@ class ButtonSubclassesTest < ComponentTestCase
   end
 
   def test_get_button_with_string_target
-    html = render(Components::Button::Get.new(
-                    name: "Merge",
-                    target: routes.herbaria_path(merge: 42),
-                    variant: :strip
-                  ))
+    html = render_button(
+      Components::Button::Get,
+      name: "Merge",
+      target: routes.herbaria_path(merge: 42),
+      variant: :strip
+    )
 
     # `variant: :strip` → no btn classes; still an anchor with the path
     assert_html(html, "a[href*='merge=42']", text: "Merge")
@@ -531,11 +485,8 @@ class ButtonSubclassesTest < ComponentTestCase
   end
 
   def test_get_button_accepts_size
-    html = render(Components::Button::Get.new(
-                    name: "Edit",
-                    target: "/foo",
-                    size: :sm
-                  ))
+    html = render_button(Components::Button::Get,
+                         name: "Edit", target: "/foo", size: :sm)
 
     assert_html(html, "a.btn-sm[href='/foo']")
   end
@@ -543,11 +494,9 @@ class ButtonSubclassesTest < ComponentTestCase
   # --- Button::ModalToggle ------------------------------------------
 
   def test_modal_toggle_renders_anchor_with_stimulus_data
-    html = render(Components::Button::ModalToggle.new(
-                    name: "Open Trust Settings",
-                    target: "/trust/path",
-                    modal_id: "trust_settings"
-                  ))
+    html = render_button(Components::Button::ModalToggle,
+                         name: "Open Trust Settings",
+                         target: "/trust/path", modal_id: "trust_settings")
 
     assert_html(html,
                 "a[data-controller='modal-toggle']" \
@@ -558,12 +507,13 @@ class ButtonSubclassesTest < ComponentTestCase
   end
 
   def test_modal_toggle_plain_text_style
-    html = render(Components::Button::ModalToggle.new(
-                    name: "Edit",
-                    target: "/edit/path",
-                    modal_id: "comment",
-                    variant: :strip
-                  ))
+    html = render_button(
+      Components::Button::ModalToggle,
+      name: "Edit",
+      target: "/edit/path",
+      modal_id: "comment",
+      variant: :strip
+    )
 
     assert_html(html, "a[data-controller='modal-toggle'][href='/edit/path']")
     assert_no_html(html, "a.btn-default")
@@ -572,12 +522,9 @@ class ButtonSubclassesTest < ComponentTestCase
   # --- Button::CollapseToggle -------------------------------------------
 
   def test_collapse_toggle_renders_button_with_state_spans
-    html = render(Components::Button::CollapseToggle.new(
-                    target_id: "map_div",
-                    open_text: "Hide Map",
-                    closed_text: "Open Map",
-                    collapsed: true
-                  ))
+    html = render_button(Components::Button::CollapseToggle,
+                         target_id: "map_div", open_text: "Hide Map",
+                         closed_text: "Open Map", collapsed: true)
 
     assert_html(html, "button[type='button'][data-toggle='collapse']" \
                       "[data-target='#map_div']")
@@ -588,10 +535,8 @@ class ButtonSubclassesTest < ComponentTestCase
   end
 
   def test_collapse_toggle_accepts_extra_class
-    html = render(Components::Button::CollapseToggle.new(
-                    target_id: "map_div",
-                    class: "map-toggle"
-                  ))
+    html = render_button(Components::Button::CollapseToggle,
+                         target_id: "map_div", class: "map-toggle")
 
     assert_html(html, "button.map-toggle")
   end
@@ -599,13 +544,20 @@ class ButtonSubclassesTest < ComponentTestCase
   # `params:` threads hidden fields into the generated form so callers
   # can dispatch multiple actions to one endpoint without separate routes.
   def test_params_adds_hidden_fields_to_form
-    html = render(Components::Button::Put.new(
-                    name: "Exclude",
-                    target: "/projects/1/violations",
-                    params: { project: { do: "exclude", obs_id: 42 } }
-                  ))
+    html = render_button(
+      Components::Button::Put,
+      name: "Exclude",
+      target: "/projects/1/violations",
+      params: { project: { do: "exclude", obs_id: 42 } }
+    )
 
     assert_html(html, "form input[name='project[do]'][value='exclude']")
     assert_html(html, "form input[name='project[obs_id]'][value='42']")
+  end
+
+  private
+
+  def render_button(klass, **)
+    render(klass.new(**))
   end
 end

--- a/test/components/button/external_test.rb
+++ b/test/components/button/external_test.rb
@@ -4,10 +4,8 @@ require("test_helper")
 
 class Components::Button::ExternalTest < ComponentTestCase
   def test_renders_btn_default_with_external_attrs
-    html = render(Components::Button::External.new(
-                    name: "BLAST it",
-                    url: "https://blast.ncbi.nlm.nih.gov"
-                  ))
+    html = render_external(name: "BLAST it",
+                           url: "https://blast.ncbi.nlm.nih.gov")
 
     assert_html(html,
                 "a[href='https://blast.ncbi.nlm.nih.gov']",
@@ -16,32 +14,28 @@ class Components::Button::ExternalTest < ComponentTestCase
   end
 
   def test_accepts_style_override
-    html = render(Components::Button::External.new(
-                    name: "Go",
-                    url: "https://example.com",
-                    variant: :link
-                  ))
+    html = render_external(name: "Go", url: "https://example.com",
+                           variant: :link)
 
     assert_html(html, "a[target='_blank'][rel='noopener noreferrer']")
   end
 
   def test_accepts_size
-    html = render(Components::Button::External.new(
-                    name: "Go",
-                    url: "https://example.com",
-                    size: :sm
-                  ))
+    html = render_external(name: "Go", url: "https://example.com", size: :sm)
 
     assert_html(html, "a[target='_blank']")
   end
 
   def test_href_matches_url_kwarg
     url = "https://hobix.com/textile"
-    html = render(Components::Button::External.new(
-                    name: "Textile Docs",
-                    url: url
-                  ))
+    html = render_external(name: "Textile Docs", url: url)
 
     assert_html(html, "a[href='#{url}']")
+  end
+
+  private
+
+  def render_external(**)
+    render(Components::Button::External.new(**))
   end
 end

--- a/test/components/button/project_test.rb
+++ b/test/components/button/project_test.rb
@@ -4,9 +4,7 @@ require("test_helper")
 
 class Components::ProjectButtonTest < ComponentTestCase
   def test_renders_a_get_button_with_the_supplied_name_and_target
-    html = render(
-      Components::Button::Project.new(name: "Map", target: "/some/path")
-    )
+    html = render_button
 
     # Renders a Button::Get → plain anchor link.
     assert_html(html, "a[href='/some/path']", text: "Map")
@@ -18,10 +16,14 @@ class Components::ProjectButtonTest < ComponentTestCase
   # exception for styling-abstraction components), assert on the
   # class set this component is supposed to emit.
   def test_renders_btn_default_at_btn_lg_size_with_row_spacing
-    html = render(
-      Components::Button::Project.new(name: "Map", target: "/some/path")
-    )
+    html = render_button
 
     assert_html(html, "a.btn.btn-default.btn-lg.my-3.mr-3[href='/some/path']")
+  end
+
+  private
+
+  def render_button
+    render(Components::Button::Project.new(name: "Map", target: "/some/path"))
   end
 end

--- a/test/components/button/submit_test.rb
+++ b/test/components/button/submit_test.rb
@@ -4,52 +4,46 @@ require("test_helper")
 
 class Components::Button::SubmitTest < ComponentTestCase
   def test_renders_button_with_submit_type_and_default_style
-    html = render(Components::Button::Submit.new(name: "Save"))
+    html = render_submit(name: "Save")
 
     assert_html(html, "button[type='submit'].btn.btn-default", text: "Save")
   end
 
   def test_default_disable_with_matches_name
-    html = render(Components::Button::Submit.new(name: "Save"))
+    html = render_submit(name: "Save")
 
     assert_html(html, "button[data-disable-with='Save']")
   end
 
   def test_explicit_disable_with_overrides_name
-    html = render(Components::Button::Submit.new(
-                    name: "Save",
-                    disable_with: "Saving…"
-                  ))
+    html = render_submit(name: "Save", disable_with: "Saving…")
 
     assert_html(html, "button[data-disable-with='Saving…']")
     assert_no_html(html, "button[data-disable-with='Save']")
   end
 
   def test_submits_with_emits_turbo_data_attr
-    html = render(Components::Button::Submit.new(
-                    name: "Save",
-                    submits_with: "Saving…"
-                  ))
+    html = render_submit(name: "Save", submits_with: "Saving…")
 
     assert_html(html, "button[data-turbo-submits-with='Saving…']")
   end
 
   def test_accepts_variant_override
-    html = render(Components::Button::Submit.new(
-                    name: "Create",
-                    variant: :primary
-                  ))
+    html = render_submit(name: "Create", variant: :primary)
 
     assert_html(html, "button[type='submit'].btn-primary")
     assert_no_html(html, "button.btn-default")
   end
 
   def test_accepts_size
-    html = render(Components::Button::Submit.new(
-                    name: "Go",
-                    size: :sm
-                  ))
+    html = render_submit(name: "Go", size: :sm)
 
     assert_html(html, "button.btn.btn-default.btn-sm[type='submit']")
+  end
+
+  private
+
+  def render_submit(**)
+    render(Components::Button::Submit.new(**))
   end
 end

--- a/test/components/button_test.rb
+++ b/test/components/button_test.rb
@@ -127,11 +127,10 @@ class Components::ButtonDispatcherTest < ComponentTestCase
   # ---- type: :post / :put / :patch / :delete -------------------------
 
   def test_type_post_emits_post_form_with_submit
-    html = render(Components::Button.new(
-                    type: :post,
-                    name: "Join",
-                    target: routes.herbarium_path(id: @herbarium.id)
-                  ))
+    html = render_dispatch(
+      type: :post, name: "Join",
+      target: routes.herbarium_path(id: @herbarium.id)
+    )
 
     assert_html(html, "form[method='post']")
     assert_html(html, "button[type='submit']", text: "Join")
@@ -139,32 +138,27 @@ class Components::ButtonDispatcherTest < ComponentTestCase
   end
 
   def test_type_put_emits_hidden_method_put
-    html = render(Components::Button.new(
-                    type: :put,
-                    name: "Save",
-                    target: routes.herbarium_path(id: @herbarium.id)
-                  ))
+    html = render_dispatch(
+      type: :put, name: "Save",
+      target: routes.herbarium_path(id: @herbarium.id)
+    )
 
     assert_html(html, "input[name='_method'][value='put']")
     assert_html(html, "button[type='submit']", text: "Save")
   end
 
   def test_type_patch_emits_hidden_method_patch
-    html = render(Components::Button.new(
-                    type: :patch,
-                    name: "Update",
-                    target: routes.herbarium_path(id: @herbarium.id)
-                  ))
+    html = render_dispatch(
+      type: :patch, name: "Update",
+      target: routes.herbarium_path(id: @herbarium.id)
+    )
 
     assert_html(html, "input[name='_method'][value='patch']")
     assert_html(html, "button[type='submit']", text: "Update")
   end
 
   def test_type_delete_emits_hidden_method_delete
-    html = render(Components::Button.new(
-                    type: :delete,
-                    target: @herbarium
-                  ))
+    html = render_dispatch(type: :delete, target: @herbarium)
 
     assert_html(html, "input[name='_method'][value='delete']")
     assert_html(html, "button[type='submit']")
@@ -174,18 +168,14 @@ class Components::ButtonDispatcherTest < ComponentTestCase
 
   def test_type_get_renders_anchor_to_target
     path = routes.herbarium_path(id: @herbarium.id)
-    html = render(Components::Button.new(
-                    type: :get, name: "Show", target: path
-                  ))
+    html = render_dispatch(type: :get, name: "Show", target: path)
 
     assert_html(html, "a[href='#{path}']", text: "Show")
     assert_no_html(html, "form")
   end
 
   def test_type_edit_links_to_edit_path_with_edit_icon
-    html = render(Components::Button.new(
-                    type: :edit, target: @herbarium
-                  ))
+    html = render_dispatch(type: :edit, target: @herbarium)
 
     expected = routes.edit_herbarium_path(id: @herbarium.id)
     assert_html(html, "a[href='#{expected}']")
@@ -194,11 +184,7 @@ class Components::ButtonDispatcherTest < ComponentTestCase
 
   def test_type_new_links_to_provided_path_with_add_icon
     path = routes.new_herbarium_path
-    html = render(Components::Button.new(
-                    type: :new,
-                    target: path,
-                    name: "New herbarium"
-                  ))
+    html = render_dispatch(type: :new, target: path, name: "New herbarium")
 
     assert_html(html, "a[href='#{path}']", text: "New herbarium")
     assert_html(html, "a span.glyphicon")
@@ -208,9 +194,7 @@ class Components::ButtonDispatcherTest < ComponentTestCase
     path = routes.new_download_species_list_path(
       id: species_lists(:first_species_list).id
     )
-    html = render(Components::Button.new(
-                    type: :download, target: path
-                  ))
+    html = render_dispatch(type: :download, target: path)
 
     assert_html(html, "a[href='#{path}']")
     assert_html(html, "a span.glyphicon")
@@ -219,18 +203,15 @@ class Components::ButtonDispatcherTest < ComponentTestCase
   # ---- type: :submit ---------------------------------------------------
 
   def test_type_submit_renders_button_with_submit_type
-    html = render(Components::Button.new(type: :submit, name: "Go"))
+    html = render_dispatch(type: :submit, name: "Go")
 
     assert_html(html, "button[type='submit']", text: "Go")
     assert_no_html(html, "form")
   end
 
   def test_type_submit_passes_submits_with_kwarg
-    html = render(Components::Button.new(
-                    type: :submit,
-                    name: "Save",
-                    submits_with: "Saving…"
-                  ))
+    html = render_dispatch(type: :submit, name: "Save",
+                           submits_with: "Saving…")
 
     assert_html(html,
                 "button[type='submit']" \
@@ -241,9 +222,7 @@ class Components::ButtonDispatcherTest < ComponentTestCase
 
   def test_type_external_opens_in_new_tab_with_noopener
     url = "https://blast.ncbi.nlm.nih.gov"
-    html = render(Components::Button.new(
-                    type: :external, name: "BLAST", url: url
-                  ))
+    html = render_dispatch(type: :external, name: "BLAST", url: url)
 
     assert_html(html,
                 "a[href='#{url}']" \
@@ -259,12 +238,8 @@ class Components::ButtonDispatcherTest < ComponentTestCase
       project_id: @project.id,
       candidate: users(:rolf).id
     )
-    html = render(Components::Button.new(
-                    type: :modal,
-                    name: "Trust settings",
-                    target: path,
-                    modal_id: "trust_settings"
-                  ))
+    html = render_dispatch(type: :modal, name: "Trust settings",
+                           target: path, modal_id: "trust_settings")
 
     assert_html(html, "a[href='#{path}']", text: "Trust settings")
     assert_html(html, "a[data-modal='modal_trust_settings']")
@@ -276,13 +251,9 @@ class Components::ButtonDispatcherTest < ComponentTestCase
   # ---- type: :collapse_toggle ------------------------------------------
 
   def test_type_collapse_toggle_renders_two_state_spans
-    html = render(Components::Button.new(
-                    type: :collapse_toggle,
-                    target_id: "map_div",
-                    open_text: "Hide map",
-                    closed_text: "Open map",
-                    collapsed: true
-                  ))
+    html = render_dispatch(type: :collapse_toggle, target_id: "map_div",
+                           open_text: "Hide map", closed_text: "Open map",
+                           collapsed: true)
 
     assert_html(html, "button[type='button'][data-toggle='collapse']" \
                       "[data-target='#map_div']")
@@ -297,27 +268,18 @@ class Components::ButtonDispatcherTest < ComponentTestCase
   # Components::IconWithText's own render_icon_text, never in
   # CollapseContent's spans).
   def test_type_collapse_toggle_with_icon_has_text_gap
-    html = render(Components::Button.new(
-                    type: :collapse_toggle,
-                    target_id: "map_div",
-                    open_text: "Hide map",
-                    closed_text: "Show map",
-                    icon: :globe,
-                    collapsed: true
-                  ))
+    html = render_dispatch(type: :collapse_toggle, target_id: "map_div",
+                           open_text: "Hide map", closed_text: "Show map",
+                           icon: :globe, collapsed: true)
 
     assert_html(html, "button span.collapse-toggle-open.icon-text-gap")
     assert_html(html, "button span.collapse-toggle-closed.icon-text-gap")
   end
 
   def test_type_collapse_toggle_without_icon_has_no_text_gap
-    html = render(Components::Button.new(
-                    type: :collapse_toggle,
-                    target_id: "map_div",
-                    open_text: "Hide map",
-                    closed_text: "Show map",
-                    collapsed: true
-                  ))
+    html = render_dispatch(type: :collapse_toggle, target_id: "map_div",
+                           open_text: "Hide map", closed_text: "Show map",
+                           collapsed: true)
 
     assert_no_html(html, ".icon-text-gap")
   end
@@ -326,11 +288,8 @@ class Components::ButtonDispatcherTest < ComponentTestCase
 
   def test_type_project_dispatches_to_project_with_lg_size
     path = routes.checklist_path(project_id: @project.id)
-    html = render(Components::Button.new(
-                    type: :project,
-                    name: "View checklist",
-                    target: path
-                  ))
+    html = render_dispatch(type: :project, name: "View checklist",
+                           target: path)
 
     assert_html(html, "a[href='#{path}']", text: "View checklist")
     assert_html(html, "a.btn-lg")
@@ -347,10 +306,7 @@ class Components::ButtonDispatcherTest < ComponentTestCase
   # ---- plain button (no dispatch) --------------------------------------
 
   def test_no_type_renders_plain_button_element
-    html = render(Components::Button.new(
-                    name: "Cancel",
-                    data: { dismiss: "modal" }
-                  ))
+    html = render_dispatch(name: "Cancel", data: { dismiss: "modal" })
 
     assert_html(html, "button[type='button'][data-dismiss='modal']",
                 text: "Cancel")
@@ -360,32 +316,23 @@ class Components::ButtonDispatcherTest < ComponentTestCase
   # ---- variant/size flow through dispatcher ----------------------------
 
   def test_delete_with_string_target_uses_destroy_label
-    html = render(Components::Button.new(type: :delete,
-                                         target: "/items/1/delete",
-                                         name: nil))
+    html = render_dispatch(type: :delete, target: "/items/1/delete",
+                           name: nil)
 
     assert_html(html, "form[action='/items/1/delete']")
     assert_html(html, "button[type='submit']", text: :destroy.ti)
   end
 
   def test_variant_passes_through_mutation_dispatch
-    html = render(Components::Button.new(
-                    type: :delete,
-                    target: @herbarium,
-                    variant: :danger
-                  ))
+    html = render_dispatch(type: :delete, target: @herbarium,
+                           variant: :danger)
 
     assert_html(html, "button[type='submit'].btn-danger")
   end
 
   def test_size_passes_through_get_dispatch
     path = routes.herbarium_path(id: @herbarium.id)
-    html = render(Components::Button.new(
-                    type: :get,
-                    name: "Show",
-                    target: path,
-                    size: :sm
-                  ))
+    html = render_dispatch(type: :get, name: "Show", target: path, size: :sm)
 
     assert_html(html, "a.btn-sm[href='#{path}']")
   end
@@ -413,5 +360,11 @@ class Components::ButtonDispatcherTest < ComponentTestCase
         span(class: "block-sentinel") { plain("from block") }
       end
     end
+  end
+
+  private
+
+  def render_dispatch(**, &block)
+    render(Components::Button.new(**), &block)
   end
 end

--- a/test/components/carousel/item_test.rb
+++ b/test/components/carousel/item_test.rb
@@ -17,9 +17,7 @@ class Components::Carousel::ItemTest < ComponentTestCase
   # thread through to `obs:`, or the caption silently falls back to
   # the image-only branch on every carousel-driven lightbox.
   def test_observation_object_threads_into_lightbox_caption
-    html = render(Components::Carousel::Item.new(
-                    user: @user, image: @image, object: @obs
-                  ))
+    html = render_item(object: @obs)
 
     caption = Nokogiri::HTML5.fragment(html).at_css(".lightbox-caption")
     assert_includes(caption.to_html, "obs-what")
@@ -32,11 +30,15 @@ class Components::Carousel::ItemTest < ComponentTestCase
   def test_non_observation_object_does_not_thread_into_obs
     location = locations(:burbank)
 
-    html = render(Components::Carousel::Item.new(
-                    user: @user, image: @image, object: location
-                  ))
+    html = render_item(object: location)
 
     caption = Nokogiri::HTML5.fragment(html).at_css(".lightbox-caption")
     assert_not_includes(caption.to_html, "obs-what")
+  end
+
+  private
+
+  def render_item(**)
+    render(Components::Carousel::Item.new(user: @user, image: @image, **))
   end
 end

--- a/test/components/carousel_test.rb
+++ b/test/components/carousel_test.rb
@@ -34,13 +34,13 @@ class CarouselTest < ComponentTestCase
   # Slides are rendered inside `.carousel-inner`; thumbs inside the
   # indicator `<ol>`. First registration of each gets `.active`.
   def test_renders_slides_and_thumbs_in_their_wrappers
-    html = render(Harness.new(
-                    carousel_args: { carousel_id: "test_carousel" },
-                    slides: [{ id: "slide_1", content: "SLIDE_ONE" },
-                             { id: "slide_2", content: "SLIDE_TWO" }],
-                    thumbs: [{ id: "thumb_1", content: "THUMB_ONE" },
-                             { id: "thumb_2", content: "THUMB_TWO" }]
-                  ))
+    html = render_carousel(
+      carousel_args: { carousel_id: "test_carousel" },
+      slides: [{ id: "slide_1", content: "SLIDE_ONE" },
+               { id: "slide_2", content: "SLIDE_TWO" }],
+      thumbs: [{ id: "thumb_1", content: "THUMB_ONE" },
+               { id: "thumb_2", content: "THUMB_TWO" }]
+    )
 
     assert_html(html, "div.carousel.slide[id='test_carousel']" \
                       "[data-ride='false'][data-interval='false']")
@@ -59,11 +59,11 @@ class CarouselTest < ComponentTestCase
 
   # `class:` on item / thumb is composed onto the wrapper's class list.
   def test_item_and_thumb_classes_are_composed
-    html = render(Harness.new(
-                    carousel_args: { carousel_id: "c" },
-                    slides: [{ class: "carousel-item", content: "S" }],
-                    thumbs: [{ class: "mr-2", content: "T" }]
-                  ))
+    html = render_carousel(
+      carousel_args: { carousel_id: "c" },
+      slides: [{ class: "carousel-item", content: "S" }],
+      thumbs: [{ class: "mr-2", content: "T" }]
+    )
 
     assert_html(html, "div.item.carousel-item.active", text: "S")
     assert_html(html, "li.carousel-indicator.mx-1.mr-2.active", text: "T")
@@ -72,12 +72,12 @@ class CarouselTest < ComponentTestCase
   # Caller-supplied `data:` merges with the primitive's auto-filled
   # `data-target` / `data-slide-to`.
   def test_thumb_data_merges_with_auto_target_and_slide_to
-    html = render(Harness.new(
-                    carousel_args: { carousel_id: "c" },
-                    thumbs: [{ data: { form_images_target: "thumbnail",
-                                       image_uuid: "42" },
-                               content: "T" }]
-                  ))
+    html = render_carousel(
+      carousel_args: { carousel_id: "c" },
+      thumbs: [{ data: { form_images_target: "thumbnail",
+                         image_uuid: "42" },
+                 content: "T" }]
+    )
 
     assert_html(html, "li.carousel-indicator[data-target='#c']" \
                       "[data-slide-to='0']" \
@@ -89,18 +89,18 @@ class CarouselTest < ComponentTestCase
   # `inner_class_extra` decorate the `.carousel-inner` div. `indicators_id`
   # / `indicators_class_extra` decorate the indicator `<ol>`.
   def test_id_and_class_extras_are_applied
-    html = render(Harness.new(
-                    carousel_args: {
-                      carousel_id: "obs_carousel",
-                      wrapper_class: "image-form-carousel",
-                      inner_id: "added_images",
-                      inner_class_extra: "form-inner",
-                      indicators_id: "added_thumbnails",
-                      indicators_class_extra: "d-none"
-                    },
-                    slides: [{ content: "s" }],
-                    thumbs: [{ content: "t" }]
-                  ))
+    html = render_carousel(
+      carousel_args: {
+        carousel_id: "obs_carousel",
+        wrapper_class: "image-form-carousel",
+        inner_id: "added_images",
+        inner_class_extra: "form-inner",
+        indicators_id: "added_thumbnails",
+        indicators_class_extra: "d-none"
+      },
+      slides: [{ content: "s" }],
+      thumbs: [{ content: "t" }]
+    )
 
     assert_html(html, "div.carousel.slide.image-form-carousel")
     assert_html(html, "div.carousel-inner.bg-light.form-inner" \
@@ -112,13 +112,13 @@ class CarouselTest < ComponentTestCase
   # `extra_data` merges into the outer div's `data-*` attributes,
   # alongside the always-emitted `data-ride` / `data-interval` pair.
   def test_extra_data_merges_into_outer_data_attributes
-    html = render(Harness.new(
-                    carousel_args: {
-                      carousel_id: "wire_test",
-                      extra_data: { form_images_target: "carousel" }
-                    },
-                    slides: [{ content: "s" }]
-                  ))
+    html = render_carousel(
+      carousel_args: {
+        carousel_id: "wire_test",
+        extra_data: { form_images_target: "carousel" }
+      },
+      slides: [{ content: "s" }]
+    )
 
     assert_html(html, "div.carousel[data-form-images-target='carousel']")
   end
@@ -128,8 +128,8 @@ class CarouselTest < ComponentTestCase
   # `controls_wrap_class` prop, when set, wraps Controls in a div with
   # that class (Form::UploadGallery uses `carousel-control-wrap row`).
   def test_controls_render_inline_by_default
-    html = render(Harness.new(carousel_args: { carousel_id: "c" },
-                              slides: [{ content: "s" }]))
+    html = render_carousel(carousel_args: { carousel_id: "c" },
+                           slides: [{ content: "s" }])
 
     assert_html(html, "div.carousel-inner a.left.carousel-control")
     assert_html(html, "div.carousel-inner a.right.carousel-control")
@@ -137,13 +137,13 @@ class CarouselTest < ComponentTestCase
   end
 
   def test_controls_can_be_wrapped_in_a_named_div
-    html = render(Harness.new(
-                    carousel_args: {
-                      carousel_id: "c",
-                      controls_wrap_class: "carousel-control-wrap row"
-                    },
-                    slides: [{ content: "s" }]
-                  ))
+    html = render_carousel(
+      carousel_args: {
+        carousel_id: "c",
+        controls_wrap_class: "carousel-control-wrap row"
+      },
+      slides: [{ content: "s" }]
+    )
 
     assert_html(html, "div.carousel-inner " \
                       "div.carousel-control-wrap.row " \
@@ -153,10 +153,10 @@ class CarouselTest < ComponentTestCase
   # `show_controls: false` suppresses the prev/next strip entirely
   # (`ImageGallery` passes this when there's only one image).
   def test_show_controls_false_suppresses_controls
-    html = render(Harness.new(
-                    carousel_args: { carousel_id: "c", show_controls: false },
-                    slides: [{ content: "s" }]
-                  ))
+    html = render_carousel(
+      carousel_args: { carousel_id: "c", show_controls: false },
+      slides: [{ content: "s" }]
+    )
 
     assert_no_html(html, "a.carousel-control")
   end
@@ -166,12 +166,12 @@ class CarouselTest < ComponentTestCase
   # (and the first slide stops being active). `Matrix::Carousel` uses
   # this for its `top_img` semantics.
   def test_explicit_active_kwarg_overrides_default_first_active
-    html = render(Harness.new(
-                    carousel_args: { carousel_id: "c" },
-                    slides: [{ id: "s1", content: "first" },
-                             { id: "s2", active: true, content: "second" },
-                             { id: "s3", content: "third" }]
-                  ))
+    html = render_carousel(
+      carousel_args: { carousel_id: "c" },
+      slides: [{ id: "s1", content: "first" },
+               { id: "s2", active: true, content: "second" },
+               { id: "s3", content: "third" }]
+    )
 
     assert_html(html, "div.item.active[id='s2']", text: "second")
     assert_no_html(html, "div.item.active[id='s1']")
@@ -180,12 +180,12 @@ class CarouselTest < ComponentTestCase
 
   # `active:` works the same on thumbs.
   def test_explicit_active_kwarg_overrides_first_active_thumb
-    html = render(Harness.new(
-                    carousel_args: { carousel_id: "c" },
-                    slides: [{ content: "s" }],
-                    thumbs: [{ id: "t1", content: "first" },
-                             { id: "t2", active: true, content: "second" }]
-                  ))
+    html = render_carousel(
+      carousel_args: { carousel_id: "c" },
+      slides: [{ content: "s" }],
+      thumbs: [{ id: "t1", content: "first" },
+               { id: "t2", active: true, content: "second" }]
+    )
 
     assert_html(html, "li.carousel-indicator.active[id='t2']")
     assert_no_html(html, "li.carousel-indicator.active[id='t1']")
@@ -195,14 +195,20 @@ class CarouselTest < ComponentTestCase
   # Registered thumbs are silently dropped (the matrix-box carousel
   # uses this — no thumbnail strip per-box).
   def test_show_indicators_false_suppresses_indicator_strip
-    html = render(Harness.new(
-                    carousel_args: { carousel_id: "c",
-                                     show_indicators: false },
-                    slides: [{ content: "s" }],
-                    thumbs: [{ content: "ignored" }]
-                  ))
+    html = render_carousel(
+      carousel_args: { carousel_id: "c", show_indicators: false },
+      slides: [{ content: "s" }],
+      thumbs: [{ content: "ignored" }]
+    )
 
     assert_no_html(html, "ol.carousel-indicators")
     assert_not_includes(html, "ignored")
+  end
+
+  private
+
+  def render_carousel(carousel_args:, slides: [], thumbs: [])
+    render(Harness.new(carousel_args: carousel_args,
+                       slides: slides, thumbs: thumbs))
   end
 end

--- a/test/components/collapsible_test.rb
+++ b/test/components/collapsible_test.rb
@@ -17,7 +17,7 @@ class CollapsibleTest < ComponentTestCase
   end
 
   def test_closed_by_default
-    html = render(Components::Collapsible.new(id: "foo"))
+    html = render_collapsible(id: "foo")
 
     assert_html(html, "div.collapse#foo")
     assert_no_html(html, "div.in")
@@ -25,39 +25,36 @@ class CollapsibleTest < ComponentTestCase
   end
 
   def test_expanded_adds_in_class
-    html = render(Components::Collapsible.new(id: "foo", expanded: true))
+    html = render_collapsible(id: "foo", expanded: true)
 
     assert_html(html, "div.collapse.in#foo")
   end
 
   def test_panel_adds_panel_collapse_class
-    html = render(Components::Collapsible.new(id: "foo", panel: true))
+    html = render_collapsible(id: "foo", panel: true)
 
     assert_html(html, "div.collapse.panel-collapse#foo")
     assert_no_html(html, "div.in")
   end
 
   def test_expanded_panel_with_class
-    html = render(Components::Collapsible.new(
-                    id: "foo", expanded: true, panel: true,
-                    class: "custom-class"
-                  ))
+    html = render_collapsible(id: "foo", expanded: true, panel: true,
+                              class: "custom-class")
 
     assert_html(html, "div.collapse.in.panel-collapse.custom-class#foo")
   end
 
   def test_nil_id_omits_id_attr
-    html = render(Components::Collapsible.new)
+    html = render_collapsible
 
     assert_html(html, "div.collapse")
     assert_no_html(html, "div[id]")
   end
 
   def test_extra_attrs_forwarded
-    html = render(Components::Collapsible.new(
-                    id: "geo",
-                    data: { form_exif_target: "collapseFields" }
-                  ))
+    html = render_collapsible(
+      id: "geo", data: { form_exif_target: "collapseFields" }
+    )
 
     assert_html(html,
                 "div.collapse#geo[data-form-exif-target='collapseFields']")
@@ -66,13 +63,13 @@ class CollapsibleTest < ComponentTestCase
   def test_id_kwarg_always_wins_over_any_other_id_source
     # `id:` is an explicit prop, so it always claims that keyword --
     # there's no bucket a caller could stash a conflicting id in.
-    html = render(Components::Collapsible.new(id: "real", data: { foo: "bar" }))
+    html = render_collapsible(id: "real", data: { foo: "bar" })
 
     assert_html(html, "div.collapse#real[data-foo='bar']")
   end
 
   def test_element_kwarg_renders_alternate_tag
-    html = render(Components::Collapsible.new(id: "foo", element: :tbody))
+    html = render_collapsible(id: "foo", element: :tbody)
 
     assert_html(html, "tbody.collapse#foo")
     assert_no_html(html, "div.collapse")
@@ -87,6 +84,10 @@ class CollapsibleTest < ComponentTestCase
   end
 
   private
+
+  def render_collapsible(**, &block)
+    render(Components::Collapsible.new(**), &block)
+  end
 
   # Returns an anonymous Components::Base instance whose view_template
   # runs the given block in Phlex context (so `plain`, `div`, `render`

--- a/test/components/column_test.rb
+++ b/test/components/column_test.rb
@@ -25,76 +25,81 @@ class ColumnTest < ComponentTestCase
   end
 
   def test_default_renders_div_with_no_width_classes
-    html = render(Components::Column.new)
+    html = render_column
 
     assert_html(html, "div[class='']")
   end
 
   def test_single_breakpoint
-    html = render(Components::Column.new(sm: 6))
+    html = render_column(sm: 6)
 
     assert_html(html, "div.col-sm-6")
   end
 
   def test_multiple_breakpoints
-    html = render(Components::Column.new(xs: 12, sm: 6, md: 4, lg: 3))
+    html = render_column(xs: 12, sm: 6, md: 4, lg: 3)
 
     assert_html(html, "div.col-xs-12.col-sm-6.col-md-4.col-lg-3")
   end
 
   def test_offset_xs
-    html = render(Components::Column.new(xs: 4, offset_xs: 4))
+    html = render_column(xs: 4, offset_xs: 4)
 
     assert_html(html, "div.col-xs-4.col-xs-offset-4")
   end
 
   def test_col_flag_adds_bare_col_class
-    html = render(Components::Column.new(col: true, sm: 4))
+    html = render_column(col: true, sm: 4)
 
     assert_html(html, "div.col.col-sm-4")
   end
 
   def test_hide_at_and_show_at_pair
-    html = render(Components::Column.new(sm: 6, hide_at: :xs, show_at: :sm))
+    html = render_column(sm: 6, hide_at: :xs, show_at: :sm)
 
     assert_html(html, "div.col-sm-6.d-none.d-sm-block")
   end
 
   def test_show_at_xs_hide_at_sm
-    html = render(Components::Column.new(show_at: :xs, hide_at: :sm))
+    html = render_column(show_at: :xs, hide_at: :sm)
 
     assert_html(html, "div.d-block.d-sm-none")
   end
 
   def test_hide_at_alone
-    html = render(Components::Column.new(md: 6, hide_at: :md))
+    html = render_column(md: 6, hide_at: :md)
 
     assert_html(html, "div.col-md-6.d-md-none")
   end
 
   def test_extra_class_merges_with_width_classes
-    html = render(Components::Column.new(sm: 6, class: "text-center"))
+    html = render_column(sm: 6, class: "text-center")
 
     assert_html(html, "div.col-sm-6.text-center")
   end
 
   def test_element_override
-    html = render(Components::Column.new(element: :nav, xs: 8, sm: 2))
+    html = render_column(element: :nav, xs: 8, sm: 2)
 
     assert_html(html, "nav.col-xs-8.col-sm-2")
     assert_no_html(html, "div")
   end
 
   def test_other_attributes_pass_through
-    html = render(Components::Column.new(sm: 6, id: "foo",
-                                         data: { turbo: "true" }))
+    html = render_column(sm: 6, id: "foo", data: { turbo: "true" })
 
     assert_html(html, "div.col-sm-6#foo[data-turbo='true']")
   end
 
   def test_yields_block_content
-    html = render(Components::Column.new(sm: 6)) { "hi" }
+    html = render_column(sm: 6) { "hi" }
 
     assert_includes(html, "hi")
+  end
+
+  private
+
+  def render_column(**, &block)
+    render(Components::Column.new(**), &block)
   end
 end

--- a/test/components/container_test.rb
+++ b/test/components/container_test.rb
@@ -17,42 +17,40 @@ class ContainerTest < ComponentTestCase
   end
 
   def test_default_is_a_plain_div_with_no_width_class
-    html = render(Components::Container.new)
+    html = render_container
 
     assert_html(html, "div")
     assert_no_html(html, "div[class*='container']")
   end
 
   def test_width_renders_matching_class
-    html = render(Components::Container.new(width: :wide))
+    html = render_container(width: :wide)
 
     assert_html(html, "div.container-wide")
   end
 
   def test_element_renders_alternate_tag
-    html = render(Components::Container.new(element: :main, width: :text))
+    html = render_container(element: :main, width: :text)
 
     assert_html(html, "main.container-text")
     assert_no_html(html, "div.container-text")
   end
 
   def test_extra_class_merges_with_width_class
-    html = render(Components::Container.new(width: :text, class: "ml-4"))
+    html = render_container(width: :text, class: "ml-4")
 
     assert_html(html, "div.container-text.ml-4")
   end
 
   def test_extra_class_alone_with_no_width
-    html = render(Components::Container.new(class: "hidden-print"))
+    html = render_container(class: "hidden-print")
 
     assert_html(html, "div.hidden-print")
     assert_no_html(html, "div.container-full")
   end
 
   def test_other_attrs_pass_through
-    html = render(Components::Container.new(
-                    id: "content", data: { controller: "lightgallery" }
-                  ))
+    html = render_container(id: "content", data: { controller: "lightgallery" })
 
     assert_html(html, "div#content[data-controller='lightgallery']")
   end
@@ -66,6 +64,10 @@ class ContainerTest < ComponentTestCase
   end
 
   private
+
+  def render_container(**, &block)
+    render(Components::Container.new(**), &block)
+  end
 
   # Returns an anonymous Components::Base instance whose view_template
   # runs the given block in Phlex context (so `plain`, `div`, `render`

--- a/test/components/description/mod_links_test.rb
+++ b/test/components/description/mod_links_test.rb
@@ -6,9 +6,7 @@ class DescriptionModLinksTest < ComponentTestCase
   def test_renders_nothing_for_anonymous_viewer
     desc = name_descriptions(:peltigera_user_desc)
 
-    html = render(Components::Description::ModLinks.new(
-                    description: desc, user: nil
-                  )).strip
+    html = render_mod_links(description: desc, user: nil).strip
 
     # No user → no writer → no admin → Clone is the only icon that
     # always shows (state-agnostic), so the strip renders just the
@@ -21,9 +19,7 @@ class DescriptionModLinksTest < ComponentTestCase
   def test_renders_edit_for_writer
     desc = name_descriptions(:peltigera_user_desc)
 
-    html = render(Components::Description::ModLinks.new(
-                    description: desc, user: desc.user
-                  ))
+    html = render_mod_links(description: desc, user: desc.user)
 
     assert_html(html, ".edit_name_description_link_#{desc.id}")
   end
@@ -33,9 +29,7 @@ class DescriptionModLinksTest < ComponentTestCase
     admin = users(:rolf)
     stub_admin_mode!
 
-    html = render(Components::Description::ModLinks.new(
-                    description: desc, user: admin
-                  ))
+    html = render_mod_links(description: desc, user: admin)
 
     # Admin-only icons (Move, Merge, AdjustPermissions for name desc)
     assert_html(html, ".move_this_description_name_description_link")
@@ -47,9 +41,7 @@ class DescriptionModLinksTest < ComponentTestCase
     desc = location_descriptions(:albion_desc)
     stub_admin_mode!
 
-    html = render(Components::Description::ModLinks.new(
-                    description: desc, user: users(:rolf)
-                  ))
+    html = render_mod_links(description: desc, user: users(:rolf))
 
     assert_no_html(html,
                    ".adjust_permissions_location_description_link")
@@ -63,9 +55,7 @@ class DescriptionModLinksTest < ComponentTestCase
       desc.source_type == :public
     stub_admin_mode!
 
-    html = render(Components::Description::ModLinks.new(
-                    description: desc, user: users(:rolf)
-                  ))
+    html = render_mod_links(description: desc, user: users(:rolf))
 
     path = routes.publish_name_description_path(desc.id)
     assert_html(html, "form[action='#{path}']")
@@ -77,9 +67,7 @@ class DescriptionModLinksTest < ComponentTestCase
     skip("Need a project-sourced description") if
       desc.source_type != "project" || desc.source_object.nil?
 
-    html = render(Components::Description::ModLinks.new(
-                    description: desc, user: users(:rolf)
-                  ))
+    html = render_mod_links(description: desc, user: users(:rolf))
 
     # Project icon points at the project's show page.
     assert_html(html,
@@ -93,12 +81,16 @@ class DescriptionModLinksTest < ComponentTestCase
     skip("Need a public, non-default name desc") unless
       desc.public && desc.parent.description_id != desc.id
 
-    html = render(Components::Description::ModLinks.new(
-                    description: desc, user: users(:rolf)
-                  ))
+    html = render_mod_links(description: desc, user: users(:rolf))
 
     path = routes.make_default_name_description_path(desc.id)
     assert_html(html, "form[action='#{path}']")
     assert_html(html, "input[name='_method'][value='put']")
+  end
+
+  private
+
+  def render_mod_links(**)
+    render(Components::Description::ModLinks.new(**))
   end
 end

--- a/test/components/description/previous_version_test.rb
+++ b/test/components/description/previous_version_test.rb
@@ -9,9 +9,7 @@ class PreviousVersionTest < ComponentTestCase
   end
 
   def test_renders_current_version_label
-    html = render(Components::Description::PreviousVersion.new(
-                    obj: @name, versions: @name.versions.to_a
-                  ))
+    html = render_previous_version(obj: @name)
 
     assert_includes(html, "#{:version.ti}: #{@name.version}")
   end
@@ -19,9 +17,7 @@ class PreviousVersionTest < ComponentTestCase
   def test_renders_previous_version_link_when_multi_version
     skip("Need a name with multiple versions") if @name.versions.size <= 1
 
-    html = render(Components::Description::PreviousVersion.new(
-                    obj: @name, versions: @name.versions.to_a
-                  ))
+    html = render_previous_version(obj: @name)
 
     assert_html(html, "a.previous_version_link",
                 text: :show_name_previous_version.t)
@@ -34,10 +30,16 @@ class PreviousVersionTest < ComponentTestCase
 
     # Use a fresh Name with only one version implicitly.
     name = names(:agaricus_campestris)
-    html = render(Components::Description::PreviousVersion.new(
-                    obj: name, versions: name.versions.to_a
-                  ))
+    html = render_previous_version(obj: name)
 
     assert_no_html(html, "a.previous_version_link")
+  end
+
+  private
+
+  def render_previous_version(obj:)
+    render(Components::Description::PreviousVersion.new(
+             obj: obj, versions: obj.versions.to_a
+           ))
   end
 end

--- a/test/components/dropdown_test.rb
+++ b/test/components/dropdown_test.rb
@@ -20,11 +20,8 @@ class DropdownTest < ComponentTestCase
   # without wrapping it in a Collection). Exercises the
   # `when ::Tab::Base then [section.to_a]` branch.
   def test_renders_single_tab_base_section
-    html = render(Components::Dropdown.new(
-                    id: "single_tab_toggle",
-                    menu_id: "single_tab_menu",
-                    label: "Menu"
-                  )) do |menu|
+    html = render_dropdown(id: "single_tab_toggle",
+                           menu_id: "single_tab_menu") do |menu|
       menu.section(Tab::Project::Summary.new(project: @project))
     end
 
@@ -74,11 +71,7 @@ class DropdownTest < ComponentTestCase
   # redundant inside a menu (the label is already visible) and
   # Bootstrap's tooltip JS can interfere with dropdown click handling.
   def test_tooltip_data_stripped_from_link
-    html = render(Components::Dropdown.new(
-                    id: "tip_toggle",
-                    menu_id: "tip_menu",
-                    label: "Menu"
-                  )) do |menu|
+    html = render_dropdown(id: "tip_toggle", menu_id: "tip_menu") do |menu|
       menu.section([["Edit", "/edit",
                      { data: { tooltip_target: "tip",
                                title: "Edit this",
@@ -97,11 +90,8 @@ class DropdownTest < ComponentTestCase
   # Exercises the `else []` branch + the early-return in
   # `view_template`.
   def test_nil_section_renders_nothing
-    html = render(Components::Dropdown.new(
-                    id: "empty_toggle",
-                    menu_id: "empty_menu",
-                    label: "Empty"
-                  )) do |menu|
+    html = render_dropdown(id: "empty_toggle", menu_id: "empty_menu",
+                           label: "Empty") do |menu|
       menu.section(nil)
     end
 
@@ -110,12 +100,13 @@ class DropdownTest < ComponentTestCase
 
   private
 
+  def render_dropdown(id:, menu_id:, label: "Menu", &block)
+    render(Components::Dropdown.new(id: id, menu_id: menu_id, label: label),
+           &block)
+  end
+
   def render_dropdown_with_button(button:)
-    render(Components::Dropdown.new(
-             id: "test_toggle",
-             menu_id: "test_menu",
-             label: "Menu"
-           )) do |menu|
+    render_dropdown(id: "test_toggle", menu_id: "test_menu") do |menu|
       menu.section([["Action", "/some/path", { button: button }]])
     end
   end

--- a/test/components/form/errors_test.rb
+++ b/test/components/form/errors_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class FormErrorsTest < ComponentTestCase
   def test_renders_nothing_when_no_errors
-    html = render(Components::Form::Errors.new(model: GlossaryTerm.new))
+    html = render_errors(model: GlossaryTerm.new)
 
     assert_equal("", html)
   end
@@ -12,7 +12,7 @@ class FormErrorsTest < ComponentTestCase
   def test_renders_error_count_and_messages
     term = GlossaryTerm.new
     term.errors.add(:name, :blank)
-    html = render(Components::Form::Errors.new(model: term))
+    html = render_errors(model: term)
 
     assert_html(html, "#error_explanation.alert-danger")
     assert_html(html, "#error_explanation h2")
@@ -29,9 +29,15 @@ class FormErrorsTest < ComponentTestCase
     term = GlossaryTerm.new
     term.errors.add(:name, :blank)
     term.errors.add(:base, :invalid)
-    html = render(Components::Form::Errors.new(model: term))
+    html = render_errors(model: term)
 
     error_text = Nokogiri::HTML(html).at_css("#error_explanation").text
     assert_includes(error_text, "2 #{:errors.t}")
+  end
+
+  private
+
+  def render_errors(model:)
+    render(Components::Form::Errors.new(model: model))
   end
 end

--- a/test/components/form/notes_test.rb
+++ b/test/components/form/notes_test.rb
@@ -15,7 +15,7 @@ class FormNotesTest < ComponentTestCase
   # --- Panel wrap is always present ---
 
   def test_renders_collapsible_panel_with_notes_heading
-    html = render(MultiPartFormNotes.new(Observation.new, action: "/t"))
+    html = multi_part_html
 
     # Panel uses panel_id as its outer element id.
     assert_html(html, "div#test_notes")
@@ -31,7 +31,7 @@ class FormNotesTest < ComponentTestCase
   # --- Multi-part mode ---
 
   def test_multi_part_renders_textareas_and_textile_help_below
-    html = render(MultiPartFormNotes.new(Observation.new, action: "/t"))
+    html = multi_part_html
 
     # Inner notes div derives id from panel_id.
     assert_html(html, "#test_notes_fields")
@@ -56,7 +56,7 @@ class FormNotesTest < ComponentTestCase
   end
 
   def test_multi_part_textile_help_renders_below_textareas
-    html = render(MultiPartFormNotes.new(Observation.new, action: "/t"))
+    html = multi_part_html
 
     # The textile help is the last child of the notes-fields div,
     # below all the textareas (not above them).
@@ -69,7 +69,7 @@ class FormNotesTest < ComponentTestCase
   # --- Single-part mode ---
 
   def test_single_part_mode_renders_one_large_textarea
-    html = render(SinglePartFormNotes.new(Observation.new, action: "/t"))
+    html = single_part_html
 
     # The lone textarea is rows=10.
     assert_html(html,
@@ -83,7 +83,7 @@ class FormNotesTest < ComponentTestCase
   end
 
   def test_single_part_mode_renders_above_help_above_textarea
-    html = render(SinglePartFormNotes.new(Observation.new, action: "/t"))
+    html = single_part_html
 
     # Caller-supplied prose help renders ABOVE the textarea, inline
     # (no collapse wrapping — visible whenever the panel is open).
@@ -95,7 +95,7 @@ class FormNotesTest < ComponentTestCase
   end
 
   def test_single_part_mode_textile_help_renders_below_textarea
-    html = render(SinglePartFormNotes.new(Observation.new, action: "/t"))
+    html = single_part_html
 
     # Textile help still renders below the textarea — same as
     # multi-part mode. Above-help is the only extra in single-part.
@@ -165,7 +165,7 @@ class FormNotesTest < ComponentTestCase
   end
 
   def test_no_adopt_controller_without_adopt_options
-    html = render(MultiPartFormNotes.new(Observation.new, action: "/t"))
+    html = multi_part_html
 
     assert_no_html(html, "[data-controller='notes-adopt']")
   end
@@ -183,6 +183,16 @@ class FormNotesTest < ComponentTestCase
     assert_html(html, "button[data-notes-action='hide']")
     assert_no_html(html, "button[data-notes-action='adopt']")
     assert_no_html(html, "button[data-notes-action='concatenate']")
+  end
+
+  private
+
+  def multi_part_html
+    render(MultiPartFormNotes.new(Observation.new, action: "/t"))
+  end
+
+  def single_part_html
+    render(SinglePartFormNotes.new(Observation.new, action: "/t"))
   end
 end
 

--- a/test/components/help/collapse_info_trigger_test.rb
+++ b/test/components/help/collapse_info_trigger_test.rb
@@ -4,9 +4,7 @@ require("test_helper")
 
 class Components::Help::CollapseInfoTriggerTest < ComponentTestCase
   def test_renders_collapse_link_with_question_icon
-    html = render(Components::Help::CollapseInfoTrigger.new(
-                    target_id: "help_text_1"
-                  ))
+    html = render_trigger(target_id: "help_text_1")
 
     assert_html(html, "a[href='#help_text_1']")
     assert_html(html, "a.info-collapse-trigger")
@@ -14,11 +12,15 @@ class Components::Help::CollapseInfoTriggerTest < ComponentTestCase
   end
 
   def test_renders_with_extra_class
-    html = render(Components::Help::CollapseInfoTrigger.new(
-                    target_id: "help_text_2",
-                    extra_class: "custom-trigger"
-                  ))
+    html = render_trigger(target_id: "help_text_2",
+                          extra_class: "custom-trigger")
 
     assert_html(html, "a.info-collapse-trigger.custom-trigger")
+  end
+
+  private
+
+  def render_trigger(**)
+    render(Components::Help::CollapseInfoTrigger.new(**))
   end
 end

--- a/test/components/help/tooltip_test.rb
+++ b/test/components/help/tooltip_test.rb
@@ -4,9 +4,7 @@ require("test_helper")
 
 class HelpTooltipTest < ComponentTestCase
   def test_renders_span_with_context_help_class_and_tooltip_data
-    html = render(Components::Help::Tooltip.new(
-                    label: "(?)", title: "Click for explanation"
-                  ))
+    html = render_tooltip(label: "(?)", title: "Click for explanation")
 
     assert_html(html, "span.context-help", text: "(?)")
     # Tooltip wiring: the tooltip Stimulus controller reads
@@ -18,21 +16,23 @@ class HelpTooltipTest < ComponentTestCase
   end
 
   def test_extra_class_appends_to_context_help
-    html = render(Components::Help::Tooltip.new(
-                    label: "(?)", extra_class: "filter-help"
-                  ))
+    html = render_tooltip(label: "(?)", extra_class: "filter-help")
 
     assert_html(html, "span.context-help.filter-help")
   end
 
   def test_caller_data_attrs_merge_with_tooltip_data
-    html = render(Components::Help::Tooltip.new(
-                    label: "(?)", data: { other: "v" }
-                  ))
+    html = render_tooltip(label: "(?)", data: { other: "v" })
 
     # Caller's custom data attrs deep-merge with the tooltip
     # wiring — both end up on the span.
     assert_html(html, "span[data-tooltip-target='tip']")
     assert_html(html, "span[data-other='v']")
+  end
+
+  private
+
+  def render_tooltip(**)
+    render(Components::Help::Tooltip.new(**))
   end
 end

--- a/test/components/help_test.rb
+++ b/test/components/help_test.rb
@@ -4,28 +4,27 @@ require("test_helper")
 
 class HelpTest < ComponentTestCase
   def test_plain_block_with_string
-    html = render(Components::Help.new(element: :p, content: "Help text"))
+    html = render_help(element: :p, content: "Help text")
 
     # Default plain shape: a `help-block`-classed element.
     assert_html(html, "p.help-block", text: "Help text")
   end
 
   def test_plain_block_with_block_content
-    html = render(Components::Help.new(element: :div)) { "From block" }
+    html = render_help(element: :div) { "From block" }
 
     # Block-form content takes precedence over `content:`.
     assert_html(html, "div.help-block", text: "From block")
   end
 
   def test_content_only_uses_default_div_element
-    html = render(Components::Help.new(content: "Help text"))
+    html = render_help(content: "Help text")
 
     assert_html(html, "div.help-block", text: "Help text")
   end
 
   def test_well_wraps_in_bootstrap_well
-    html = render(Components::Help.new(element: :p, content: "Help",
-                                       well: true))
+    html = render_help(element: :p, content: "Help", well: true)
 
     # The `well:` flavour wraps content in a Bootstrap well; the
     # element kwarg is intentionally ignored for the well shape.
@@ -34,8 +33,7 @@ class HelpTest < ComponentTestCase
   end
 
   def test_arrow_implies_well_and_adds_arrow_div
-    html = render(Components::Help.new(element: :div, content: "Help",
-                                       arrow: :up))
+    html = render_help(element: :div, content: "Help", arrow: :up)
 
     # Setting `arrow:` is the legacy `help_block_with_arrow` shape —
     # always a well, with an `arrow-up`/`arrow-down` sibling. `mt-3`
@@ -46,8 +44,7 @@ class HelpTest < ComponentTestCase
   end
 
   def test_arrow_down_omits_mt3
-    html = render(Components::Help.new(element: :div, content: "Help",
-                                       arrow: :down))
+    html = render_help(element: :div, content: "Help", arrow: :down)
 
     # Down arrows hang below the well — no leading `mt-3`.
     assert_no_html(html, "div.mt-3")
@@ -55,17 +52,14 @@ class HelpTest < ComponentTestCase
   end
 
   def test_extra_class_appended_to_plain_block
-    html = render(Components::Help.new(element: :p, content: "Help",
-                                       class: "extra-thing"))
+    html = render_help(element: :p, content: "Help", class: "extra-thing")
 
     assert_html(html, "p.help-block.extra-thing", text: "Help")
   end
 
   def test_id_and_extra_attrs_passed_through
-    html = render(Components::Help.new(
-                    element: :div, content: "Help",
-                    id: "h1", data: { x: "v" }
-                  ))
+    html = render_help(element: :div, content: "Help",
+                       id: "h1", data: { x: "v" })
 
     # id and arbitrary data-* asserted independently so renaming
     # the wrapper element or reshuffling attribute order doesn't
@@ -78,7 +72,7 @@ class HelpTest < ComponentTestCase
   def test_renders_nothing_when_neither_content_nor_block
     # Empty wrappers are noise the form layout doesn't need; the
     # component bails out when given neither content source.
-    html = render(Components::Help.new(element: :p))
+    html = render_help(element: :p)
 
     assert_equal("", html.to_s.strip)
   end
@@ -88,16 +82,14 @@ class HelpTest < ComponentTestCase
     # reveal help" shape. The collapse wrapper takes the id; an
     # external `data-target="#<id>"` trigger toggles its
     # `.collapse` visibility class.
-    html = render(Components::Help.new(
-                    collapse_id: "field_help_x"
-                  )) { "Help" }
+    html = render_help(collapse_id: "field_help_x") { "Help" }
 
     assert_html(html, "div.collapse#field_help_x > " \
                       "div.well.help-block", text: "Help")
   end
 
   def test_collapse_id_implies_well_even_without_explicit_kwarg
-    html = render(Components::Help.new(collapse_id: "x")) { "h" }
+    html = render_help(collapse_id: "x") { "h" }
 
     # No need to pass `well: true` alongside `collapse_id:` — the
     # collapse markup only makes sense around a well.
@@ -117,24 +109,28 @@ class HelpTest < ComponentTestCase
   # `.help-block` for everything else to keep the inline shape inline.
 
   def test_span_element_renders_help_note_class
-    html = render(Components::Help.new(element: :span, content: "(optional)"))
+    html = render_help(element: :span, content: "(optional)")
 
     assert_html(html, "span.help-note", text: "(optional)")
   end
 
   def test_span_block_form_renders_block_content
-    html = render(Components::Help.new(element: :span)) { "From block" }
+    html = render_help(element: :span) { "From block" }
 
     assert_html(html, "span.help-note", text: "From block")
   end
 
   def test_span_extra_class_and_attrs_pass_through
-    html = render(Components::Help.new(
-                    element: :span, content: "x",
-                    class: "extra-thing", id: "h", data: { foo: "bar" }
-                  ))
+    html = render_help(element: :span, content: "x",
+                       class: "extra-thing", id: "h", data: { foo: "bar" })
 
     assert_html(html, "span#h.help-note.extra-thing")
     assert_html(html, "span[data-foo='bar']")
+  end
+
+  private
+
+  def render_help(**, &block)
+    render(Components::Help.new(**), &block)
   end
 end

--- a/test/components/icon_test.rb
+++ b/test/components/icon_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 class LinkIconTest < ComponentTestCase
   def test_glyph_only
-    html = render(Components::Icon.new(type: :globe))
+    html = render_icon(type: :globe)
 
     assert_html(html, "span.glyphicon.glyphicon-globe.link-icon")
     # No sr-only inner span when title is absent — just the bare glyph.
@@ -12,7 +12,7 @@ class LinkIconTest < ComponentTestCase
   end
 
   def test_unknown_type_renders_nothing
-    html = render(Components::Icon.new(type: :bogus_not_a_real_icon))
+    html = render_icon(type: :bogus_not_a_real_icon)
 
     # Unknown icon type silently emits nothing — matches the legacy
     # `link_icon` helper's `return "" unless LINK_ICON_INDEX[type]`.
@@ -20,10 +20,7 @@ class LinkIconTest < ComponentTestCase
   end
 
   def test_title_adds_tooltip_and_sr_only_label
-    html = render(Components::Icon.new(
-                    type: :edit, title: :edit.ti,
-                    class: "text-primary"
-                  ))
+    html = render_icon(type: :edit, title: :edit.ti, class: "text-primary")
 
     assert_html(html,
                 "span.glyphicon-edit.link-icon.text-primary" \
@@ -33,20 +30,22 @@ class LinkIconTest < ComponentTestCase
   end
 
   def test_caller_data_attrs_merge_with_tooltip_data
-    html = render(Components::Icon.new(
-                    type: :globe, title: "Tooltip text",
-                    data: { other: "v" }
-                  ))
+    html = render_icon(type: :globe, title: "Tooltip text",
+                       data: { other: "v" })
 
     # Tooltip target still present alongside caller's custom data attr.
     assert_html(html, "span[data-tooltip-target='tip'][data-other='v']")
   end
 
   def test_extra_attrs_passed_through
-    html = render(Components::Icon.new(
-                    type: :globe, id: "my_icon"
-                  ))
+    html = render_icon(type: :globe, id: "my_icon")
 
     assert_html(html, "span#my_icon.glyphicon-globe")
+  end
+
+  private
+
+  def render_icon(**)
+    render(Components::Icon.new(**))
   end
 end

--- a/test/components/id_badge_test.rb
+++ b/test/components/id_badge_test.rb
@@ -5,7 +5,7 @@ require("test_helper")
 class IDBadgeTest < ComponentTestCase
   def test_renders_object_id_in_clipboard_button
     obs = observations(:minimal_unknown_obs)
-    html = render(Components::IDBadge.new(object: obs, size: :md))
+    html = render_badge(object: obs, size: :md)
 
     # The badge is a `<button>` whose visible content is the object id.
     assert_html(html, "button[type='button']", text: obs.id.to_s)
@@ -20,7 +20,7 @@ class IDBadgeTest < ComponentTestCase
   def test_renders_question_mark_when_object_id_nil
     # Newly-built (unpersisted) model has no id — fall back to "?"
     # so the badge still renders without a NoMethodError.
-    html = render(Components::IDBadge.new(object: Observation.new, size: :md))
+    html = render_badge(object: Observation.new, size: :md)
 
     assert_html(html, "button", text: "?")
   end
@@ -28,9 +28,7 @@ class IDBadgeTest < ComponentTestCase
   def test_renders_value_when_no_object_given
     # Not an AbstractModel id -- e.g. an external site's own numeric id
     # (see Components::Link::External).
-    html = render(Components::IDBadge.new(
-                    value: "234723", size: :lg, extra_class: nil
-                  ))
+    html = render_badge(value: "234723", size: :lg, extra_class: nil)
 
     assert_html(html, "button[type='button']", text: "234723")
     assert_html(html, "button[data-controller='clipboard']")
@@ -38,18 +36,14 @@ class IDBadgeTest < ComponentTestCase
 
   def test_object_id_wins_over_value_when_both_given
     obs = observations(:minimal_unknown_obs)
-    html = render(Components::IDBadge.new(
-                    object: obs, value: "999999", size: :md
-                  ))
+    html = render_badge(object: obs, value: "999999", size: :md)
 
     assert_html(html, "button", text: obs.id.to_s)
   end
 
   def test_extra_class_overrides_default_spacing
     obs = observations(:minimal_unknown_obs)
-    html = render(Components::IDBadge.new(
-                    object: obs, size: :md, extra_class: "custom-class"
-                  ))
+    html = render_badge(object: obs, size: :md, extra_class: "custom-class")
 
     # Caller-supplied extra_class joins the base `badge badge-id`
     # classes.
@@ -61,7 +55,7 @@ class IDBadgeTest < ComponentTestCase
 
     { xl: "badge-xl", lg: "badge-lg",
       md: "badge-md", sm: "badge-sm" }.each do |size, css_class|
-      html = render(Components::IDBadge.new(object: obs, size: size))
+      html = render_badge(object: obs, size: size)
 
       assert_html(html, "button.badge-id.#{css_class}")
     end
@@ -75,18 +69,22 @@ class IDBadgeTest < ComponentTestCase
 
   def test_default_tooltip_title
     obs = observations(:minimal_unknown_obs)
-    html = render(Components::IDBadge.new(object: obs, size: :md))
+    html = render_badge(object: obs, size: :md)
 
     assert_html(html, "button[data-title='#{:copy_this_id.ti}']")
   end
 
   def test_title_prop_overrides_default_tooltip_title
     obs = observations(:minimal_unknown_obs)
-    html = render(Components::IDBadge.new(
-                    object: obs, size: :md, title: "Copy Foo ID"
-                  ))
+    html = render_badge(object: obs, size: :md, title: "Copy Foo ID")
 
     assert_html(html, "button[data-title='Copy Foo ID']")
     assert_no_html(html, "button[data-title='#{:copy_this_id.ti}']")
+  end
+
+  private
+
+  def render_badge(**)
+    render(Components::IDBadge.new(**))
   end
 end

--- a/test/components/image_fragment/exif_link_test.rb
+++ b/test/components/image_fragment/exif_link_test.rb
@@ -3,25 +3,28 @@
 require("test_helper")
 
 class ImageFragmentEXIFLinkTest < ComponentTestCase
-  def test_renders_modal_toggle_button
-    image = images(:connected_coprinus_comatus_image)
+  def setup
+    super
+    @image = images(:connected_coprinus_comatus_image)
+  end
 
-    html = render(Components::ImageFragment::EXIFLink.new(
-                    image_id: image.id
-                  ))
+  def test_renders_modal_toggle_button
+    html = render_link(image_id: @image.id)
 
     assert_html(html, "a[data-controller='modal-toggle']" \
-                      "[href='#{routes.exif_image_path(id: image.id)}']",
+                      "[href='#{routes.exif_image_path(id: @image.id)}']",
                 text: :image_show_exif.t.as_displayed)
   end
 
   def test_applies_custom_link_class
-    image = images(:connected_coprinus_comatus_image)
-
-    html = render(Components::ImageFragment::EXIFLink.new(
-                    image_id: image.id, link_class: "my-custom"
-                  ))
+    html = render_link(image_id: @image.id, link_class: "my-custom")
 
     assert_html(html, "a.my-custom")
+  end
+
+  private
+
+  def render_link(**)
+    render(Components::ImageFragment::EXIFLink.new(**))
   end
 end

--- a/test/components/image_fragment/lazy_vote_interface_test.rb
+++ b/test/components/image_fragment/lazy_vote_interface_test.rb
@@ -9,9 +9,7 @@ class ImageFragmentLazyVoteInterfaceTest < ComponentTestCase
   end
 
   def test_renders_lazy_turbo_frame_for_overlay_context
-    html = render(Components::ImageFragment::LazyVoteInterface.new(
-                    image: @image
-                  ))
+    html = render_interface
 
     assert_html(html, "turbo-frame#image_vote_#{@image.id}" \
                       "[loading='lazy'][src]")
@@ -21,13 +19,19 @@ class ImageFragmentLazyVoteInterfaceTest < ComponentTestCase
   end
 
   def test_renders_lazy_turbo_frame_for_lightbox_context
-    html = render(Components::ImageFragment::LazyVoteInterface.new(
-                    image: @image, context: :lightbox
-                  ))
+    html = render_interface(context: :lightbox)
 
     assert_html(html, "turbo-frame#lightbox_image_vote_#{@image.id}" \
                       "[loading='lazy']")
     frame_src = Nokogiri::HTML5.fragment(html).at_css("turbo-frame")["src"]
     assert_includes(frame_src, "context=lightbox")
+  end
+
+  private
+
+  def render_interface(context: nil)
+    opts = { image: @image }
+    opts[:context] = context if context
+    render(Components::ImageFragment::LazyVoteInterface.new(**opts))
   end
 end

--- a/test/components/image_fragment/original_link_test.rb
+++ b/test/components/image_fragment/original_link_test.rb
@@ -9,7 +9,7 @@ class ImageFragmentOriginalLinkTest < ComponentTestCase
   end
 
   def test_renders_link_to_original_with_image_instance
-    html = render(Components::ImageFragment::OriginalLink.new(image: @image))
+    html = render_link(image: @image)
 
     assert_html(html, "a[href='/images/#{@image.id}/original']",
                 text: :image_show_original.l)
@@ -33,20 +33,20 @@ class ImageFragmentOriginalLinkTest < ComponentTestCase
   end
 
   def test_renders_link_with_image_id
-    html = render(
-      Components::ImageFragment::OriginalLink.new(image_id: @image.id)
-    )
+    html = render_link(image_id: @image.id)
 
     assert_html(html, "a[href='/images/#{@image.id}/original']")
   end
 
   def test_applies_custom_link_class
-    html = render(
-      Components::ImageFragment::OriginalLink.new(
-        image: @image, link_class: "my-custom"
-      )
-    )
+    html = render_link(image: @image, link_class: "my-custom")
 
     assert_html(html, "a.my-custom")
+  end
+
+  private
+
+  def render_link(**)
+    render(Components::ImageFragment::OriginalLink.new(**))
   end
 end

--- a/test/components/image_gallery_test.rb
+++ b/test/components/image_gallery_test.rb
@@ -11,12 +11,7 @@ class ImageGalleryTest < ComponentTestCase
   end
 
   def test_renders_carousel_with_images
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: @images,
-      object: @obs
-    )
-    html = render(component)
+    html = render_gallery
 
     # Basic structure
     assert_includes(html, "carousel")
@@ -76,10 +71,7 @@ class ImageGalleryTest < ComponentTestCase
   # key) can't bake one viewer's vote state into shared HTML.
   def test_carousel_item_renders_vote_section
     image = @images.first
-    component = Components::ImageGallery.new(
-      user: @user, images: [image], object: @obs
-    )
-    html = render(component)
+    html = render_gallery(images: [image])
 
     assert_html(html,
                 ".carousel-item turbo-frame#image_vote_#{image.id}" \
@@ -88,12 +80,7 @@ class ImageGalleryTest < ComponentTestCase
 
   def test_renders_single_image_without_controls
     image = @images.first
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: [image],
-      object: @obs
-    )
-    html = render(component)
+    html = render_gallery(images: [image])
 
     assert_includes(html, "carousel")
     assert_includes(html, "carousel-item")
@@ -103,13 +90,7 @@ class ImageGalleryTest < ComponentTestCase
   end
 
   def test_thumbnail_navigation_when_enabled
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: @images,
-      object: @obs,
-      thumbnails: true
-    )
-    html = render(component)
+    html = render_gallery(thumbnails: true)
 
     # Should have thumbnail navigation
     assert_includes(html, "carousel-indicators")
@@ -139,13 +120,7 @@ class ImageGalleryTest < ComponentTestCase
   end
 
   def test_no_thumbnail_navigation_when_disabled
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: @images,
-      object: @obs,
-      thumbnails: false
-    )
-    html = render(component)
+    html = render_gallery(thumbnails: false)
 
     # Should not have thumbnail navigation or heading
     assert_not_includes(html, "carousel-indicators")
@@ -154,16 +129,12 @@ class ImageGalleryTest < ComponentTestCase
 
   def test_renders_with_custom_options
     links = '<a href="/test">Test Link</a>'
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: @images,
-      object: @obs,
+    html = render_gallery(
       title: "Custom Gallery Title",
       links: links,
       panel_id: "custom_panel_id",
       thumbnails: true
     )
-    html = render(component)
 
     # Custom title in panel heading
     assert_includes(html, "Custom Gallery Title")
@@ -188,10 +159,7 @@ class ImageGalleryTest < ComponentTestCase
   # the image-show page, so only that page live-updates; this one
   # catches up on the next load via the #4808 cache-busting URL token.
   def test_does_not_subscribe_to_action_cable_for_image_streams
-    component = Components::ImageGallery.new(
-      user: @user, images: @images, object: @obs
-    )
-    html = render(component)
+    html = render_gallery
 
     assert_no_html(html, "turbo-cable-stream-source")
   end
@@ -199,12 +167,7 @@ class ImageGalleryTest < ComponentTestCase
   def test_filters_nil_images
     # Create array with nils mixed in
     images_with_nil = [@images.first, nil, nil]
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: images_with_nil,
-      object: @obs
-    )
-    html = render(component)
+    html = render_gallery(images: images_with_nil)
 
     # Should render successfully without errors
     assert_includes(html, "carousel")
@@ -214,12 +177,7 @@ class ImageGalleryTest < ComponentTestCase
   end
 
   def test_renders_no_images_message_when_empty
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: [],
-      object: @obs
-    )
-    html = render(component)
+    html = render_gallery(images: [])
 
     # Should show styled message area
     assert_includes(html, "text-muted")
@@ -239,14 +197,8 @@ class ImageGalleryTest < ComponentTestCase
   end
 
   def test_renders_custom_title_when_empty
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: [],
-      object: @obs,
-      title: "Custom Gallery Title",
-      thumbnails: true
-    )
-    html = render(component)
+    html = render_gallery(images: [], title: "Custom Gallery Title",
+                          thumbnails: true)
 
     # Title in panel heading
     assert_includes(html, "Custom Gallery Title")
@@ -260,26 +212,14 @@ class ImageGalleryTest < ComponentTestCase
   end
 
   def test_no_heading_when_thumbnails_disabled
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: [],
-      object: @obs,
-      thumbnails: false
-    )
-    html = render(component)
+    html = render_gallery(images: [], thumbnails: false)
 
     # Should not have panel heading
     assert_not_includes(html, "panel-heading")
   end
 
   def test_panel_id_is_passed_through
-    component = Components::ImageGallery.new(
-      user: @user,
-      images: [],
-      object: @obs,
-      panel_id: "custom_panel_id"
-    )
-    html = render(component)
+    html = render_gallery(images: [], panel_id: "custom_panel_id")
 
     assert_includes(html, "custom_panel_id")
   end
@@ -313,9 +253,7 @@ class ImageGalleryTest < ComponentTestCase
     leak_image = images(:connected_coprinus_comatus_image)
     leak_obs = leak_image.observations.first || @obs
 
-    html = render(Components::ImageGallery.new(
-                    user: @user, images: [leak_image], object: leak_obs
-                  ))
+    html = render_gallery(images: [leak_image], object: leak_obs)
 
     # Vote bar IS in the carousel-caption (a lazy Turbo Frame -- #4895).
     assert_html(html, ".carousel-caption turbo-frame")
@@ -324,5 +262,13 @@ class ImageGalleryTest < ComponentTestCase
     # in the lightbox's hidden `.lightbox-caption` element instead.)
     assert_no_html(html, ".carousel-caption .image-copyright")
     assert_no_html(html, ".carousel-caption .image-notes")
+  end
+
+  private
+
+  def render_gallery(images: @images, object: @obs, **)
+    render(Components::ImageGallery.new(
+             user: @user, images: images, object: object, **
+           ))
   end
 end

--- a/test/components/inline_crud_links_test.rb
+++ b/test/components/inline_crud_links_test.rb
@@ -17,9 +17,7 @@ class InlineCRUDLinksTest < ComponentTestCase
     stranger = users(:lone_wolf)
     cn = collection_numbers(:detailed_unknown_coll_num_one)
 
-    html = render(Components::InlineCRUDLinks.new(
-                    target: cn, observation: @obs, user: stranger
-                  ))
+    html = render_links(target: cn, observation: @obs, user: stranger)
 
     assert_no_html(html, "span.text-nowrap")
     assert_equal("", html.strip)
@@ -29,9 +27,7 @@ class InlineCRUDLinksTest < ComponentTestCase
     cn = collection_numbers(:detailed_unknown_coll_num_one)
     obs = cn.observations.first
 
-    html = render(Components::InlineCRUDLinks.new(
-                    target: cn, observation: obs, user: cn.user
-                  ))
+    html = render_links(target: cn, observation: obs, user: cn.user)
 
     # Edit → ModalLink, modal_identifier carries the record's id
     assert_html(html,
@@ -60,9 +56,7 @@ class InlineCRUDLinksTest < ComponentTestCase
     obs = seq.observation
 
     # No `observation:` -- Sequence derives it from `@target.observation`.
-    html = render(Components::InlineCRUDLinks.new(
-                    target: seq, user: seq.user
-                  ))
+    html = render_links(target: seq, user: seq.user)
 
     assert_html(html,
                 "a[data-modal='modal_sequence_#{seq.id}']")
@@ -78,9 +72,7 @@ class InlineCRUDLinksTest < ComponentTestCase
     link = external_links(:coprinus_comatus_obs_inaturalist_link)
 
     # No `observation:` -- ExternalLink's handlers never read it.
-    html = render(Components::InlineCRUDLinks.new(
-                    target: link, user: link.user
-                  ))
+    html = render_links(target: link, user: link.user)
 
     assert_html(html,
                 "a[data-modal='modal_external_link_#{link.id}']")
@@ -91,9 +83,7 @@ class InlineCRUDLinksTest < ComponentTestCase
     record = herbarium_records(:coprinus_comatus_rolf_spec)
     obs = record.observations.first
 
-    html = render(Components::InlineCRUDLinks.new(
-                    target: record, observation: obs, user: record.user
-                  ))
+    html = render_links(target: record, observation: obs, user: record.user)
 
     assert_html(html,
                 "a[data-modal='modal_herbarium_record_#{record.id}']")
@@ -113,9 +103,7 @@ class InlineCRUDLinksTest < ComponentTestCase
   def test_naming_edit_and_destroy_links
     naming = namings(:detailed_unknown_naming)
 
-    html = render(Components::InlineCRUDLinks.new(
-                    target: naming, user: naming.user
-                  ))
+    html = render_links(target: naming, user: naming.user)
 
     assert_html(html, "a[data-modal='modal_obs_#{naming.observation_id}" \
                       "_naming_#{naming.id}']")
@@ -129,9 +117,7 @@ class InlineCRUDLinksTest < ComponentTestCase
   def test_comment_edit_and_destroy_links
     comment = comments(:minimal_unknown_obs_comment_1)
 
-    html = render(Components::InlineCRUDLinks.new(
-                    target: comment, user: comment.user
-                  ))
+    html = render_links(target: comment, user: comment.user)
 
     assert_html(html, "a[data-modal='modal_comment_#{comment.id}']")
     expected_path = routes.comment_path(comment.id)
@@ -141,9 +127,7 @@ class InlineCRUDLinksTest < ComponentTestCase
   def test_name_description_uses_icon_link_edit
     desc = name_descriptions(:peltigera_user_desc)
 
-    html = render(Components::InlineCRUDLinks.new(
-                    target: desc, user: desc.user
-                  ))
+    html = render_links(target: desc, user: desc.user)
 
     # NameDescription edit is an IconLink, NOT a ModalLink
     assert_html(html, "a.edit_name_description_link_#{desc.id}")
@@ -154,9 +138,7 @@ class InlineCRUDLinksTest < ComponentTestCase
     seq = sequences(:deposited_sequence)
     extra_html = '<a href="/archive">archive</a>'.html_safe
 
-    html = render(Components::InlineCRUDLinks.new(
-                    target: seq, user: seq.user, extras: [extra_html]
-                  ))
+    html = render_links(target: seq, user: seq.user, extras: [extra_html])
 
     assert_html(html, "a[href='/archive']")
     assert_html(html,
@@ -174,9 +156,7 @@ class InlineCRUDLinksTest < ComponentTestCase
     obs = observations(:detailed_unknown_obs)
     tab = ::Tab::CollectionNumber::New.new(observation: obs)
 
-    html = render(Components::InlineCRUDLinks.new(
-                    modal_id: "collection_number", tab: tab
-                  ))
+    html = render_links(modal_id: "collection_number", tab: tab)
 
     assert_html(html, "a[data-modal='modal_collection_number'] " \
                       "span.glyphicon-plus")
@@ -185,5 +165,11 @@ class InlineCRUDLinksTest < ComponentTestCase
     assert_html(html, "a[title='#{tab.title}']")
     assert_html(html, "a span.sr-only", text: tab.title)
     assert_no_html(html, "a span.d-sm-inline")
+  end
+
+  private
+
+  def render_links(**)
+    render(Components::InlineCRUDLinks.new(**))
   end
 end

--- a/test/components/inline_link_block_test.rb
+++ b/test/components/inline_link_block_test.rb
@@ -21,45 +21,47 @@ class InlineLinkBlockTest < ComponentTestCase
   end
 
   def test_renders_nothing_when_items_empty
-    html = render(Components::InlineLinkBlock.new(items: []))
+    html = render_links(items: [])
 
     assert_equal("", html.to_s.strip)
   end
 
   def test_single_item_rendered_inside_nowrap_span
-    html = render(Components::InlineLinkBlock.new(
-                    items: ["<b>edit</b>".html_safe]
-                  ))
+    html = render_links(items: ["<b>edit</b>".html_safe])
 
     assert_html(html, "span.text-nowrap b", text: "edit")
   end
 
   def test_leading_separator_is_nbsp
-    html = render(Components::InlineLinkBlock.new(items: ["x"]))
+    html = render_links(items: ["x"])
     text = Nokogiri::HTML(html).at_css("span.text-nowrap").text
 
     assert_equal("\u00A0x", text)
   end
 
   def test_multiple_items_rendered_with_nbsp_dividers
-    html = render(Components::InlineLinkBlock.new(items: %w[a b c]))
+    html = render_links(items: %w[a b c])
     text = Nokogiri::HTML(html).at_css("span.text-nowrap").text
 
     assert_equal("\u00A0a\u00A0b\u00A0c", text)
   end
 
   def test_string_items_rendered_as_trusted_html
-    html = render(Components::InlineLinkBlock.new(
-                    items: ["<i>archive</i>".html_safe]
-                  ))
+    html = render_links(items: ["<i>archive</i>".html_safe])
 
     assert_html(html, "span.text-nowrap i", text: "archive")
   end
 
   def test_phlex_component_items_rendered
     button = Components::Button.new(name: "Edit", variant: :strip)
-    html = render(Components::InlineLinkBlock.new(items: [button]))
+    html = render_links(items: [button])
 
     assert_html(html, "span.text-nowrap button", text: "Edit")
+  end
+
+  private
+
+  def render_links(items:)
+    render(Components::InlineLinkBlock.new(items: items))
   end
 end

--- a/test/components/license_badge_test.rb
+++ b/test/components/license_badge_test.rb
@@ -6,7 +6,7 @@ class LicenseBadgeTest < ComponentTestCase
   def test_renders_div_with_license_id
     license = licenses(:ccnc25)
 
-    html = render(Components::LicenseBadge.new(license: license))
+    html = render_badge(license: license)
 
     assert_html(html, "#license a[href='#{license.url}'][rel='license']")
   end
@@ -14,9 +14,15 @@ class LicenseBadgeTest < ComponentTestCase
   def test_renders_badge_image
     license = licenses(:ccnc25)
 
-    html = render(Components::LicenseBadge.new(license: license))
+    html = render_badge(license: license)
 
     assert_html(html, "img[src='#{license.badge_url}']" \
                       "[alt='#{license.display_name}']")
+  end
+
+  private
+
+  def render_badge(license:)
+    render(Components::LicenseBadge.new(license: license))
   end
 end

--- a/test/components/link/active_test.rb
+++ b/test/components/link/active_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 class ActiveLinkTest < ComponentTestCase
   def test_renders_link_with_nav_active_stimulus_data_attrs
-    html = render(Components::Link::Active.new(content: "Home", path: "/"))
+    html = render_active(content: "Home", path: "/")
 
     assert_html(html, "a[href='/']" \
                       "[data-nav-active-target='link']" \
@@ -13,9 +13,7 @@ class ActiveLinkTest < ComponentTestCase
   end
 
   def test_caller_data_attrs_deep_merge_with_stimulus_attrs
-    html = render(Components::Link::Active.new(
-                    content: "Home", path: "/", data: { my_attr: "v" }
-                  ))
+    html = render_active(content: "Home", path: "/", data: { my_attr: "v" })
 
     # Stimulus wiring + caller's custom data both on the anchor.
     assert_html(html, "a[data-nav-active-target='link']" \
@@ -23,17 +21,21 @@ class ActiveLinkTest < ComponentTestCase
   end
 
   def test_caller_class_passes_through
-    html = render(Components::Link::Active.new(
-                    content: "Home", path: "/", class: "list-group-item"
-                  ))
+    html = render_active(content: "Home", path: "/", class: "list-group-item")
 
     assert_html(html, "a.list-group-item[href='/']")
   end
 
   def test_html_safe_content_not_escaped
     safe_text = "<b>bold</b>".html_safe
-    html = render(Components::Link::Active.new(content: safe_text, path: "/"))
+    html = render_active(content: safe_text, path: "/")
 
     assert_html(html, "a b", text: "bold")
+  end
+
+  private
+
+  def render_active(**)
+    render(Components::Link::Active.new(**))
   end
 end

--- a/test/components/link/external_test.rb
+++ b/test/components/link/external_test.rb
@@ -12,9 +12,7 @@ class Components::Link::ExternalTest < ComponentTestCase
   # ---- Generic (content, path) form ----
 
   def test_renders_link_with_target_blank_and_noopener
-    html = render(Components::Link::External.new(
-                    content: "GBIF", path: "https://gbif.org"
-                  ))
+    html = render_link(content: "GBIF", path: "https://gbif.org")
 
     assert_html(html, "a[href='https://gbif.org']" \
                       "[target='_blank']" \
@@ -23,21 +21,15 @@ class Components::Link::ExternalTest < ComponentTestCase
   end
 
   def test_passes_extra_opts_through
-    html = render(
-      Components::Link::External.new(
-        content: "GBIF", path: "https://gbif.org", id: "gbif_link"
-      )
-    )
+    html = render_link(content: "GBIF", path: "https://gbif.org",
+                       id: "gbif_link")
 
     assert_html(html, "a[id='gbif_link'][target='_blank']")
   end
 
   def test_does_not_override_caller_class
-    html = render(
-      Components::Link::External.new(
-        content: "EOL", path: "https://eol.org", class: "my-class"
-      )
-    )
+    html = render_link(content: "EOL", path: "https://eol.org",
+                       class: "my-class")
 
     assert_html(html, "a.my-class[target='_blank']")
   end
@@ -46,7 +38,7 @@ class Components::Link::ExternalTest < ComponentTestCase
 
   def test_tab_form_uses_tab_title_path_and_html_options
     tab = FakeTab.new
-    html = render(Components::Link::External.new(tab: tab))
+    html = render_link(tab: tab)
 
     assert_html(html, "a[href='https://example.com']" \
                       "[target='_blank'][rel='noopener noreferrer']",
@@ -58,7 +50,7 @@ class Components::Link::ExternalTest < ComponentTestCase
 
   def test_inat_link_renders_relationship_date_and_id_badge
     link = external_links(:coprinus_comatus_obs_inaturalist_link)
-    html = render(Components::Link::External.new(link: link))
+    html = render_link(link: link)
 
     assert_html(html, "a[href='#{link.url}']" \
                       "[target='_blank'][rel='noopener noreferrer']",
@@ -82,7 +74,7 @@ class Components::Link::ExternalTest < ComponentTestCase
                             external_id: "372490529")
     assert_nil(link.url, "Import links store external_id, not url")
 
-    html = render(Components::Link::External.new(link: link))
+    html = render_link(link: link)
 
     assert_html(html, "a[href='#{site.observation_url("372490529")}']" \
                       "[target='_blank'][rel='noopener noreferrer']",
@@ -92,7 +84,7 @@ class Components::Link::ExternalTest < ComponentTestCase
 
   def test_mycoportal_link_renders_relationship_date_and_id_badge
     link = external_links(:coprinus_comatus_obs_mycoportal_link)
-    html = render(Components::Link::External.new(link: link))
+    html = render_link(link: link)
 
     assert_html(html,
                 "a[href='#{link.url}']" \
@@ -111,8 +103,14 @@ class Components::Link::ExternalTest < ComponentTestCase
     link = ExternalLink.new(external_site: site,
                             url: "https://genbank.example/123")
 
-    html = render(Components::Link::External.new(link: link))
+    html = render_link(link: link)
 
     assert_no_html(html, "button.badge-id")
+  end
+
+  private
+
+  def render_link(**)
+    render(Components::Link::External.new(**))
   end
 end

--- a/test/components/link/get_test.rb
+++ b/test/components/link/get_test.rb
@@ -63,8 +63,7 @@ class LinkGetTest < ComponentTestCase
     controller.define_singleton_method(:controller_name) { "herbarium_records" }
     controller.define_singleton_method(:action_name) { "show" }
 
-    html = render(Components::Link::Get.new(name: "Edit", target: record,
-                                            action: :edit))
+    html = render_link(name: "Edit", target: record, action: :edit)
 
     expected = routes.edit_herbarium_record_path(id: record.id, back: :show)
     assert_html(html, "a[href='#{expected}']")
@@ -75,8 +74,7 @@ class LinkGetTest < ComponentTestCase
     controller.define_singleton_method(:controller_name) { "herbarium_records" }
     controller.define_singleton_method(:action_name) { "index" }
 
-    html = render(Components::Link::Get.new(name: "Edit", target: record,
-                                            action: :edit))
+    html = render_link(name: "Edit", target: record, action: :edit)
 
     expected = routes.edit_herbarium_record_path(id: record.id, back: :index)
     assert_html(html, "a[href='#{expected}']")
@@ -87,8 +85,7 @@ class LinkGetTest < ComponentTestCase
     controller.define_singleton_method(:controller_name) { "observations" }
     controller.define_singleton_method(:action_name) { "show" }
 
-    html = render(Components::Link::Get.new(name: "Edit", target: record,
-                                            action: :edit))
+    html = render_link(name: "Edit", target: record, action: :edit)
 
     expected = routes.edit_herbarium_record_path(id: record.id)
     assert_html(html, "a[href='#{expected}']")

--- a/test/components/link/icon_test.rb
+++ b/test/components/link/icon_test.rb
@@ -4,9 +4,7 @@ require("test_helper")
 
 class IconLinkTest < ComponentTestCase
   def test_plain_icon_link
-    html = render(Components::Link::Icon.new(
-                    content: "Edit", path: "/foo", icon: :edit
-                  ))
+    html = render_icon(content: "Edit", path: "/foo", icon: :edit)
 
     # Outer anchor: href, tooltip title, icon-link class, the
     # data-tooltip-target pair the tooltip Stimulus controller reads
@@ -21,14 +19,13 @@ class IconLinkTest < ComponentTestCase
 
   def test_blank_text_renders_nothing
     # Matches legacy `icon_link_to` — silent no-op when text is nil.
-    html = render(Components::Link::Icon.new(content: nil, path: "/x",
-                                             icon: :edit))
+    html = render_icon(content: nil, path: "/x", icon: :edit)
 
     assert_equal("", html)
   end
 
   def test_no_icon_falls_back_to_plain_link
-    html = render(Components::Link::Icon.new(content: "Label", path: "/x"))
+    html = render_icon(content: "Label", path: "/x")
 
     # Without an `:icon`, render as a plain link with the text.
     assert_html(html, "a[href='/x']", text: "Label")
@@ -37,21 +34,17 @@ class IconLinkTest < ComponentTestCase
   end
 
   def test_show_text_replaces_sr_only_with_visible_label
-    html = render(Components::Link::Icon.new(
-                    content: "Delete", path: "/d",
-                    icon: :delete, show_text: true
-                  ))
+    html = render_icon(content: "Delete", path: "/d",
+                       icon: :delete, show_text: true)
 
     assert_no_html(html, "a span.sr-only")
     assert_html(html, "a span", text: "Delete")
   end
 
   def test_stateful_renders_active_icon_and_label
-    html = render(Components::Link::Icon.new(
-                    content: "Subscribe", path: "/s",
-                    icon: :tracking,
-                    active_icon: :check, active_content: "Subscribed"
-                  ))
+    html = render_icon(content: "Subscribe", path: "/s",
+                       icon: :tracking,
+                       active_icon: :check, active_content: "Subscribed")
 
     # Both icons + both labels render; the active pair carries the
     # `active-icon` / `active-label` modifier classes the JS toggles
@@ -65,10 +58,8 @@ class IconLinkTest < ComponentTestCase
   end
 
   def test_button_to_mode
-    html = render(Components::Link::Icon.new(
-                    content: "Delete", path: "/d",
-                    icon: :delete, button_to: true
-                  ))
+    html = render_icon(content: "Delete", path: "/d",
+                       icon: :delete, button_to: true)
 
     # button_to wraps a button in a form; `role='button'` is added so
     # the form-styled `<button>` is announced as a button by AT.
@@ -77,20 +68,16 @@ class IconLinkTest < ComponentTestCase
   end
 
   def test_extra_class_appends_to_icon_link
-    html = render(Components::Link::Icon.new(
-                    content: "Edit", path: "/x",
-                    icon: :edit, class: "extra-thing"
-                  ))
+    html = render_icon(content: "Edit", path: "/x",
+                       icon: :edit, class: "extra-thing")
 
     # Caller's `:class` deep-merges with the default `icon-link` class.
     assert_html(html, "a.icon-link.extra-thing")
   end
 
   def test_arbitrary_data_attrs_deep_merge_onto_link
-    html = render(Components::Link::Icon.new(
-                    content: "X", path: "/x",
-                    icon: :edit, data: { my_attr: "v" }
-                  ))
+    html = render_icon(content: "X", path: "/x",
+                       icon: :edit, data: { my_attr: "v" })
 
     # `data: { ... }` from the caller deep_merges with the tooltip
     # data attrs, so both the tooltip wiring AND the caller's custom
@@ -106,7 +93,7 @@ class IconLinkTest < ComponentTestCase
     project = projects(:eol_project)
     tab = Tab::Project::Summary.new(project: project)
 
-    html = render(Components::Link::Icon.new(tab: tab))
+    html = render_icon(tab: tab)
 
     assert_html(html, "a[href='#{tab.path}']", text: tab.title)
   end
@@ -115,59 +102,47 @@ class IconLinkTest < ComponentTestCase
     desc = name_descriptions(:peltigera_user_desc)
     tab = Tab::Description::Clone.new(description: desc)
 
-    html = render(Components::Link::Icon.new(tab: tab))
+    html = render_icon(tab: tab)
 
     assert_html(html, "a[data-turbo-confirm]")
   end
 
   def test_no_button_kwarg_renders_plain_link
-    html = render(Components::Link::Icon.new(content: "Edit", path: "/x",
-                                             icon: :edit))
+    html = render_icon(content: "Edit", path: "/x", icon: :edit)
 
     assert_no_html(html, "a.btn")
   end
 
   def test_button_default_kwarg_adds_btn_framing
-    html = render(Components::Link::Icon.new(
-                    content: "Next", path: "/x",
-                    icon: :next, button: :default
-                  ))
+    html = render_icon(content: "Next", path: "/x",
+                       icon: :next, button: :default)
 
     assert_html(html, "a.icon-link.btn.btn-default")
   end
 
   def test_button_variant_kwarg_adds_matching_btn_class
-    html = render(Components::Link::Icon.new(
-                    content: "Next", path: "/x",
-                    icon: :next, button: :outline
-                  ))
+    html = render_icon(content: "Next", path: "/x",
+                       icon: :next, button: :outline)
 
     assert_html(html, "a.btn.btn-outline-default")
   end
 
   def test_size_kwarg_adds_size_class_alongside_button
-    html = render(Components::Link::Icon.new(
-                    content: "Next", path: "/x",
-                    icon: :next, button: :default, size: :lg
-                  ))
+    html = render_icon(content: "Next", path: "/x",
+                       icon: :next, button: :default, size: :lg)
 
     assert_html(html, "a.btn.btn-default.btn-lg")
   end
 
   def test_button_strip_kwarg_adds_no_btn_framing
-    html = render(Components::Link::Icon.new(
-                    content: "Next", path: "/x",
-                    icon: :next, button: :strip
-                  ))
+    html = render_icon(content: "Next", path: "/x",
+                       icon: :next, button: :strip)
 
     assert_no_html(html, "a.btn")
   end
 
   def test_size_kwarg_without_button_does_not_dangle
-    html = render(Components::Link::Icon.new(
-                    content: "Next", path: "/x",
-                    icon: :next, size: :lg
-                  ))
+    html = render_icon(content: "Next", path: "/x", icon: :next, size: :lg)
 
     # No `.btn` base class, so `.btn-lg` alone must not appear either --
     # a dangling size modifier with no button framing isn't valid
@@ -177,10 +152,8 @@ class IconLinkTest < ComponentTestCase
   end
 
   def test_size_kwarg_with_button_strip_does_not_dangle
-    html = render(Components::Link::Icon.new(
-                    content: "Next", path: "/x",
-                    icon: :next, button: :strip, size: :lg
-                  ))
+    html = render_icon(content: "Next", path: "/x",
+                       icon: :next, button: :strip, size: :lg)
 
     assert_no_html(html, "a.btn")
     assert_no_html(html, "a.btn-lg")
@@ -193,5 +166,11 @@ class IconLinkTest < ComponentTestCase
       Components::Link::Icon.new(content: "Next", path: "/x",
                                  icon: :next, class: "btn btn-primary")
     end
+  end
+
+  private
+
+  def render_icon(**)
+    render(Components::Link::Icon.new(**))
   end
 end

--- a/test/components/link/location_test.rb
+++ b/test/components/link/location_test.rb
@@ -5,9 +5,7 @@ require("test_helper")
 class LocationLinkTest < ComponentTestCase
   def test_renders_show_location_link_when_location_given
     burbank = locations(:burbank)
-    html = render(Components::Link::Location.new(
-                    where: burbank.name, location: burbank
-                  ))
+    html = render_location(where: burbank.name, location: burbank)
 
     # Asserted attribute-by-attribute so the test pins behavior
     # (where it links, what selector class it carries) rather than
@@ -23,9 +21,7 @@ class LocationLinkTest < ComponentTestCase
 
   def test_count_suffix_appended
     burbank = locations(:burbank)
-    html = render(Components::Link::Location.new(
-                    where: burbank.name, location: burbank, count: 7
-                  ))
+    html = render_location(where: burbank.name, location: burbank, count: 7)
 
     # Locations index uses count to show "<name> (7)".
     assert_includes(html, "(7)")
@@ -33,9 +29,8 @@ class LocationLinkTest < ComponentTestCase
 
   def test_click_appends_map_icon_link
     burbank = locations(:burbank)
-    html = render(Components::Link::Location.new(
-                    where: burbank.name, location: burbank, click: true
-                  ))
+    html = render_location(where: burbank.name, location: burbank,
+                           click: true)
 
     location_href = routes.location_path(id: burbank.id)
     # A standalone icon link, distinct from the label's own anchor --
@@ -46,7 +41,7 @@ class LocationLinkTest < ComponentTestCase
 
   def test_without_location_renders_observations_index_link
     where = "Some Place, USA"
-    html = render(Components::Link::Location.new(where: where))
+    html = render_location(where: where)
 
     # Fallback: no resolved Location → link to observations index
     # filtered by `where=`, with a distinct selector class.
@@ -58,9 +53,7 @@ class LocationLinkTest < ComponentTestCase
   def test_query_param_forwarded_on_location_link
     burbank = locations(:burbank)
     query = Query.lookup_and_save(:Location)
-    html = render(Components::Link::Location.new(
-                    location: burbank, query: query
-                  ))
+    html = render_location(location: burbank, query: query)
 
     # query: is forwarded via add_q_param — href gets a ?q[...] query string
     base_path = routes.location_path(id: burbank.id)
@@ -68,10 +61,14 @@ class LocationLinkTest < ComponentTestCase
   end
 
   def test_click_on_where_link_appends_search_suffix
-    html = render(Components::Link::Location.new(
-                    where: "Some Place, USA", click: true
-                  ))
+    html = render_location(where: "Some Place, USA", click: true)
 
     assert_includes(html, :search.ti)
+  end
+
+  private
+
+  def render_location(**)
+    render(Components::Link::Location.new(**))
   end
 end

--- a/test/components/link/object_test.rb
+++ b/test/components/link/object_test.rb
@@ -5,7 +5,7 @@ require("test_helper")
 class ObjectLinkTest < ComponentTestCase
   def test_renders_anchor_to_object_show_page
     project = projects(:bolete_project)
-    html = render(Components::Link::Object.new(object: project))
+    html = render_object(object: project)
 
     # Behavior pinned: where it links + the selector class + the
     # default visible text comes from `object.title.t`.
@@ -16,13 +16,18 @@ class ObjectLinkTest < ComponentTestCase
 
   def test_name_override_replaces_default_label
     project = projects(:bolete_project)
-    html = render(Components::Link::Object.new(object: project,
-                                               name: "BP"))
+    html = render_object(object: project, name: "BP")
 
     assert_html(html, "a.project_link_#{project.id}", text: "BP")
   end
 
   def test_nil_object_renders_nothing
-    assert_equal("", render(Components::Link::Object.new(object: nil)))
+    assert_equal("", render_object(object: nil))
+  end
+
+  private
+
+  def render_object(**)
+    render(Components::Link::Object.new(**))
   end
 end

--- a/test/components/link/user_test.rb
+++ b/test/components/link/user_test.rb
@@ -5,7 +5,7 @@ require("test_helper")
 class UserLinkTest < ComponentTestCase
   def test_renders_anchor_to_user_show_with_unique_text_name
     rolf = users(:rolf)
-    html = render(Components::Link::User.new(user: rolf))
+    html = render_link(user: rolf)
 
     # Behavior pinned: where it links + the selector class. Each
     # attribute asserted separately so attribute order can drift
@@ -17,7 +17,7 @@ class UserLinkTest < ComponentTestCase
 
   def test_name_override_replaces_default_label
     rolf = users(:rolf)
-    html = render(Components::Link::User.new(user: rolf, name: "RS"))
+    html = render_link(user: rolf, name: "RS")
 
     assert_html(html, "a.user_link_#{rolf.id}", text: "RS")
   end
@@ -26,7 +26,7 @@ class UserLinkTest < ComponentTestCase
     # Some callers (translations versions, comments author lookup)
     # only have the user id at hand. Fall back to "User #<id>"
     # rather than blowing up trying to `unique_text_name` an integer.
-    html = render(Components::Link::User.new(user: 42))
+    html = render_link(user: 42)
 
     assert_html(html, "a[href='#{routes.user_path(42)}']",
                 text: "#{:user.ti} #42")
@@ -34,7 +34,7 @@ class UserLinkTest < ComponentTestCase
   end
 
   def test_integer_id_with_name_uses_name
-    html = render(Components::Link::User.new(user: 42, name: "rolf"))
+    html = render_link(user: 42, name: "rolf")
 
     assert_html(html, "a.user_link_42", text: "rolf")
   end
@@ -43,7 +43,7 @@ class UserLinkTest < ComponentTestCase
     # Matches the legacy helper's "unknown user" fallback so
     # callers (e.g. ip_stats with a missing User row) can pass nil
     # without conditional logic.
-    html = render(Components::Link::User.new(user: nil))
+    html = render_link(user: nil)
 
     assert_no_html(html, "a")
     assert_includes(html, :unknown_user_name.t)
@@ -51,15 +51,19 @@ class UserLinkTest < ComponentTestCase
 
   def test_attributes_passed_through_with_class_merged
     rolf = users(:rolf)
-    html = render(Components::Link::User.new(
-                    user: rolf,
-                    attributes: { id: "my_link", class: "extra" }
-                  ))
+    html = render_link(user: rolf,
+                       attributes: { id: "my_link", class: "extra" })
 
     # Caller's class merges with the auto `user_link_<id>`; the
     # caller's `id:` flows through unchanged.
     assert_html(html, "a#my_link")
     assert_html(html, "a.user_link_#{rolf.id}")
     assert_html(html, "a.extra")
+  end
+
+  private
+
+  def render_link(**)
+    render(Components::Link::User.new(**))
   end
 end

--- a/test/components/list_group/item_test.rb
+++ b/test/components/list_group/item_test.rb
@@ -44,9 +44,8 @@ class ListGroupItemTest < ComponentTestCase
     # Composition contract: the block renders inside the wrapper
     # element. The CommentRow case (ListGroupItem wrapping a
     # CommentItem) depends on this.
-    html = render(Components::ListGroup::Item.new(class: "comment",
-                                                  id: "x")) do
-      render(Components::ListGroup::Item.new(class: "inner")) { "hi" }
+    html = render_item(class: "comment", id: "x") do
+      render_item(class: "inner") { "hi" }
     end
 
     assert_html(html,

--- a/test/components/list_group_test.rb
+++ b/test/components/list_group_test.rb
@@ -55,7 +55,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_renders_plain_list_group_with_items
-    html = render(Components::ListGroup.new) do |list|
+    html = render_list do |list|
       list.item { "one" }
       list.item { "two" }
     end
@@ -67,7 +67,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_flush_adds_list_group_flush_class
-    html = render(Components::ListGroup.new(flush: true)) do |list|
+    html = render_list(flush: true) do |list|
       list.item { "x" }
     end
 
@@ -77,7 +77,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_ul_element_switches_items_to_li
-    html = render(Components::ListGroup.new(element: :ul)) do |list|
+    html = render_list(element: :ul) do |list|
       list.item { "one" }
       list.item { "two" }
     end
@@ -89,10 +89,8 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_container_id_and_class_extras_flow_through
-    html = render(Components::ListGroup.new(
-                    id: "namings_table_rows",
-                    flush: true, class: "namings"
-                  )) do |list|
+    html = render_list(id: "namings_table_rows", flush: true,
+                       class: "namings") do |list|
       list.item { "x" }
     end
 
@@ -102,9 +100,9 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_container_data_attributes_pass_through
-    html = render(Components::ListGroup.new(
-                    attributes: { data: { controller: "section-update" } }
-                  )) do |list|
+    html = render_list(
+      attributes: { data: { controller: "section-update" } }
+    ) do |list|
       list.item { "x" }
     end
 
@@ -114,7 +112,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_per_item_id_and_class_extras_flow_through
-    html = render(Components::ListGroup.new) do |list|
+    html = render_list do |list|
       list.item(id: "naming_42", class: "consensus-row") { "x" }
     end
 
@@ -124,7 +122,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_per_item_arbitrary_attributes_pass_through
-    html = render(Components::ListGroup.new) do |list|
+    html = render_list do |list|
       list.item(data: { foo: "bar" }) { "x" }
     end
 
@@ -138,7 +136,7 @@ class ListGroupTest < ComponentTestCase
     # `.list-group-item` child — so it shows iff no real rows
     # exist. Works seamlessly with Turbo Stream `append` / `remove`
     # broadcasts that only touch real items.
-    html = render(Components::ListGroup.new) do |list|
+    html = render_list do |list|
       list.item { "real row" }
       list.empty { "nothing yet" }
     end
@@ -152,7 +150,7 @@ class ListGroupTest < ComponentTestCase
   end
 
   def test_empty_slot_renders_even_without_real_items
-    html = render(Components::ListGroup.new) do |list|
+    html = render_list do |list|
       list.empty { "nothing yet" }
     end
 
@@ -166,7 +164,7 @@ class ListGroupTest < ComponentTestCase
     # Empty list with neither items nor placeholder: just the outer
     # container. Helpful for streamed-in content where items arrive
     # via Turbo later.
-    html = render(Components::ListGroup.new) do |list|
+    html = render_list do |list|
       # intentionally empty — no list.item / list.empty calls
       _ = list
     end
@@ -179,7 +177,7 @@ class ListGroupTest < ComponentTestCase
     # Each block must close over its OWN value of `n` from the loop,
     # not a single shared one — proves the deferred-render pattern
     # captures iteration-local bindings correctly.
-    html = render(Components::ListGroup.new) do |list|
+    html = render_list do |list|
       (1..3).each do |n|
         list.item { "row #{n}" }
       end
@@ -189,5 +187,11 @@ class ListGroupTest < ComponentTestCase
     assert_includes(html, "row 1")
     assert_includes(html, "row 2")
     assert_includes(html, "row 3")
+  end
+
+  private
+
+  def render_list(**, &block)
+    render(Components::ListGroup.new(**), &block)
   end
 end

--- a/test/components/map_test.rb
+++ b/test/components/map_test.rb
@@ -17,7 +17,7 @@ class MapTest < ComponentTestCase
   end
 
   def test_renders_map_with_default_attributes
-    html = render(Components::Map.new(objects: [@location]))
+    html = render_map(objects: [@location])
 
     # All default attributes on one element
     assert_html(
@@ -33,20 +33,20 @@ class MapTest < ComponentTestCase
   end
 
   def test_renders_map_without_controller_when_nil
-    html = render(Components::Map.new(objects: [@location], controller: nil))
+    html = render_map(objects: [@location], controller: nil)
 
     assert_no_html(html, "#map_div[data-controller]")
   end
 
   def test_renders_map_with_custom_options
-    html = render(Components::Map.new(
-                    objects: [@location],
-                    map_type: "location",
-                    editable: true,
-                    map_open: false,
-                    need_elevations_value: false,
-                    map_div: "custom_map"
-                  ))
+    html = render_map(
+      objects: [@location],
+      map_type: "location",
+      editable: true,
+      map_open: false,
+      need_elevations_value: false,
+      map_div: "custom_map"
+    )
 
     assert_html(
       html,
@@ -59,7 +59,7 @@ class MapTest < ComponentTestCase
   end
 
   def test_renders_json_data_attributes
-    html = render(Components::Map.new(objects: [@location]))
+    html = render_map(objects: [@location])
     doc = Nokogiri::HTML(html)
     map_div = doc.at_css("#map_div")
 
@@ -82,23 +82,22 @@ class MapTest < ComponentTestCase
 
   def test_renders_nothing_to_map_when_no_mappable_objects
     # Empty objects
-    html = render(Components::Map.new(objects: []))
+    html = render_map(objects: [])
     assert_html(html, "body", text: :runtime_map_nothing_to_map.t)
 
     # Unknown location (no coordinates)
     unknown = Location.new(name: "Earth")
-    html = render(Components::Map.new(objects: [unknown]))
+    html = render_map(objects: [unknown])
     assert_html(html, "body", text: :runtime_map_nothing_to_map.t)
 
     # Custom message
-    html = render(Components::Map.new(objects: [],
-                                      nothing_to_map: "Custom message"))
+    html = render_map(objects: [], nothing_to_map: "Custom message")
     assert_html(html, "body", text: "Custom message")
   end
 
   def test_renders_with_observation
     observation = observations(:detailed_unknown_obs)
-    html = render(Components::Map.new(objects: [observation]))
+    html = render_map(objects: [observation])
 
     assert_html(html, "#map_div")
   end
@@ -237,7 +236,7 @@ class MapTest < ComponentTestCase
   def test_clustering_under_cap_emits_clustering_data_attr
     obs = build_min_obs(lat: 1, lng: 1, vote_cache: 3.0,
                         text_name: "Sp.", observed_on: Date.new(2024, 1, 1))
-    html = render(Components::Map.new(objects: [obs], clustering: true))
+    html = render_map(objects: [obs], clustering: true)
 
     assert_html(html, "#map_div[data-clustering='true']")
     doc = Nokogiri::HTML(html)
@@ -256,7 +255,7 @@ class MapTest < ComponentTestCase
                     text_name: "Sp #{i}",
                     observed_on: Date.new(2024, 1, i + 1))
     end
-    html = render(Components::Map.new(objects: obs, clustering: true))
+    html = render_map(objects: obs, clustering: true)
 
     assert_no_html(html, "#map_div[data-clustering]")
   ensure
@@ -269,10 +268,10 @@ class MapTest < ComponentTestCase
   def test_capped_with_clustering_renders_visible_cap_banner
     obs = build_min_obs(lat: 1, lng: 1, vote_cache: 3.0,
                         text_name: "Sp.", observed_on: Date.new(2024, 1, 1))
-    html = render(Components::Map.new(objects: [obs], clustering: true,
-                                      capped: true,
-                                      observations_loaded_count: 10_000,
-                                      observations_total_count: 12_345))
+    html = render_map(objects: [obs], clustering: true,
+                      capped: true,
+                      observations_loaded_count: 10_000,
+                      observations_total_count: 12_345)
 
     assert_html(html, "#map_cap_banner.alert.alert-warning")
     doc = Nokogiri::HTML(html)
@@ -286,10 +285,10 @@ class MapTest < ComponentTestCase
   def test_uncapped_with_clustering_renders_hidden_cap_banner
     obs = build_min_obs(lat: 1, lng: 1, vote_cache: 3.0,
                         text_name: "Sp.", observed_on: Date.new(2024, 1, 1))
-    html = render(Components::Map.new(objects: [obs], clustering: true,
-                                      capped: false,
-                                      observations_loaded_count: 100,
-                                      observations_total_count: 100))
+    html = render_map(objects: [obs], clustering: true,
+                      capped: false,
+                      observations_loaded_count: 100,
+                      observations_total_count: 100)
 
     assert_html(html, "#map_cap_banner[style*='display:none']")
   end
@@ -297,20 +296,19 @@ class MapTest < ComponentTestCase
   def test_no_cap_banner_without_clustering
     obs = build_min_obs(lat: 1, lng: 1, vote_cache: 3.0,
                         text_name: "Sp.", observed_on: Date.new(2024, 1, 1))
-    html = render(Components::Map.new(objects: [obs]))
+    html = render_map(objects: [obs])
 
     assert_no_html(html, "#map_cap_banner")
   end
 
   def test_zoom_forwarded_as_data_zoom
-    html = render(Components::Map.new(objects: [@location], zoom: 4))
+    html = render_map(objects: [@location], zoom: 4)
 
     assert_html(html, "#map_div[data-zoom='4']")
   end
 
   def test_cluster_query_string_forwarded_when_present
-    html = render(Components::Map.new(objects: [@location],
-                                      cluster_query_string: "q=ABC"))
+    html = render_map(objects: [@location], cluster_query_string: "q=ABC")
 
     assert_html(html, "#map_div[data-cluster-query-string='q=ABC']")
   end
@@ -322,31 +320,29 @@ class MapTest < ComponentTestCase
 
   def test_location_format_prop_wins_over_user_prop_and_current_user
     controller.instance_variable_set(:@user, users(:roy)) # scientific
-    html = render(Components::Map.new(objects: [@location],
-                                      user: users(:roy),
-                                      location_format: "postal"))
+    html = render_map(objects: [@location], user: users(:roy),
+                      location_format: "postal")
 
     assert_html(html, "#map_div[data-location-format='postal']")
   end
 
   def test_location_format_falls_back_to_user_prop
     controller.instance_variable_set(:@user, users(:rolf)) # postal
-    html = render(Components::Map.new(objects: [@location],
-                                      user: users(:roy)))
+    html = render_map(objects: [@location], user: users(:roy))
 
     assert_html(html, "#map_div[data-location-format='scientific']")
   end
 
   def test_location_format_falls_back_to_current_user_without_user_prop
     controller.instance_variable_set(:@user, users(:roy)) # scientific
-    html = render(Components::Map.new(objects: [@location]))
+    html = render_map(objects: [@location])
 
     assert_html(html, "#map_div[data-location-format='scientific']")
   end
 
   def test_location_format_defaults_to_postal_without_any_user
     controller.instance_variable_set(:@user, nil)
-    html = render(Components::Map.new(objects: [@location]))
+    html = render_map(objects: [@location])
 
     assert_html(html, "#map_div[data-location-format='postal']")
   end
@@ -358,7 +354,7 @@ class MapTest < ComponentTestCase
   def test_legend_renders_when_objects_include_observations
     obs = build_min_obs(lat: 1, lng: 1, vote_cache: 3.0,
                         text_name: "Sp.", observed_on: Date.new(2024, 1, 1))
-    html = render(Components::Map.new(objects: [obs]))
+    html = render_map(objects: [obs])
 
     assert_html(html, ".map-legend")
     # Confirmed/tentative/disputed/mixed band labels.
@@ -369,7 +365,7 @@ class MapTest < ComponentTestCase
   end
 
   def test_legend_suppressed_on_location_only_map
-    html = render(Components::Map.new(objects: [@location]))
+    html = render_map(objects: [@location])
 
     assert_no_html(html, ".map-legend")
   end
@@ -400,8 +396,12 @@ class MapTest < ComponentTestCase
     )
   end
 
+  def render_map(**)
+    render(Components::Map.new(**))
+  end
+
   def render_map_json(objects)
-    html = render(Components::Map.new(objects: objects))
+    html = render_map(objects: objects)
     doc = Nokogiri::HTML(html)
     JSON.parse(doc.at_css("#map_div")["data-collection"])
   end

--- a/test/components/matrix/box/footer_test.rb
+++ b/test/components/matrix/box/footer_test.rb
@@ -80,9 +80,7 @@ class MatrixBoxFooterTest < ComponentTestCase
     project = projects(:bolete_project)
     obs = observations(:coprinus_comatus_obs)
     dick = users(:dick) # member of bolete_admins
-    html = render(
-      Components::Matrix::Box.new(user: dick, object: obs, project: project)
-    )
+    html = render_box(user: dick, object: obs, project: project)
 
     expected_path = routes.exclude_observation_project_update_path(
       project_id: project.id, id: obs.id
@@ -93,9 +91,7 @@ class MatrixBoxFooterTest < ComponentTestCase
   def test_project_admin_footer_hidden_for_non_admin
     project = projects(:bolete_project)
     obs = observations(:coprinus_comatus_obs)
-    html = render(
-      Components::Matrix::Box.new(user: @user, object: obs, project: project)
-    )
+    html = render_box(user: @user, object: obs, project: project)
 
     expected_path = routes.exclude_observation_project_update_path(
       project_id: project.id, id: obs.id
@@ -105,14 +101,16 @@ class MatrixBoxFooterTest < ComponentTestCase
 
   def test_project_admin_footer_hidden_without_project
     obs = observations(:coprinus_comatus_obs)
-    html = render(
-      Components::Matrix::Box.new(user: @user, object: obs)
-    )
+    html = render_box(user: @user, object: obs)
 
     assert_no_html(html, "div.panel-footer.text-center")
   end
 
   private
+
+  def render_box(**)
+    render(Components::Matrix::Box.new(**))
+  end
 
   # Renders render_footer_detail(detail) in a Phlex context.
   def render_detail(detail)

--- a/test/components/matrix/table_test.rb
+++ b/test/components/matrix/table_test.rb
@@ -9,7 +9,7 @@ class MatrixTableTest < ComponentTestCase
   end
 
   def test_renders_empty_table_when_no_objects
-    component = Components::Matrix::Table.new
+    component = build_table
     html = render(component)
 
     assert_includes(html, "list-unstyled")
@@ -21,11 +21,7 @@ class MatrixTableTest < ComponentTestCase
       observations(:coprinus_comatus_obs),
       observations(:agaricus_campestris_obs)
     ]
-    component = Components::Matrix::Table.new(
-      objects: observations,
-      user: @user,
-      cached: false
-    )
+    component = build_table(objects: observations, cached: false)
     html = render(component)
 
     assert_includes(html, "box_#{observations.first.id}")
@@ -36,11 +32,7 @@ class MatrixTableTest < ComponentTestCase
     obs = observations(:coprinus_comatus_obs)
     # Stub transferred to return true
     obs.thumb_image.stub(:transferred, true) do
-      component = Components::Matrix::Table.new(
-        objects: [obs],
-        user: @user,
-        cached: true
-      )
+      component = build_table(objects: [obs], cached: true)
 
       # Expect cache to be called
       cache_called = false
@@ -59,11 +51,7 @@ class MatrixTableTest < ComponentTestCase
     obs = observations(:coprinus_comatus_obs)
     # Stub transferred to return false
     obs.thumb_image.stub(:transferred, false) do
-      component = Components::Matrix::Table.new(
-        objects: [obs],
-        user: @user,
-        cached: true
-      )
+      component = build_table(objects: [obs], cached: true)
 
       # Expect cache NOT to be called
       cache_called = false
@@ -85,11 +73,7 @@ class MatrixTableTest < ComponentTestCase
 
   def test_caches_objects_without_thumb_image
     user = users(:katrina)
-    component = Components::Matrix::Table.new(
-      objects: [user],
-      user: @user,
-      cached: true
-    )
+    component = build_table(objects: [user], cached: true)
 
     # Expect cache to be called for user objects
     cache_called = false
@@ -114,9 +98,7 @@ class MatrixTableTest < ComponentTestCase
   def test_caches_image_objects_with_transferred_true
     image = images(:connected_coprinus_comatus_image)
     image.stub(:transferred, true) do
-      component = Components::Matrix::Table.new(
-        objects: [image], user: @user, cached: true
-      )
+      component = build_table(objects: [image], cached: true)
 
       cache_called = false
       component.stub(:low_level_cache, lambda { |_key, &block|
@@ -134,9 +116,7 @@ class MatrixTableTest < ComponentTestCase
   def test_does_not_cache_image_objects_with_transferred_false
     image = images(:connected_coprinus_comatus_image)
     image.stub(:transferred, false) do
-      component = Components::Matrix::Table.new(
-        objects: [image], user: @user, cached: true
-      )
+      component = build_table(objects: [image], cached: true)
 
       cache_called = false
       component.stub(:low_level_cache, lambda { |_key, &block|
@@ -201,11 +181,7 @@ class MatrixTableTest < ComponentTestCase
     assert_nil(obs.thumb_image,
                "Test requires observation with nil thumb_image")
 
-    component = Components::Matrix::Table.new(
-      objects: [obs],
-      user: @user,
-      cached: true
-    )
+    component = build_table(objects: [obs], cached: true)
 
     # Expect cache to be called when thumb_image is nil
     cache_called = false
@@ -224,11 +200,7 @@ class MatrixTableTest < ComponentTestCase
 
   def test_does_not_render_identify_ui_and_footer_when_identify_is_false
     obs = observations(:coprinus_comatus_obs)
-    component = Components::Matrix::Table.new(
-      objects: [obs],
-      user: @user,
-      identify: false
-    )
+    component = build_table(objects: [obs], identify: false)
     html = render(component)
 
     # Should not have identify UI or footer
@@ -242,11 +214,7 @@ class MatrixTableTest < ComponentTestCase
     # Must eager-load observation_views for identify footer to render
     obs = Observation.includes(:observation_views).
           find(observations(:coprinus_comatus_obs).id)
-    component = Components::Matrix::Table.new(
-      objects: [obs],
-      user: @user,
-      identify: true
-    )
+    component = build_table(objects: [obs], identify: true)
     html = render(component)
 
     # Should have identify UI and footer
@@ -260,7 +228,7 @@ class MatrixTableTest < ComponentTestCase
   end
 
   def test_renders_with_block
-    component = Components::Matrix::Table.new
+    component = build_table
     html = render(component) do |table|
       table.render(
         Components::Matrix::Box.new(
@@ -284,9 +252,7 @@ class MatrixTableTest < ComponentTestCase
   # the whole page needs zero per-frame fetches.
   def test_renders_vote_interface_streams_after_boxes
     obs = observations(:coprinus_comatus_obs)
-    html = render(Components::Matrix::Table.new(
-                    objects: [obs], user: @user, cached: false
-                  ))
+    html = render(build_table(objects: [obs], cached: false))
 
     image_id = obs.thumb_image.id
     assert_html(
@@ -302,16 +268,14 @@ class MatrixTableTest < ComponentTestCase
   def test_no_vote_interface_streams_for_objects_without_thumb_images
     obs = observations(:coprinus_comatus_obs)
     obs.stub(:thumb_image, nil) do
-      html = render(Components::Matrix::Table.new(
-                      objects: [obs], user: @user, cached: false
-                    ))
+      html = render(build_table(objects: [obs], cached: false))
 
       assert_no_html(html, "turbo-stream")
     end
   end
 
   def test_no_vote_interface_streams_in_block_form
-    html = render(Components::Matrix::Table.new) do |table|
+    html = render(build_table) do |table|
       table.render(Components::Matrix::Box.new(id: 456) do
         view_context.tag.div { "Block content" }
       end)
@@ -323,11 +287,7 @@ class MatrixTableTest < ComponentTestCase
   def test_cache_key_includes_locale
     obs = observations(:coprinus_comatus_obs)
     obs.thumb_image.stub(:transferred, true) do
-      component = Components::Matrix::Table.new(
-        objects: [obs],
-        user: @user,
-        cached: true
-      )
+      component = build_table(objects: [obs], cached: true)
 
       # Capture the cache key that gets passed to low_level_cache
       captured_key = nil
@@ -349,12 +309,7 @@ class MatrixTableTest < ComponentTestCase
   def test_does_not_cache_when_identify_is_true
     obs = observations(:coprinus_comatus_obs)
     obs.thumb_image.stub(:transferred, true) do
-      component = Components::Matrix::Table.new(
-        objects: [obs],
-        user: @user,
-        cached: true,
-        identify: true
-      )
+      component = build_table(objects: [obs], cached: true, identify: true)
 
       cache_called = false
       component.stub(:low_level_cache, lambda { |_key, &block|
@@ -378,9 +333,7 @@ class MatrixTableTest < ComponentTestCase
       keys = []
 
       # Render with English locale
-      component_en = Components::Matrix::Table.new(
-        objects: [obs], user: @user, cached: true
-      )
+      component_en = build_table(objects: [obs], cached: true)
       component_en.stub(:low_level_cache, lambda { |key, &block|
         keys << key
         block.call
@@ -389,9 +342,7 @@ class MatrixTableTest < ComponentTestCase
       end
 
       # Render with Spanish locale (new component instance)
-      component_es = Components::Matrix::Table.new(
-        objects: [obs], user: @user, cached: true
-      )
+      component_es = build_table(objects: [obs], cached: true)
       component_es.stub(:low_level_cache, lambda { |key, &block|
         keys << key
         block.call
@@ -451,9 +402,7 @@ class MatrixTableTest < ComponentTestCase
     real_store.write(first_key, ["<li>already cached</li>", {}])
     spy = CountingCacheStore.new(real_store)
 
-    component = Components::Matrix::Table.new(
-      objects: observations, user: @user, cached: true
-    )
+    component = build_table(objects: observations, cached: true)
 
     # Phlex-rails' low_level_cache gates on perform_caching (unset,
     # so falsy, in the test env by default) -- without this, it always
@@ -496,9 +445,7 @@ class MatrixTableTest < ComponentTestCase
   def test_batched_store_is_cleared_after_render_completes
     obs = observations(:coprinus_comatus_obs)
     obs.thumb_image.update_column(:transferred, true)
-    component = Components::Matrix::Table.new(
-      objects: [obs], user: @user, cached: true
-    )
+    component = build_table(objects: [obs], cached: true)
 
     original_perform_caching =
       Rails.application.config.action_controller.perform_caching
@@ -520,9 +467,7 @@ class MatrixTableTest < ComponentTestCase
   def test_render_cached_boxes_skips_the_batched_read_when_caching_is_off
     obs = observations(:coprinus_comatus_obs)
     obs.thumb_image.update_column(:transferred, true)
-    component = Components::Matrix::Table.new(
-      objects: [obs], user: @user, cached: true
-    )
+    component = build_table(objects: [obs], cached: true)
     spy = CountingCacheStore.new(ActiveSupport::Cache::MemoryStore.new)
 
     original_cache = Rails.cache
@@ -545,5 +490,11 @@ class MatrixTableTest < ComponentTestCase
       "wasted read_multi on every render"
     )
     assert_equal(0, spy.write_multi_calls)
+  end
+
+  private
+
+  def build_table(**)
+    Components::Matrix::Table.new(user: @user, **)
   end
 end

--- a/test/components/modal/close_button_test.rb
+++ b/test/components/modal/close_button_test.rb
@@ -4,14 +4,14 @@ require("test_helper")
 
 class ModalCloseButtonTest < ComponentTestCase
   def test_default_renders_dismiss_only_cancel_button
-    html = render(Components::Modal::CloseButton.new)
+    html = render_close_button
 
     assert_html(html, "button[data-dismiss='modal']", text: :cancel.ti)
     assert_no_html(html, "a")
   end
 
   def test_target_kwarg_renders_navigational_get_button
-    html = render(Components::Modal::CloseButton.new(target: "/foo/cancel"))
+    html = render_close_button(target: "/foo/cancel")
 
     # Still dismisses the modal via JS AND navigates to the real path.
     assert_html(html, "a[href='/foo/cancel'][data-dismiss='modal']",
@@ -23,22 +23,20 @@ class ModalCloseButtonTest < ComponentTestCase
     # caller has a plain String path handy; some want to pass a model
     # and let CRUDPathBuilding derive the path.
     herbarium = herbaria(:nybg_herbarium)
-    html = render(Components::Modal::CloseButton.new(target: herbarium))
+    html = render_close_button(target: herbarium)
 
     assert_html(html, "a[href='#{routes.herbarium_path(id: herbarium.id)}']" \
                        "[data-dismiss='modal']")
   end
 
   def test_name_kwarg_overrides_default_label
-    html = render(Components::Modal::CloseButton.new(name: "Nevermind"))
+    html = render_close_button(name: "Nevermind")
 
     assert_html(html, "button[data-dismiss='modal']", text: "Nevermind")
   end
 
   def test_extra_data_attrs_merge_with_dismiss
-    html = render(Components::Modal::CloseButton.new(
-                    data: { action: "confirm-modal#cancel" }
-                  ))
+    html = render_close_button(data: { action: "confirm-modal#cancel" })
 
     assert_html(html, "button[data-dismiss='modal']" \
                        "[data-action='confirm-modal#cancel']")
@@ -48,9 +46,7 @@ class ModalCloseButtonTest < ComponentTestCase
     # A caller-supplied data: { dismiss: ... } must never win -- that
     # would silently break the component's whole point (closing the
     # modal).
-    html = render(Components::Modal::CloseButton.new(
-                    data: { dismiss: "something-else" }
-                  ))
+    html = render_close_button(data: { dismiss: "something-else" })
 
     assert_html(html, "button[data-dismiss='modal']")
     assert_no_html(html, "button[data-dismiss='something-else']")
@@ -60,5 +56,9 @@ class ModalCloseButtonTest < ComponentTestCase
 
   def routes
     Rails.application.routes.url_helpers
+  end
+
+  def render_close_button(**)
+    render(Components::Modal::CloseButton.new(**))
   end
 end

--- a/test/components/modal_test.rb
+++ b/test/components/modal_test.rb
@@ -4,9 +4,7 @@ require("test_helper")
 
 class ModalTest < ComponentTestCase
   def test_renders_chrome_with_body_and_footer_slots
-    html = render(Components::Modal.new(
-                    id: "modal_thing", title: "Pick a thing"
-                  )) do |m|
+    html = render_modal(id: "modal_thing", title: "Pick a thing") do |m|
       m.with_body { "<p>body content</p>".html_safe }
       m.with_footer { "<button>OK</button>".html_safe }
     end
@@ -41,16 +39,14 @@ class ModalTest < ComponentTestCase
     # taxon names showed literal `<b><i>Xylaria</i></b>` instead of
     # italicized bold text.
     title = "Add Comment to <b><i>Xylaria polymorpha</i></b>".html_safe
-    html = render(Components::Modal.new(id: "modal_html", title: title))
+    html = render_modal(id: "modal_html", title: title)
 
     assert_html(html, ".modal-title > b > i", text: "Xylaria polymorpha")
     assert_not_includes(html, "&lt;b&gt;")
   end
 
   def test_auto_open_adds_backdrop_and_display_block
-    html = render(Components::Modal.new(
-                    id: "modal_auto", title: "Auto", auto_open: true
-                  ))
+    html = render_modal(id: "modal_auto", title: "Auto", auto_open: true)
 
     assert_html(html, ".modal-backdrop.fade.in")
     assert_includes(html, "class=\"modal fade in\"")
@@ -58,13 +54,11 @@ class ModalTest < ComponentTestCase
   end
 
   def test_extras_class_data_and_id_overrides
-    html = render(Components::Modal.new(
-                    id: "modal_x", title: "T",
-                    extra_class: "modal-form",
-                    extra_data: { identifier: "x", foo: "bar" },
-                    title_id: "modal_x_header",
-                    body_id: "modal_x_body"
-                  )) do |m|
+    html = render_modal(id: "modal_x", title: "T",
+                        extra_class: "modal-form",
+                        extra_data: { identifier: "x", foo: "bar" },
+                        title_id: "modal_x_header",
+                        body_id: "modal_x_body") do |m|
       m.with_body { "b".html_safe }
     end
 
@@ -76,9 +70,7 @@ class ModalTest < ComponentTestCase
   end
 
   def test_title_content_slot_overrides_title_prop
-    html = render(Components::Modal.new(
-                    id: "modal_slot", title: "ignored"
-                  )) do |m|
+    html = render_modal(id: "modal_slot", title: "ignored") do |m|
       m.with_title_content { "<strong>custom</strong>".html_safe }
     end
 
@@ -90,10 +82,8 @@ class ModalTest < ComponentTestCase
     # Singleton layout modals (e.g. ModalConfirm) need their own
     # Stimulus controller, not the default `modal`. Passing
     # `controller: "confirm-modal"` replaces the data-controller attr.
-    html = render(Components::Modal.new(
-                    id: "modal_c", title: "t",
-                    controller: "confirm-modal"
-                  ))
+    html = render_modal(id: "modal_c", title: "t",
+                        controller: "confirm-modal")
 
     assert_html(html, ".modal[data-controller='confirm-modal']")
     # Default `modal` controller is NOT present alongside.
@@ -104,9 +94,8 @@ class ModalTest < ComponentTestCase
     # Headerless modals (ModalConfirm renders its title in the body for
     # Stimulus targeting; ModalProgressSpinner has no title at all)
     # need to suppress the entire `.modal-header` div.
-    html = render(Components::Modal.new(
-                    id: "modal_h", title: "ignored", header: false
-                  )) do |m|
+    html = render_modal(id: "modal_h", title: "ignored",
+                        header: false) do |m|
       m.with_body { "<p>just body</p>".html_safe }
     end
 
@@ -122,9 +111,8 @@ class ModalTest < ComponentTestCase
     # `body_class:` adds extra CSS classes to `.modal-body` while
     # keeping the base `modal-body` class. Used by ModalConfirm
     # (`py-4`) and ModalProgressSpinner (`text-center`).
-    html = render(Components::Modal.new(
-                    id: "modal_b", title: "t", body_class: "py-4 text-center"
-                  )) do |m|
+    html = render_modal(id: "modal_b", title: "t",
+                        body_class: "py-4 text-center") do |m|
       m.with_body { "x".html_safe }
     end
 
@@ -138,9 +126,7 @@ class ModalTest < ComponentTestCase
     # (typically a form) that emits its own `.modal-body` and
     # `.modal-footer`, so a single `<form>` tag wraps both — keeping
     # the submit button (in `.modal-footer`) naturally inside the form.
-    html = render(Components::Modal.new(
-                    id: "modal_form", title: "Edit"
-                  )) do |m|
+    html = render_modal(id: "modal_form", title: "Edit") do |m|
       m.with_form_content do
         '<form action="/x" method="post">' \
           '<div class="modal-body"><input name="foo"></div>' \
@@ -171,9 +157,7 @@ class ModalTest < ComponentTestCase
     # `with_form_content` wins. (Callers shouldn't mix them; this just
     # documents the precedence so a stray `with_body` call doesn't
     # silently double-render.)
-    html = render(Components::Modal.new(
-                    id: "modal_either", title: "T"
-                  )) do |m|
+    html = render_modal(id: "modal_either", title: "T") do |m|
       m.with_body { "<p>should-not-appear</p>".html_safe }
       m.with_footer { "<button>also-not</button>".html_safe }
       m.with_form_content { "<form><p>wins</p></form>".html_safe }
@@ -182,5 +166,11 @@ class ModalTest < ComponentTestCase
     assert_html(html, ".modal-content > form > p", text: "wins")
     assert_no_html(html, ".modal-body")
     assert_no_html(html, ".modal-footer")
+  end
+
+  private
+
+  def render_modal(**, &block)
+    render(Components::Modal.new(**), &block)
   end
 end

--- a/test/components/nav_tabs_test.rb
+++ b/test/components/nav_tabs_test.rb
@@ -107,9 +107,7 @@ class NavTabsTest < ComponentTestCase
     project = projects(:bolete_project)
     collection = Tab::Project::AdminSubtabs.new(project: project)
 
-    html = render(Components::NavTabs.new(
-                    current: "members", tabs: collection
-                  ))
+    html = render_with(current: "members", tabs: collection)
 
     # Collection contributed 4 tabs; the one keyed "members" is active.
     assert_html(html, "ul.nav-tabs > li.nav-item", count: 4)
@@ -123,7 +121,7 @@ class NavTabsTest < ComponentTestCase
     project = projects(:bolete_project)
     collection = Tab::Project::AdminSubtabs.new(project: project)
 
-    html = render(Components::NavTabs.new) do |tabs|
+    html = render_with do |tabs|
       tabs.add_all(collection)
       tabs.tab("Extra", "/extra", key: "extra")
     end

--- a/test/components/observation_fragment/mark_as_reviewed_toggle_test.rb
+++ b/test/components/observation_fragment/mark_as_reviewed_toggle_test.rb
@@ -4,9 +4,7 @@ require "test_helper"
 
 class ObservationFragmentMarkAsReviewedToggleTest < ComponentTestCase
   def test_renders_with_default_parameters
-    html = render_component(Components::ObservationFragment::MarkAsReviewedToggle.new(
-                              observation_view: build_obs_view(123)
-                            ))
+    html = render_component(observation_view: build_obs_view(123))
 
     assert_includes(html, "caption_reviewed_toggle_123")
     assert_includes(html, "caption_reviewed_123")
@@ -15,31 +13,24 @@ class ObservationFragmentMarkAsReviewedToggleTest < ComponentTestCase
   end
 
   def test_renders_with_custom_selector
-    html = render_component(Components::ObservationFragment::MarkAsReviewedToggle.new(
-                              observation_view: build_obs_view(456),
-                              selector: "box_reviewed"
-                            ))
+    html = render_component(observation_view: build_obs_view(456),
+                            selector: "box_reviewed")
 
     assert_includes(html, "box_reviewed_toggle_456")
     assert_includes(html, "box_reviewed_456")
   end
 
   def test_renders_with_label_class
-    html = render_component(Components::ObservationFragment::MarkAsReviewedToggle.new(
-                              observation_view: build_obs_view(789),
-                              label_class: "stretched-link"
-                            ))
+    html = render_component(observation_view: build_obs_view(789),
+                            label_class: "stretched-link")
 
     assert_includes(html, "stretched-link")
     assert_includes(html, "caption-reviewed-link")
   end
 
   def test_renders_with_reviewed_true
-    html = render_component(
-      Components::ObservationFragment::MarkAsReviewedToggle.new(
-        observation_view: build_obs_view(111, reviewed: true)
-      )
-    )
+    html = render_component(observation_view: build_obs_view(111,
+                                                             reviewed: true))
 
     assert_includes(html, "Marked as reviewed")
     assert_includes(html, "checked")
@@ -47,9 +38,7 @@ class ObservationFragmentMarkAsReviewedToggleTest < ComponentTestCase
 
   def test_renders_with_reviewed_false
     html = render_component(
-      Components::ObservationFragment::MarkAsReviewedToggle.new(
-        observation_view: build_obs_view(222, reviewed: false)
-      )
+      observation_view: build_obs_view(222, reviewed: false)
     )
 
     assert_includes(html, "Mark as reviewed")
@@ -57,19 +46,14 @@ class ObservationFragmentMarkAsReviewedToggleTest < ComponentTestCase
   end
 
   def test_renders_with_reviewed_nil
-    html = render_component(
-      Components::ObservationFragment::MarkAsReviewedToggle.new(
-        observation_view: build_obs_view(333, reviewed: nil)
-      )
-    )
+    html = render_component(observation_view: build_obs_view(333,
+                                                             reviewed: nil))
 
     assert_includes(html, "Mark as reviewed")
   end
 
   def test_includes_turbo_data_attributes
-    html = render_component(Components::ObservationFragment::MarkAsReviewedToggle.new(
-                              observation_view: build_obs_view(444)
-                            ))
+    html = render_component(observation_view: build_obs_view(444))
 
     assert_includes(html, "data-turbo=\"true\"")
     assert_includes(html, "data-controller=\"reviewed-toggle\"")
@@ -78,9 +62,7 @@ class ObservationFragmentMarkAsReviewedToggleTest < ComponentTestCase
   end
 
   def test_form_uses_put_method
-    html = render_component(Components::ObservationFragment::MarkAsReviewedToggle.new(
-                              observation_view: build_obs_view(555)
-                            ))
+    html = render_component(observation_view: build_obs_view(555))
 
     assert_includes(html, "method=\"post\"")
     assert_includes(html, "_method")
@@ -88,9 +70,7 @@ class ObservationFragmentMarkAsReviewedToggleTest < ComponentTestCase
   end
 
   def test_checkbox_has_correct_css_classes
-    html = render_component(Components::ObservationFragment::MarkAsReviewedToggle.new(
-                              observation_view: build_obs_view(777)
-                            ))
+    html = render_component(observation_view: build_obs_view(777))
 
     assert_includes(html, "d-inline")
     assert_includes(html, "form-group")
@@ -100,11 +80,9 @@ class ObservationFragmentMarkAsReviewedToggleTest < ComponentTestCase
 
   def test_all_parameters_together
     html = render_component(
-      Components::ObservationFragment::MarkAsReviewedToggle.new(
-        observation_view: build_obs_view(999, reviewed: true),
-        selector: "custom_selector",
-        label_class: "custom-class"
-      )
+      observation_view: build_obs_view(999, reviewed: true),
+      selector: "custom_selector",
+      label_class: "custom-class"
     )
 
     assert_includes(html, "custom_selector_toggle_999")
@@ -118,5 +96,9 @@ class ObservationFragmentMarkAsReviewedToggleTest < ComponentTestCase
 
   def build_obs_view(obs_id, reviewed: nil)
     ObservationView.new(observation_id: obs_id, reviewed: reviewed)
+  end
+
+  def render_component(**)
+    render(Components::ObservationFragment::MarkAsReviewedToggle.new(**))
   end
 end

--- a/test/components/panel_test.rb
+++ b/test/components/panel_test.rb
@@ -5,12 +5,10 @@ require("test_helper")
 class PanelTest < ComponentTestCase
   def test_panel_with_heading_and_collapsible_content
     edit_link = view_context.link_to("Edit", "/edit", class: "btn btn-sm")
-    html = render(Components::Panel.new(
-                    collapsible: true,
-                    collapse_target: "#collapsing_panel",
-                    expanded: false,
-                    collapse_message: "Show details"
-                  )) do |panel|
+    html = render_panel(collapsible: true,
+                        collapse_target: "#collapsing_panel",
+                        expanded: false,
+                        collapse_message: "Show details") do |panel|
       panel.with_heading { "Test Heading" }
       panel.with_heading_links { edit_link }
 
@@ -61,7 +59,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_with_footer
-    html = render(Components::Panel.new) do |panel|
+    html = render_panel do |panel|
       panel.with_heading { "Test Heading" }
       panel.with_body { "Panel content" }
       panel.with_footer { "Footer text" }
@@ -72,7 +70,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_with_custom_class
-    html = render(Components::Panel.new(panel_class: "custom-class")) do |panel|
+    html = render_panel(panel_class: "custom-class") do |panel|
       panel.with_heading { "Test" }
       panel.with_body { "Content" }
     end
@@ -81,7 +79,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_with_multiple_bodies
-    html = render(Components::Panel.new) do |panel|
+    html = render_panel do |panel|
       panel.with_heading { "Test" }
       panel.with_body { "First body" }
       panel.with_body { "Second body" }
@@ -92,7 +90,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_with_body_id_and_data
-    html = render(Components::Panel.new) do |panel|
+    html = render_panel do |panel|
       panel.with_heading { "Test" }
       panel.with_body(classes: "p-0", id: "my_section",
                       data: { controller: "section-update",
@@ -108,7 +106,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_with_thumbnail
-    html = render(Components::Panel.new) do |panel|
+    html = render_panel do |panel|
       panel.with_heading { "Test" }
       panel.with_thumbnail { "Thumbnail content" }
       panel.with_body { "Body content" }
@@ -119,7 +117,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_with_carousel_for_thumbnail
-    html = render(Components::Panel.new) do |panel|
+    html = render_panel do |panel|
       panel.with_heading { "Test" }
       panel.with_thumbnail(classes: "carousel") { "Carousel content" }
       panel.with_body { "Body content" }
@@ -131,7 +129,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_with_multiple_footers
-    html = render(Components::Panel.new) do |panel|
+    html = render_panel do |panel|
       panel.with_heading { "Test" }
       panel.with_body { "Content" }
       panel.with_footer { "First footer" }
@@ -150,7 +148,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_with_sizing_enabled
-    html = render(Components::Panel.new(sizing: true)) do |panel|
+    html = render_panel(sizing: true) do |panel|
       panel.with_heading { "Test" }
       panel.with_thumbnail { "Thumbnail" }
       panel.with_body { "Body content" }
@@ -171,7 +169,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_without_sizing
-    html = render(Components::Panel.new(sizing: false)) do |panel|
+    html = render_panel(sizing: false) do |panel|
       panel.with_heading { "Test" }
       panel.with_thumbnail { "Thumbnail" }
       panel.with_body { "Body content" }
@@ -192,8 +190,7 @@ class PanelTest < ComponentTestCase
     obs = observations(:coprinus_comatus_obs)
     image = obs.thumb_image
 
-    component = Components::Panel.new
-    html = render(component) do |panel|
+    html = render_panel do |panel|
       panel.with_heading { "Observation" }
       panel.with_thumbnail do
         render(Components::InteractiveImage.new(
@@ -222,8 +219,7 @@ class PanelTest < ComponentTestCase
     obs = observations(:coprinus_comatus_obs)
     image = obs.thumb_image
 
-    component = Components::Panel.new(sizing: true)
-    html = render(component) do |panel|
+    html = render_panel(sizing: true) do |panel|
       panel.with_heading { "Observation" }
       panel.with_thumbnail do
         render(Components::InteractiveImage.new(
@@ -252,7 +248,7 @@ class PanelTest < ComponentTestCase
   end
 
   def test_panel_with_unwrapped_body_for_list_group
-    html = render(Components::Panel.new) do |panel|
+    html = render_panel do |panel|
       panel.with_heading { "Comments" }
       panel.with_body(wrapper: false) do
         view_context.tag.ul(class: "list-group") do
@@ -267,5 +263,11 @@ class PanelTest < ComponentTestCase
     assert_no_html(html, ".panel-body ul.list-group")
     # ul.list-group should be a (descendant) child of .panel.panel-default
     assert_html(html, ".panel.panel-default > ul.list-group")
+  end
+
+  private
+
+  def render_panel(**, &block)
+    render(Components::Panel.new(**), &block)
   end
 end

--- a/test/components/panel_test.rb
+++ b/test/components/panel_test.rb
@@ -192,14 +192,7 @@ class PanelTest < ComponentTestCase
 
     html = render_panel do |panel|
       panel.with_heading { "Observation" }
-      panel.with_thumbnail do
-        render(Components::InteractiveImage.new(
-                 user: user,
-                 image: image,
-                 size: :thumbnail,
-                 votes: false
-               ))
-      end
+      panel.with_thumbnail { render_interactive_image(user:, image:) }
       panel.with_body { "Observation details" }
     end
 
@@ -221,14 +214,7 @@ class PanelTest < ComponentTestCase
 
     html = render_panel(sizing: true) do |panel|
       panel.with_heading { "Observation" }
-      panel.with_thumbnail do
-        render(Components::InteractiveImage.new(
-                 user: user,
-                 image: image,
-                 size: :thumbnail,
-                 votes: false
-               ))
-      end
+      panel.with_thumbnail { render_interactive_image(user:, image:) }
       panel.with_body { "Details" }
     end
 
@@ -269,5 +255,11 @@ class PanelTest < ComponentTestCase
 
   def render_panel(**, &block)
     render(Components::Panel.new(**), &block)
+  end
+
+  def render_interactive_image(user:, image:)
+    render(Components::InteractiveImage.new(
+             user: user, image: image, size: :thumbnail, votes: false
+           ))
   end
 end

--- a/test/components/row_test.rb
+++ b/test/components/row_test.rb
@@ -4,28 +4,26 @@ require("test_helper")
 
 class RowTest < ComponentTestCase
   def test_default_is_a_plain_row_div
-    html = render(Components::Row.new)
+    html = render_row
 
     assert_html(html, "div.row")
   end
 
   def test_element_renders_alternate_tag
-    html = render(Components::Row.new(element: :ul))
+    html = render_row(element: :ul)
 
     assert_html(html, "ul.row")
     assert_no_html(html, "div.row")
   end
 
   def test_extra_class_merges_with_row_class
-    html = render(Components::Row.new(class: "mt-3 align-items-center"))
+    html = render_row(class: "mt-3 align-items-center")
 
     assert_html(html, "div.row.mt-3.align-items-center")
   end
 
   def test_other_attrs_pass_through
-    html = render(Components::Row.new(
-                    id: "main_row", data: { controller: "foo" }
-                  ))
+    html = render_row(id: "main_row", data: { controller: "foo" })
 
     assert_html(html, "div.row#main_row[data-controller='foo']")
   end
@@ -39,6 +37,10 @@ class RowTest < ComponentTestCase
   end
 
   private
+
+  def render_row(**, &block)
+    render(Components::Row.new(**), &block)
+  end
 
   # Returns an anonymous Components::Base instance whose view_template
   # runs the given block in Phlex context (so `plain`, `div`, `render`

--- a/test/components/table_test.rb
+++ b/test/components/table_test.rb
@@ -12,7 +12,7 @@ class TableTest < ComponentTestCase
       TestRow.new(name: "Bob", age: 25)
     ]
 
-    html = render(Components::Table.new(rows)) do |t|
+    html = render_table(rows) do |t|
       t.column("Name", &:name)
       t.column("Age", &:age)
     end
@@ -36,7 +36,7 @@ class TableTest < ComponentTestCase
   def test_renders_empty_table_with_no_rows
     rows = []
 
-    html = render(Components::Table.new(rows)) do |t|
+    html = render_table(rows) do |t|
       t.column("Name", &:name)
     end
 
@@ -51,8 +51,7 @@ class TableTest < ComponentTestCase
   def test_accepts_custom_class
     rows = [TestRow.new(name: "Test")]
 
-    html = render(Components::Table.new(rows,
-                                        class: "table-sm w-100")) do |t|
+    html = render_table(rows, class: "table-sm w-100") do |t|
       t.column("Name", &:name)
     end
 
@@ -62,7 +61,7 @@ class TableTest < ComponentTestCase
   def test_variant_kwarg_adds_bootstrap_modifier_class
     rows = [TestRow.new(name: "Test")]
 
-    html = render(Components::Table.new(rows, variant: :striped)) do |t|
+    html = render_table(rows, variant: :striped) do |t|
       t.column("Name", &:name)
     end
 
@@ -72,8 +71,7 @@ class TableTest < ComponentTestCase
   def test_variant_kwarg_accepts_array_for_multiple_modifiers
     rows = [TestRow.new(name: "Test")]
 
-    html = render(Components::Table.new(rows,
-                                        variant: [:striped, :hover])) do |t|
+    html = render_table(rows, variant: [:striped, :hover]) do |t|
       t.column("Name", &:name)
     end
 
@@ -83,7 +81,7 @@ class TableTest < ComponentTestCase
   def test_identifier_kwarg_adds_table_identifier_class
     rows = [TestRow.new(name: "Test")]
 
-    html = render(Components::Table.new(rows, identifier: "my-widget")) do |t|
+    html = render_table(rows, identifier: "my-widget") do |t|
       t.column("Name", &:name)
     end
 
@@ -93,7 +91,7 @@ class TableTest < ComponentTestCase
   def test_accepts_custom_id
     rows = [TestRow.new(name: "Test")]
 
-    html = render(Components::Table.new(rows, id: "my-table")) do |t|
+    html = render_table(rows, id: "my-table") do |t|
       t.column("Name", &:name)
     end
 
@@ -112,7 +110,7 @@ class TableTest < ComponentTestCase
   def test_works_with_activerecord_objects
     user_list = [users(:rolf), users(:mary)]
 
-    html = render(Components::Table.new(user_list)) do |t|
+    html = render_table(user_list) do |t|
       t.column("Login", &:login)
     end
 
@@ -125,7 +123,7 @@ class TableTest < ComponentTestCase
   def test_column_content_can_include_html
     rows = [TestRow.new(name: "Alice", url: "/users/1")]
 
-    html = render(Components::Table.new(rows)) do |t|
+    html = render_table(rows) do |t|
       t.column("Name") do |row|
         view_context.link_to(row.name, row.url)
       end
@@ -137,7 +135,7 @@ class TableTest < ComponentTestCase
   def test_per_column_class_lands_on_both_th_and_td
     rows = [TestRow.new(name: "Alice")]
 
-    html = render(Components::Table.new(rows)) do |t|
+    html = render_table(rows) do |t|
       t.column("Name", class: "text-right", &:name)
     end
 
@@ -148,7 +146,7 @@ class TableTest < ComponentTestCase
   def test_per_column_arbitrary_attrs_forwarded_to_th_and_td
     rows = [TestRow.new(name: "Alice")]
 
-    html = render(Components::Table.new(rows)) do |t|
+    html = render_table(rows) do |t|
       t.column("Name", width: "33%", data: { x: "v" }, &:name)
     end
 
@@ -160,8 +158,7 @@ class TableTest < ComponentTestCase
   def test_tbody_id_for_turbo_stream_targeting
     rows = [TestRow.new(name: "Alice")]
 
-    html = render(Components::Table.new(rows,
-                                        tbody_id: "users_tbody")) do |t|
+    html = render_table(rows, tbody_id: "users_tbody") do |t|
       t.column("Name", &:name)
     end
 
@@ -171,11 +168,9 @@ class TableTest < ComponentTestCase
   def test_table_attributes_hash_lands_on_table_element
     rows = [TestRow.new(name: "Alice")]
 
-    html = render(Components::Table.new(
-                    rows,
-                    attributes: { cols: "1",
-                                  data: { controller: "name-list" } }
-                  )) do |t|
+    html = render_table(
+      rows, attributes: { cols: "1", data: { controller: "name-list" } }
+    ) do |t|
       t.column("Name", &:name)
     end
 
@@ -218,7 +213,7 @@ class TableTest < ComponentTestCase
   def test_headers_false_skips_thead
     rows = [TestRow.new(name: "Alice")]
 
-    html = render(Components::Table.new(rows, show_headers: false)) do |t|
+    html = render_table(rows, show_headers: false) do |t|
       t.column("Name", &:name)
     end
 
@@ -238,7 +233,7 @@ class TableTest < ComponentTestCase
     # Block return values become the cell content — production
     # callers use Phlex `plain` / `trusted_html` etc. inside the
     # block because the block runs in Phlex view context there.
-    html = render(Components::Table.new(rows)) do |t|
+    html = render_table(rows) do |t|
       t.heading { "Section label:" }
       t.column("Name", &:name)
       t.column("Age", &:age)
@@ -257,7 +252,7 @@ class TableTest < ComponentTestCase
   def test_heading_forwards_attributes_to_th
     rows = []
 
-    html = render(Components::Table.new(rows)) do |t|
+    html = render_table(rows) do |t|
       t.heading(class: "text-center", data: { foo: "bar" }) { "Curators:" }
       t.column("a", &:name)
       t.column("b", &:name)
@@ -271,7 +266,7 @@ class TableTest < ComponentTestCase
   def test_heading_with_show_headers_false_renders_no_thead
     rows = [TestRow.new(name: "Alice")]
 
-    html = render(Components::Table.new(rows, show_headers: false)) do |t|
+    html = render_table(rows, show_headers: false) do |t|
       t.heading { "Suppressed:" }
       t.column("Name", &:name)
     end
@@ -290,6 +285,12 @@ class TableTest < ComponentTestCase
     assert_html(html, "table tbody:first-child tr td", text: "A")
     assert_html(html, "table tbody#collapse-1.collapse tr td", text: "B")
     assert_html(html, "table tbody#collapse-2.collapse tr td", text: "C")
+  end
+
+  private
+
+  def render_table(rows, **, &block)
+    render(Components::Table.new(rows, **), &block)
   end
 end
 

--- a/test/views/controllers/comments/show_test.rb
+++ b/test/views/controllers/comments/show_test.rb
@@ -16,8 +16,7 @@ module Views::Controllers::Comments
       # author, summary, comment.
       comment = comments(:minimal_unknown_obs_comment_1)
 
-      html = render(Show.new(comment: comment, target: comment.target,
-                             user: @user))
+      html = render_show(comment: comment, target: comment.target)
 
       assert_html(html, "a.user_link_#{comment.user.id}")
       assert_includes(html, comment.summary)
@@ -34,11 +33,16 @@ module Views::Controllers::Comments
       comment = ::Comment.create!(target: target, user: @user,
                                   summary: "On the Name", comment: "")
 
-      html = render(Show.new(comment: comment, target: target,
-                             user: @user))
+      html = render_show(comment: comment, target: target)
 
       assert_includes(html, "On the Name")
       assert_html(html, "a.user_link_#{@user.id}")
+    end
+
+    private
+
+    def render_show(**)
+      render(Show.new(user: @user, **))
     end
   end
 end

--- a/test/views/controllers/descriptions/authors/show_test.rb
+++ b/test/views/controllers/descriptions/authors/show_test.rb
@@ -10,9 +10,7 @@ class Views::Controllers::Descriptions::Authors::ShowTest <
     desc.add_author(rolf)
     desc.reload
 
-    html = render(Views::Controllers::Descriptions::Authors::Show.new(
-                    object: desc, authors: desc.authors.to_a
-                  ))
+    html = render_show(object: desc, authors: desc.authors.to_a)
 
     # Each author row has a remove-author destroy button posting to
     # description_authors_path with the user id in `remove=…`.
@@ -24,9 +22,7 @@ class Views::Controllers::Descriptions::Authors::ShowTest <
   def test_renders_add_author_form_for_other_users_pool
     desc = location_descriptions(:albion_desc)
 
-    html = render(Views::Controllers::Descriptions::Authors::Show.new(
-                    object: desc, authors: []
-                  ))
+    html = render_show(object: desc, authors: [])
 
     # User autocompleter input — the field name is namespaced under
     # the `AddAuthor` FormObject (`add_author[user]`). The controller's
@@ -46,16 +42,18 @@ class Views::Controllers::Descriptions::Authors::ShowTest <
     name_desc = name_descriptions(:peltigera_user_desc)
     location_desc = location_descriptions(:albion_desc)
 
-    name_html = render(Views::Controllers::Descriptions::Authors::Show.new(
-                         object: name_desc, authors: []
-                       ))
-    loc_html = render(Views::Controllers::Descriptions::Authors::Show.new(
-                        object: location_desc, authors: []
-                      ))
+    name_html = render_show(object: name_desc, authors: [])
+    loc_html = render_show(object: location_desc, authors: [])
 
     note_text = :review_authors_note.t.strip_html
     sanitize = ActionView::Base.full_sanitizer.method(:sanitize)
     assert_includes(sanitize.call(name_html), note_text)
     assert_not_includes(sanitize.call(loc_html), note_text)
+  end
+
+  private
+
+  def render_show(**)
+    render(Views::Controllers::Descriptions::Authors::Show.new(**))
   end
 end

--- a/test/views/controllers/descriptions/list_test.rb
+++ b/test/views/controllers/descriptions/list_test.rb
@@ -17,9 +17,7 @@ class Views::Controllers::Descriptions::ListTest < ComponentTestCase
     name = names_with_descriptions
     description_count = list_descriptions_for(name)
 
-    html = render(Views::Controllers::Descriptions::List.new(
-                    user: @user, object: name, type: :name
-                  ))
+    html = render_list(object: name, type: :name)
     doc = Nokogiri::HTML.fragment(html)
 
     assert_operator(description_count, :>, 0,
@@ -31,9 +29,7 @@ class Views::Controllers::Descriptions::ListTest < ComponentTestCase
   def test_readable_descriptions_render_as_links
     name = names_with_descriptions
 
-    html = render(Views::Controllers::Descriptions::List.new(
-                    user: @user, object: name, type: :name
-                  ))
+    html = render_list(object: name, type: :name)
 
     readable, unreadable = name.descriptions.partition do |desc|
       desc.is_reader?(@user)
@@ -53,9 +49,7 @@ class Views::Controllers::Descriptions::ListTest < ComponentTestCase
            where(name_descriptions: { id: nil }).first
     assert_empty(name.descriptions)
 
-    html = render(Views::Controllers::Descriptions::List.new(
-                    user: @user, object: name, type: :name
-                  ))
+    html = render_list(object: name, type: :name)
 
     assert_equal("", html.strip)
   end
@@ -63,15 +57,17 @@ class Views::Controllers::Descriptions::ListTest < ComponentTestCase
   def test_emits_empty_text_when_no_descriptions
     name = Name.left_joins(:descriptions).
            where(name_descriptions: { id: nil }).first
-    html = render(Views::Controllers::Descriptions::List.new(
-                    user: @user, object: name, type: :name,
-                    empty_text: "No descriptions here."
-                  ))
+    html = render_list(object: name, type: :name,
+                       empty_text: "No descriptions here.")
 
     assert_includes(html, "No descriptions here.")
   end
 
   private
+
+  def render_list(**)
+    render(Views::Controllers::Descriptions::List.new(user: @user, **))
+  end
 
   def names_with_descriptions
     Name.joins(:descriptions).group("names.id").

--- a/test/views/controllers/export/status_controls_test.rb
+++ b/test/views/controllers/export/status_controls_test.rb
@@ -11,7 +11,7 @@ module Views::Controllers::Export
 
     def test_no_render_for_non_reviewer
       controller.define_singleton_method(:reviewer?) { false }
-      html = render(StatusControls.new(object: names(:fungi)))
+      html = render_controls(object: names(:fungi))
 
       assert_equal("", html)
     end
@@ -19,7 +19,7 @@ module Views::Controllers::Export
     def test_ok_for_export_true_bolds_current_state
       name = names(:fungi)
       name.update_attribute(:ok_for_export, true)
-      html = render(StatusControls.new(object: name))
+      html = render_controls(object: name)
 
       # Current state ("OK to export") is bold; the flip target
       # ("Don't export") renders as a PUT-method button with value: 0.
@@ -34,7 +34,7 @@ module Views::Controllers::Export
       # the flip target ("Don't export") becomes bold.
       name = names(:fungi)
       name.update_attribute(:ok_for_export, false)
-      html = render(StatusControls.new(object: name))
+      html = render_controls(object: name)
 
       assert_html(html, "form button[type='submit']",
                   text: :review_ok_for_export.t)
@@ -44,7 +44,7 @@ module Views::Controllers::Export
     def test_diagnostic_flag_for_image
       image = images(:in_situ_image)
       image.update_attribute(:diagnostic, true)
-      html = render(StatusControls.new(object: image, flag: :diagnostic))
+      html = render_controls(object: image, flag: :diagnostic)
       dom_id = ActionView::RecordIdentifier.dom_id(image, :diagnostic)
 
       assert_html(html, "b", text: :review_diagnostic.t)
@@ -61,7 +61,7 @@ module Views::Controllers::Export
 
     def test_wraps_in_dom_id_for_turbo_replace
       name = names(:fungi)
-      html = render(StatusControls.new(object: name))
+      html = render_controls(object: name)
       dom_id = ActionView::RecordIdentifier.dom_id(name, :ok_for_export)
 
       assert_html(html, "div##{dom_id}")
@@ -69,7 +69,7 @@ module Views::Controllers::Export
 
     def test_flip_button_opts_into_turbo
       name = names(:fungi)
-      html = render(StatusControls.new(object: name))
+      html = render_controls(object: name)
 
       # `CRUDBase#button_html_options` shallow-merges the caller's
       # `data:` onto the *button's* html options, not the form's — so
@@ -77,6 +77,12 @@ module Views::Controllers::Export
       # (or refuted) by a browser-level system test, since we can't
       # assume Turbo Drive's opt-in check reads the submitter element.
       assert_html(html, "button[data-turbo='true']")
+    end
+
+    private
+
+    def render_controls(**)
+      render(StatusControls.new(**))
     end
   end
 end

--- a/test/views/controllers/herbaria/show/curator_table_test.rb
+++ b/test/views/controllers/herbaria/show/curator_table_test.rb
@@ -12,7 +12,7 @@ module Views::Controllers::Herbaria
     # A curator of the herbarium sees delete buttons for all curators.
     def test_renders_delete_buttons_for_curator
       controller.instance_variable_set(:@user, users(:rolf))
-      html = render(Show::CuratorTable.new(herbarium: @herb))
+      html = render_curator_table
 
       roy = users(:roy)
       curator_path = routes.herbaria_curator_path(@herb, user: roy.id)
@@ -25,9 +25,15 @@ module Views::Controllers::Herbaria
     # A non-curator sees no delete buttons.
     def test_no_delete_button_for_non_curator
       controller.instance_variable_set(:@user, users(:mary))
-      html = render(Show::CuratorTable.new(herbarium: @herb))
+      html = render_curator_table
 
       assert_no_html(html, "button[id*='delete_herbarium_curator_link']")
+    end
+
+    private
+
+    def render_curator_table
+      render(Show::CuratorTable.new(herbarium: @herb))
     end
   end
 end

--- a/test/views/controllers/images/show/vote_panel_test.rb
+++ b/test/views/controllers/images/show/vote_panel_test.rb
@@ -19,7 +19,7 @@ module Views::Controllers::Images
       def test_renders_heading_for_logged_out_viewer
         controller.instance_variable_set(:@user, nil)
 
-        html = render(VotePanel.new(image: @image))
+        html = render_panel
 
         assert_html(html, "#image_vote_content")
         assert_html(html, "table.table-show-votes")
@@ -29,7 +29,7 @@ module Views::Controllers::Images
       def test_renders_vote_grid_for_logged_in_viewer
         controller.instance_variable_set(:@user, users(:rolf))
 
-        html = render(VotePanel.new(image: @image))
+        html = render_panel
 
         assert_html(html, "a[data-role='image_vote']")
         assert_html(html, "table.table-show-votes")
@@ -39,7 +39,7 @@ module Views::Controllers::Images
         image_votes(:in_situ_image_mary_vote).update!(anonymous: true)
         controller.instance_variable_set(:@user, users(:rolf))
 
-        html = render(VotePanel.new(image: @image))
+        html = render_panel
 
         doc = Nokogiri::HTML.fragment(html)
         assert_includes(doc.css("table.table-show-votes td").map(&:text),
@@ -47,6 +47,12 @@ module Views::Controllers::Images
         assert_no_html(html,
                        "table.table-show-votes " \
                        "a[href*='#{users(:mary).id}']")
+      end
+
+      private
+
+      def render_panel
+        render(VotePanel.new(image: @image))
       end
     end
   end

--- a/test/views/controllers/images/votes/show_test.rb
+++ b/test/views/controllers/images/votes/show_test.rb
@@ -11,7 +11,7 @@ module Views::Controllers::Images::Votes
     end
 
     def test_renders_vote_interface_inside_matching_turbo_frame
-      html = render(Show.new(image: @image, user: @user))
+      html = render_show
 
       assert_html(html, "turbo-frame#image_vote_#{@image.id}")
       assert_html(html, "turbo-frame .vote-section#image_vote_#{@image.id}")
@@ -19,7 +19,7 @@ module Views::Controllers::Images::Votes
     end
 
     def test_lightbox_context_renders_prefixed_frame_and_content
-      html = render(Show.new(image: @image, user: @user, context: :lightbox))
+      html = render_show(context: :lightbox)
 
       assert_html(html, "turbo-frame#lightbox_image_vote_#{@image.id}")
       assert_html(html,
@@ -28,10 +28,16 @@ module Views::Controllers::Images::Votes
     end
 
     def test_renders_for_anonymous_viewer
-      html = render(Show.new(image: @image, user: nil))
+      html = render_show(user: nil)
 
       assert_html(html, "turbo-frame#image_vote_#{@image.id}")
       assert_html(html, ".vote-section.require-user")
+    end
+
+    private
+
+    def render_show(**)
+      render(Show.new(image: @image, user: @user, **))
     end
   end
 end

--- a/test/views/controllers/info/site_stats_test.rb
+++ b/test/views/controllers/info/site_stats_test.rb
@@ -18,17 +18,20 @@ module Views::Controllers::Info
     def test_renders_with_observations
       observations = Observation.where.not(thumb_image_id: nil).
                      limit(6).to_a
-      site_data = ::SiteData.new.get_site_data
-      html = render(SiteStats.new(site_data: site_data,
-                                  observations: observations))
+      html = render_stats(observations: observations)
       assert_html(html, "table.table tr td")
     end
 
     def test_renders_without_observations
-      site_data = ::SiteData.new.get_site_data
-      html = render(SiteStats.new(site_data: site_data,
-                                  observations: nil))
+      html = render_stats(observations: nil)
       assert_html(html, "table.table")
+    end
+
+    private
+
+    def render_stats(**)
+      site_data = ::SiteData.new.get_site_data
+      render(SiteStats.new(site_data: site_data, **))
     end
   end
 end

--- a/test/views/controllers/locations/form_test.rb
+++ b/test/views/controllers/locations/form_test.rb
@@ -74,12 +74,9 @@ module Views::Controllers::Locations
 
     def test_renders_existing_location_form
       location = locations(:burbank)
-      html = render(Form.new(
-                      location,
-                      display_name: location.display_name,
-                      original_name: location.display_name,
-                      local: true
-                    ))
+      html = render_form(location,
+                         display_name: location.display_name,
+                         original_name: location.display_name)
 
       assert_html(html, "form[action*='/locations/#{location.id}']")
       assert_html(html, "button[type='submit']", text: :update.ti)
@@ -94,13 +91,9 @@ module Views::Controllers::Locations
 
     def test_renders_dubious_location_warning_container_when_provided
       reasons = [[:location_dubious_empty, {}], [:location_dubious_commas, {}]]
-      html = render(Form.new(
-                      @location,
-                      display_name: "test",
-                      original_name: "test",
-                      dubious_where_reasons: reasons,
-                      local: true
-                    ))
+      html = render_form(@location,
+                         display_name: "test", original_name: "test",
+                         dubious_where_reasons: reasons)
 
       assert_html(html, "#dubious_location_messages.alert-warning")
       reasons.each do |tag, args|
@@ -113,12 +106,9 @@ module Views::Controllers::Locations
       location = locations(:burbank)
       location.update!(locked: true)
 
-      html = render(Form.new(
-                      location,
-                      display_name: location.display_name,
-                      original_name: location.display_name,
-                      local: true
-                    ))
+      html = render_form(location,
+                         display_name: location.display_name,
+                         original_name: location.display_name)
 
       # Locked-display style: the explanatory text lives in a
       # `.help-block` div next to the read-only fields.
@@ -126,24 +116,21 @@ module Views::Controllers::Locations
     end
 
     def test_enables_turbo_for_modal_rendering
-      html = render(Form.new(
-                      @location,
-                      display_name: "test",
-                      original_name: "test",
-                      local: false
-                    ))
+      html = render_form(@location, display_name: "test",
+                                    original_name: "test", local: false)
 
       assert_html(html, "form[data-turbo='true']")
     end
 
     private
 
-    def render_form
+    def render_form(location = @location, local: true, **)
       render(Form.new(
-               @location,
+               location,
                display_name: "test location",
                original_name: "test location",
-               local: true
+               local: local,
+               **
              ))
     end
   end

--- a/test/views/controllers/observations/consensus_name_link_test.rb
+++ b/test/views/controllers/observations/consensus_name_link_test.rb
@@ -30,7 +30,7 @@ module Views::Controllers::Observations
     def test_current_name_logged_in_renders_consensus_link_only
       obs = observations(:minimal_unknown_obs)
 
-      html = render(ConsensusNameLink.new(observation: obs, user: @user))
+      html = render_link(observation: obs)
 
       assert_html(html, "a.obs_consensus_naming_link_#{obs.name.id}")
       assert_html(html, "a[href='#{routes.name_path(id: obs.name.id)}']")
@@ -44,7 +44,7 @@ module Views::Controllers::Observations
     def test_current_name_logged_out_renders_textile_name_only
       obs = observations(:minimal_unknown_obs)
 
-      html = render(ConsensusNameLink.new(observation: obs, user: nil))
+      html = render_link(observation: obs, user: nil)
 
       # No `<a>` — just the textile-rendered display name.
       assert_no_html(html, "a")
@@ -57,7 +57,7 @@ module Views::Controllers::Observations
       obs = deprecated_obs
       preferred = obs.name.best_preferred_synonym
 
-      html = render(ConsensusNameLink.new(observation: obs, user: @user))
+      html = render_link(observation: obs)
 
       assert_html(html,
                   "a.obs_consensus_deprecated_synonym_link_#{obs.name.id}")
@@ -71,7 +71,7 @@ module Views::Controllers::Observations
       obs = deprecated_obs
       preferred = obs.name.best_preferred_synonym
 
-      html = render(ConsensusNameLink.new(observation: obs, user: nil))
+      html = render_link(observation: obs, user: nil)
 
       # No `<a>` tags at all logged-out — just textile-rendered
       # name + flag + textile-rendered preferred synonym.
@@ -87,7 +87,7 @@ module Views::Controllers::Observations
       @user.update!(view_owner_id: true)
       obs = observations(:owner_only_favorite_ne_consensus)
 
-      html = render(ConsensusNameLink.new(observation: obs, user: @user))
+      html = render_link(observation: obs)
 
       assert_html(html, "a.obs_consensus_naming_link_#{obs.name.id}")
       assert_html(html, ".obs-site-id-flag",
@@ -98,7 +98,7 @@ module Views::Controllers::Observations
       @user.update!(view_owner_id: false)
       obs = observations(:owner_only_favorite_ne_consensus)
 
-      html = render(ConsensusNameLink.new(observation: obs, user: @user))
+      html = render_link(observation: obs)
 
       assert_html(html, "a.obs_consensus_naming_link_#{obs.name.id}")
       assert_no_html(html, ".obs-site-id-flag")
@@ -110,13 +110,17 @@ module Views::Controllers::Observations
       # owner-preference state.
       obs = observations(:owner_only_favorite_ne_consensus)
 
-      html = render(ConsensusNameLink.new(observation: obs, user: nil))
+      html = render_link(observation: obs, user: nil)
 
       assert_no_html(html, "a")
       assert_no_html(html, ".obs-site-id-flag")
     end
 
     private
+
+    def render_link(**)
+      render(ConsensusNameLink.new(user: @user, **))
+    end
 
     def deprecated_obs
       @deprecated_obs ||= begin

--- a/test/views/controllers/observations/form/location_help_test.rb
+++ b/test/views/controllers/observations/form/location_help_test.rb
@@ -6,7 +6,7 @@ module Views::Controllers::Observations
   class Form::LocationHelpTest < ComponentTestCase
     def test_renders_two_paragraphs_with_postal_examples_by_default
       controller.instance_variable_set(:@user, users(:rolf))
-      html = render(Form::LocationHelp.new)
+      html = render_help
 
       # Postal: postal-format example city appears as written.
       assert_includes(html, Form::LocationHelp::POSTAL_LOC1)
@@ -17,13 +17,19 @@ module Views::Controllers::Observations
 
     def test_scientific_format_flips_example_locations
       controller.instance_variable_set(:@user, users(:roy))
-      html = render(Form::LocationHelp.new)
+      html = render_help
 
       # Scientific: reverse-name flip on the example cities.
       assert_includes(html,
                       Location.reverse_name(Form::LocationHelp::POSTAL_LOC1))
       assert_includes(html,
                       Location.reverse_name(Form::LocationHelp::POSTAL_LOC2))
+    end
+
+    private
+
+    def render_help
+      render(Form::LocationHelp.new)
     end
   end
 end

--- a/test/views/controllers/observations/namings/suggestions/show_test.rb
+++ b/test/views/controllers/observations/namings/suggestions/show_test.rb
@@ -25,8 +25,7 @@ module Views::Controllers::Observations::Namings::Suggestions
       confident = ::Suggestion.new("Coprinus comatus", 80)
       borderline = ::Suggestion.new("Agrocybe arvalis", 25)
 
-      html = render(Show.new(observation: @observation, user: @user,
-                             suggestions: [confident, borderline]))
+      html = render_show(suggestions: [confident, borderline])
 
       # Two `<h3>` section headings, one per group.
       assert_html(html, "h3", count: 2)
@@ -46,8 +45,7 @@ module Views::Controllers::Observations::Namings::Suggestions
       existing_name = @observation.namings.first.name
       sugg = ::Suggestion.new(existing_name.text_name, 80)
 
-      html = render(Show.new(observation: @observation, user: @user,
-                             suggestions: [sugg]))
+      html = render_show(suggestions: [sugg])
 
       assert_includes(html, :suggestions_already_proposed.t)
       assert_no_html(html, "a[href*='new_observation_naming']")
@@ -58,8 +56,7 @@ module Views::Controllers::Observations::Namings::Suggestions
       # renders so no `<h3>` heading appears.
       useless = ::Suggestion.new("Coprinus comatus", 3)
 
-      html = render(Show.new(observation: @observation, user: @user,
-                             suggestions: [useless]))
+      html = render_show(suggestions: [useless])
 
       assert_no_html(html, "h3")
     end
@@ -71,8 +68,7 @@ module Views::Controllers::Observations::Namings::Suggestions
       assert(@observation.images.length > 1, "fixture sanity")
       sugg = ::Suggestion.new("Coprinus comatus", 80)
 
-      html = render(Show.new(observation: @observation, user: @user,
-                             suggestions: [sugg]))
+      html = render_show(suggestions: [sugg])
 
       assert_includes(html, :suggestions_max.t)
       assert_includes(html, :suggestions_avg.t)
@@ -87,8 +83,7 @@ module Views::Controllers::Observations::Namings::Suggestions
       assert_equal(1, single_image_obs.images.length, "fixture sanity")
       sugg = ::Suggestion.new("Coprinus comatus", 80)
 
-      html = render(Show.new(observation: single_image_obs, user: @user,
-                             suggestions: [sugg]))
+      html = render_show(observation: single_image_obs, suggestions: [sugg])
 
       doc = Nokogiri::HTML(html)
       sugg_col = doc.at_css(".obs-suggestions-column")
@@ -102,10 +97,15 @@ module Views::Controllers::Observations::Namings::Suggestions
       # (which falls into "good"); push above 80 here.
       sugg = ::Suggestion.new("Coprinus comatus", 85)
 
-      html = render(Show.new(observation: @observation, user: @user,
-                             suggestions: [sugg]))
+      html = render_show(suggestions: [sugg])
 
       assert_includes(html, :suggestions_excellent.t)
+    end
+
+    private
+
+    def render_show(observation: @observation, **)
+      render(Show.new(observation: observation, user: @user, **))
     end
   end
 end

--- a/test/views/controllers/observations/namings/votes/table_test.rb
+++ b/test/views/controllers/observations/namings/votes/table_test.rb
@@ -10,7 +10,7 @@ module Views::Controllers::Observations::Namings::Votes
     end
 
     def test_renders_table_with_header_value_rows_and_totals
-      html = render(Table.new(naming: @naming))
+      html = render_table
 
       assert_html(html, "table.table-naming-votes")
       # Five column headers — five separate `assert_includes` since
@@ -27,7 +27,7 @@ module Views::Controllers::Observations::Namings::Votes
     # (U+00A0) so the column keeps its width even when empty. A
     # regular space would let some browsers collapse the cell.
     def test_spacer_cells_contain_non_breaking_space
-      html = render(Table.new(naming: @naming))
+      html = render_table
       doc = Nokogiri::HTML(html)
 
       header_rows = doc.css("table.table-naming-votes tr")
@@ -49,7 +49,7 @@ module Views::Controllers::Observations::Namings::Votes
     # displayed label actually matches that resolution (not, say, a
     # leftover pre-resolved string from before the refactor).
     def test_renders_resolved_confidence_label_per_row
-      html = render(Table.new(naming: @naming))
+      html = render_table
 
       @naming.votes.map(&:value).uniq.each do |val|
         next if val.zero?
@@ -60,7 +60,7 @@ module Views::Controllers::Observations::Namings::Votes
     end
 
     def test_renders_voter_user_links_for_non_anonymous_votes
-      html = render(Table.new(naming: @naming))
+      html = render_table
 
       assert_html(html, "table.table-naming-votes a[href*='/users/']")
     end
@@ -76,9 +76,15 @@ module Views::Controllers::Observations::Namings::Votes
                      user: u, value: val, favorite: false)
       end
 
-      html = render(Table.new(naming: @naming.reload))
+      html = render_table(naming: @naming.reload)
 
       assert_html(html, "td small", text: "...")
+    end
+
+    private
+
+    def render_table(naming: @naming)
+      render(Table.new(naming: naming))
     end
   end
 end

--- a/test/views/controllers/observations/show/details_test.rb
+++ b/test/views/controllers/observations/show/details_test.rb
@@ -63,9 +63,7 @@ class Views::Controllers::Observations::Show::DetailsTest <
     sites = ::ExternalSite.all.to_a
     skip("Need at least one ExternalSite fixture") if sites.empty?
 
-    html = render(Views::Controllers::Observations::Show::Details.new(
-                    obs: obs, user: nil, sites: sites, siblings: []
-                  ))
+    html = render(panel_with(obs, nil, sites: sites))
 
     assert_no_html(html, "#observation_external_links")
   end
@@ -79,9 +77,7 @@ class Views::Controllers::Observations::Show::DetailsTest <
     sites = ::ExternalSite.all.to_a
     skip("Need at least one ExternalSite fixture") if sites.empty?
 
-    html = render(Views::Controllers::Observations::Show::Details.new(
-                    obs: obs, user: @user, sites: sites, siblings: []
-                  ))
+    html = render(panel_with(obs, sites: sites))
 
     bodies = Nokogiri::HTML5.fragment(html).css(
       "#observation_details > .panel-body"
@@ -207,9 +203,9 @@ class Views::Controllers::Observations::Show::DetailsTest <
     Nokogiri::HTML.fragment(html).at_css(".obs-who").text
   end
 
-  def panel_with(obs, user = @user)
+  def panel_with(obs, user = @user, sites: [])
     Views::Controllers::Observations::Show::Details.new(
-      obs: obs, user: user, sites: [], siblings: []
+      obs: obs, user: user, sites: sites, siblings: []
     )
   end
 end

--- a/test/views/controllers/observations/show/species_lists_panel_test.rb
+++ b/test/views/controllers/observations/show/species_lists_panel_test.rb
@@ -29,11 +29,7 @@ class Views::Controllers::Observations::Show::SpeciesListsPanelTest <
     assert(user.species_list_ids.none?,
            "Need user fixture who owns no species lists")
 
-    html = render(
-      Views::Controllers::Observations::Show::SpeciesListsPanel.new(
-        obs: obs, user: user
-      )
-    )
+    html = render(panel_with(obs, user))
 
     assert_equal("", html)
   end
@@ -46,11 +42,7 @@ class Views::Controllers::Observations::Show::SpeciesListsPanelTest <
     assert(user.species_list_ids.any?,
            "Need user fixture who owns at least one species list")
 
-    html = render(
-      Views::Controllers::Observations::Show::SpeciesListsPanel.new(
-        obs: obs, user: user
-      )
-    )
+    html = render(panel_with(obs, user))
 
     assert_html(
       html,
@@ -93,9 +85,9 @@ class Views::Controllers::Observations::Show::SpeciesListsPanelTest <
     Rails.application.routes.url_helpers
   end
 
-  def panel_with(obs)
+  def panel_with(obs, user = @user)
     Views::Controllers::Observations::Show::SpeciesListsPanel.new(
-      obs: obs, user: @user
+      obs: obs, user: user
     )
   end
 end

--- a/test/views/controllers/observations/show/specimen_panel/collection_numbers_section_test.rb
+++ b/test/views/controllers/observations/show/specimen_panel/collection_numbers_section_test.rb
@@ -25,11 +25,7 @@ class Views::Controllers::Observations::Show::SpecimenPanel
             first
       skip("Need an obs fixture without collection_numbers") unless obs
 
-      html = render(
-        CollectionNumbersSection.new(
-          obs: obs, user: obs.user, has_sibling_records: true
-        )
-      )
+      html = render(panel_with(obs, obs.user, has_sibling_records: true))
 
       assert_includes(html, "#{:collection_numbers.ti}:")
       assert_no_html(html, "li")
@@ -41,11 +37,7 @@ class Views::Controllers::Observations::Show::SpecimenPanel
       obs = ::Observation.where.missing(:collection_numbers).first
       skip("Need an obs fixture without collection_numbers") unless obs
 
-      html = render(
-        CollectionNumbersSection.new(
-          obs: obs, user: obs.user, has_sibling_records: false
-        )
-      )
+      html = render(panel_with(obs, obs.user))
 
       assert_includes(html, :no_objects.t(type: :collection_number))
       assert_no_html(html, "li")
@@ -58,11 +50,7 @@ class Views::Controllers::Observations::Show::SpecimenPanel
       obs = cn.observations.first
       stranger = users(:lone_wolf)
 
-      html = render(
-        CollectionNumbersSection.new(
-          obs: obs, user: stranger, has_sibling_records: false
-        )
-      )
+      html = render(panel_with(obs, stranger))
 
       # Readonly rows render in the same tight-list shape as the
       # editable list (unified via RecordListSection), just without
@@ -73,9 +61,9 @@ class Views::Controllers::Observations::Show::SpecimenPanel
 
     private
 
-    def panel_with(obs, user = @user)
+    def panel_with(obs, user = @user, has_sibling_records: false)
       CollectionNumbersSection.new(
-        obs: obs, user: user, has_sibling_records: false
+        obs: obs, user: user, has_sibling_records: has_sibling_records
       )
     end
   end

--- a/test/views/controllers/observations/show/specimen_panel/herbarium_records_section_test.rb
+++ b/test/views/controllers/observations/show/specimen_panel/herbarium_records_section_test.rb
@@ -21,11 +21,7 @@ class Views::Controllers::Observations::Show::SpecimenPanel
             first
       skip("Need an obs fixture without herbarium_records") unless obs
 
-      html = render(
-        HerbariumRecordsSection.new(
-          obs: obs, user: obs.user, has_sibling_records: true
-        )
-      )
+      html = render(panel_with(obs, obs.user, has_sibling_records: true))
 
       assert_includes(html, "#{:herbarium_records.ti}:")
       assert_no_html(html, "li")
@@ -37,11 +33,7 @@ class Views::Controllers::Observations::Show::SpecimenPanel
       obs = ::Observation.where.missing(:herbarium_records).first
       skip("Need an obs fixture without herbarium_records") unless obs
 
-      html = render(
-        HerbariumRecordsSection.new(
-          obs: obs, user: obs.user, has_sibling_records: false
-        )
-      )
+      html = render(panel_with(obs, obs.user))
 
       assert_includes(html, :no_objects.t(type: :herbarium_record))
       assert_no_html(html, "li")
@@ -55,20 +47,16 @@ class Views::Controllers::Observations::Show::SpecimenPanel
       stranger = users(:lone_wolf)
       skip("lone_wolf curates herbaria") if stranger.curated_herbaria.any?
 
-      html = render(
-        HerbariumRecordsSection.new(
-          obs: obs, user: stranger, has_sibling_records: false
-        )
-      )
+      html = render(panel_with(obs, stranger))
 
       assert_no_html(html, "a[data-modal*='herbarium_record']")
     end
 
     private
 
-    def panel_with(obs, user = @user)
+    def panel_with(obs, user = @user, has_sibling_records: false)
       HerbariumRecordsSection.new(
-        obs: obs, user: user, has_sibling_records: false
+        obs: obs, user: user, has_sibling_records: has_sibling_records
       )
     end
   end

--- a/test/views/controllers/projects/list_item_test.rb
+++ b/test/views/controllers/projects/list_item_test.rb
@@ -11,7 +11,7 @@ module Views::Controllers::Projects
 
     def test_renders_project
       project = projects(:eol_project)
-      html = render(ListItem.new(project: project))
+      html = render_item(project: project)
 
       # No `.list-group-item` wrapper — supplied by the caller.
       assert_no_html(html, "div.list-group-item")
@@ -27,7 +27,7 @@ module Views::Controllers::Projects
     def test_open_membership_badge
       project = projects(:eol_project)
       project.open_membership = true
-      html = render(ListItem.new(project: project))
+      html = render_item(project: project)
 
       assert_html(html, "span.ml-4")
       assert_includes(html, :open.ti)
@@ -36,9 +36,15 @@ module Views::Controllers::Projects
     def test_closed_membership_no_badge
       project = projects(:eol_project)
       project.open_membership = false
-      html = render(ListItem.new(project: project))
+      html = render_item(project: project)
 
       assert_no_html(html, "span.ml-4")
+    end
+
+    private
+
+    def render_item(**)
+      render(ListItem.new(**))
     end
   end
 end

--- a/test/views/controllers/projects/members/groups_test.rb
+++ b/test/views/controllers/projects/members/groups_test.rb
@@ -11,9 +11,7 @@ module Views::Controllers::Projects::Members
 
     def test_renders_member_and_admin_groups
       project = projects(:eol_project)
-      html = render(Groups.new(
-                      project: project, user: @user
-                    ))
+      html = render_groups(project: project, user: @user)
 
       # Member heading
       assert_includes(html, :change_member_status_members.t)
@@ -24,13 +22,17 @@ module Views::Controllers::Projects::Members
     def test_admin_sees_edit_links
       project = projects(:eol_project)
       # rolf is the project owner/admin
-      html = render(Groups.new(
-                      project: project, user: project.user
-                    ))
+      html = render_groups(project: project, user: project.user)
 
       assert_includes(html, :change_member_status_change_status.t)
       assert_html(html,
                   "a[href*='edit'][href*='project']")
+    end
+
+    private
+
+    def render_groups(**)
+      render(Groups.new(**))
     end
   end
 end

--- a/test/views/controllers/projects/violations/target_location_form_test.rb
+++ b/test/views/controllers/projects/violations/target_location_form_test.rb
@@ -189,10 +189,7 @@ module Views::Controllers::Projects::Violations
         name: Name.unknown
       )
 
-      html = render(TargetLocationForm.new(
-                      obs: obs, project: @project,
-                      existing_locations: existing_for(obs)
-                    ))
+      html = render_form(obs: obs)
 
       assert_html(html, "input[type='radio'][disabled]")
 
@@ -225,10 +222,7 @@ module Views::Controllers::Projects::Violations
         name: Name.unknown
       )
 
-      html = render(TargetLocationForm.new(
-                      obs: obs, project: @project,
-                      existing_locations: existing_for(obs)
-                    ))
+      html = render_form(obs: obs)
 
       encoded = "Unique+County+X42%2C+California%2C+USA"
       assert_html(html,
@@ -250,10 +244,7 @@ module Views::Controllers::Projects::Violations
       original_stderr = $stderr
       $stderr = stderr_io
       begin
-        render(TargetLocationForm.new(
-                 obs: obs, project: @project,
-                 existing_locations: existing_for(obs)
-               ))
+        render_form(obs: obs)
       ensure
         $stderr = original_stderr
       end
@@ -262,10 +253,10 @@ module Views::Controllers::Projects::Violations
 
     private
 
-    def render_form
+    def render_form(obs: @obs)
       render(TargetLocationForm.new(
-               obs: @obs, project: @project,
-               existing_locations: existing_for(@obs)
+               obs: obs, project: @project,
+               existing_locations: existing_for(obs)
              ))
     end
 

--- a/test/views/controllers/sequences/show_test.rb
+++ b/test/views/controllers/sequences/show_test.rb
@@ -14,7 +14,7 @@ module Views::Controllers::Sequences
     # component produces the required external-navigation attrs.
     def test_blast_link_opens_in_new_tab
       seq = sequences(:local_sequence)
-      html = render(Show.new(sequence: seq))
+      html = render_show(sequence: seq)
 
       assert_html(html, "a[target='_blank'][rel='noopener noreferrer']" \
                         "[href*='blast.ncbi.nlm.nih.gov']")
@@ -27,11 +27,17 @@ module Views::Controllers::Sequences
     # without conflicting.
     def test_deposited_sequence_shows_deposit_line_and_blast_link
       seq = sequences(:deposited_sequence)
-      html = render(Show.new(sequence: seq))
+      html = render_show(sequence: seq)
 
       # BLAST link + deposit archive + deposit accession all open externally
       assert_html(html, "a[target='_blank'][href*='blast.ncbi.nlm.nih.gov']")
       assert_html(html, "a[target='_blank'][href*='ncbi.nlm.nih.gov/nuccore']")
+    end
+
+    private
+
+    def render_show(**)
+      render(Show.new(**))
     end
   end
 end

--- a/test/views/controllers/translations/index_test.rb
+++ b/test/views/controllers/translations/index_test.rb
@@ -27,15 +27,14 @@ module Views::Controllers::Translations
         ::TranslationsController::TranslationsUIComment.new("a comment"),
         ::TranslationsController::TranslationsUITagField.new(tag_with_string)
       ]
-      html = render(Index.new(
-                      lang: @lang,
-                      tag: tag_with_string,
-                      index: index,
-                      strings: strings,
-                      edit_tags: [tag_with_string],
-                      official_records: records,
-                      translated_records: records
-                    ))
+      html = render_index(
+        tag: tag_with_string,
+        index: index,
+        strings: strings,
+        edit_tags: [tag_with_string],
+        official_records: records,
+        translated_records: records
+      )
       assert_html(html, "p.major_header")
       assert_html(html, "p.minor_header")
       assert_html(html, "p.comment")
@@ -50,16 +49,18 @@ module Views::Controllers::Translations
     # construction, before `render_item` ever runs.
     def test_render_item_raises_for_unrecognized_type
       error = assert_raises(RuntimeError) do
-        render(Index.new(
-                 lang: @lang, index: [UnknownItemType.new("x")],
-                 official_records: {}, translated_records: {}
-               ))
+        render_index(index: [UnknownItemType.new("x")],
+                     official_records: {}, translated_records: {})
       end
       assert_match(/Unexpected form item type: .*UnknownItemType/,
                    error.message)
     end
 
     private
+
+    def render_index(**)
+      render(Index.new(lang: @lang, **))
+    end
 
     def build_records(lang, tag, text)
       return {} unless lang.translation_strings.first

--- a/test/views/controllers/users/show/user_stats_test.rb
+++ b/test/views/controllers/users/show/user_stats_test.rb
@@ -30,8 +30,7 @@ module Views::Controllers::Users
             count: nil, points: 0 },
           { label: "Bonus reason", count: nil, points: 10 }
         ]
-        html = render(UserStats.new(show_user: @user, name: @user.login,
-                                    rows: rows))
+        html = render_stats(rows: rows)
         link_path = routes.observations_path(by_user: @user.id)
         assert_html(html, "tr td a[href='#{link_path}']")
         assert_includes(html, "Unlinked Field")
@@ -46,10 +45,15 @@ module Views::Controllers::Users
           { field: :observations, label: "Observations", count: 0,
             weight: 1, points: 0 }
         ]
-        html = render(UserStats.new(show_user: @user, name: @user.login,
-                                    rows: rows))
+        html = render_stats(rows: rows)
         # Empty body still has the panel header but no hr/total tr.
         assert_no_html(html, "tr td hr")
+      end
+
+      private
+
+      def render_stats(**)
+        render(UserStats.new(show_user: @user, name: @user.login, **))
       end
     end
   end

--- a/test/views/controllers/versions/previous_test.rb
+++ b/test/views/controllers/versions/previous_test.rb
@@ -6,11 +6,7 @@ class Views::Controllers::Versions::PreviousTest < ComponentTestCase
   def test_renders_panel_with_type_tagged_id
     name = names(:peltigera)
 
-    html = render(
-      Views::Controllers::Versions::Previous.new(
-        obj: name, versions: name.versions.to_a
-      )
-    )
+    html = render_previous(obj: name, versions: name.versions.to_a)
 
     # Panel id is `<type_tag>_versions` — e.g. `name_versions`.
     assert_html(html, "##{name.type_tag}_versions")
@@ -19,11 +15,7 @@ class Views::Controllers::Versions::PreviousTest < ComponentTestCase
   def test_renders_one_row_per_version_in_reverse_order
     name = names(:peltigera)
 
-    html = render(
-      Views::Controllers::Versions::Previous.new(
-        obj: name, versions: name.versions.to_a
-      )
-    )
+    html = render_previous(obj: name, versions: name.versions.to_a)
 
     # The latest version's anchor carries `latest_version_link`; the
     # remaining anchors carry `initial_version_link`.
@@ -37,13 +29,15 @@ class Views::Controllers::Versions::PreviousTest < ComponentTestCase
     name = names(:peltigera)
     versions = name.versions.to_a
 
-    html = render(
-      Views::Controllers::Versions::Previous.new(
-        obj: name, versions: versions,
-        args: { bold: ->(_v) { true } }
-      )
-    )
+    html = render_previous(obj: name, versions: versions,
+                           args: { bold: ->(_v) { true } })
 
     assert_html(html, "a strong")
+  end
+
+  private
+
+  def render_previous(**)
+    render(Views::Controllers::Versions::Previous.new(**))
   end
 end

--- a/test/views/full_page_base_test.rb
+++ b/test/views/full_page_base_test.rb
@@ -76,7 +76,7 @@ class Views::FullPageBaseTest < ComponentTestCase
 
   def test_default_layout_is_application
     stub_session!(layout: "")
-    html = render(Page.new)
+    html = render_page
 
     assert_html(html, "div.stub-app")
     assert_no_html(html, "div.stub-printable")
@@ -84,7 +84,7 @@ class Views::FullPageBaseTest < ComponentTestCase
 
   def test_printable_session_picks_printable_layout
     stub_session!(layout: "printable")
-    html = render(Page.new)
+    html = render_page
 
     assert_html(html, "div.stub-printable")
     assert_no_html(html, "div.stub-app")
@@ -93,14 +93,14 @@ class Views::FullPageBaseTest < ComponentTestCase
 
   def test_unknown_session_layout_falls_back_to_application
     stub_session!(layout: "BOGUS_LAYOUT")
-    html = render(Page.new)
+    html = render_page
 
     assert_html(html, "div.stub-app")
   end
 
   def test_capture_emits_action_content_inside_layout
     stub_session!(layout: "")
-    html = render(Page.new)
+    html = render_page
 
     # The page's `<div id="page-inner">` is captured, then emitted
     # inside the stub layout's wrapper.
@@ -110,7 +110,7 @@ class Views::FullPageBaseTest < ComponentTestCase
   def test_canonical_url_forwarded_from_controller_ivar
     stub_session!(layout: "")
     controller.instance_variable_set(:@canonical_url, "https://test.example/x")
-    render(Page.new)
+    render_page
 
     assert_equal("https://test.example/x",
                  RecordingApplication::CAPTURED[:props][:canonical_url])
@@ -119,7 +119,7 @@ class Views::FullPageBaseTest < ComponentTestCase
   def test_any_content_filters_applied_forwarded_from_controller_ivar
     stub_session!(layout: "")
     controller.instance_variable_set(:@any_content_filters_applied, true)
-    render(Page.new)
+    render_page
 
     assert_equal(true,
                  RecordingApplication::CAPTURED[:props][:any_content_filters_applied])
@@ -127,7 +127,7 @@ class Views::FullPageBaseTest < ComponentTestCase
 
   def test_ivars_unset_pass_nil
     stub_session!(layout: "")
-    render(Page.new)
+    render_page
 
     assert_nil(RecordingApplication::CAPTURED[:props][:canonical_url])
     assert_nil(RecordingApplication::CAPTURED[:props][:any_content_filters_applied])
@@ -142,12 +142,16 @@ class Views::FullPageBaseTest < ComponentTestCase
     stub_session!(layout: "printable")
     controller.instance_variable_set(:@canonical_url, "https://test.example/x")
 
-    render(Page.new) # must not raise
+    render_page # must not raise
 
     assert(RecordingPrintable::CAPTURED[:invoked])
   end
 
   private
+
+  def render_page
+    render(Page.new)
+  end
 
   def stub_session!(layout:)
     s = { layout: layout }

--- a/test/views/full_page_base_test.rb
+++ b/test/views/full_page_base_test.rb
@@ -76,7 +76,7 @@ class Views::FullPageBaseTest < ComponentTestCase
 
   def test_default_layout_is_application
     stub_session!(layout: "")
-    html = render_page
+    html = render(Page.new)
 
     assert_html(html, "div.stub-app")
     assert_no_html(html, "div.stub-printable")
@@ -84,7 +84,7 @@ class Views::FullPageBaseTest < ComponentTestCase
 
   def test_printable_session_picks_printable_layout
     stub_session!(layout: "printable")
-    html = render_page
+    html = render(Page.new)
 
     assert_html(html, "div.stub-printable")
     assert_no_html(html, "div.stub-app")
@@ -93,14 +93,14 @@ class Views::FullPageBaseTest < ComponentTestCase
 
   def test_unknown_session_layout_falls_back_to_application
     stub_session!(layout: "BOGUS_LAYOUT")
-    html = render_page
+    html = render(Page.new)
 
     assert_html(html, "div.stub-app")
   end
 
   def test_capture_emits_action_content_inside_layout
     stub_session!(layout: "")
-    html = render_page
+    html = render(Page.new)
 
     # The page's `<div id="page-inner">` is captured, then emitted
     # inside the stub layout's wrapper.
@@ -110,7 +110,7 @@ class Views::FullPageBaseTest < ComponentTestCase
   def test_canonical_url_forwarded_from_controller_ivar
     stub_session!(layout: "")
     controller.instance_variable_set(:@canonical_url, "https://test.example/x")
-    render_page
+    render(Page.new)
 
     assert_equal("https://test.example/x",
                  RecordingApplication::CAPTURED[:props][:canonical_url])
@@ -119,7 +119,7 @@ class Views::FullPageBaseTest < ComponentTestCase
   def test_any_content_filters_applied_forwarded_from_controller_ivar
     stub_session!(layout: "")
     controller.instance_variable_set(:@any_content_filters_applied, true)
-    render_page
+    render(Page.new)
 
     assert_equal(true,
                  RecordingApplication::CAPTURED[:props][:any_content_filters_applied])
@@ -127,7 +127,7 @@ class Views::FullPageBaseTest < ComponentTestCase
 
   def test_ivars_unset_pass_nil
     stub_session!(layout: "")
-    render_page
+    render(Page.new)
 
     assert_nil(RecordingApplication::CAPTURED[:props][:canonical_url])
     assert_nil(RecordingApplication::CAPTURED[:props][:any_content_filters_applied])
@@ -142,16 +142,12 @@ class Views::FullPageBaseTest < ComponentTestCase
     stub_session!(layout: "printable")
     controller.instance_variable_set(:@canonical_url, "https://test.example/x")
 
-    render_page # must not raise
+    render(Page.new) # must not raise
 
     assert(RecordingPrintable::CAPTURED[:invoked])
   end
 
   private
-
-  def render_page
-    render(Page.new)
-  end
 
   def stub_session!(layout:)
     s = { layout: layout }

--- a/test/views/layouts/app/message_alert_test.rb
+++ b/test/views/layouts/app/message_alert_test.rb
@@ -10,16 +10,22 @@ module Views::Layouts::App
     # This fails if the entity gets double-escaped (an earlier bug).
     def test_renders_trusted_message_not_double_escaped
       message = :observation_resync_failed.t
-      html = render(MessageAlert.new(message: message, level: :danger))
+      html = render_alert(message: message, level: :danger)
 
       assert_html(html, "div.alert.alert-danger#flash_notices",
                   text: message.as_displayed)
     end
 
     def test_level_drives_alert_class
-      html = render(MessageAlert.new(message: "Done", level: :success))
+      html = render_alert(message: "Done", level: :success)
 
       assert_html(html, "div.alert.alert-success", text: "Done")
+    end
+
+    private
+
+    def render_alert(**)
+      render(MessageAlert.new(**))
     end
   end
 end

--- a/test/views/layouts/application_test.rb
+++ b/test/views/layouts/application_test.rb
@@ -35,7 +35,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Doctype / html / body skeleton --------------------------------
 
   def test_doctype_and_html_skeleton
-    html = render_page
+    html = render(FakePage.new)
 
     assert_match(/\A<!doctype html><html\b/, html)
     assert_html(html, "html[class='']")
@@ -46,7 +46,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Head ----------------------------------------------------------
 
   def test_head_renders_app_head_subcomponent
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "head > meta[name='viewport']")
     assert_html(html, "head > meta[name='turbo-prefetch']")
@@ -57,14 +57,14 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   def test_canonical_link_emitted_when_controller_sets_ivar
     controller.instance_variable_set(:@canonical_url,
                                      "https://test.example/foo")
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html,
                 "head > link[rel='canonical'][href='https://test.example/foo']")
   end
 
   def test_canonical_link_absent_when_no_ivar
-    html = render_page
+    html = render(FakePage.new)
 
     assert_no_html(html, "head > link[rel='canonical']")
   end
@@ -72,7 +72,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Body class ----------------------------------------------------
 
   def test_body_class_combines_controller_action_theme_format_login_state
-    html = render_page
+    html = render(FakePage.new)
     body = Nokogiri::HTML5.parse(html).at_css("body")
     classes = body["class"].split
 
@@ -84,7 +84,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_body_class_uses_no_user_when_anonymous
     controller.instance_variable_set(:@user, nil)
-    html = render_page
+    html = render(FakePage.new)
     body = Nokogiri::HTML5.parse(html).at_css("body")
     classes = body["class"].split
 
@@ -94,20 +94,20 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_body_class_collapses_create_into_new
     stub_controller_state!("observations", "create")
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "body.observations__new")
   end
 
   def test_body_class_collapses_update_into_edit
     stub_controller_state!("observations", "update")
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "body.observations__edit")
   end
 
   def test_body_carries_lazyload_tooltip_stimulus_controller
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "body[data-controller='lazyload tooltip']")
   end
@@ -115,21 +115,21 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Main container + chrome anchors --------------------------------
 
   def test_main_container_present
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "#main_container[data-controller='nav links']")
     assert_html(html, "#main_container[data-nav-target='container']")
   end
 
   def test_main_emits_action_block_inside
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "main#content #fake-action-content",
                 text: "HELLO_INNER")
   end
 
   def test_bottom_singletons_present
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "#modal_progress_spinner")
     assert_html(html, "#mo_confirm")
@@ -140,7 +140,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_page_flash_renders_empty_when_no_notice
     stub_session!(notice: nil, layout: "")
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "#page_flash")
     # No flash content — Nokogiri text on #page_flash strips whitespace.
@@ -154,7 +154,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
     # MO's flash notice encoding: leading digit is the level
     # (0=notice, 1=warning, 2=error), rest is the message.
     stub_session!(notice: "0Hello flash", layout: "")
-    html = render_page
+    html = render(FakePage.new)
 
     flash = Nokogiri::HTML5.parse(html).at_css("#page_flash")
     assert_includes(flash.text, "Hello flash",
@@ -163,7 +163,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_page_flash_renders_warning_at_warning_level
     stub_session!(notice: "1Watch out", layout: "")
-    html = render_page
+    html = render(FakePage.new)
 
     flash = Nokogiri::HTML5.parse(html).at_css("#page_flash")
     assert_includes(flash.text, "Watch out")
@@ -171,7 +171,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_page_flash_renders_error_at_error_level
     stub_session!(notice: "2It broke", layout: "")
-    html = render_page
+    html = render(FakePage.new)
 
     flash = Nokogiri::HTML5.parse(html).at_css("#page_flash")
     assert_includes(flash.text, "It broke")
@@ -180,10 +180,6 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Helpers --------------------------------------------------------
 
   private
-
-  def render_page
-    render(FakePage.new)
-  end
 
   def stub_request_context!
     langs = Language.where.not(beta: true).to_a

--- a/test/views/layouts/application_test.rb
+++ b/test/views/layouts/application_test.rb
@@ -35,7 +35,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Doctype / html / body skeleton --------------------------------
 
   def test_doctype_and_html_skeleton
-    html = render(FakePage.new)
+    html = render_page
 
     assert_match(/\A<!doctype html><html\b/, html)
     assert_html(html, "html[class='']")
@@ -46,7 +46,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Head ----------------------------------------------------------
 
   def test_head_renders_app_head_subcomponent
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "head > meta[name='viewport']")
     assert_html(html, "head > meta[name='turbo-prefetch']")
@@ -57,14 +57,14 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   def test_canonical_link_emitted_when_controller_sets_ivar
     controller.instance_variable_set(:@canonical_url,
                                      "https://test.example/foo")
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html,
                 "head > link[rel='canonical'][href='https://test.example/foo']")
   end
 
   def test_canonical_link_absent_when_no_ivar
-    html = render(FakePage.new)
+    html = render_page
 
     assert_no_html(html, "head > link[rel='canonical']")
   end
@@ -72,7 +72,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Body class ----------------------------------------------------
 
   def test_body_class_combines_controller_action_theme_format_login_state
-    html = render(FakePage.new)
+    html = render_page
     body = Nokogiri::HTML5.parse(html).at_css("body")
     classes = body["class"].split
 
@@ -84,7 +84,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_body_class_uses_no_user_when_anonymous
     controller.instance_variable_set(:@user, nil)
-    html = render(FakePage.new)
+    html = render_page
     body = Nokogiri::HTML5.parse(html).at_css("body")
     classes = body["class"].split
 
@@ -94,20 +94,20 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_body_class_collapses_create_into_new
     stub_controller_state!("observations", "create")
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "body.observations__new")
   end
 
   def test_body_class_collapses_update_into_edit
     stub_controller_state!("observations", "update")
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "body.observations__edit")
   end
 
   def test_body_carries_lazyload_tooltip_stimulus_controller
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "body[data-controller='lazyload tooltip']")
   end
@@ -115,21 +115,21 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Main container + chrome anchors --------------------------------
 
   def test_main_container_present
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "#main_container[data-controller='nav links']")
     assert_html(html, "#main_container[data-nav-target='container']")
   end
 
   def test_main_emits_action_block_inside
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "main#content #fake-action-content",
                 text: "HELLO_INNER")
   end
 
   def test_bottom_singletons_present
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "#modal_progress_spinner")
     assert_html(html, "#mo_confirm")
@@ -140,7 +140,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_page_flash_renders_empty_when_no_notice
     stub_session!(notice: nil, layout: "")
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "#page_flash")
     # No flash content — Nokogiri text on #page_flash strips whitespace.
@@ -154,7 +154,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
     # MO's flash notice encoding: leading digit is the level
     # (0=notice, 1=warning, 2=error), rest is the message.
     stub_session!(notice: "0Hello flash", layout: "")
-    html = render(FakePage.new)
+    html = render_page
 
     flash = Nokogiri::HTML5.parse(html).at_css("#page_flash")
     assert_includes(flash.text, "Hello flash",
@@ -163,7 +163,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_page_flash_renders_warning_at_warning_level
     stub_session!(notice: "1Watch out", layout: "")
-    html = render(FakePage.new)
+    html = render_page
 
     flash = Nokogiri::HTML5.parse(html).at_css("#page_flash")
     assert_includes(flash.text, "Watch out")
@@ -171,7 +171,7 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
 
   def test_page_flash_renders_error_at_error_level
     stub_session!(notice: "2It broke", layout: "")
-    html = render(FakePage.new)
+    html = render_page
 
     flash = Nokogiri::HTML5.parse(html).at_css("#page_flash")
     assert_includes(flash.text, "It broke")
@@ -180,6 +180,10 @@ class Views::Layouts::ApplicationTest < ComponentTestCase
   # ---- Helpers --------------------------------------------------------
 
   private
+
+  def render_page
+    render(FakePage.new)
+  end
 
   def stub_request_context!
     langs = Language.where.not(beta: true).to_a

--- a/test/views/layouts/authors_and_editors_test.rb
+++ b/test/views/layouts/authors_and_editors_test.rb
@@ -58,11 +58,7 @@ module Views::Layouts
         editors: [dick]
       )
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: desc,
-                                versions: [],
-                                user: nil
-                              ))
+      html = render_component(obj: desc, versions: [], user: nil)
 
       assert_includes(html, "Rolf")
       assert_includes(html, "Mary")
@@ -87,11 +83,7 @@ module Views::Layouts
         true
       end
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: desc,
-                                versions: [],
-                                user: rolf
-                              ))
+      html = render_component(obj: desc, versions: [], user: rolf)
 
       assert_includes(html, "Mary")
       # Component should render successfully for admin users
@@ -108,11 +100,7 @@ module Views::Layouts
         id: 123
       )
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: desc,
-                                versions: [],
-                                user: rolf
-                              ))
+      html = render_component(obj: desc, versions: [], user: rolf)
 
       assert_includes(html, "Mary")
       # Component should render successfully for non-author users
@@ -129,11 +117,7 @@ module Views::Layouts
         id: 123
       )
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: desc,
-                                versions: [],
-                                user: rolf
-                              ))
+      html = render_component(obj: desc, versions: [], user: rolf)
 
       assert_includes(html, "Rolf")
       assert_includes(html, "Mary")
@@ -147,11 +131,7 @@ module Views::Layouts
         editors: [users(:dick)]
       )
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: desc,
-                                versions: [],
-                                user: nil
-                              ))
+      html = render_component(obj: desc, versions: [], user: nil)
 
       # Should render without error even with no authors
       assert_not_nil(html)
@@ -172,11 +152,7 @@ module Views::Layouts
         TestVersion.new(user_id: katrina.id)
       ]
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: obj,
-                                versions: versions,
-                                user: nil
-                              ))
+      html = render_component(obj: obj, versions: versions, user: nil)
 
       assert_includes(html, "Rolf")
       assert_includes(html, "Mary")
@@ -190,11 +166,7 @@ module Views::Layouts
       rolf = users(:rolf)
       obj = TestObject.new(user: rolf, type_tag: :location)
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: obj,
-                                versions: [],
-                                user: nil
-                              ))
+      html = render_component(obj: obj, versions: [], user: nil)
 
       assert_includes(html, "Rolf")
       # Should show user who defined/created the object
@@ -213,11 +185,7 @@ module Views::Layouts
         TestVersion.new(user_id: mary.id)
       ]
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: obj,
-                                versions: versions,
-                                user: nil
-                              ))
+      html = render_component(obj: obj, versions: versions, user: nil)
 
       assert_includes(html, "Rolf")
       # Rolf should only appear once as creator, not as editor
@@ -230,11 +198,7 @@ module Views::Layouts
       name = names(:fungi)
       versions = name.versions.to_a
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: name,
-                                versions: versions,
-                                user: users(:rolf)
-                              ))
+      html = render_component(obj: name, versions: versions, user: users(:rolf))
 
       assert_not_nil(html)
       # Should render without errors
@@ -244,11 +208,8 @@ module Views::Layouts
       location = locations(:albion)
       versions = location.versions.to_a
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: location,
-                                versions: versions,
-                                user: users(:rolf)
-                              ))
+      html = render_component(obj: location, versions: versions,
+                              user: users(:rolf))
 
       assert_not_nil(html)
     end
@@ -260,11 +221,7 @@ module Views::Layouts
         type_tag: :name_description
       )
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: desc,
-                                versions: [],
-                                user: nil
-                              ))
+      html = render_component(obj: desc, versions: [], user: nil)
 
       assert_includes(html, "Rolf")
     end
@@ -275,11 +232,7 @@ module Views::Layouts
         type_tag: :glossary_term
       )
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: obj,
-                                versions: [],
-                                user: nil
-                              ))
+      html = render_component(obj: obj, versions: [], user: nil)
 
       assert_includes(html, "Rolf")
     end
@@ -294,15 +247,17 @@ module Views::Layouts
         editors: []
       )
 
-      html = render_component(AuthorsAndEditors.new(
-                                obj: desc,
-                                versions: [],
-                                user: nil
-                              ))
+      html = render_component(obj: desc, versions: [], user: nil)
 
       # Should render "User #<id>" when given an integer
       assert_includes(html, "User ##{user_id}")
       assert_includes(html, "user_link_#{user_id}")
+    end
+
+    private
+
+    def render_component(**)
+      render(AuthorsAndEditors.new(**))
     end
   end
 end

--- a/test/views/layouts/header/edit_delete_icons_test.rb
+++ b/test/views/layouts/header/edit_delete_icons_test.rb
@@ -14,26 +14,26 @@ module Views::Layouts
     end
 
     def test_always_renders_ul
-      html = render(Header::EditDeleteIcons.new(object: @obs, user: @non_owner))
+      html = render_icons(user: @non_owner)
 
       assert_html(html, "ul.object_edit")
     end
 
     def test_renders_empty_ul_when_cannot_edit
-      html = render(Header::EditDeleteIcons.new(object: @obs, user: @non_owner))
+      html = render_icons(user: @non_owner)
 
       assert_no_html(html, "ul.object_edit li")
     end
 
     def test_renders_empty_ul_with_nil_user
-      html = render(Header::EditDeleteIcons.new(object: @obs, user: nil))
+      html = render_icons(user: nil)
 
       assert_html(html, "ul.object_edit")
       assert_no_html(html, "ul.object_edit li")
     end
 
     def test_renders_edit_and_delete_li_when_owner
-      html = render(Header::EditDeleteIcons.new(object: @obs, user: @owner))
+      html = render_icons(user: @owner)
 
       assert_html(html, "ul.object_edit li", count: 2)
     end
@@ -42,11 +42,17 @@ module Views::Layouts
     # can't be edited on MO) but keeps delete — a separate lifecycle.
     def test_reflection_suppresses_edit_icon_but_keeps_delete
       @obs.update_column(:reflected_at, Time.zone.now)
-      html = render(Header::EditDeleteIcons.new(object: @obs, user: @owner))
+      html = render_icons(user: @owner)
 
       assert_html(html, "ul.object_edit li", count: 1)
       assert_no_html(html, "a[href$='/edit']",
                      "a reflection should have no edit-form link")
+    end
+
+    private
+
+    def render_icons(**)
+      render(Header::EditDeleteIcons.new(object: @obs, **))
     end
   end
 end

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -20,19 +20,13 @@ module Views::Layouts
     end
 
     def test_renders_nothing_when_no_object
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: nil,
-                      query: @query
-                    ))
+      html = render_nav(object: nil, query: @query)
 
       assert_equal("", html)
     end
 
     def test_renders_nothing_when_no_query
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: nil
-                    ))
+      html = render_nav(object: @middle_obs, query: nil)
 
       assert_equal("", html)
     end
@@ -40,10 +34,7 @@ module Views::Layouts
     def test_renders_basic_structure
       @query.current_id = @middle_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @middle_obs, query: @query)
 
       # Main container
       assert_includes(html, 'class="nav flex-bar object_pager"')
@@ -60,10 +51,7 @@ module Views::Layouts
     def test_prev_link_disabled_when_first_item
       @query.current_id = @first_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @first_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @first_obs, query: @query)
 
       # Prev link should have disabled class
       assert_html(html, "a.prev_object_link.disabled")
@@ -75,10 +63,7 @@ module Views::Layouts
     def test_next_link_disabled_when_last_item
       @query.current_id = @last_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @last_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @last_obs, query: @query)
 
       # Next link should have disabled class
       assert_html(html, "a.next_object_link.disabled")
@@ -90,10 +75,7 @@ module Views::Layouts
     def test_both_links_enabled_when_middle_item
       @query.current_id = @middle_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @middle_obs, query: @query)
 
       assert_html(html, "a.prev_object_link:not(.disabled)")
       assert_html(html, "a.next_object_link:not(.disabled)")
@@ -102,10 +84,7 @@ module Views::Layouts
     def test_prev_link_has_correct_href
       @query.current_id = @middle_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @middle_obs, query: @query)
 
       # Get the prev_id from the query
       expected_href = "/observations/#{@query.prev_id}"
@@ -116,10 +95,7 @@ module Views::Layouts
     def test_next_link_has_correct_href
       @query.current_id = @middle_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @middle_obs, query: @query)
 
       # Get the next_id from the query
       expected_href = "/observations/#{@query.next_id}"
@@ -134,10 +110,7 @@ module Views::Layouts
       # translation tags are lowercase-only (#4843).
       @query.current_id = @middle_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @middle_obs, query: @query)
 
       assert_includes(html, :prev_object.t(type: "Observation"))
       assert_includes(html, :next_object.t(type: "Observation"))
@@ -146,10 +119,7 @@ module Views::Layouts
     def test_index_link_uses_grid_icon_for_observations
       @query.current_id = @middle_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @middle_obs, query: @query)
 
       # Grid icon for observations
       assert_nested(
@@ -165,10 +135,7 @@ module Views::Layouts
       middle_name = Name.find(name_ids[1])
       name_query.current_id = middle_name.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: middle_name,
-                      query: name_query
-                    ))
+      html = render_nav(object: middle_name, query: name_query)
 
       # List icon for non-observations
       assert_nested(
@@ -181,10 +148,7 @@ module Views::Layouts
     def test_links_are_styled_as_large_link_buttons
       @query.current_id = @middle_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @middle_obs, query: @query)
 
       # Framed as buttons via Link::Icon's button:/size: kwargs, not
       # via raw btn/btn-lg strings in Navbar::LINK_CLASSES. :link
@@ -202,10 +166,7 @@ module Views::Layouts
     def test_links_have_tooltips
       @query.current_id = @middle_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @middle_obs, query: @query)
 
       # All links should have tooltip data attributes
       assert_html(html, "a.prev_object_link[data-tooltip-target='tip']")
@@ -216,10 +177,7 @@ module Views::Layouts
     def test_link_nesting_structure
       @query.current_id = @middle_obs.id
 
-      html = render(Views::Layouts::Header::ShowPrevNextNav.new(
-                      object: @middle_obs,
-                      query: @query
-                    ))
+      html = render_nav(object: @middle_obs, query: @query)
 
       # Links should be nested in li elements
       assert_nested(
@@ -241,6 +199,12 @@ module Views::Layouts
         parent_selector: "a.prev_object_link",
         child_selector: "span.sr-only"
       )
+    end
+
+    private
+
+    def render_nav(**)
+      render(Views::Layouts::Header::ShowPrevNextNav.new(**))
     end
   end
 end

--- a/test/views/layouts/header/sorter_test.rb
+++ b/test/views/layouts/header/sorter_test.rb
@@ -23,28 +23,25 @@ module Views::Layouts
     end
 
     def test_renders_nothing_when_no_query
-      html = render(Header::Sorter.new(query: nil, sorts: @sorts))
+      html = render_sorter(query: nil)
 
       assert_equal("", html)
     end
 
     def test_renders_nothing_when_no_sorts
-      html = render(Header::Sorter.new(query: query_with(num_results: 5),
-                                       sorts: nil))
+      html = render_sorter(query: query_with(num_results: 5), sorts: nil)
 
       assert_equal("", html)
     end
 
     def test_renders_nothing_when_only_one_result
-      html = render(Header::Sorter.new(query: query_with(num_results: 1),
-                                       sorts: @sorts))
+      html = render_sorter(query: query_with(num_results: 1))
 
       assert_equal("", html)
     end
 
     def test_renders_outer_ul_with_label_and_dropdown
-      html = render(Header::Sorter.new(query: query_with(num_results: 5),
-                                       sorts: @sorts))
+      html = render_sorter(query: query_with(num_results: 5))
 
       # Outer is a `<ul>`, not a `<div>` — semantically a list of nav
       # items (label + dropdown).
@@ -64,8 +61,7 @@ module Views::Layouts
     end
 
     def test_menu_contains_mobile_only_sort_by_header
-      html = render(Header::Sorter.new(query: query_with(num_results: 5),
-                                       sorts: @sorts))
+      html = render_sorter(query: query_with(num_results: 5))
 
       # `menu_header:` slot — visible-xs `<li>` rendered above the
       # section's links.
@@ -74,11 +70,9 @@ module Views::Layouts
     end
 
     def test_active_sort_is_marked_active_and_disabled
-      html = render(Header::Sorter.new(
-                      query: query_with(num_results: 5,
-                                        order_by: "created_at"),
-                      sorts: @sorts
-                    ))
+      html = render_sorter(
+        query: query_with(num_results: 5, order_by: "created_at")
+      )
 
       # `args[:active] = true` in the Sorter's tuples flows through
       # `Components::Dropdown#render_link`: the current sort gets
@@ -90,11 +84,9 @@ module Views::Layouts
     end
 
     def test_reverse_link_is_appended
-      html = render(Header::Sorter.new(
-                      query: query_with(num_results: 5,
-                                        order_by: "created_at"),
-                      sorts: @sorts
-                    ))
+      html = render_sorter(
+        query: query_with(num_results: 5, order_by: "created_at")
+      )
 
       # `Reverse` is always the last tuple in the menu, with the
       # `<plural>_by_reverse_<current>_link` id-style class.
@@ -103,11 +95,10 @@ module Views::Layouts
     end
 
     def test_link_all_skips_active_disabled_state
-      html = render(Header::Sorter.new(
-                      query: query_with(num_results: 5,
-                                        order_by: "created_at"),
-                      sorts: @sorts, link_all: true
-                    ))
+      html = render_sorter(
+        query: query_with(num_results: 5, order_by: "created_at"),
+        link_all: true
+      )
 
       # With `link_all: true`, no tuple is `.active`; every option
       # stays a live, undisabled link.
@@ -117,6 +108,10 @@ module Views::Layouts
     end
 
     private
+
+    def render_sorter(sorts: @sorts, **)
+      render(Header::Sorter.new(sorts: sorts, **))
+    end
 
     # Real `Query` instance — Sorter's prop type rejects duck-typed
     # stubs. `num_results` is stubbed via `define_singleton_method`

--- a/test/views/layouts/printable_test.rb
+++ b/test/views/layouts/printable_test.rb
@@ -26,7 +26,7 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_renders_basic_document_skeleton
-    html = render_page
+    html = render(FakePage.new)
 
     assert_match(/\A<!doctype html><html\b/, html)
     assert_html(html, "html[lang='en']")
@@ -35,7 +35,7 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_head_contains_charset_and_print_metadata
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "head > meta[charset='utf-8']")
     assert_html(html, "head > link[rel='SHORTCUT ICON']")
@@ -45,14 +45,14 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_head_contains_rss_discovery_link
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html,
                 "head > link[rel='alternate'][type='application/rss+xml']")
   end
 
   def test_head_contains_document_title_from_content_for
-    html = render_page
+    html = render(FakePage.new)
 
     # `:app_title.l` may contain HTML entities; route through
     # `as_displayed` so Nokogiri's text comparison matches the
@@ -62,7 +62,7 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_head_contains_inline_print_style
-    html = render_page
+    html = render(FakePage.new)
 
     style = Nokogiri::HTML5.parse(html).at_css("head > style")&.text.to_s
     assert_match(/page-break-before:\s*always/, style)
@@ -70,13 +70,13 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_body_renders_inner_action_content
-    html = render_page
+    html = render(FakePage.new)
 
     assert_html(html, "body > #inner-page", text: "INNER")
   end
 
   def test_no_application_chrome
-    html = render_page
+    html = render(FakePage.new)
 
     assert_no_html(html, "#main_container")
     assert_no_html(html, "#sidebar")
@@ -87,10 +87,6 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   private
-
-  def render_page
-    render(FakePage.new)
-  end
 
   # Sessions are disabled in `ComponentTestCase`; stub the read of
   # `session[:layout]` that `FullPageBase#layout_class` does.

--- a/test/views/layouts/printable_test.rb
+++ b/test/views/layouts/printable_test.rb
@@ -26,7 +26,7 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_renders_basic_document_skeleton
-    html = render(FakePage.new)
+    html = render_page
 
     assert_match(/\A<!doctype html><html\b/, html)
     assert_html(html, "html[lang='en']")
@@ -35,7 +35,7 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_head_contains_charset_and_print_metadata
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "head > meta[charset='utf-8']")
     assert_html(html, "head > link[rel='SHORTCUT ICON']")
@@ -45,14 +45,14 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_head_contains_rss_discovery_link
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html,
                 "head > link[rel='alternate'][type='application/rss+xml']")
   end
 
   def test_head_contains_document_title_from_content_for
-    html = render(FakePage.new)
+    html = render_page
 
     # `:app_title.l` may contain HTML entities; route through
     # `as_displayed` so Nokogiri's text comparison matches the
@@ -62,7 +62,7 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_head_contains_inline_print_style
-    html = render(FakePage.new)
+    html = render_page
 
     style = Nokogiri::HTML5.parse(html).at_css("head > style")&.text.to_s
     assert_match(/page-break-before:\s*always/, style)
@@ -70,13 +70,13 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   def test_body_renders_inner_action_content
-    html = render(FakePage.new)
+    html = render_page
 
     assert_html(html, "body > #inner-page", text: "INNER")
   end
 
   def test_no_application_chrome
-    html = render(FakePage.new)
+    html = render_page
 
     assert_no_html(html, "#main_container")
     assert_no_html(html, "#sidebar")
@@ -87,6 +87,10 @@ class Views::Layouts::PrintableTest < ComponentTestCase
   end
 
   private
+
+  def render_page
+    render(FakePage.new)
+  end
 
   # Sessions are disabled in `ComponentTestCase`; stub the read of
   # `session[:layout]` that `FullPageBase#layout_class` does.

--- a/test/views/layouts/top_nav/context_nav_test.rb
+++ b/test/views/layouts/top_nav/context_nav_test.rb
@@ -16,7 +16,7 @@ class Views::Layouts::TopNav
     # No links → no markup at all (the entire dropdown is conditional
     # on having something to put inside it).
     def test_renders_nothing_when_links_empty
-      html = render(Views::Layouts::TopNav::ContextNav.new(links: []))
+      html = render_top_bar([])
 
       assert_equal("", html)
     end
@@ -25,7 +25,7 @@ class Views::Layouts::TopNav
     # that returns `[edit_tab, destroy_tab_if_admin]` shouldn't
     # collapse the dropdown when one entry is nil.
     def test_renders_nothing_when_all_links_are_nil
-      html = render(Views::Layouts::TopNav::ContextNav.new(links: [nil, nil]))
+      html = render_top_bar([nil, nil])
 
       assert_equal("", html)
     end


### PR DESCRIPTION
Part of a sweep to tighten codebase for CC, since it can spew vast amounts of un-DRY code if given bad examples.

## Summary

DRY sweep across every `test/components/**/*_test.rb` and `test/views/**/*_test.rb` file that repeated `render(SomeClass.new(...))` inline across sibling test methods instead of extracting a single private `render_x` helper, per the "Extract DRY Render Helper" convention in `.claude/rules/testing.md`.

- Fixed 71 files identified by an initial manual audit.
- Added `MO/DryTestRenderHelper`, a new custom RuboCop cop (`lib/rubocop/cop/mo/dry_test_render_helper.rb`), so this pattern gets caught automatically going forward instead of relying on the documented convention alone. It flags `render(<Const>.new(...))` repeated across two or more sibling `test_*` methods in the same class; a call already routed through a helper never matches, so already-DRY files stay silent.
- Running the new cop against the whole `test/components`/`test/views` tree surfaced 17 additional files the manual audit had missed (including a second, separate violation inside `panel_test.rb` that the first pass hadn't caught) — fixed those the same way.
- The cop is scoped via `Include` in `.rubocop.yml` to `test/components/**/*_test.rb` and `test/views/**/*_test.rb`, matching the sweep's own scope.

After all fixes, `bundle exec rubocop --only MO/DryTestRenderHelper test/components test/views` reports zero offenses across all 293 files.

## Test plan

- [x] `bundle exec rubocop` clean on every changed Ruby file (87 files) vs `main`
- [x] `bundle exec rubocop --only MO/DryTestRenderHelper test/components test/views` — 0 offenses
- [x] Ran the full test file for every touched test (all green) as each batch was DRY'd
