### PR TITLE
Dummy `TestPages::IconSpriteComparison` page: pick basic vs halflings Glyphicons 2.0 sprite per icon (#3797)

### DIFF
--- a/app/classes/test_pages/icon_sprite_svg.rb
+++ b/app/classes/test_pages/icon_sprite_svg.rb
@@ -45,12 +45,18 @@ module TestPages::IconSpriteSvg
   # reliable than reimplementing path-bounds math server-side for a
   # throwaway page. No untrusted interpolation -- a static script, so
   # a plain SafeBuffer wrap is enough (see Phlex::TrustedHtml).
+  #
+  # 2% padding, not the original 8%: confirmed via real screenshot
+  # pixel measurements (not browser-side ink measurement, which
+  # proved unreliable) that 8% was needlessly eating into the same
+  # budget the 2.8rem height fix (see sprite_icon.rb) was trying to
+  # recover -- font glyphs render close to edge-to-edge in their box.
   def self.bbox_fit_script
     <<~JS.html_safe
       document.querySelectorAll(".sprite-icon-fit").forEach((svg) => {
         const path = svg.querySelector("path");
         const box = path.getBBox();
-        const pad = Math.max(box.width, box.height) * 0.08;
+        const pad = Math.max(box.width, box.height) * 0.02;
         svg.setAttribute(
           "viewBox",
           [box.x - pad, box.y - pad, box.width + 2 * pad, box.height + 2 * pad].join(" ")

--- a/app/classes/test_pages/icon_sprite_svg.rb
+++ b/app/classes/test_pages/icon_sprite_svg.rb
@@ -49,18 +49,33 @@ module TestPages::IconSpriteSvg
   # 2% padding, not the original 8%: confirmed via real screenshot
   # pixel measurements (not browser-side ink measurement, which
   # proved unreliable) that 8% was needlessly eating into the same
-  # budget the 2.8rem height fix (see sprite_icon.rb) was trying to
-  # recover -- font glyphs render close to edge-to-edge in their box.
+  # budget the 2.8rem sizing (below) was trying to recover -- font
+  # glyphs render close to edge-to-edge in their box.
+  #
+  # object-fit: contain into a 2.8rem square -- cap whichever
+  # dimension the icon's own aspect ratio makes larger at 2.8rem, let
+  # the other follow proportionally. A single fixed dimension (e.g.
+  # always height: 2.8rem, width: auto) let the two widest icons
+  # (envelope, chevron-down/up) render oversized since nothing capped
+  # their free-scaling width; always-square "meet" fitting (the
+  # original approach) letterboxed every other non-square icon
+  # instead. This is the one rule both size cleanly.
   def self.bbox_fit_script
     <<~JS.html_safe
       document.querySelectorAll(".sprite-icon-fit").forEach((svg) => {
         const path = svg.querySelector("path");
         const box = path.getBBox();
         const pad = Math.max(box.width, box.height) * 0.02;
-        svg.setAttribute(
-          "viewBox",
-          [box.x - pad, box.y - pad, box.width + 2 * pad, box.height + 2 * pad].join(" ")
-        );
+        const w = box.width + 2 * pad;
+        const h = box.height + 2 * pad;
+        svg.setAttribute("viewBox", [box.x - pad, box.y - pad, w, h].join(" "));
+        if (w >= h) {
+          svg.style.width = "2.8rem";
+          svg.style.height = "auto";
+        } else {
+          svg.style.height = "2.8rem";
+          svg.style.width = "auto";
+        }
       });
     JS
   end

--- a/app/classes/test_pages/icon_sprite_svg.rb
+++ b/app/classes/test_pages/icon_sprite_svg.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Extracts individual <path> "d" attribute data from the licensed
+# Glyphicons 2.0 sprite files (vendor/assets/images/icons/,
+# gitignored) for the throwaway TestPages::IconSpriteComparison page
+# (GH #3797) -- delete alongside it once the sprite-variant picks are
+# locked in.
+#
+# These are absolute-grid-coordinate sprites (every path shares one
+# huge canvas), not <symbol>s with a local viewBox, so each extracted
+# path still needs a per-icon viewBox fitted client-side -- see
+# app/views/controllers/test_pages/icon_sprite_comparison/show.rb's
+# bbox-fit script.
+module TestPages::IconSpriteSvg
+  SPRITE_DIR = Rails.root.join("vendor/assets/images/icons")
+
+  # Returns the "d" attribute string for `id` within `sprite_name`
+  # ("basic" or "halflings"), or nil if the id isn't in that sprite
+  # (missing files, e.g. icon-library not cloned locally, are treated
+  # the same as a missing id).
+  def self.d_for(sprite_name, id)
+    return nil if id.nil?
+
+    path_data_for(sprite_name)[id]
+  end
+
+  def self.path_data_for(sprite_name)
+    @path_data ||= {}
+    @path_data[sprite_name] ||= extract_path_data(sprite_name)
+  end
+  private_class_method :path_data_for
+
+  def self.extract_path_data(sprite_name)
+    file = SPRITE_DIR.join("glyphicons-#{sprite_name}.svg")
+    return {} unless File.exist?(file)
+
+    doc = Nokogiri::XML(File.read(file))
+    doc.remove_namespaces!
+    doc.xpath("//path[@id]").to_h { |node| [node["id"], node["d"]] }
+  end
+  private_class_method :extract_path_data
+
+  # Fits each sprite-icon SVG's viewBox to its actual path bounding
+  # box via the browser's own SVG geometry (getBBox) -- far more
+  # reliable than reimplementing path-bounds math server-side for a
+  # throwaway page. No untrusted interpolation -- a static script, so
+  # a plain SafeBuffer wrap is enough (see Phlex::TrustedHtml).
+  def self.bbox_fit_script
+    <<~JS.html_safe
+      document.querySelectorAll(".sprite-icon-fit").forEach((svg) => {
+        const path = svg.querySelector("path");
+        const box = path.getBBox();
+        const pad = Math.max(box.width, box.height) * 0.08;
+        svg.setAttribute(
+          "viewBox",
+          [box.x - pad, box.y - pad, box.width + 2 * pad, box.height + 2 * pad].join(" ")
+        );
+      });
+    JS
+  end
+end

--- a/app/controllers/test_pages/icon_sprite_comparison_controller.rb
+++ b/app/controllers/test_pages/icon_sprite_comparison_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module TestPages
+  # Dummy comparison page: for every Components::Icon::GLYPHS entry,
+  # renders the current Bootstrap 3 Glyphicon next to its candidate
+  # replacement(s) in the licensed Glyphicons 2.0 sprites (basic and
+  # halflings, when both offer a version), so the team can pick which
+  # sprite variant to use per icon. See GH issue #3797. Delete this
+  # whole test page once the picks are locked in.
+  class IconSpriteComparisonController < ApplicationController
+    before_action :login_required
+
+    def show
+      render(Views::Controllers::TestPages::IconSpriteComparison::Show.new)
+    end
+  end
+end

--- a/app/views/controllers/test_pages/icon_sprite_comparison/show.rb
+++ b/app/views/controllers/test_pages/icon_sprite_comparison/show.rb
@@ -55,7 +55,7 @@ class Views::Controllers::TestPages::IconSpriteComparison::Show <
     [:synonyms, "random", "random", "random_1_"],
     [:adjust, "resize-vertical", "resize-vertical", nil],
     [:make_default, "star", "star", "star_1_"],
-    [:publish, "upload", "circle-up", "circle-up"],
+    [:publish, "upload", "circle-empty-up", nil],
     [:check, "ok-circle", "circle-empty-check", nil],
     [:deprecate, "ok-circle", "circle-empty-check", nil],
     [:approve, "exclamation-sign", "circle-alert", "circle-alert_1_"],

--- a/app/views/controllers/test_pages/icon_sprite_comparison/show.rb
+++ b/app/views/controllers/test_pages/icon_sprite_comparison/show.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+# Dummy test page for GH issue #3797: for every Components::Icon::GLYPHS
+# entry, renders the current Bootstrap 3 Glyphicon next to its candidate
+# replacement(s) in the licensed Glyphicons 2.0 sprites (vendor/assets/
+# images/icons/, gitignored -- clone MushroomObserver/icon-library
+# there first), so the team can pick which sprite variant to use per
+# icon before Components::Icon gets converted to emit SVG <use> markup.
+# Delete this whole page (controller, route, this file) once the picks
+# are locked in.
+#
+# "Basic" and "halflings" are the two sprites Glyphicons 2.0 ships.
+# Most icons exist in both -- often as genuinely different artwork, not
+# just a duplicate -- which is exactly why this page exists instead of
+# picking blind from grep output.
+class Views::Controllers::TestPages::IconSpriteComparison::Show <
+      Views::FullPageBase
+  # [MO icon key, old Bootstrap glyphicon suffix, basic sprite id or
+  # nil, halflings sprite id or nil]. Halflings ids ending "_N_" are
+  # Illustrator's auto-disambiguation suffix from exporting the same
+  # icon name into both sprites -- NOT a marker of a lesser variant,
+  # the artwork genuinely differs from the basic version.
+  ICON_ROWS = [
+    [:add, "plus", "plus", "plus_1_"],
+    [:edit, "edit", "square-edit", "square-edit"],
+    [:delete, "remove-circle", "circle-empty-remove", nil],
+    [:remove, "remove-circle", "circle-empty-remove", nil],
+    [:trash, "trash", "bin", "bin_1_"],
+    [:back, "step-backward", "chevron-last-left", "chevron-last-left"],
+    [:show, "eye-open", "eye", "eye_1_"],
+    [:hide, "eye-close", "eye-off", "eye-off_1_"],
+    [:x, "remove", "menu-close", "menu-close_1_"],
+    [:cancel, "remove", "times", "times_1_"],
+    [:reuse, "share", "repeat", "repeat"],
+    [:send, "send", "send", "send_1_"],
+    [:log_in, "log-in", "log-in", "log-in_1_"],
+    [:log_out, "log-out", "log-out", "log-out_1_"],
+    [:admin, "text-background", "user-worker", nil],
+    [:inbox, "inbox", "inbox", "inbox_1_"],
+    [:interests, "bullhorn", "announcement", "announcement_1_"],
+    [:tracking, "bullhorn", "announcement", "announcement_1_"],
+    [:settings, "cog", "cogwheel", "cogwheel_1_"],
+    [:ban, "ban-circle", "no-symbol", "no-symbol_1_"],
+    [:plus, "plus-sign", "circle-plus", "circle-plus_1_"],
+    [:minus, "minus-sign", "circle-minus", "circle-minus_1_"],
+    [:email, "envelope", "envelope", "envelope_1_"],
+    [:question, "question-sign", "circle-question", "circle-question_1_"],
+    [:info, "question-sign", "circle-question", "circle-question_1_"],
+    [:alert, "alert", "triangle-alert", "triangle-alert_1_"],
+    [:list, "list", "list", "list_1_"],
+    [:copy, "copy", "copy_1_", nil],
+    [:clone, "duplicate", "block-move", nil],
+    [:merge, "transfer", "exchange", "exchange_1_"],
+    [:move, "random", "random", "random_1_"],
+    [:synonyms, "random", "random", "random_1_"],
+    [:adjust, "resize-vertical", "resize-vertical", nil],
+    [:make_default, "star", "star", "star_1_"],
+    [:publish, "upload", "circle-up", "circle-up"],
+    [:check, "ok-circle", "circle-empty-check", nil],
+    [:deprecate, "ok-circle", "circle-empty-check", nil],
+    [:approve, "exclamation-sign", "circle-alert", "circle-alert_1_"],
+    [:manage_lists, "indent-left", "indent-left", "indent-left"],
+    [:observations, "tags", "tags", nil],
+    [:print, "print", "print", "print"],
+    [:globe, "globe", "world-east", nil],
+    [:map, "globe", "world-east", nil],
+    [:place, "map-marker", "map-marker", "map-marker_1_"],
+    [:find_on_map, "screenshot", "drop-plus", "drop-plus_1_"],
+    [:apply, "check", "square-checkbox", "square-checkbox"],
+    [:chevron_down, "chevron-down", "chevron-down", "chevron-down_1_"],
+    [:chevron_up, "chevron-up", "chevron-up", "chevron-up_1_"],
+    [:chevron_left, "chevron-left", "chevron-left", "chevron-left_1_"],
+    [:chevron_right, "chevron-right", "chevron-right", "chevron-right_1_"],
+    [:qrcode, "qrcode", "qr-code", "qr-code_1_"],
+    [:mobile, "phone", "mobile-phone", "mobile-phone"],
+    [:project, "th-list", "thumbnails-list", nil],
+    [:download, "download-alt", "save-as", "save-as_1_"],
+    [:new_window, "new-window", "square-new-window", "square-new-window"],
+    [:search, "search", "search", "search_1_"],
+    [:prev, "triangle-left", "chevron-left", "chevron-left_1_"],
+    [:next, "triangle-right", "chevron-right", "chevron-right_1_"],
+    [:goto, "share-alt", "step-forward", "step-forward"],
+    [:grid, "th", "thumbnails-small", "thumbnails-small_1_"],
+    [:menu, "align-justify", "menu", "menu_1_"],
+    [:fullscreen, "fullscreen", "fullscreen", "fullscreen_1_"],
+    [:matrix, "th-large", "thumbnails", "thumbnails_1_"],
+    [:info_circle, "info-sign", "circle-info", "circle-info_1_"],
+    [:user, "user", "user", "user_1_"]
+  ].freeze
+
+  ISSUE_URL = "https://github.com/MushroomObserver/mushroom-observer/" \
+              "issues/3797"
+
+  def view_template
+    add_page_title("Icon sprite comparison (dummy test page, #3797)")
+    render_explanation
+    render_comparison_table
+    render_bbox_fit_script
+  end
+
+  private
+
+  def render_explanation
+    p(class: "text-muted") do
+      plain("Dummy comparison page for ")
+      a(href: ISSUE_URL) { "GH #3797" }
+      plain(" -- pick basic vs halflings per icon (or flag a better " \
+            "candidate), then delete this page. \"_N_\" halflings ids " \
+            "are Illustrator's export-collision suffix, not a lesser " \
+            "variant -- the artwork genuinely differs from basic.")
+    end
+  end
+
+  def render_comparison_table
+    render(Components::Table.new(ICON_ROWS, variant: :striped)) do |t|
+      t.column("MO key") { |row| key_cell(row) }
+      t.column("Old suffix") { |row| old_suffix_cell(row) }
+      t.column("Current (Glyphicon)") { |row| glyphicon_cell(row[0]) }
+      t.column("Basic") { |row| sprite_cell("basic", row[2]) }
+      t.column("Halflings") { |row| sprite_cell("halflings", row[3]) }
+    end
+  end
+
+  def key_cell(row)
+    code { row[0].to_s }
+  end
+
+  def old_suffix_cell(row)
+    code { row[1] }
+  end
+
+  def glyphicon_cell(key)
+    large_icon { render(Components::Icon.new(type: key)) }
+  end
+
+  def sprite_cell(sprite_name, id)
+    return large_icon { plain("—") } if id.nil?
+
+    path_data = TestPages::IconSpriteSvg.d_for(sprite_name, id)
+    return large_icon { plain("id not found: #{id}") } if path_data.nil?
+
+    large_icon do
+      render(SpriteIcon.new(path_data: path_data))
+      icon_caption("#{sprite_name}##{id}")
+    end
+  end
+
+  def large_icon(&block)
+    div(style: "font-size: 2.5rem;", &block)
+  end
+
+  def icon_caption(text)
+    div(class: "small text-muted", style: "font-size: 0.9rem;") { text }
+  end
+
+  def render_bbox_fit_script
+    script { trusted_html(TestPages::IconSpriteSvg.bbox_fit_script) }
+  end
+end

--- a/app/views/controllers/test_pages/icon_sprite_comparison/show/sprite_icon.rb
+++ b/app/views/controllers/test_pages/icon_sprite_comparison/show/sprite_icon.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# One <svg><path/></svg> fragment for the icon-sprite comparison page.
+# A real Phlex::SVG subclass (not Phlex::HTML) -- Phlex::HTML only
+# registers the bare <svg> wrapper tag, not nested SVG elements like
+# <path>. Rendered via the ordinary `render(...)` from the parent
+# Phlex::HTML view; Phlex shares one output buffer across component
+# types, so this composes normally.
+class Views::Controllers::TestPages::IconSpriteComparison::Show::
+      SpriteIcon < Phlex::SVG
+  def initialize(path_data:)
+    super()
+    @path_data = path_data
+  end
+
+  def view_template
+    svg(class: "sprite-icon-fit", style: "width: 2.5rem; height: 2.5rem;",
+        xmlns: "http://www.w3.org/2000/svg") do
+      path(d: @path_data, fill: "#262626")
+    end
+  end
+end

--- a/app/views/controllers/test_pages/icon_sprite_comparison/show/sprite_icon.rb
+++ b/app/views/controllers/test_pages/icon_sprite_comparison/show/sprite_icon.rb
@@ -14,20 +14,12 @@ class Views::Controllers::TestPages::IconSpriteComparison::Show::
   end
 
   def view_template
-    # height only, width auto -- forcing an exact-square box (the
-    # earlier width+height: 2.5rem) letterboxed every non-square icon
-    # under the SVG's default "meet" scaling, wasting real width/height
-    # that a font glyph's own advance-width never has to give up.
-    #
-    # 2.8rem, not 2.5rem: MO's own .glyphicon { font-size: 112%; }
-    # (_icons.scss) already boosts the Current column's font glyph
-    # 12% past the 2.5rem the wrapping div sets -- confirmed via
-    # getComputedStyle (28px rendered vs. a 25px wrapper). Matching
-    # that here, plus dropping the fit padding below from 8% to 2%,
-    # closed the remaining gap on square/circular icons (circle-plus,
-    # circle-question, alert) that the width:auto change alone
-    # couldn't touch, since their aspect ratio is already ~1.
-    svg(class: "sprite-icon-fit", style: "height: 2.8rem; width: auto;",
+    # Initial size is a placeholder -- TestPages::IconSpriteSvg's
+    # bbox-fit script overrides both width and height per icon once it
+    # knows the icon's own aspect ratio (object-fit: contain into a
+    # 2.8rem square; see that file for why a single fixed dimension
+    # doesn't work for every icon).
+    svg(class: "sprite-icon-fit", style: "height: 2.8rem; width: 2.8rem;",
         xmlns: "http://www.w3.org/2000/svg") do
       path(d: @path_data, fill: "#262626")
     end

--- a/app/views/controllers/test_pages/icon_sprite_comparison/show/sprite_icon.rb
+++ b/app/views/controllers/test_pages/icon_sprite_comparison/show/sprite_icon.rb
@@ -14,7 +14,13 @@ class Views::Controllers::TestPages::IconSpriteComparison::Show::
   end
 
   def view_template
-    svg(class: "sprite-icon-fit", style: "width: 2.5rem; height: 2.5rem;",
+    # height only, width auto -- forcing an exact-square box (the
+    # earlier width+height: 2.5rem) letterboxed every non-square icon
+    # under the SVG's default "meet" scaling, wasting real width/height
+    # that a font glyph's own advance-width never has to give up.
+    # Confirmed live: this alone closed most of the "SVG looks smaller
+    # than the font glyph" gap across eye/bin/chevron-last-left.
+    svg(class: "sprite-icon-fit", style: "height: 2.5rem; width: auto;",
         xmlns: "http://www.w3.org/2000/svg") do
       path(d: @path_data, fill: "#262626")
     end

--- a/app/views/controllers/test_pages/icon_sprite_comparison/show/sprite_icon.rb
+++ b/app/views/controllers/test_pages/icon_sprite_comparison/show/sprite_icon.rb
@@ -18,9 +18,16 @@ class Views::Controllers::TestPages::IconSpriteComparison::Show::
     # earlier width+height: 2.5rem) letterboxed every non-square icon
     # under the SVG's default "meet" scaling, wasting real width/height
     # that a font glyph's own advance-width never has to give up.
-    # Confirmed live: this alone closed most of the "SVG looks smaller
-    # than the font glyph" gap across eye/bin/chevron-last-left.
-    svg(class: "sprite-icon-fit", style: "height: 2.5rem; width: auto;",
+    #
+    # 2.8rem, not 2.5rem: MO's own .glyphicon { font-size: 112%; }
+    # (_icons.scss) already boosts the Current column's font glyph
+    # 12% past the 2.5rem the wrapping div sets -- confirmed via
+    # getComputedStyle (28px rendered vs. a 25px wrapper). Matching
+    # that here, plus dropping the fit padding below from 8% to 2%,
+    # closed the remaining gap on square/circular icons (circle-plus,
+    # circle-question, alert) that the width:auto change alone
+    # couldn't touch, since their aspect ratio is already ~1.
+    svg(class: "sprite-icon-fit", style: "height: 2.8rem; width: auto;",
         xmlns: "http://www.w3.org/2000/svg") do
       path(d: @path_data, fill: "#262626")
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -832,6 +832,8 @@ MushroomObserver::Application.routes.draw do
   # ----- Test pages  -------------------------------------------
   namespace :test_pages do
     resource :flash_redirection, only: [:show], controller: "flash_redirection"
+    resource :icon_sprite_comparison, only: [:show],
+                                      controller: "icon_sprite_comparison"
   end
 
   # ----- Translations: standard actions  -------------------------------------


### PR DESCRIPTION
## What this is

A throwaway `TestPages` page, not meant to merge to `main` as-is: for every `Components::Icon::GLYPHS` key (65 total), renders the current Bootstrap 3 Glyphicon next to candidate replacements from both Glyphicons 2.0 sprites (`basic` and `halflings`), so the sprite-variant pick per icon comes from actually looking at them rather than guessing from `grep` output on sprite ids.

Visit `/test_pages/icon_sprite_comparison` (login required) to review. Requires the private `MushroomObserver/icon-library` repo cloned into `vendor/assets/images/icons/` (gitignored) — see `script/dev_setup_macos --icons-only` / `script/dev_setup_ubuntu --icons-only` on `#5001`.

## Why a page instead of picking from grep output

Many icons exist in both sprites under the same name but as genuinely different artwork -- confirmed by diffing the raw `d` path data, not just id presence. Halflings ids with a trailing `_N_` (e.g. `plus_1_`) are Illustrator's export-collision suffix from the same name appearing in both sprite source files, not a marker of a lesser/duplicate variant.

A striking number of the Glyphicons 2.0 icons turned out to be inconsistently sized against each other and, in a fair number of cases, not very good -- worse than expected for a licensed set. Some picks in `ICON_ROWS` are still likely to change as review continues.

## Implementation notes

- `app/views/controllers/test_pages/icon_sprite_comparison/show.rb` -- the `ICON_ROWS` constant is the actual mapping table (`[mo_key, old_bootstrap_suffix, basic_id_or_nil, halflings_id_or_nil]`), one row per `GLYPHS` key.
- `app/views/controllers/test_pages/icon_sprite_comparison/show/sprite_icon.rb` -- a `Phlex::SVG` (not `Phlex::HTML`) subclass rendering one `<svg><path/></svg>` fragment. `Phlex::HTML` only registers the bare `<svg>` wrapper tag, not nested SVG elements like `<path>`, so this needed its own `Phlex::SVG` component, composed into the parent HTML view via ordinary `render(...)`.
- `app/classes/test_pages/icon_sprite_svg.rb` -- server-side extraction of raw path `d` data via Nokogiri from the local sprite files, plus a client-side `getBBox()`-based viewBox-fit script. These are absolute-grid-coordinate sprites (every path shares one huge canvas), not `<symbol>`s with a local viewBox, so each icon needs its own bounding box computed -- done in-browser rather than reimplementing SVG path-bounds math server-side.

## Not in this PR

Actually converting `Components::Icon` to emit SVG `<use>` markup is separate work, deferred until the sprite-variant picks here are locked in and `#5001` (icon-library dev-setup wiring) lands.

## Test plan

- [x] `bundle exec rubocop` clean on every touched/new file
- [x] Rendered server-side via `ApplicationController.renderer.render` to confirm every `ICON_ROWS` id resolves (no "id not found" output) and the SVG count matches the expected row count
- [ ] Visual review of the rendered page itself, in progress
