### PR TITLE
Make the observation form's Geolocation section usable as loaded

### DIFF
--- a/app/components/form/checkbox_collapse.rb
+++ b/app/components/form/checkbox_collapse.rb
@@ -47,7 +47,15 @@ class Components::Form::CheckboxCollapse < Components::Base
       merge(@attributes[:label_aria] || {})
   end
 
+  # The box and the section it controls are one state, so `expanded:`
+  # decides both. Leaving the checkbox to derive its own state from the
+  # field breaks whenever the field is not a real attribute: the
+  # observation form's `has_geolocation` is only a scope, so the box
+  # rendered unchecked over an open section full of coordinates, and
+  # clicking it to "fix" that collapsed the section instead. A caller
+  # that genuinely needs them to differ can still pass `checked:`.
   def passthrough_attrs
-    @attributes.except(:label_data, :label_aria)
+    { checked: @expanded }.merge(@attributes.except(:label_data,
+                                                    :label_aria))
   end
 end

--- a/app/components/form/location_map.rb
+++ b/app/components/form/location_map.rb
@@ -13,6 +13,10 @@ class Components::Form::LocationMap < Components::Base
   prop :id, String, default: ""
   prop :map_type, String, default: "location"
   prop :user, _Nilable(User), default: nil
+  # Coordinates already saved on the record, as opposed to
+  # prefilled defaults on a new form. Only the former should be
+  # announced to the locality autocompleter on connect.
+  prop :announce_point, _Boolean, default: false
 
   def view_template
     render_map_div
@@ -35,7 +39,8 @@ class Components::Form::LocationMap < Components::Base
       location_format: location_format,
       map_target: "mapDiv",
       editable: "true",
-      map_type: @map_type
+      map_type: @map_type,
+      announce_point: @announce_point.to_s
     }
   end
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -155,6 +155,32 @@ export default class extends GeocodeController {
       .catch((e) => {
         this.showGoogleMapsError("Google Maps failed to load", e)
       })
+
+    this.announceExistingPoint()
+  }
+
+  // An observation being edited already has its coordinates in the
+  // inputs, but nothing had told the locality autocompleter about them:
+  // the swap to "locations containing this point" only ever fired from
+  // bufferInputs (the lat/lng input action) or a map click. So a form
+  // loaded with saved coordinates offered no locality dropdown until the
+  // values were cleared, saved, and typed in again. Announce the point
+  // we already have, once, on connect.
+  //
+  // Only when the coordinates are saved on the record (announcePoint).
+  // A new observation's form prefills lat/lng from the user's last one,
+  // and those are a default the user has not chosen for this record --
+  // announcing them would pre-empt the EXIF of the photo they are about
+  // to attach.
+  announceExistingPoint() {
+    if (this.mapDivTarget.dataset.announcePoint !== "true") return
+    if (!["observation", "hybrid"].includes(this.map_type)) return
+    if (!this.hasLatInputTarget || !this.hasLngInputTarget) return
+
+    const center = this.validateLatLngInputs(false)
+    if (!center) return
+
+    this.sendPointChanged(center)
   }
 
   // Lock rectangle so it's not editable, and show this state in the icon link

--- a/app/views/controllers/observations/form/details.rb
+++ b/app/views/controllers/observations/form/details.rb
@@ -227,7 +227,8 @@ class Views::Controllers::Observations::Form::Details < Views::Base
 
   def render_map
     render(Components::Form::LocationMap.new(
-             id: "observation_form_map", map_type: "observation"
+             id: "observation_form_map", map_type: "observation",
+             announce_point: update? && @observation.lat.present?
            ))
   end
 

--- a/test/components/form/checkbox_collapse_test.rb
+++ b/test/components/form/checkbox_collapse_test.rb
@@ -82,9 +82,32 @@ class FormCheckboxCollapseTest < ComponentTestCase
     assert_html(html, "label", text: :approved.ti)
   end
 
+  # The box and the section are one state. Deriving the box from the
+  # field breaks when the field is not a real attribute -- the
+  # observation form's `has_geolocation` is only a scope, so the box
+  # rendered unchecked over an open section (#5002).
+  def test_checkbox_is_checked_when_expanded
+    html = render_collapse(expanded: true)
+
+    assert_html(html, "input[type='checkbox'][checked]")
+  end
+
+  def test_checkbox_is_unchecked_when_collapsed
+    html = render_collapse(expanded: false)
+
+    assert_no_html(html, "input[type='checkbox'][checked]")
+  end
+
+  def test_checked_can_be_overridden_by_the_caller
+    html = render_collapse(expanded: true, attributes: { checked: false })
+
+    assert_no_html(html, "input[type='checkbox'][checked]")
+  end
+
   private
 
-  def render_collapse(expanded: false, attributes: {}, label: "Specimen")
+  def render_collapse(expanded: false, attributes: {},
+                      label: "Specimen")
     form = TestForm.new(@obs, action: "/observations")
     the_form = form
     form.render_block = proc do

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -46,6 +46,32 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     )
   end
 
+  # The Geolocation section opens when the observation has coordinates,
+  # so its checkbox has to agree -- it rendered unchecked over an open
+  # section full of coordinates, and clicking it to "fix" that collapsed
+  # the section instead (#5002).
+  def test_edit_checks_geolocation_when_the_observation_has_coordinates
+    obs = observations(:unknown_with_lat_lng)
+    assert(obs.lat.present?, "fixture needs coordinates")
+    login(obs.user.login)
+
+    get(:edit, params: { id: obs.id })
+
+    assert_select("input[type=checkbox][name='observation[has_geolocation]']" \
+                  "[checked]")
+  end
+
+  def test_edit_leaves_geolocation_unchecked_without_coordinates
+    obs = observations(:minimal_unknown_obs)
+    obs.update_columns(lat: nil, lng: nil)
+    login(obs.user.login)
+
+    get(:edit, params: { id: obs.id })
+
+    assert_select("input[type=checkbox][name='observation[has_geolocation]']" \
+                  "[checked]", count: 0)
+  end
+
   # Editing the primary of a multi-member occurrence, a sibling key it
   # doesn't store is an :inherit row -- a disabled textarea plus buttons
   # with Inherit active and the sibling value as an adopt button.

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1157,6 +1157,25 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
   end
   private :assert_date_is_now
 
+  # Editing an observation that already has coordinates: the Geolocation
+  # box must be checked, and the locality autocompleter must already be
+  # offering the localities containing that point. Neither happened --
+  # the box was bound to a non-attribute, and the swap to
+  # "location_containing" only ever fired from typing in the lat/lng
+  # inputs, so the form had to be cleared, saved and re-typed (#5002).
+  def test_edit_form_with_coordinates_is_ready_to_use
+    obs = observations(:unknown_with_lat_lng)
+    assert(obs.lat.present?, "fixture needs coordinates")
+    login!(obs.user)
+
+    visit("/observations/#{obs.id}/edit")
+    assert_selector("#observation_form")
+
+    assert_checked_field("observation_has_geolocation", visible: :all)
+    assert_selector("#observation_location_autocompleter" \
+                    "[data-type='location_containing']", wait: 6)
+  end
+
   def assert_geolocation_is_empty
     assert_field("observation_lat", with: "", visible: :all)
     assert_field("observation_lng", with: "", visible: :all)


### PR DESCRIPTION
Fixes #5002. Editing an observation that already has coordinates showed the Geolocation section **open and populated but with its checkbox unchecked**, and the Locality field offered **no dropdown of localities containing the point** until the coordinates were cleared, saved, and typed in again.

Two independent causes.

## 1. The checkbox was bound to something that is not an attribute

`render_geolocation_toggle` renders `checkbox_field(:has_geolocation, ...)`, but `has_geolocation` exists only as a **scope**:

```ruby
Observation.find(657740).respond_to?(:has_geolocation)  # => false
```

So its checked state resolved to nil and it rendered unchecked **always**, while the section's open/closed state came from a separate source (`expanded: @observation.lat.present?`). Two mechanisms disagreeing exactly when an observation has coordinates.

That combination is actively hostile: the label carries `data-toggle="collapse"`, so a user who sees an unchecked box and clicks it *collapses* the open section and hides the populated fields.

**Fix:** the box and the section it toggles are one state, so `Components::Form::CheckboxCollapse` now derives `checked` from `expanded`. A caller that genuinely needs them to differ can still pass `checked:`. This is a no-op for the other caller (the specimen section, where the field is real and the two already agreed), and it prevents the same bug in any future one.

`has_geolocation` is not in `permitted_observation_args`, so nothing server-side reads the submitted value — it is purely a UI toggle.

## 2. The point already in the inputs was never announced

The swap to the `location_containing` autocompleter happens in `GeocodeController#sendPointChanged`, whose only callers are `MapController#bufferInputs` (the action bound to the lat/lng inputs) and map interactions. Nothing called it from `connect()`, so a form loaded with saved coordinates had everything it needed and simply never asked.

**Fix:** `MapController#announceExistingPoint()` sends the point once on connect. It runs synchronously in `connect()`, independent of whether the Google Maps loader resolves.

**Gated deliberately.** A *new* observation's form prefills lat/lng from the user's last observation, and those are a default the user has not chosen for this record — announcing them would pre-empt the EXIF of the photo they are about to attach. So `Components::Form::LocationMap` gains an `announce_point` flag, set by the details view only when `update? && @observation.lat.present?`. I found this the hard way: without the gate, the EXIF-driven system tests changed behaviour.

## Tests

- `test/components/form/checkbox_collapse_test.rb` — checked follows expanded, both directions, plus the caller override.
- `test/controllers/observations_controller_update_test.rb` — the edit form renders the box checked when the observation has coordinates, unchecked when it does not.
- `test/system/observation_form_system_test.rb` — loads the edit form for an observation with coordinates and asserts, with no interaction at all, that the box is checked and the autocompleter has already swapped to `data-type="location_containing"`.

Each was confirmed to **fail without the corresponding fix**:

```
without the component fix: FAIL test_edit_checks_geolocation_when_the_observation_has_coordinates
without the JS fix:        FAIL expected to find css
                           "#observation_location_autocompleter[data-type='location_containing']"
```

## Test plan

- [x] `bin/rails test test/components/form/ test/controllers/observations_controller_update_test.rb test/views/controllers/observations/` — 400 tests, 0 failures
- [x] `bin/rails test test/system/observation_form_system_test.rb` — 14 tests, 2 failures, and **the same 2 fail on unmodified main** (`test_post_edit_and_destroy_with_details_and_location`, `test_typing_location_overrides_exif_location`). This file is somewhat flaky — an intermediate run showed different failures — so worth watching CI rather than trusting one local run.
- [ ] Manual: edit an observation that has coordinates. The Geolocation box should be checked with the section open, and the Locality field should offer the containing localities without touching anything.
- [ ] Manual: start a new observation. Lat/lng prefilled from your last observation should **not** trigger a locality dropdown, and attaching a geotagged photo should still drive the location from its EXIF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
