### PR TITLE
Grant `editing` trust on project creation and `Project#join`, and backfill untouched `hidden_gps`

### DIFF
--- a/app/controllers/concerns/field_slip_project_joinable.rb
+++ b/app/controllers/concerns/field_slip_project_joinable.rb
@@ -3,9 +3,8 @@
 # Joining a project by using one of its field slips.
 #
 # A slip's code prefix is an invitation: scanning a slip for an
-# open-membership project enrolls you in it. That is why the trust level
-# here is "editing" rather than the "hidden_gps" a plain self-service
-# `Project#join` grants — someone handed you a printed slip.
+# open-membership project enrolls you in it, at the "editing" trust
+# every other enrollment path grants.
 #
 # Shared by the field slip form and the observation form so the rule has
 # one definition; before #4932 only the field slip form did this, and

--- a/app/controllers/projects_controller/creation.rb
+++ b/app/controllers/projects_controller/creation.rb
@@ -68,10 +68,16 @@ module ProjectsController::Creation
   end
 
   def finalize_saved_project
+    # Same trust the add-member and field-slip paths grant, and said out
+    # loud for the same reason: someone setting a project up almost
+    # always wants its admins able to work on the observations they put
+    # in it, and being the creator should not make them the one admin
+    # whose observations nobody else can touch.
     ProjectMember.create!(project: @project, user: @user,
-                          trust_level: "hidden_gps")
+                          trust_level: "editing")
     @project.log_create
     flash_notice(:add_project_success.t)
+    flash_notice(:add_members_with_editing.l)
     redirect_to(project_path(@project.id))
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -279,7 +279,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     return unless can_join?(user)
 
     ProjectMember.create!(project: self, user:,
-                          trust_level: "hidden_gps")
+                          trust_level: "editing")
     user_group.users << user unless user_group.users.member?(user)
   end
 

--- a/script/upgrade_untouched_hidden_gps_trust.rb
+++ b/script/upgrade_untouched_hidden_gps_trust.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Raises project memberships still sitting on the "hidden_gps" trust
+# level they were never asked about, to the "editing" level every
+# enrollment path now grants.
+#
+#   bin/rails runner script/upgrade_untouched_hidden_gps_trust.rb
+#   bin/rails runner script/upgrade_untouched_hidden_gps_trust.rb --apply
+#
+# "Allow project admins to edit associated observations by default"
+# (2025-07-11) set that default for the add-member and join paths, but
+# project creation and `Project#join` kept handing out "hidden_gps", so
+# creators in particular ended up as the one admin whose observations
+# their co-admins could not edit.
+#
+# Only rows whose `updated_at` still matches their `created_at` are
+# touched. A member who has been to the trust modal chose what they
+# have, whatever they chose, and is left alone.
+
+APPLY = ARGV.delete("--apply")
+abort("Unknown argument(s): #{ARGV.join(" ")}") if ARGV.any?
+
+# Timestamps are written together on insert but not to the same
+# fractional second, so "never updated" needs a little slack rather
+# than equality.
+UNTOUCHED_SLACK = 2.seconds
+
+def untouched?(member)
+  (member.updated_at - member.created_at).abs <= UNTOUCHED_SLACK
+end
+
+candidates = ProjectMember.hidden_gps.includes(:project, :user).to_a
+untouched, chosen = candidates.partition { |m| untouched?(m) }
+
+warn("hidden_gps memberships: #{candidates.size}")
+warn("  never changed since creation (will be raised): #{untouched.size}")
+warn("  changed at some point (left alone):            #{chosen.size}")
+chosen.each do |m|
+  warn("    keeping #{m.user&.login} on #{m.project&.title.inspect} " \
+       "(changed #{m.updated_at})")
+end
+
+creators = untouched.count { |m| m.project&.user_id == m.user_id }
+warn("  of those to raise, #{creators} are the project's creator, " \
+     "#{untouched.size - creators} are other members")
+
+untouched.each_slice(100).with_index do |slice, batch|
+  slice.each do |member|
+    warn("  #{member.user&.login} on #{member.project&.title.to_s[0, 50]} " \
+         "hidden_gps -> editing")
+    # update_column, so `updated_at` keeps saying "this member has
+    # never chosen a trust level" -- which stays true, and is what any
+    # later analysis of deliberate choices needs to rely on.
+    member.update_column(:trust_level, ProjectMember.trust_levels[:editing]) if
+      APPLY
+  end
+  warn("  ...#{[(batch + 1) * 100, untouched.size].min}/#{untouched.size}")
+end
+
+warn("")
+if APPLY
+  warn("Raised #{untouched.size} membership(s) to editing.")
+else
+  warn("Dry run - nothing written. To apply: bin/rails runner " \
+       "script/upgrade_untouched_hidden_gps_trust.rb --apply")
+end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -337,6 +337,23 @@ class ProjectsControllerTest < FunctionalTestCase
     assert_equal([rolf], admin_group.users)
   end
 
+  # The creator is a project admin by definition, and every other way
+  # of becoming one grants "editing". Leaving the creator lower made
+  # them the one admin whose observations their co-admins could not
+  # edit -- in a project they set up so those people could work on it.
+  def test_create_project_trusts_the_creator_with_editing
+    title = "Trusting Project"
+
+    post_requires_login(:create, build_params(title, "summary"))
+
+    project = Project.find_by(title: title)
+    assert_not_nil(project, "Cannot find Project")
+    member = ProjectMember.find_by(project: project, user: rolf)
+    assert_not_nil(member, "Cannot find ProjectMember")
+    assert_equal("editing", member.trust_level)
+    assert_flash_success([:add_project_success, :add_members_with_editing])
+  end
+
   def test_create_project_with_any_dates
     title = "Project without start or end"
     start = Time.zone.today

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -970,6 +970,23 @@ class ProjectTest < UnitTestCase
     assert_not(Project.admin_power?(obs, nil))
   end
 
+  # Adding your observations to a project is largely the point of
+  # joining it, so the admins should be able to work on them -- the
+  # same trust the web join button and a field slip scan already
+  # grant. This path is API2's.
+  def test_join_trusts_the_project_with_editing
+    project = projects(:open_membership_project)
+    user = users(:mary)
+    assert(project.can_join?(user), "fixture must allow self-enrollment")
+
+    project.join(user)
+
+    member = ProjectMember.find_by(project: project, user: user)
+    assert_not_nil(member, "Cannot find ProjectMember")
+    assert_equal("editing", member.trust_level)
+    assert_includes(project.user_group.users, user)
+  end
+
   private
 
   # An observation owned by an eol member (mary), added to eol_project


### PR DESCRIPTION
This was found by Deana noticing that she was not able to edit my observations in the NEMF 2026 project which was surprising to me.

A project admin could not edit an observation belonging to the project's own creator. The creator's `ProjectMember` row was `hidden_gps`, and every other admin on that project was `editing`.

## This decision was already made

`00db7de2bc` ("Allow project admins to edit associated observations by default", 2025-07-11) set `editing` as the default in `update_project_membership`, with the `add_members_with_editing` flash. That covers the add-member flow and the web Join button, which posts to `members#create` and goes through the same code. `FieldSlipProjectJoinable` and `Project#add_administrator` grant `editing` too.

Two paths were missed and still hardcoded `hidden_gps`: **project creation** and **`Project#join`** (reachable only from API2's `update_project`). This PR brings them in line, and adds the same flash to creation so the grant is stated rather than silent.

The production data shows the gap clearly. Of the 107 non-creator `hidden_gps` memberships, 105 predate the July 2025 commit and only 2 came after -- while **14 project creators have landed on `hidden_gps` since**, because creation was never updated.

## Is anyone actually choosing hidden_gps?

Essentially nobody. Of 148 `hidden_gps` rows, **146 have never been modified since they were created** -- the member took whatever default they were handed and never visited the trust modal. (The Dec 2023 `AddTrustLevelToProjectMembers` migration bulk-updated rows, so that era is excluded from this comparison; 689 of the 691 `no_trust` rows carry its 2023-12-10 timestamp.)

The 2 exceptions are weak evidence at best:

- One is a **single-member private project**, where trust level has no effect at all -- there are no other admins to grant or withhold editing from -- and the change came 15 seconds after the project was created.
- The other is a project of mine.

For contrast, `editing` rows were modified after creation 18.5% of the time (23 of 124), so people do find and use the trust modal. They just about never use it to land on `hidden_gps`.

## Backfilling

`script/upgrade_untouched_hidden_gps_trust.rb` raises existing rows, dry-run by default per `.claude/rules/dry_run_scripts.md`:

```bash
bin/rails runner script/upgrade_untouched_hidden_gps_trust.rb          # dry run
bin/rails runner script/upgrade_untouched_hidden_gps_trust.rb --apply
```

It only touches rows whose `updated_at` still matches their `created_at`. A member who has been to the trust modal chose what they have, whatever they chose, and is left alone -- the script prints those by name so the skips are visible. It writes with `update_column`, so `updated_at` keeps saying "this member has never chosen a trust level", which stays true and is what any later analysis of deliberate choices depends on.

Against the production copy: 146 raised, 2 kept, and the observation that started this became editable by the project's other admins.

## Test plan

- [x] `bin/rails test test/models/project_test.rb test/controllers/projects_controller_test.rb test/controllers/projects/members_controller_test.rb` -- 154 tests, 0 failures, including two new ones pinning the creation and join defaults plus the creation flash
- [x] `bin/rails test test/classes/api2_test.rb` -- 34 tests, 0 failures (API2 is `Project#join`'s only caller)
- [ ] Manual: create a project, confirm the flash says admins can edit your observations and that your own membership reads "Allow Editing" in Trust Settings.
- [ ] On deploy: run the script dry, eyeball the skip list, then `--apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
