### PR TITLE
Broaden image transform permission

### DIFF
--- a/app/controllers/images/transformations_controller.rb
+++ b/app/controllers/images/transformations_controller.rb
@@ -9,7 +9,9 @@ module Images
       image = find_or_goto_index(Image, params[:id].to_s)
       return unless image
 
-      transform_image_and_flash_notices(image) if permission!(image)
+      if authorized_to_transform?(image)
+        transform_image_and_flash_notices(image)
+      end
 
       # A full-page redirect tears down and re-subscribes the
       # turbo_stream_from([@image, :processed]) Action Cable
@@ -26,6 +28,17 @@ module Images
     end
 
     private
+
+    # Broader than `permission!(image)`: also allows anyone who can
+    # edit an Observation this image belongs to (project admin of the
+    # observation's project, or the observation's collector), not just
+    # the image's own owner/project. See Image#can_transform?, #4989.
+    def authorized_to_transform?(image)
+      return true if image.can_transform?(@user, site_admin: in_admin_mode?)
+
+      flash_error(:permission_denied.l)
+      false
+    end
 
     def transform_image_and_flash_notices(image)
       case params[:op]

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1203,6 +1203,21 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     Project.can_edit?(self, user)
   end
 
+  # Rotate/mirror controls (#4989): permitted in Admin mode, or for
+  # anyone who could edit this image directly (owner, or admin of a
+  # project the image itself is attached to, if the image's owner
+  # trusts that project at "editing" level), or anyone who can edit
+  # an Observation this image belongs to (owner/collector, or admin
+  # of a project the *observation* belongs to, again gated on the
+  # observation owner's trust). Deliberately broader than `can_edit?`
+  # alone, which only looks at the image's own project attachments.
+  def can_transform?(user, site_admin: false)
+    return true if site_admin
+    return false unless user
+
+    can_edit?(user) || observations.any? { |obs| obs.can_edit?(user) }
+  end
+
   ##############################################################################
   #
   #  :section: Callbacks and Logging

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1203,20 +1203,22 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
     Project.can_edit?(self, user)
   end
 
-  # Rotate/mirror controls (#4989): permitted in Admin mode, or for
-  # anyone who could edit this image directly (owner, or admin of a
-  # project the image itself is attached to, if the image's owner
-  # trusts that project at "editing" level), or anyone who can edit
-  # an Observation this image belongs to (owner/collector, or admin
-  # of a project the *observation* belongs to, again gated on the
-  # observation owner's trust). Deliberately broader than `can_edit?`
-  # alone, which only looks at the image's own project attachments.
+  # #4989: broader than `can_edit?` -- also grants admins of any
+  # project an observation belongs to, regardless of owner trust.
   def can_transform?(user, site_admin: false)
     return true if site_admin
     return false unless user
 
-    can_edit?(user) || observations.any? { |obs| obs.can_edit?(user) }
+    can_edit?(user) ||
+      observations.any? { |obs| obs_transformable?(obs, user) }
   end
+
+  def obs_transformable?(obs, user)
+    obs.can_edit?(user) || obs.projects.any? do |project|
+      project.is_admin?(user)
+    end
+  end
+  private :obs_transformable?
 
   ##############################################################################
   #

--- a/app/views/controllers/images/show/image_panel.rb
+++ b/app/views/controllers/images/show/image_panel.rb
@@ -31,10 +31,14 @@ module Views::Controllers::Images
       # --- Heading: rotate / mirror / original / EXIF ---------------
 
       def render_controls
-        render_transform_controls if permission?(@image)
+        render_transform_controls if can_transform?
         ImageFragment(type: :original_link, image: @image)
         plain(" | ")
         ImageFragment(type: :exif_link, image_id: @image.id)
+      end
+
+      def can_transform?
+        @image.can_transform?(current_user, site_admin: in_admin_mode?)
       end
 
       def render_transform_controls

--- a/test/controllers/images/transformations_controller_test.rb
+++ b/test/controllers/images/transformations_controller_test.rb
@@ -59,6 +59,39 @@ module Images
       assert_select("#flash_notices", text: :image_show_transform_note.l)
     end
 
+    # #4989: an admin of a project the image's *observation* belongs
+    # to (not the image itself) may transform the image.
+    def test_transform_allowed_for_project_admin_of_observation
+      image = images(:commercial_inquiry_image)
+      obs = observations(:detailed_unknown_obs)
+      image.observations << obs
+      admin = dick
+      assert_true(obs.can_edit?(admin),
+                  "Fixture expectation: dick can edit detailed_unknown_obs " \
+                  "via bolete_project admin")
+
+      login(admin.login)
+      put(:update, params: { id: image.id, op: "rotate_left",
+                             size: admin.image_size })
+
+      assert_flash(:image_show_transform_note)
+      assert_redirected_to(image_path(image.id))
+    end
+
+    def test_transform_denied_for_unrelated_user
+      image = images(:commercial_inquiry_image)
+      outsider = katrina
+      assert_false(image.can_transform?(outsider),
+                   "Fixture expectation: katrina has no tie to this image")
+
+      login(outsider.login)
+      put(:update, params: { id: image.id, op: "rotate_left",
+                             size: outsider.image_size })
+
+      assert_flash(:permission_denied)
+      assert_redirected_to(image_path(image.id))
+    end
+
     # Real file + real job run, unlike run_transform above -- confirms
     # rotation actually swapped width/height, not just the flash text.
     def test_transform_rotate_swaps_dimensions

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -187,6 +187,53 @@ class ImagesControllerTest < FunctionalTestCase
     assert_select("form[action=?]", image_field_slip_extract_path(image.id))
   end
 
+  # #4989: rotate/mirror controls follow permission on the image itself
+  # OR on the Observation it belongs to -- not just the image's own
+  # (separate) project attachment.
+  def test_show_hides_transform_buttons_from_unrelated_user
+    image = images(:commercial_inquiry_image)
+    login("katrina")
+
+    get(:show, params: { id: image.id })
+
+    assert_select(
+      "form[action=?]",
+      transform_image_path(id: image.id, op: "rotate_left",
+                           size: katrina.image_size),
+      count: 0
+    )
+  end
+
+  def test_show_offers_transform_buttons_to_project_admin_of_observation
+    image = images(:commercial_inquiry_image)
+    obs = observations(:detailed_unknown_obs)
+    image.observations << obs
+    admin = dick
+    assert(obs.can_edit?(admin), "premise: dick can edit this observation")
+
+    login(admin.login)
+    get(:show, params: { id: image.id })
+
+    assert_select(
+      "form[action=?]",
+      transform_image_path(id: image.id, op: "rotate_left",
+                           size: admin.image_size)
+    )
+  end
+
+  def test_show_offers_transform_buttons_in_admin_mode
+    image = images(:commercial_inquiry_image)
+    admin = make_admin("katrina")
+
+    get(:show, params: { id: image.id })
+
+    assert_select(
+      "form[action=?]",
+      transform_image_path(id: image.id, op: "rotate_left",
+                           size: admin.image_size)
+    )
+  end
+
   def test_show_image_info_panel_heading
     image = images(:peltigera_image)
     login

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -150,6 +150,59 @@ class ImageTest < UnitTestCase
     assert_true(img.can_edit?(dick))
   end
 
+  def test_can_transform_site_admin_bypasses_everything
+    img = images(:commercial_inquiry_image)
+
+    assert_true(img.can_transform?(katrina, site_admin: true),
+                "Site admin mode should permit transforming any image")
+  end
+
+  def test_can_transform_own_image
+    img = images(:commercial_inquiry_image)
+    assert_equal(rolf, img.user, "Fixture expectation: rolf owns this image")
+
+    assert_true(img.can_transform?(rolf),
+                "Image owner should be able to transform their own image")
+  end
+
+  def test_can_transform_via_project_admin_of_image_itself
+    img = images(:in_situ_image)
+    assert_equal(mary, img.user, "Fixture expectation: mary owns this image")
+
+    # Dick is bolete_admins, and this image is directly attached to
+    # bolete_project (fixture-level, not via its observation).
+    assert_true(img.can_transform?(dick),
+                "Project admin of a project the image is directly " \
+                "attached to should be able to transform it")
+  end
+
+  def test_can_transform_via_project_admin_of_observation
+    img = images(:commercial_inquiry_image)
+    obs = observations(:detailed_unknown_obs)
+    assert_equal(mary, obs.user,
+                 "Fixture expectation: mary owns this observation")
+    img.observations << obs
+
+    # Dick is bolete_admins; bolete_project contains `obs` (not `img`
+    # directly), and `obs`'s owner (mary) trusts bolete_project with
+    # "editing" trust. Dick should therefore be able to transform an
+    # image attached only to that observation, per #4989.
+    assert_true(img.can_transform?(dick),
+                "Admin of a project the image's observation belongs to " \
+                "should be able to transform the image")
+  end
+
+  def test_can_transform_denies_unrelated_user
+    img = images(:commercial_inquiry_image)
+    obs = observations(:detailed_unknown_obs)
+    img.observations << obs
+
+    assert_false(img.can_transform?(katrina),
+                 "A user with no ownership/admin/collector tie to the " \
+                 "image or its observations should not be able to " \
+                 "transform it")
+  end
+
   def test_validation
     img = Image.new
     assert_false(img.valid?)

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -169,10 +169,8 @@ class ImageTest < UnitTestCase
     img = images(:in_situ_image)
     assert_equal(mary, img.user, "Fixture expectation: mary owns this image")
 
-    # Dick is bolete_admins, and this image is directly attached to
-    # bolete_project (fixture-level, not via its observation).
     assert_true(img.can_transform?(dick),
-                "Project admin of a project the image is directly " \
+                "Admin of a project the image is directly " \
                 "attached to should be able to transform it")
   end
 
@@ -183,13 +181,25 @@ class ImageTest < UnitTestCase
                  "Fixture expectation: mary owns this observation")
     img.observations << obs
 
-    # Dick is bolete_admins; bolete_project contains `obs` (not `img`
-    # directly), and `obs`'s owner (mary) trusts bolete_project with
-    # "editing" trust. Dick should therefore be able to transform an
-    # image attached only to that observation, per #4989.
     assert_true(img.can_transform?(dick),
                 "Admin of a project the image's observation belongs to " \
                 "should be able to transform the image")
+  end
+
+  def test_can_transform_via_project_admin_regardless_of_owner_trust
+    img = images(:commercial_inquiry_image)
+    obs = observations(:agaricus_campestris_obs)
+    assert_equal(rolf, obs.user,
+                 "Fixture expectation: rolf owns this observation")
+    project = projects(:one_genus_two_species_project)
+    assert_nil(ProjectMember.find_by(project:, user: rolf),
+               "Fixture expectation: rolf has no trust relationship with " \
+               "this project")
+    img.observations << obs
+
+    assert_true(img.can_transform?(dick),
+                "Project admin should be able to transform images of " \
+                "the project's observations regardless of owner trust")
   end
 
   def test_can_transform_denies_unrelated_user
@@ -198,9 +208,8 @@ class ImageTest < UnitTestCase
     img.observations << obs
 
     assert_false(img.can_transform?(katrina),
-                 "A user with no ownership/admin/collector tie to the " \
-                 "image or its observations should not be able to " \
-                 "transform it")
+                 "User without ownership/admin/collector tie to the " \
+                 "Image or its Obss should be unable to transform it")
   end
 
   def test_validation


### PR DESCRIPTION
Allow Project and Site Admins to rotate/mirror all Images in Observations in the Project.
Facilitates human review of Field Slip data.

## Manual Test Plan — Image transform links for admins (#4989)

### Setup

1. Have (or create) three accounts: `owner`, `admin`, `outsider`.
2. As `owner`, create an Observation with at least one image attached.
3. As `owner` (or a Site Admin), create a Project, and add `admin` to it as a **Project Admin**.
4. As `owner`, join that Project as a member and set your trust level to **"Editing"** (Project → Members → your row → Trust).
5. Do **not** add the image itself to the Project's image list — only attach the *Observation* to the Project. This isolates the new "permission via the Observation" path from the pre-existing "permission via the image's own project" path.

- [x] **1. Owner still sees and can use the controls (regression check)** 

- Log in as `owner`, open the image's show page.
- **Expect:** `Rotate Left | Rotate Right | Mirror | Show Original Image | Show EXIF Header` all visible.
- Click **Rotate Left**.
- **Expect:** success flash notice, and the image visibly rotates.

- [x] **2. Unrelated user does not see the controls**

- Log in as `outsider` (no relation to the image, its Observation, or the Project).
- Open the same image's show page.
- **Expect:** only `Show Original Image | Show EXIF Header` — no Rotate/Mirror links.

- [x] **3. Project admin of the *Observation's* project sees and can use the controls (the core #4989 fix)**

- Log in as `admin`.
- Open the image's show page (same image as above — still not directly attached to the Project).
- **Expect:** `Rotate Left | Rotate Right | Mirror` are visible even though `admin` doesn't own the image and the image isn't itself in the Project.
- Click **Mirror**.
- **Expect:** success flash notice, and the image visibly mirrors.

- [x] **4. Site Admin mode bypasses everything**

- Log in as any user with Site Admin rights, but who has no relation to the image/Observation/Project.
- Enable **Admin Mode** (top nav toggle).
- Open the image's show page.
- **Expect:** Rotate/Mirror links visible and usable regardless of ownership/project ties.
- Turn Admin Mode back off, reload the page.
- **Expect:** Rotate/Mirror links disappear again (assuming this user has no other tie to the image).

- [x] **5. Original Image / EXIF links are unaffected**

- Repeat step 2 (as `outsider`) and confirm `Show Original Image` and `Show EXIF Header` still work and display correctly — these were never permission-gated and shouldn't change.