### PR TITLE
DRY up `API2::*Test` param hashes (issue #4707)

### DIFF
--- a/test/api2_extensions.rb
+++ b/test/api2_extensions.rb
@@ -23,7 +23,9 @@ module API2Extensions
   # from `api2_model.type_tag` -- the same mechanism `do_basic_get_test`
   # already relies on -- so it doesn't need repeating at every call site.
   def api2_model
-    raise("Define api2_model in #{self.class} before calling params_*")
+    raise(NotImplementedError.new(
+            "Define api2_model in #{self.class} before calling params_*"
+          ))
   end
 
   # GET is unauthenticated by design -- ModelAPI#get never calls

--- a/test/api2_extensions.rb
+++ b/test/api2_extensions.rb
@@ -17,6 +17,36 @@ module API2Extensions
     API2::OrderedRange.new(*)
   end
 
+  # Each test class overrides this with its own model class (e.g.
+  # `def api2_model = Name`), matching how ModelAPI subclasses declare
+  # `def model`. The four `params_*` helpers below derive `action:`
+  # from `api2_model.type_tag` -- the same mechanism `do_basic_get_test`
+  # already relies on -- so it doesn't need repeating at every call site.
+  def api2_model
+    raise("Define api2_model in #{self.class} before calling params_*")
+  end
+
+  # GET is unauthenticated by design -- ModelAPI#get never calls
+  # must_authenticate!, unlike post/patch/delete -- so no api_key here.
+  def params_get(**opts)
+    { method: :get, action: api2_model.type_tag }.merge(opts)
+  end
+
+  def params_post(**opts)
+    { method: :post, action: api2_model.type_tag, api_key: @api_key.key }.
+      merge(opts)
+  end
+
+  def params_patch(**opts)
+    { method: :patch, action: api2_model.type_tag, api_key: @api_key.key }.
+      merge(opts)
+  end
+
+  def params_delete(**opts)
+    { method: :delete, action: api2_model.type_tag, api_key: @api_key.key }.
+      merge(opts)
+  end
+
   def date(str)
     Date.parse(str)
   end

--- a/test/classes/api2/api_keys_test.rb
+++ b/test/classes/api2/api_keys_test.rb
@@ -11,6 +11,8 @@ class API2::APIKeysTest < UnitTestCase
   #  :section: APIKey Requests
   # ----------------------------
 
+  def api2_model = APIKey
+
   def test_page_length_methods
     api = API2::APIKeyAPI.new
     assert_equal(1000, api.high_detail_page_length)
@@ -20,12 +22,7 @@ class API2::APIKeysTest < UnitTestCase
   end
 
   def test_getting_api_keys
-    params = {
-      method: :get,
-      action: :api_key,
-      api_key: @api_key.key,
-      user: rolf.id
-    }
+    params = params_get(api_key: @api_key.key, user: rolf.id)
     # No GET requests allowed now.
     assert_api_fail(params)
   end
@@ -34,12 +31,7 @@ class API2::APIKeysTest < UnitTestCase
     @for_user = rolf
     @app = "  Mushroom  Mapper  "
     @verified = true
-    params = {
-      method: :post,
-      action: :api_key,
-      api_key: @api_key.key,
-      app: @app
-    }
+    params = params_post(app: @app)
     # No email sent when creating key for yourself (verified immediately)
     assert_no_enqueued_jobs do
       api = API2.execute(params)
@@ -55,12 +47,7 @@ class API2::APIKeysTest < UnitTestCase
     @for_user = rolf.email
     @app = "  Mushroom  Mapper  "
     @verified = true
-    params = {
-      method: :post,
-      action: :api_key,
-      api_key: @api_key.key,
-      app: @app
-    }
+    params = params_post(app: @app)
     # No email sent when creating key for yourself (verified immediately)
     assert_no_enqueued_jobs do
       api = API2.execute(params)
@@ -75,13 +62,7 @@ class API2::APIKeysTest < UnitTestCase
     @for_user = katrina
     @app = "  Mushroom  Mapper  "
     @verified = false
-    params = {
-      method: :post,
-      action: :api_key,
-      api_key: @api_key.key,
-      app: @app,
-      for_user: @for_user.id
-    }
+    params = params_post(app: @app, for_user: @for_user.id)
     # Email sent when creating key for another user without their password
     assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
       api = API2.execute(params)
@@ -99,14 +80,8 @@ class API2::APIKeysTest < UnitTestCase
     @for_user = katrina
     @app = "  Mushroom  Mapper  "
     @verified = true
-    params = {
-      method: :post,
-      action: :api_key,
-      api_key: @api_key.key,
-      app: @app,
-      for_user: @for_user.id,
-      password: "testpassword"
-    }
+    params = params_post(app: @app, for_user: @for_user.id,
+                         password: "testpassword")
     # No email sent when password provided (verified immediately)
     assert_no_enqueued_jobs do
       api = API2.execute(params)
@@ -122,14 +97,8 @@ class API2::APIKeysTest < UnitTestCase
     @for_user = rolf
     @app = api_key.notes
     @verified = true
-    params = {
-      method: :post,
-      action: :api_key,
-      api_key: @api_key.key,
-      app: @app,
-      for_user: @for_user.id,
-      password: "testpassword"
-    }
+    params = params_post(app: @app, for_user: @for_user.id,
+                         password: "testpassword")
     # No email sent - returns existing verified key
     assert_no_enqueued_jobs do
       api = API2.execute(params)
@@ -146,24 +115,13 @@ class API2::APIKeysTest < UnitTestCase
   end
 
   def test_patching_api_keys
-    params = {
-      method: :patch,
-      action: :api_key,
-      api_key: @api_key.key,
-      id: @api_key.id,
-      set_app: "new app"
-    }
+    params = params_patch(id: @api_key.id, set_app: "new app")
     # No PATCH requests allowed now.
     assert_api_fail(params)
   end
 
   def test_deleting_api_keys
-    params = {
-      method: :delete,
-      action: :api_key,
-      api_key: @api_key.key,
-      id: @api_key.id
-    }
+    params = params_delete(id: @api_key.id)
     # No DELETE requests allowed now.
     assert_api_fail(params)
   end

--- a/test/classes/api2/collection_numbers_test.rb
+++ b/test/classes/api2/collection_numbers_test.rb
@@ -14,9 +14,7 @@ class API2::CollectionNumbersTest < UnitTestCase
   #  :section: Collection Number Requests
   # ---------------------------------------
 
-  def params_get(**)
-    { method: :get, action: :collection_number }.merge(**)
-  end
+  def api2_model = CollectionNumber
 
   def test_getting_collection_numbers_created_at
     nums = CollectionNumber.where(CollectionNumber[:created_at].year.eq(2006))
@@ -83,14 +81,8 @@ class API2::CollectionNumbersTest < UnitTestCase
     @name      = "Someone Else"
     @number    = "13579a"
     @user      = rolf
-    params = {
-      method: :post,
-      action: :collection_number,
-      api_key: @api_key.key,
-      observation: @obs.id,
-      collector: @name,
-      number: @number
-    }
+    params = params_post(observation: @obs.id, collector: @name,
+                         number: @number)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.except(:observation))
     assert_api_fail(params.except(:number))
@@ -111,14 +103,8 @@ class API2::CollectionNumbersTest < UnitTestCase
     rolfs_num = collection_numbers(:coprinus_comatus_coll_num)
     marys_num = collection_numbers(:minimal_unknown_coll_num)
     rolfs_rec = herbarium_records(:coprinus_comatus_rolf_spec)
-    params = {
-      method: :patch,
-      action: :collection_number,
-      api_key: @api_key.key,
-      id: rolfs_num.id,
-      set_collector: "New",
-      set_number: "42"
-    }
+    params = params_patch(id: rolfs_num.id, set_collector: "New",
+                          set_number: "42")
     assert_equal("Rolf Singer 1", rolfs_rec.accession_number)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.merge(id: marys_num.id))
@@ -130,12 +116,7 @@ class API2::CollectionNumbersTest < UnitTestCase
     old_obs   = rolfs_num.observations.first
     rolfs_obs = observations(:agaricus_campestris_obs)
     marys_obs = observations(:detailed_unknown_obs)
-    params = {
-      method: :patch,
-      action: :collection_number,
-      api_key: @api_key.key,
-      id: rolfs_num.id
-    }
+    params = params_patch(id: rolfs_num.id)
     assert_api_fail(params.merge(add_observation: marys_obs.id))
     assert_api_pass(params.merge(add_observation: rolfs_obs.id))
     assert_obj_arrays_equal([old_obs, rolfs_obs], rolfs_num.reload.observations,
@@ -151,13 +132,7 @@ class API2::CollectionNumbersTest < UnitTestCase
     num2 = collection_numbers(:agaricus_campestris_coll_num)
     obs1 = num1.observations.first
     obs2 = num2.observations.first
-    params = {
-      method: :patch,
-      action: :collection_number,
-      api_key: @api_key.key,
-      id: num1.id,
-      set_number: num2.number
-    }
+    params = params_patch(id: num1.id, set_number: num2.number)
     assert_api_pass(params)
     assert_obj_arrays_equal(obs1.reload.collection_numbers,
                             obs2.reload.collection_numbers)
@@ -167,12 +142,7 @@ class API2::CollectionNumbersTest < UnitTestCase
   def test_deleting_collection_numbers
     rolfs_num = collection_numbers(:coprinus_comatus_coll_num)
     marys_num = collection_numbers(:minimal_unknown_coll_num)
-    params = {
-      method: :delete,
-      action: :collection_number,
-      api_key: @api_key.key,
-      id: rolfs_num.id
-    }
+    params = params_delete(id: rolfs_num.id)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.merge(id: marys_num.id))
     assert_api_pass(params)

--- a/test/classes/api2/comments_test.rb
+++ b/test/classes/api2/comments_test.rb
@@ -14,9 +14,7 @@ class API2::CommentsTest < UnitTestCase
   #  :section: Comment Requests
   # -----------------------------
 
-  def params_get(**)
-    { method: :get, action: :comment }.merge(**)
-  end
+  def api2_model = Comment
 
   def com1
     @com1 ||= comments(:minimal_unknown_obs_comment_1)
@@ -83,14 +81,8 @@ class API2::CommentsTest < UnitTestCase
     @target  = names(:petigera)
     @summary = "misspelling"
     @content = "The correct one is 'Peltigera'."
-    params = {
-      method: :post,
-      action: :comment,
-      api_key: @api_key.key,
-      target: "name ##{@target.id}",
-      summary: @summary,
-      content: @content
-    }
+    params = params_post(target: "name ##{@target.id}", summary: @summary,
+                         content: @content)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.except(:target))
     assert_api_fail(params.except(:summary))
@@ -103,14 +95,8 @@ class API2::CommentsTest < UnitTestCase
   def test_patching_comments
     com1 = comments(:minimal_unknown_obs_comment_1) # rolf's comment
     com2 = comments(:minimal_unknown_obs_comment_2) # dick's comment
-    params = {
-      method: :patch,
-      action: :comment,
-      api_key: @api_key.key,
-      id: com1.id,
-      set_summary: "new summary",
-      set_content: "new comment"
-    }
+    params = params_patch(id: com1.id, set_summary: "new summary",
+                          set_content: "new comment")
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.merge(id: com2.id))
     assert_api_fail(params.merge(set_summary: ""))
@@ -123,12 +109,7 @@ class API2::CommentsTest < UnitTestCase
   def test_deleting_comments
     com1 = comments(:minimal_unknown_obs_comment_1) # rolf's comment
     com2 = comments(:minimal_unknown_obs_comment_2) # dick's comment
-    params = {
-      method: :delete,
-      action: :comment,
-      api_key: @api_key.key,
-      id: com1.id
-    }
+    params = params_delete(id: com1.id)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.merge(id: com2.id))
     assert_api_pass(params)

--- a/test/classes/api2/external_links_test.rb
+++ b/test/classes/api2/external_links_test.rb
@@ -14,6 +14,8 @@ class API2::ExternalLinksTest < UnitTestCase
   #  :section: ExternalLink Requests
   # ----------------------------------
 
+  def api2_model = ExternalLink
+
   def test_getting_external_links
     other_obs = observations(:agaricus_campestris_obs)
     link1 = external_links(:coprinus_comatus_obs_mycoportal_link)
@@ -21,7 +23,7 @@ class API2::ExternalLinksTest < UnitTestCase
     link3 = ExternalLink.create!(user: rolf, observation: other_obs,
                                  external_site: link1.external_site,
                                  url: "#{link1.external_site.base_url}876876")
-    params = { method: :get, action: :external_link }
+    params = params_get
 
     assert_api_pass(params.merge(id: link2.id))
     assert_api_results([link2])
@@ -55,14 +57,8 @@ class API2::ExternalLinksTest < UnitTestCase
     rolfs_key = api_keys(:rolfs_api_key)
     site = external_sites(:mycoportal)
     base_url = site.base_url
-    params = {
-      method: :post,
-      action: :external_link,
-      api_key: rolfs_key.key,
-      observation: rolfs_obs.id,
-      external_site: site.id,
-      url: "#{base_url}blah"
-    }
+    params = params_post(api_key: rolfs_key.key, observation: rolfs_obs.id,
+                         external_site: site.id, url: "#{base_url}blah")
     assert_api_pass(params)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.except(:observation))
@@ -89,13 +85,7 @@ class API2::ExternalLinksTest < UnitTestCase
     site = external_sites(:mycoportal)
     base_url = site.base_url
     new_url = "#{base_url}something_else"
-    params = {
-      method: :patch,
-      action: :external_link,
-      api_key: @api_key.key,
-      id: link.id,
-      set_url: new_url
-    }
+    params = params_patch(id: link.id, set_url: new_url)
     @api_key.update!(user: dick)
     assert_api_fail(params)
     @api_key.update!(user: rolf)
@@ -118,12 +108,7 @@ class API2::ExternalLinksTest < UnitTestCase
     assert_users_equal(rolf, link.observation.user)
     assert_false(link.external_site&.project&.member?(dick))
     site = link.external_site
-    params = {
-      method: :delete,
-      action: :external_link,
-      api_key: @api_key.key,
-      id: link.id
-    }
+    params = params_delete(id: link.id)
     recreate_params = {
       user: mary,
       observation: link.observation,

--- a/test/classes/api2/external_sites_test.rb
+++ b/test/classes/api2/external_sites_test.rb
@@ -14,14 +14,12 @@ class API2::ExternalSitesTest < UnitTestCase
   #  :section: ExternalSite Requests
   # ----------------------------------
 
+  def api2_model = ExternalSite
+
   def test_getting_external_sites
-    params = {
-      method: :get,
-      action: :external_site
-    }
     sites = ExternalSite.where(ExternalSite[:name].matches("%inat%"))
     assert_not_empty(sites)
-    assert_api_pass(params.merge(name: "inat"))
+    assert_api_pass(params_get(name: "inat"))
     assert_api_results(sites)
   end
 end

--- a/test/classes/api2/field_slips_test.rb
+++ b/test/classes/api2/field_slips_test.rb
@@ -15,9 +15,7 @@ class API2::FieldSlipsTest < UnitTestCase
   #  :section: Field Slip Requests
   # ---------------------------------------
 
-  def params_get(**)
-    { method: :get, action: :field_slip }.merge(**)
-  end
+  def api2_model = FieldSlip
 
   def test_getting_field_slips_by_code
     slip = field_slips(:field_slip_one)
@@ -61,13 +59,7 @@ class API2::FieldSlipsTest < UnitTestCase
   def test_posting_field_slip
     obs = observations(:detailed_unknown_obs)
     code = "NEMF-#{rand(100_000)}"
-    params = {
-      method: :post,
-      action: :field_slip,
-      api_key: @api_key.key,
-      code: code,
-      observation: obs.id
-    }
+    params = params_post(code: code, observation: obs.id)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.except(:code))
     assert_api_pass(params)
@@ -79,12 +71,7 @@ class API2::FieldSlipsTest < UnitTestCase
 
   def test_posting_field_slip_duplicate_code
     slip = field_slips(:field_slip_one)
-    params = {
-      method: :post,
-      action: :field_slip,
-      api_key: @api_key.key,
-      code: slip.code
-    }
+    params = params_post(code: slip.code)
     # Should fail because code already exists
     assert_api_fail(params)
   end
@@ -92,13 +79,7 @@ class API2::FieldSlipsTest < UnitTestCase
   def test_patching_field_slip
     slip = field_slips(:field_slip_one)
     new_code = "UPDATED-#{rand(100_000)}"
-    params = {
-      method: :patch,
-      action: :field_slip,
-      api_key: @api_key.key,
-      id: slip.id,
-      set_code: new_code
-    }
+    params = params_patch(id: slip.id, set_code: new_code)
     assert_api_pass(params)
     slip.reload
     assert_equal(new_code.upcase, slip.code)
@@ -107,13 +88,7 @@ class API2::FieldSlipsTest < UnitTestCase
   def test_patching_field_slip_observation
     slip = field_slips(:field_slip_one)
     obs = observations(:detailed_unknown_obs)
-    params = {
-      method: :patch,
-      action: :field_slip,
-      api_key: @api_key.key,
-      id: slip.id,
-      set_observation: obs.id
-    }
+    params = params_patch(id: slip.id, set_observation: obs.id)
     assert_api_pass(params)
     obs.reload
     assert_equal(slip.id, obs.field_slip_id)
@@ -132,12 +107,7 @@ class API2::FieldSlipsTest < UnitTestCase
 
   def test_field_slip_renders_json
     slip = field_slips(:field_slip_one)
-    params = {
-      method: :get,
-      action: :field_slip,
-      id: slip.id,
-      detail: :high
-    }
+    params = params_get(id: slip.id, detail: :high)
     assert_api_pass(params)
 
     # Verify the API returns the slip without errors
@@ -147,12 +117,7 @@ class API2::FieldSlipsTest < UnitTestCase
 
   def test_field_slip_renders_xml
     slip = field_slips(:field_slip_one)
-    params = {
-      method: :get,
-      action: :field_slip,
-      id: slip.id,
-      detail: :low
-    }
+    params = params_get(id: slip.id, detail: :low)
     assert_api_pass(params)
 
     # Verify the API returns the slip without errors
@@ -181,12 +146,7 @@ class API2::FieldSlipsTest < UnitTestCase
 
   def test_patching_field_slip_without_params
     slip = field_slips(:field_slip_one)
-    params = {
-      method: :patch,
-      action: :field_slip,
-      api_key: @api_key.key,
-      id: slip.id
-    }
+    params = params_patch(id: slip.id)
     # Should fail because no set_* parameters provided
     assert_api_fail(params)
   end
@@ -199,13 +159,8 @@ class API2::FieldSlipsTest < UnitTestCase
       notes: "Test API key for permission check"
     )
 
-    params = {
-      method: :patch,
-      action: :field_slip,
-      api_key: other_key.key,
-      id: slip.id,
-      set_code: "NEW-CODE"
-    }
+    params = params_patch(api_key: other_key.key, id: slip.id,
+                          set_code: "NEW-CODE")
     # Should fail because user doesn't have edit permission
     assert_api_fail(params)
   end

--- a/test/classes/api2/herbaria_test.rb
+++ b/test/classes/api2/herbaria_test.rb
@@ -14,9 +14,7 @@ class API2::HerbariaTest < UnitTestCase
   #  :section: Herbarium Requests
   # -------------------------------
 
-  def params_get(**)
-    { method: :get, action: :herbarium }.merge(**)
-  end
+  def api2_model = Herbarium
 
   def test_getting_herbaria_created_at
     herbs = Herbarium.created_on("2012-10-21")

--- a/test/classes/api2/herbarium_records_test.rb
+++ b/test/classes/api2/herbarium_records_test.rb
@@ -14,9 +14,7 @@ class API2::HerbariumRecordsTest < UnitTestCase
   #  :section: Herbarium Record Requests
   # --------------------------------------
 
-  def params_get(**)
-    { method: :get, action: :herbarium_record }.merge(**)
-  end
+  def api2_model = HerbariumRecord
 
   def test_getting_herbarium_records_created_at
     recs = HerbariumRecord.where(HerbariumRecord[:created_at].year.eq(2012))
@@ -117,16 +115,10 @@ class API2::HerbariumRecordsTest < UnitTestCase
     @accession_number = "13579a"
     @notes            = "i make good specimen"
     @user             = rolf
-    params = {
-      method: :post,
-      action: :herbarium_record,
-      api_key: @api_key.key,
-      observation: @obs.id,
-      herbarium: @herbarium.id,
-      initial_det: @initial_det,
-      accession_number: @accession_number,
-      notes: @notes
-    }
+    params = params_post(observation: @obs.id, herbarium: @herbarium.id,
+                         initial_det: @initial_det,
+                         accession_number: @accession_number,
+                         notes: @notes)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.except(:observation))
     assert_api_fail(params.except(:herbarium))
@@ -189,16 +181,11 @@ class API2::HerbariumRecordsTest < UnitTestCase
     nybgs_rec = herbarium_records(:interesting_unknown)
     marys_rec = herbarium_records(:fundis_record)
     fundis = herbaria(:fundis_herbarium)
-    params = {
-      method: :patch,
-      action: :herbarium_record,
-      api_key: @api_key.key,
-      id: rolfs_rec.id,
-      set_herbarium: "Fungal Diversity Survey",
-      set_initial_det: " New name ",
-      set_accession_number: " 1234 ",
-      set_notes: " new notes "
-    }
+    params = params_patch(id: rolfs_rec.id,
+                          set_herbarium: "Fungal Diversity Survey",
+                          set_initial_det: " New name ",
+                          set_accession_number: " 1234 ",
+                          set_notes: " new notes ")
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.merge(id: marys_rec.id))
     assert_api_fail(params.merge(set_herbarium: ""))
@@ -221,12 +208,7 @@ class API2::HerbariumRecordsTest < UnitTestCase
     old_obs   = rolfs_rec.observations.reorder(id: :asc).first
     rolfs_obs = observations(:agaricus_campestris_obs)
     marys_obs = observations(:minimal_unknown_obs)
-    params = {
-      method: :patch,
-      action: :herbarium_record,
-      api_key: @api_key.key,
-      id: rolfs_rec.id
-    }
+    params = params_patch(id: rolfs_rec.id)
     assert_api_fail(params.merge(add_observation: marys_obs.id))
     assert_api_pass(params.merge(add_observation: rolfs_obs.id))
     assert_obj_arrays_equal([old_obs, rolfs_obs], rolfs_rec.reload.observations,
@@ -243,11 +225,7 @@ class API2::HerbariumRecordsTest < UnitTestCase
     rolfs_rec = herbarium_records(:coprinus_comatus_rolf_spec)
     nybgs_rec = herbarium_records(:interesting_unknown)
     marys_rec = herbarium_records(:fundis_record)
-    params = {
-      method: :delete,
-      action: :herbarium_record,
-      api_key: @api_key.key
-    }
+    params = params_delete
     assert_api_fail(params.except(:api_key))
     assert_api_pass(params.merge(id: rolfs_rec.id))
     assert_api_pass(params.merge(id: nybgs_rec.id))

--- a/test/classes/api2/images_test.rb
+++ b/test/classes/api2/images_test.rb
@@ -10,13 +10,11 @@ class API2::ImagesTest < UnitTestCase
     do_basic_get_test(Image)
   end
 
+  def api2_model = Image
+
   # ---------------------------
   #  :section: Image Requests
   # ---------------------------
-
-  def params_get(**)
-    { method: :get, action: :image }.merge(**)
-  end
 
   def in_situ_img
     @in_situ_img ||= images(:in_situ_image)
@@ -272,13 +270,10 @@ class API2::ImagesTest < UnitTestCase
     @height = 500
     @vote   = nil
     @obs    = nil
-    params  = {
-      method: :post,
-      action: :image,
-      api_key: @api_key.key,
+    params  = params_post(
       upload_file: Rails.root.join("test/images/sticky.jpg"),
       original_name: "strip_this"
-    }
+    )
     assert_equal("toss", @user.keep_filenames)
     File.stub(:rename, true) do
       File.stub(:chmod, true) do
@@ -307,10 +302,7 @@ class API2::ImagesTest < UnitTestCase
     @height = 500
     @vote   = 3
     @obs    = @user.observations.last
-    params  = {
-      method: :post,
-      action: :image,
-      api_key: @api_key.key,
+    params  = params_post(
       date: "20120626",
       notes: @notes,
       copyright_holder: " My Friend ",
@@ -320,7 +312,7 @@ class API2::ImagesTest < UnitTestCase
       projects: @proj.id,
       upload_file: Rails.root.join("test/images/sticky.jpg"),
       original_name: @orig
-    }
+    )
     File.stub(:rename, true) do
       File.stub(:chmod, true) do
         api = API2.execute(params)
@@ -348,12 +340,7 @@ class API2::ImagesTest < UnitTestCase
     url = "https://mushroomobserver.org/images/thumb/459340.jpg"
     stub_request(:any, url).
       to_return(Rails.root.join("test/images/test_image.curl").read)
-    params = {
-      method: :post,
-      action: :image,
-      api_key: @api_key.key,
-      upload_url: url
-    }
+    params = params_post(upload_url: url)
     File.stub(:rename, false) do
       api = API2.execute(params)
       assert_no_errors(api, "Errors while posting image")
@@ -374,16 +361,13 @@ class API2::ImagesTest < UnitTestCase
     pd = licenses(:publicdomain)
     assert(rolfs_img.can_edit?(rolf))
     assert_not(marys_img.can_edit?(rolf))
-    params = {
-      method: :patch,
-      action: :image,
-      api_key: @api_key.key,
+    params = params_patch(
       set_date: "2012-3-4",
       set_notes: "new notes",
       set_copyright_holder: "new person",
       set_license: pd.id,
       set_original_name: "new name"
-    }
+    )
     assert_api_fail(params.merge(id: marys_img.id))
     assert_api_fail(params.merge(set_date: ""))
     assert_api_fail(params.merge(set_license: ""))
@@ -416,9 +400,7 @@ class API2::ImagesTest < UnitTestCase
                                verified: Time.zone.now)
     img = images(:in_situ_image)
     assert_nil(img.dhash)
-    params = {
-      method: :patch, action: :image, id: img.id, set_dhash: 12_345
-    }
+    params = params_patch(id: img.id, set_dhash: 12_345)
 
     # A regular user's key is rejected, even for their own image.
     assert_api_fail(params.merge(api_key: @api_key.key,
@@ -449,9 +431,7 @@ class API2::ImagesTest < UnitTestCase
                                verified: Time.zone.now)
     img = images(:in_situ_image)
     max = (2**64) - 1
-    params = {
-      method: :patch, action: :image, id: img.id, api_key: admin_key.key
-    }
+    params = params_patch(id: img.id, api_key: admin_key.key)
 
     assert_api_fail(params.merge(set_dhash: -1))
     assert_api_fail(params.merge(set_dhash: 2**64))
@@ -462,11 +442,7 @@ class API2::ImagesTest < UnitTestCase
   def test_deleting_images
     rolfs_img = rolf.images.sample
     marys_img = mary.images.sample
-    params = {
-      method: :delete,
-      action: :image,
-      api_key: @api_key.key
-    }
+    params = params_delete
     assert_api_fail(params.merge(id: marys_img.id))
     assert_api_pass(params.merge(id: rolfs_img.id))
     assert_not_nil(Image.safe_find(marys_img.id))

--- a/test/classes/api2/locations_test.rb
+++ b/test/classes/api2/locations_test.rb
@@ -14,9 +14,7 @@ class API2::LocationsTest < UnitTestCase
   #  :section: Location Requests
   # ------------------------------
 
-  def params_get(**)
-    { method: :get, action: :location }.merge(**)
-  end
+  def api2_model = Location
 
   def loc_sample
     @loc_sample ||= Location.all.sample
@@ -93,19 +91,9 @@ class API2::LocationsTest < UnitTestCase
     @low   = 1350
     @notes = "Biggest Little City"
     @user  = rolf
-    params = {
-      method: :post,
-      action: :location,
-      api_key: @api_key.key,
-      name: @name,
-      north: @north,
-      south: @south,
-      east: @east,
-      west: @west,
-      high: @high,
-      low: @low,
-      notes: @notes
-    }
+    params = params_post(name: @name, north: @north, south: @south,
+                         east: @east, west: @west, high: @high, low: @low,
+                         notes: @notes)
     assert_api_pass(params)
     assert_last_location_correct
     assert_api_fail(params)
@@ -130,16 +118,8 @@ class API2::LocationsTest < UnitTestCase
   # the DubiousLocationName error text. Confirm the resolved text
   # actually made it through, not just that the request failed.
   def test_posting_location_with_dubious_name_reports_resolved_reason
-    params = {
-      method: :post,
-      action: :location,
-      api_key: @api_key.key,
-      name: "Evil Lair, Latveria",
-      north: 39.64,
-      south: 39.39,
-      east: -119.70,
-      west: -119.94
-    }
+    params = params_post(name: "Evil Lair, Latveria", north: 39.64,
+                         south: 39.39, east: -119.70, west: -119.94)
 
     assert_api_fail(params)
     message = @api.errors.first.to_s
@@ -150,20 +130,11 @@ class API2::LocationsTest < UnitTestCase
   def test_patching_locations
     albion = locations(:albion)
     burbank = locations(:burbank)
-    params = {
-      method: :patch,
-      action: :location,
-      api_key: @api_key.key,
-      id: albion.id,
-      set_name: "Reno, Nevada, USA",
-      set_north: 39.64,
-      set_south: 39.39,
-      set_east: -119.70,
-      set_west: -119.94,
-      set_high: 1700,
-      set_low: 1350,
-      set_notes: "Biggest Little City"
-    }
+    params = params_patch(id: albion.id, set_name: "Reno, Nevada, USA",
+                          set_north: 39.64, set_south: 39.39,
+                          set_east: -119.70, set_west: -119.94,
+                          set_high: 1700, set_low: 1350,
+                          set_notes: "Biggest Little City")
 
     # Just to be clear about the starting point, the only objects attached to
     # this location at first are some versions and a description, all owned by
@@ -247,12 +218,7 @@ class API2::LocationsTest < UnitTestCase
 
   def test_deleting_locations
     loc = rolf.locations.sample
-    params = {
-      method: :delete,
-      action: :location,
-      api_key: @api_key.key,
-      id: loc.id
-    }
+    params = params_delete(id: loc.id)
     # No DELETE requests should be allowed at all.
     assert_api_fail(params)
   end

--- a/test/classes/api2/name_descriptions_test.rb
+++ b/test/classes/api2/name_descriptions_test.rb
@@ -10,9 +10,7 @@ class API2::NameDescriptionsTest < UnitTestCase
     do_basic_get_test(NameDescription, public: true)
   end
 
-  def params_get(**)
-    { method: :get, action: :name_description }.merge(**)
-  end
+  def api2_model = NameDescription
 
   def test_name_description_get_names
     public = [name_descriptions(:peltigera_alt_desc),

--- a/test/classes/api2/names_test.rb
+++ b/test/classes/api2/names_test.rb
@@ -14,21 +14,7 @@ class API2::NamesTest < UnitTestCase
   #  :section: Name Requests
   # --------------------------
 
-  def params_get(**)
-    { method: :get, action: :name }.merge(**)
-  end
-
-  def params_post(**)
-    { method: :post, action: :name, api_key: @api_key.key }.merge(**)
-  end
-
-  def params_patch(**)
-    { method: :patch, action: :name, api_key: @api_key.key }.merge(**)
-  end
-
-  def params_delete(**)
-    { method: :delete, action: :name, api_key: @api_key.key }.merge(**)
-  end
+  def api2_model = Name
 
   def test_getting_names
     name = Name.with_correct_spelling.sample

--- a/test/classes/api2/observations_test.rb
+++ b/test/classes/api2/observations_test.rb
@@ -10,13 +10,11 @@ class API2::ObservationsTest < UnitTestCase
     do_basic_get_test(Observation)
   end
 
+  def api2_model = Observation
+
   # ---------------------------------
   #  :section: Observation Requests
   # ---------------------------------
-
-  def params_get(**)
-    { method: :get, action: :observation }.merge(**)
-  end
 
   def obs_sample
     @obs_sample ||= Observation.all.sample
@@ -280,12 +278,7 @@ class API2::ObservationsTest < UnitTestCase
     @lat = nil
     @long = nil
     @alt = nil
-    params = {
-      method: :post,
-      action: :observation,
-      api_key: @api_key.key,
-      location: "Anywhere"
-    }
+    params = params_post(location: "Anywhere")
     api = API2.execute(params)
     assert_no_errors(api, "Errors while posting observation")
     assert_obj_arrays_equal([Observation.last], api.results)
@@ -311,14 +304,7 @@ class API2::ObservationsTest < UnitTestCase
     @lat = burbank.center_lat
     @long = burbank.center_lng
     @alt = nil
-    params = {
-      method: :post,
-      action: :observation,
-      api_key: @api_key.key,
-      latitude: @lat,
-      longitude: @long,
-      location: "Earth"
-    }
+    params = params_post(latitude: @lat, longitude: @long, location: "Earth")
     api = API2.execute(params)
     assert_no_errors(api, "Errors while posting observation")
     assert_obj_arrays_equal([Observation.last], api.results)
@@ -354,10 +340,7 @@ class API2::ObservationsTest < UnitTestCase
     @lat = 39.229
     @long = -123.77
     @alt = 50
-    params = {
-      method: :post,
-      action: :observation,
-      api_key: @api_key.key,
+    params = params_post(
       date: "20120626",
       notes: { Cap: "scaly",
                Gills: "inky\n",
@@ -379,7 +362,7 @@ class API2::ObservationsTest < UnitTestCase
       thumbnail: @img2.id,
       images: "#{@img1.id},#{@img2.id}",
       source: "mo_iphone_app"
-    }
+    )
     api = API2.execute(params)
     assert_no_errors(api, "Errors while posting observation")
     assert_obj_arrays_equal([Observation.last], api.results)
@@ -417,14 +400,8 @@ class API2::ObservationsTest < UnitTestCase
   def test_post_observation_with_thumbnail_not_in_images
     img1 = images(:in_situ_image)
     img2 = images(:turned_over_image)
-    params = {
-      method: :post,
-      action: :observation,
-      api_key: @api_key.key,
-      location: "Anywhere",
-      thumbnail: img2.id,
-      images: img1.id.to_s
-    }
+    params = params_post(location: "Anywhere", thumbnail: img2.id,
+                         images: img1.id.to_s)
 
     api = API2.execute(params)
 
@@ -436,14 +413,8 @@ class API2::ObservationsTest < UnitTestCase
   end
 
   def test_post_observation_with_no_log
-    params = {
-      method: :post,
-      action: :observation,
-      api_key: @api_key.key,
-      location: "Anywhere",
-      name: "Agaricus campestris",
-      log: "no"
-    }
+    params = params_post(location: "Anywhere", name: "Agaricus campestris",
+                         log: "no")
     api = API2.execute(params)
     assert_no_errors(api, "Errors while posting observation")
     obs = Observation.last
@@ -453,37 +424,21 @@ class API2::ObservationsTest < UnitTestCase
   def test_post_observation_with_used_field_slip
     fs = field_slips(:field_slip_one)
     assert(fs.observations.any?, "Test needs field_slip with observation")
-    params = {
-      method: :post,
-      action: :observation,
-      api_key: @api_key.key,
-      location: "Anywhere",
-      name: "Agaricus campestris",
-      code: fs.code
-    }
+    params = params_post(location: "Anywhere", name: "Agaricus campestris",
+                         code: fs.code)
     assert_api_pass(params)
     obs = Observation.last
     assert_equal(fs, obs.field_slip)
   end
 
   def test_post_observation_with_free_field_slip
-    params = {
-      method: :post,
-      action: :observation,
-      api_key: @api_key.key,
-      location: "Anywhere",
-      name: "Agaricus campestris",
-      code: field_slips(:field_slip_no_obs).code
-    }
+    params = params_post(location: "Anywhere", name: "Agaricus campestris",
+                         code: field_slips(:field_slip_no_obs).code)
     assert_api_pass(params)
   end
 
   def test_post_observation_scientific_location
-    params = {
-      method: :post,
-      action: :observation,
-      api_key: @api_key.key
-    }
+    params = params_post
     assert_equal("postal", rolf.location_format)
 
     params[:location] = "New Place, California, USA"
@@ -524,13 +479,8 @@ class API2::ObservationsTest < UnitTestCase
   end
 
   def test_post_observation_has_specimen
-    params = {
-      method: :post,
-      action: :observation,
-      api_key: @api_key.key,
-      location: locations(:burbank).name,
-      name: names(:peltigera).text_name
-    }
+    params = params_post(location: locations(:burbank).name,
+                         name: names(:peltigera).text_name)
 
     assert_api_fail(params.merge(has_specimen: "no", herbarium: "1"))
     assert_api_fail(params.merge(has_specimen: "no", collection_number: "1"))
@@ -562,13 +512,7 @@ class API2::ObservationsTest < UnitTestCase
     obs = observations(:coprinus_comatus_obs)
     assert(obs.can_edit?(rolf), "owner would otherwise be able to edit")
     obs.update_column(:reflected_at, Time.zone.now)
-    params = {
-      method: :patch,
-      action: :observation,
-      api_key: @api_key.key,
-      id: obs.id,
-      set_date: "2012-12-12"
-    }
+    params = params_patch(id: obs.id, set_date: "2012-12-12")
     assert_api_fail(params)
     assert(@api.errors.any?(API2::ObservationIsReadOnly),
            "editing a reflection should raise ObservationIsReadOnly")
@@ -581,16 +525,13 @@ class API2::ObservationsTest < UnitTestCase
     marys_obs = observations(:detailed_unknown_obs)
     assert(rolfs_obs.can_edit?(rolf))
     assert_not(marys_obs.can_edit?(rolf))
-    params = {
-      method: :patch,
-      action: :observation,
-      api_key: @api_key.key,
+    params = params_patch(
       id: rolfs_obs.id,
       set_date: "2012-12-12",
       set_location: 'Burbank\, California\, USA',
       set_has_specimen: "no",
       set_is_collection_location: "no"
-    }
+    )
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.merge(id: marys_obs.id))
     assert_api_fail(params.merge(set_date: ""))
@@ -603,15 +544,8 @@ class API2::ObservationsTest < UnitTestCase
     assert_equal(false, rolfs_obs.specimen)
     assert_equal(false, rolfs_obs.is_collection_location)
 
-    params = {
-      method: :patch,
-      action: :observation,
-      api_key: @api_key.key,
-      id: rolfs_obs.id,
-      set_latitude: "12.34",
-      set_longitude: "-56.78",
-      set_altitude: "901"
-    }
+    params = params_patch(id: rolfs_obs.id, set_latitude: "12.34",
+                          set_longitude: "-56.78", set_altitude: "901")
     assert_api_fail(params.except(:set_latitude))
     assert_api_fail(params.except(:set_longitude))
     assert_api_pass(params)
@@ -620,12 +554,7 @@ class API2::ObservationsTest < UnitTestCase
     assert_in_delta(-56.78, rolfs_obs.lng, MO.box_epsilon)
     assert_in_delta(901, rolfs_obs.alt, MO.box_epsilon)
 
-    params = {
-      method: :patch,
-      action: :observation,
-      api_key: @api_key.key,
-      id: rolfs_obs.id
-    }
+    params = params_patch(id: rolfs_obs.id)
     assert_api_pass(params.merge(set_notes: { Other: "wow!",
                                               Cap: "red",
                                               Ring: "none",
@@ -705,11 +634,7 @@ class API2::ObservationsTest < UnitTestCase
   def test_deleting_observations
     rolfs_obs = rolf.observations.sample
     marys_obs = mary.observations.sample
-    params = {
-      method: :delete,
-      action: :observation,
-      api_key: @api_key.key
-    }
+    params = params_delete
     assert_api_fail(params.merge(id: marys_obs.id))
     assert_api_pass(params.merge(id: rolfs_obs.id))
     assert_not_nil(Observation.safe_find(marys_obs.id))

--- a/test/classes/api2/occurrences_test.rb
+++ b/test/classes/api2/occurrences_test.rb
@@ -22,9 +22,7 @@ class API2::OccurrencesTest < UnitTestCase
     @obs2.update!(occurrence: @occ)
   end
 
-  def params_get(**)
-    { method: :get, action: :occurrence }.merge(**)
-  end
+  def api2_model = Occurrence
 
   # GET tests
 
@@ -56,13 +54,10 @@ class API2::OccurrencesTest < UnitTestCase
   def test_posting_occurrence
     obs1 = observations(:coprinus_comatus_obs)
     obs2 = observations(:agaricus_campestris_obs)
-    params = {
-      method: :post,
-      action: :occurrence,
-      api_key: @api_key.key,
+    params = params_post(
       observation: "#{obs1.id},#{obs2.id}",
       primary_observation: obs1.id
-    }
+    )
     assert_api_pass(params)
     occ = Occurrence.find_by(primary_observation_id: obs1.id)
     assert_not_nil(occ, "Occurrence should have been created")
@@ -71,22 +66,16 @@ class API2::OccurrencesTest < UnitTestCase
   end
 
   def test_posting_occurrence_requires_auth
-    params = {
-      method: :post,
-      action: :occurrence,
+    params = params_post(
+      api_key: nil,
       observation: "#{@obs1.id},#{@obs2.id}"
-    }
+    )
     assert_api_fail(params)
   end
 
   def test_posting_occurrence_requires_two_observations
     obs1 = observations(:coprinus_comatus_obs)
-    params = {
-      method: :post,
-      action: :occurrence,
-      api_key: @api_key.key,
-      observation: obs1.id.to_s
-    }
+    params = params_post(observation: obs1.id.to_s)
     assert_api_fail(params)
   end
 
@@ -94,63 +83,37 @@ class API2::OccurrencesTest < UnitTestCase
 
   def test_patching_occurrence_add_observation
     obs3 = observations(:coprinus_comatus_obs)
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id,
-      add_observation: obs3.id
-    }
+    params = params_patch(id: @occ.id, add_observation: obs3.id)
     assert_api_pass(params)
     @occ.reload
     assert_includes(@occ.observation_ids, obs3.id)
   end
 
   def test_patching_occurrence_remove_observation
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id,
-      remove_observation: @obs2.id
-    }
+    params = params_patch(id: @occ.id, remove_observation: @obs2.id)
     assert_api_pass(params)
     # Occurrence should be destroyed (< 2 observations)
     assert_nil(Occurrence.find_by(id: @occ.id))
   end
 
   def test_patching_occurrence_set_primary
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id,
-      set_primary_observation: @obs2.id
-    }
+    params = params_patch(
+      id: @occ.id, set_primary_observation: @obs2.id
+    )
     assert_api_pass(params)
     @occ.reload
     assert_equal(@obs2.id, @occ.primary_observation_id)
   end
 
   def test_patching_occurrence_without_params
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id
-    }
+    params = params_patch(id: @occ.id)
     assert_api_fail(params)
   end
 
   # DELETE tests
 
   def test_deleting_occurrence
-    params = {
-      method: :delete,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id
-    }
+    params = params_delete(id: @occ.id)
     assert_api_pass(params)
     assert_nil(Occurrence.find_by(id: @occ.id))
     @obs1.reload
@@ -158,11 +121,7 @@ class API2::OccurrencesTest < UnitTestCase
   end
 
   def test_deleting_occurrence_requires_auth
-    params = {
-      method: :delete,
-      action: :occurrence,
-      id: @occ.id
-    }
+    params = params_delete(api_key: nil, id: @occ.id)
     assert_api_fail(params)
   end
 
@@ -204,13 +163,10 @@ class API2::OccurrencesTest < UnitTestCase
   def test_post_with_explicit_primary
     obs_a = observations(:peltigera_obs)
     obs_b = observations(:strobilurus_diminutivus_obs)
-    params = {
-      method: :post,
-      action: :occurrence,
-      api_key: @api_key.key,
+    params = params_post(
       observation: "#{obs_a.id},#{obs_b.id}",
       primary_observation: obs_b.id
-    }
+    )
     assert_api_pass(params)
     occ = Occurrence.find_by(primary_observation_id: obs_b.id)
     assert_not_nil(occ, "Should create with explicit primary")
@@ -220,12 +176,7 @@ class API2::OccurrencesTest < UnitTestCase
   def test_post_without_explicit_primary_picks_oldest
     obs_a = observations(:peltigera_obs)
     obs_b = observations(:strobilurus_diminutivus_obs)
-    params = {
-      method: :post,
-      action: :occurrence,
-      api_key: @api_key.key,
-      observation: "#{obs_a.id},#{obs_b.id}"
-    }
+    params = params_post(observation: "#{obs_a.id},#{obs_b.id}")
     assert_api_pass(params)
     oldest = [obs_a, obs_b].min_by(&:created_at)
     occ = Occurrence.where(
@@ -246,13 +197,7 @@ class API2::OccurrencesTest < UnitTestCase
     @obs3.update!(occurrence: occ2)
     @obs4.update!(occurrence: occ2)
 
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id,
-      add_observation: @obs3.id
-    }
+    params = params_patch(id: @occ.id, add_observation: @obs3.id)
     assert_api_pass(params)
     @occ.reload
 
@@ -265,26 +210,14 @@ class API2::OccurrencesTest < UnitTestCase
 
   def test_patch_add_observation_no_merge
     obs_new = observations(:peltigera_obs)
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id,
-      add_observation: obs_new.id
-    }
+    params = params_patch(id: @occ.id, add_observation: obs_new.id)
     assert_api_pass(params)
     @occ.reload
     assert_includes(@occ.observation_ids, obs_new.id)
   end
 
   def test_patch_add_already_included_observation
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id,
-      add_observation: @obs1.id
-    }
+    params = params_patch(id: @occ.id, add_observation: @obs1.id)
     assert_api_pass(params)
     @occ.reload
     assert_equal(2, @occ.observations.count,
@@ -294,13 +227,7 @@ class API2::OccurrencesTest < UnitTestCase
   # == Coverage: PATCH remove triggers destroy ==
 
   def test_patch_remove_triggers_destroy_if_incomplete
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id,
-      remove_observation: @obs2.id
-    }
+    params = params_patch(id: @occ.id, remove_observation: @obs2.id)
     assert_api_pass(params)
     assert_nil(Occurrence.find_by(id: @occ.id),
                "Should destroy when < 2 obs remain")
@@ -309,13 +236,9 @@ class API2::OccurrencesTest < UnitTestCase
   # == Coverage: PATCH set_primary ==
 
   def test_patch_set_primary
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id,
-      set_primary_observation: @obs2.id
-    }
+    params = params_patch(
+      id: @occ.id, set_primary_observation: @obs2.id
+    )
     assert_api_pass(params)
     @occ.reload
     assert_equal(@obs2.id, @occ.primary_observation_id)
@@ -335,25 +258,14 @@ class API2::OccurrencesTest < UnitTestCase
     )
     obs_other.update!(occurrence: occ2)
 
-    params = {
-      method: :patch,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id,
-      add_observation: obs_other.id
-    }
+    params = params_patch(id: @occ.id, add_observation: obs_other.id)
     assert_api_fail(params)
   end
 
   # == Coverage: DELETE with dissolve ==
 
   def test_delete_dissolves_occurrence
-    params = {
-      method: :delete,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id
-    }
+    params = params_delete(id: @occ.id)
     assert_api_pass(params)
     assert_nil(Occurrence.find_by(id: @occ.id))
     @obs1.reload
@@ -363,12 +275,7 @@ class API2::OccurrencesTest < UnitTestCase
   def test_delete_with_field_slip_keeps_occurrence
     fs = field_slips(:field_slip_no_obs)
     @occ.update!(field_slip: fs)
-    params = {
-      method: :delete,
-      action: :occurrence,
-      api_key: @api_key.key,
-      id: @occ.id
-    }
+    params = params_delete(id: @occ.id)
     assert_api_pass(params)
     # Occurrence should survive with field_slip
     assert(Occurrence.exists?(@occ.id),
@@ -393,23 +300,14 @@ class API2::OccurrencesTest < UnitTestCase
     obs_c = observations(:owner_only_favorite_ne_consensus)
     obs_c.update!(occurrence: occ_b)
 
-    params = {
-      method: :post,
-      action: :occurrence,
-      api_key: @api_key.key,
-      observation: "#{obs_a.id},#{obs_b.id}"
-    }
+    params = params_post(observation: "#{obs_a.id},#{obs_b.id}")
     assert_raises(ActiveRecord::RecordInvalid) do
       API2.execute(params)
     end
   end
 
   def test_post_requires_observations
-    params = {
-      method: :post,
-      action: :occurrence,
-      api_key: @api_key.key
-    }
+    params = params_post
     assert_api_fail(params)
   end
 
@@ -442,12 +340,7 @@ class API2::OccurrencesTest < UnitTestCase
 
   def test_posting_single_observation_error_message
     obs1 = observations(:peltigera_obs)
-    params = {
-      method: :post,
-      action: :occurrence,
-      api_key: @api_key.key,
-      observation: obs1.id.to_s
-    }
+    params = params_post(observation: obs1.id.to_s)
     api = API2.execute(params)
     assert(api.errors.any?,
            "Should fail with only one observation")

--- a/test/classes/api2/projects_test.rb
+++ b/test/classes/api2/projects_test.rb
@@ -14,9 +14,7 @@ class API2::ProjectsTest < UnitTestCase
   #  :section: Project Requests
   # -----------------------------
 
-  def params_get(**)
-    { method: :get, action: :project }.merge(**)
-  end
+  def api2_model = Project
 
   def prj_sample
     @prj_sample ||= Project.all.sample
@@ -113,12 +111,7 @@ class API2::ProjectsTest < UnitTestCase
     @admins  = [rolf]
     @members = [rolf]
     @user    = rolf
-    params = {
-      method: :post,
-      action: :project,
-      api_key: @api_key.key,
-      title: @title
-    }
+    params = params_post(title: @title)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.except(:title))
     assert_api_pass(params)
@@ -128,15 +121,8 @@ class API2::ProjectsTest < UnitTestCase
     @summary = "to do things"
     @admins  = [rolf, mary]
     @members = [rolf, mary, dick]
-    params = {
-      method: :post,
-      action: :project,
-      api_key: @api_key.key,
-      title: @title,
-      summary: @summary,
-      admins: "mary",
-      members: "dick"
-    }
+    params = params_post(title: @title, summary: @summary,
+                         admins: "mary", members: "dick")
     assert_api_pass(params)
     assert_last_project_correct
   end
@@ -148,12 +134,7 @@ class API2::ProjectsTest < UnitTestCase
     # assert_empty(proj.images)
     # assert_empty(proj.observations)
     # assert_empty(proj.species_lists)
-    params = {
-      method: :patch,
-      action: :project,
-      api_key: @api_key.key,
-      id: proj.id
-    }
+    params = params_patch(id: proj.id)
 
     assert_api_fail(params)
     assert_api_fail(params.except(:api_key))
@@ -217,12 +198,7 @@ class API2::ProjectsTest < UnitTestCase
 
   def test_deleting_projects
     proj = projects(:eol_project)
-    params = {
-      method: :delete,
-      action: :project,
-      api_key: @api_key.key,
-      id: proj.id
-    }
+    params = params_delete(id: proj.id)
     # No DELETE requests should be allowed at all.
     assert_api_fail(params)
   end

--- a/test/classes/api2/sequences_test.rb
+++ b/test/classes/api2/sequences_test.rb
@@ -14,9 +14,7 @@ class API2::SequencesTest < UnitTestCase
   #  :section: Sequence Requests
   # ------------------------------
 
-  def params_get(**)
-    { method: :get, action: :sequence }.merge(**)
-  end
+  def api2_model = Sequence
 
   def seq_sample
     @seq_sample ||= Sequence.all.sample
@@ -317,17 +315,14 @@ class API2::SequencesTest < UnitTestCase
     @accession = "NY123456"
     @notes     = "these are notes"
     @user      = rolf
-    params = {
-      method: :post,
-      action: :sequence,
-      api_key: @api_key.key,
+    params = params_post(
       observation: rolfs_obs.id,
       locus: @locus,
       bases: @bases,
       archive: @archive,
       accession: @accession,
       notes: @notes
-    }
+    )
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.except(:observation))
     assert_api_fail(params.except(:locus))
@@ -352,12 +347,7 @@ class API2::SequencesTest < UnitTestCase
     @archive   = nil
     @accession = nil
     @notes     = nil
-    params = {
-      method: :post,
-      action: :sequence,
-      api_key: @api_key.key,
-      observation: rolfs_obs.id
-    }
+    params = params_post(observation: rolfs_obs.id)
     assert_api_fail(params)
     assert_api_fail(params.merge(locus: @locus))
     assert_api_pass(params.merge(locus: @locus, bases: @bases))
@@ -368,12 +358,7 @@ class API2::SequencesTest < UnitTestCase
     @archive   = "GenBank"
     @accession = "AR09876"
     @notes     = nil
-    params = {
-      method: :post,
-      action: :sequence,
-      api_key: @api_key.key,
-      observation: rolfs_obs.id
-    }
+    params = params_post(observation: rolfs_obs.id)
     assert_api_fail(params)
     assert_api_fail(params.merge(locus: @locus))
     assert_api_fail(params.merge(locus: @locus, archive: @archive))
@@ -391,17 +376,14 @@ class API2::SequencesTest < UnitTestCase
     @archive   = "GenBank"
     @accession = "XX123456"
     @notes     = "new notes"
-    params = {
-      method: :patch,
-      action: :sequence,
-      api_key: @api_key.key,
+    params = params_patch(
       id: seq.id,
       set_locus: @locus,
       set_bases: @bases,
       set_archive: @archive,
       set_accession: @accession,
       set_notes: @notes
-    }
+    )
     assert_api_fail(params)
     @api_key.update!(user: dick)
     assert_api_fail(params.merge(set_locus: ""))
@@ -414,12 +396,7 @@ class API2::SequencesTest < UnitTestCase
 
   def test_deleting_sequences
     seq = dick.sequences.sample
-    params = {
-      method: :delete,
-      action: :sequence,
-      api_key: @api_key.key,
-      id: seq.id
-    }
+    params = params_delete(id: seq.id)
     assert_api_fail(params)
     assert_not_nil(Sequence.safe_find(seq.id))
     @api_key.update!(user: dick)

--- a/test/classes/api2/species_lists_test.rb
+++ b/test/classes/api2/species_lists_test.rb
@@ -10,9 +10,7 @@ class API2::SpeciesListsTest < UnitTestCase
   #  :section: SpeciesList Requests
   # ---------------------------------
 
-  def params_get(**)
-    { method: :get, action: :species_list }.merge(**)
-  end
+  def api2_model = SpeciesList
 
   def spl_sample
     @spl_sample ||= SpeciesList.all.sample
@@ -161,15 +159,8 @@ class API2::SpeciesListsTest < UnitTestCase
     @location = locations(:burbank)
     @where    = locations(:burbank).name
     @notes    = "some notes"
-    params = {
-      method: :post,
-      action: :species_list,
-      api_key: @api_key.key,
-      title: @title,
-      date: "2017-11-17",
-      location: @location.id,
-      notes: @notes
-    }
+    params = params_post(title: @title, date: "2017-11-17",
+                         location: @location.id, notes: @notes)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.except(:title))
     assert_api_fail(params.merge(title: SpeciesList.first.title))
@@ -182,12 +173,7 @@ class API2::SpeciesListsTest < UnitTestCase
     @location = Location.unknown
     @where    = Location.unknown.name
     @notes    = nil
-    params = {
-      method: :post,
-      action: :species_list,
-      api_key: @api_key.key,
-      title: @title
-    }
+    params = params_post(title: @title)
     assert_api_pass(params)
     assert_last_species_list_correct
 
@@ -196,13 +182,7 @@ class API2::SpeciesListsTest < UnitTestCase
     @location = nil
     @where    = "Bogus, Arkansas, USA"
     @notes    = nil
-    params = {
-      method: :post,
-      action: :species_list,
-      api_key: @api_key.key,
-      title: @title,
-      location: @where
-    }
+    params = params_post(title: @title, location: @where)
     assert_api_pass(params)
     assert_last_species_list_correct
   end
@@ -217,16 +197,10 @@ class API2::SpeciesListsTest < UnitTestCase
     @location = locations(:mitrula_marsh)
     @where    = locations(:mitrula_marsh).name
     @notes    = "new notes"
-    params = {
-      method: :patch,
-      action: :species_list,
-      api_key: @api_key.key,
-      id: rolfs_spl.id,
-      set_title: @title,
-      set_date: "2017-11-17",
-      set_location: @location.display_name,
-      set_notes: @notes
-    }
+    params = params_patch(id: rolfs_spl.id, set_title: @title,
+                          set_date: "2017-11-17",
+                          set_location: @location.display_name,
+                          set_notes: @notes)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.merge(id: marys_spl.id))
     assert_api_fail(
@@ -243,11 +217,7 @@ class API2::SpeciesListsTest < UnitTestCase
   def test_deleting_species_lists
     rolfs_spl = species_lists(:first_species_list)
     marys_spl = species_lists(:unknown_species_list)
-    params = {
-      method: :delete,
-      action: :species_list,
-      api_key: @api_key.key
-    }
+    params = params_delete
     assert_api_fail(params.merge(id: marys_spl.id))
     assert_api_pass(params.merge(id: rolfs_spl.id))
     assert_not_nil(SpeciesList.safe_find(marys_spl.id))

--- a/test/classes/api2/users_test.rb
+++ b/test/classes/api2/users_test.rb
@@ -15,9 +15,7 @@ class API2::UsersTest < UnitTestCase
   #  :section: User Requests
   # --------------------------
 
-  def params_get(**)
-    { method: :get, action: :user }.merge(**)
-  end
+  def api2_model = User
 
   def test_getting_users
     assert_api_pass(params_get(detail: :low))
@@ -44,14 +42,7 @@ class API2::UsersTest < UnitTestCase
     @image = nil
     @address = ""
     @new_key = nil
-    params = {
-      method: :post,
-      action: :user,
-      api_key: @api_key.key,
-      login: @login,
-      email: @email,
-      password: "secret"
-    }
+    params = params_post(login: @login, email: @email, password: "secret")
     # No API key requested, so no VerifyAccount email should be queued
     api = API2.execute(params)
     assert_no_errors(api, "Errors while posting user")
@@ -78,22 +69,11 @@ class API2::UsersTest < UnitTestCase
     @image = Image.last
     @address = " I live here "
     @new_key = "  Blah  Blah  Blah  "
-    params = {
-      method: :post,
-      action: :user,
-      api_key: @api_key.key,
-      login: @login,
-      name: @name,
-      email: @email,
-      password: "supersecret",
-      locale: @locale,
-      notes: @notes,
-      license: @license.id,
-      location: @location.id,
-      image: @image.id,
-      mailing_address: @address,
-      create_key: @new_key
-    }
+    params = params_post(login: @login, name: @name, email: @email,
+                         password: "supersecret", locale: @locale,
+                         notes: @notes, license: @license.id,
+                         location: @location.id, image: @image.id,
+                         mailing_address: @address, create_key: @new_key)
     # With create_key, VerifyAccount email should be queued
     assert_enqueued_with(
       job: ActionMailer::MailDeliveryJob,
@@ -113,18 +93,12 @@ class API2::UsersTest < UnitTestCase
   end
 
   def test_patching_users
-    params = {
-      method: :patch,
-      action: :user,
-      api_key: @api_key.key,
-      id: rolf.id,
-      set_locale: "pt",
-      set_notes: "some notes",
-      set_mailing_address: "somewhere, USA",
-      set_license: licenses(:publicdomain).id,
-      set_location: locations(:burbank).id,
-      set_image: images(:peltigera_image).id
-    }
+    params = params_patch(id: rolf.id, set_locale: "pt",
+                          set_notes: "some notes",
+                          set_mailing_address: "somewhere, USA",
+                          set_license: licenses(:publicdomain).id,
+                          set_location: locations(:burbank).id,
+                          set_image: images(:peltigera_image).id)
     assert_api_fail(params.except(:api_key))
     assert_api_fail(params.merge(set_image: mary.images.first.id))
     assert_api_fail(params.merge(set_locale: ""))
@@ -140,11 +114,7 @@ class API2::UsersTest < UnitTestCase
   end
 
   def test_deleting_users
-    params = {
-      method: :delete,
-      action: :user,
-      api_key: @api_key.key # (rolf's)
-    }
+    params = params_delete # (rolf's)
 
     # Rolf can't delete Mary.
     assert_api_fail(params.merge(id: mary.id))


### PR DESCRIPTION
Fixes #4707. Part of a sweep to tighten codebase for CC, since it can spew vast amounts of un-DRY code if given bad examples.

## Summary

Every `test/classes/api2/*_test.rb` file repeated the same `{ method: ..., action: :some_symbol, api_key: @api_key.key, ... }` hash-literal shape at each POST/PATCH/DELETE (and many GET) call site, either inline or via a per-file local `params_get` method with the action symbol hardcoded.

`test/api2_extensions.rb` (`API2Extensions`, included by every `API2::*Test`) now provides four shared helpers:

```ruby
def api2_model
  raise("Define api2_model in #{self.class} before calling params_*")
end

def params_get(**opts)
  { method: :get, action: api2_model.type_tag }.merge(opts)
end

def params_post(**opts)
  { method: :post, action: api2_model.type_tag, api_key: @api_key.key }.merge(opts)
end

def params_patch(**opts)
  { method: :patch, action: api2_model.type_tag, api_key: @api_key.key }.merge(opts)
end

def params_delete(**opts)
  { method: :delete, action: api2_model.type_tag, api_key: @api_key.key }.merge(opts)
end
```

`params_get` omits `api_key:` by design — `ModelAPI#get` never calls `must_authenticate!`, unlike post/patch/delete.

Each test file declares its resource once via `def api2_model = SomeModel` (mirroring how `ModelAPI` subclasses declare `def model`), and the action symbol is derived from `api2_model.type_tag` — the same mechanism `do_basic_get_test` already relies on. Every file's local `params_get` override and every inline params hash matching this shape was converted to call the shared helpers, keeping only the request-specific kwargs. Explicit `api_key:` overrides (a different user's key, or a deliberately omitted/nil key for an auth-failure test) are preserved as explicit kwargs, since the helper's default is simply overridden by a later merge.

`test/classes/api2/error_test.rb` doesn't include `API2Extensions` and wasn't touched. `image_votes_test.rb`, `namings_test.rb`, `votes_test.rb`, and `location_descriptions_test.rb` had no `params_*` usage and needed no changes.

## Test plan

- [x] `bundle exec rubocop test/classes/api2/` — no offenses
- [x] Every converted file run individually via `bin/rails test test/classes/api2/<file>_test.rb` — 0 failures, 0 errors across all 18 converted files
