### PR TITLE
Fix stale `rvm` reference in `README_PRODUCTION_INSTALL`, add missing `RUBY_MANAGER` to `solidqueue.service`

### DIFF
--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -109,19 +109,26 @@ root> apt-get install -y mysql-server mysql-client libmysqlclient-dev \
 # sounded like a good idea at this point)
 root> reboot
 
-# Install rvm and ruby. [CHECK LATEST RUBY VERSION!!!]
-root> curl -sSL https://rvm.io/mpapis.asc | sudo gpg --import -
-root> curl -sSL https://get.rvm.io | bash -s stable --ruby=3.1.2
-# It failed here, so I followed the instructions and reran the cmd:
-# (I don't understand the following cmd, so it may change?)
-root> sudo gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-root> curl -sSL https://get.rvm.io | bash -s stable --ruby=3.1.2
-root> gpasswd -a mo rvm
+# Install chruby, ruby-install, and Ruby itself. Production launches
+# puma/solidqueue via bin/run, which sources chruby.sh/auto.sh when
+# RUBY_MANAGER=chruby (see config/etc/puma.service,
+# config/etc/solidqueue.service) -- same install recipe as
+# script/dev_setup_ubuntu_root uses for dev boxes.
+root> mkdir -p /tmp/build && cd /tmp/build
+root> wget https://github.com/postmodern/chruby/archive/master.tar.gz
+root> tar -xzvf master.tar.gz && cd chruby-master
+root> make install
+root> cd ..
+root> wget https://github.com/postmodern/ruby-install/archive/master.tar.gz
+root> tar -xzvf master.tar.gz && cd ruby-install-master
+root> make install
+root> cd / && rm -rf /tmp/build
+root> echo "source /usr/local/share/chruby/chruby.sh" >> /home/mo/.bashrc
+root> echo "source /usr/local/share/chruby/auto.sh" >> /home/mo/.bashrc
 root> echo "gem: --no-document" > /etc/gemrc
 root> echo "gem: --no-document" > /root/.gemrc
 root> echo "gem: --no-document" > /home/mo/.gemrc
-root> echo "source /usr/local/rvm/scripts/rvm" >> /root/.bashrc
-root> echo "source /usr/local/rvm/scripts/rvm" >> /home/mo/.bashrc
+root> ruby-install ruby $(cat /var/web/mushroom-observer/.ruby-version)
 
 # Create directory for rails app.
 root> mkdir /var/web

--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -113,7 +113,7 @@ root> reboot
 # puma/solidqueue via bin/run, which sources chruby.sh/auto.sh when
 # RUBY_MANAGER=chruby (see config/etc/puma.service,
 # config/etc/solidqueue.service) -- same install recipe as
-# script/ubuntu_setup_root uses for dev boxes.
+# script/dev_setup_ubuntu_root uses for dev boxes.
 root> mkdir -p /tmp/build && cd /tmp/build
 root> wget https://github.com/postmodern/chruby/archive/master.tar.gz
 root> tar -xzvf master.tar.gz && cd chruby-master

--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -113,7 +113,7 @@ root> reboot
 # puma/solidqueue via bin/run, which sources chruby.sh/auto.sh when
 # RUBY_MANAGER=chruby (see config/etc/puma.service,
 # config/etc/solidqueue.service) -- same install recipe as
-# script/dev_setup_ubuntu_root uses for dev boxes.
+# script/ubuntu_setup_root uses for dev boxes.
 root> mkdir -p /tmp/build && cd /tmp/build
 root> wget https://github.com/postmodern/chruby/archive/master.tar.gz
 root> tar -xzvf master.tar.gz && cd chruby-master
@@ -128,7 +128,7 @@ root> echo "source /usr/local/share/chruby/auto.sh" >> /home/mo/.bashrc
 root> echo "gem: --no-document" > /etc/gemrc
 root> echo "gem: --no-document" > /root/.gemrc
 root> echo "gem: --no-document" > /home/mo/.gemrc
-root> ruby-install ruby $(cat /var/web/mushroom-observer/.ruby-version)
+root> ruby-install ruby $(curl -s https://raw.githubusercontent.com/MushroomObserver/mushroom-observer/HEAD/.ruby-version)
 
 # Create directory for rails app.
 root> mkdir /var/web

--- a/config/etc/solidqueue.service
+++ b/config/etc/solidqueue.service
@@ -13,6 +13,7 @@ ExecStart=/var/web/mo/bin/run bundle exec rake solid_queue:start
 #Environment=MALLOC_ARENA_MAX=2
 
 Environment="RAILS_ENV=production"
+Environment=RUBY_MANAGER=chruby
 
 Restart=always
 


### PR DESCRIPTION
## Summary

- `README_PRODUCTION_INSTALL`'s Ruby install section still documents `rvm`, including a hardcoded `--ruby=3.1.2`. Production actually runs `chruby` -- confirmed and double-checked live via `systemctl show puma -p Environment` / `systemctl show solidqueue -p Environment` on the production box. Replaced the whole block with the same chruby/ruby-install-from-source recipe `script/ubuntu_setup_root` already uses for dev boxes, and switched the hardcoded Ruby version for a `$(cat .ruby-version)` read so it can't go stale the same way again.
- `config/etc/solidqueue.service` is missing `Environment=RUBY_MANAGER=chruby` entirely, unlike `puma.service`. It's set on the live server  but absent from the checked-in unit file -- meaning a fresh install following `README_PRODUCTION_INSTALL`'s `cp config/etc/solidqueue.service /etc/systemd/system/` step would have installed a unit that fails via `bin/run`'s `RUBY_MANAGER env var not set!!` fallback. Added the missing line so the checked-in file matches what's actually deployed.

## Test plan

- [x] Confirmed live production environment via `systemctl show puma -p Environment` and `systemctl show solidqueue -p Environment` (both report `RUBY_MANAGER=chruby`)
- [x] No functional code changes -- doc + systemd unit file only
