### PR TITLE
Ignore a question mark when looking up a name

### DIFF
--- a/app/models/naming/name_resolver.rb
+++ b/app/models/naming/name_resolver.rb
@@ -70,8 +70,7 @@ class Naming
         # Look up name: can return zero (unrecognized), one
         # (unambiguous match), or many (multiple authors match).
         @names = Name.find_names_filling_in_authors(user, corrected)
-        corrected, @names = retry_in_canonical_case(user, corrected) if
-          @names.empty?
+        corrected, @names = retry_relaxed(user, corrected) if @names.empty?
         # end
       else
         @names = [Name.find(chosen_name)]
@@ -139,18 +138,24 @@ class Naming
     end
     # rubocop:enable Metrics/MethodLength
 
-    # A name written in one case throughout -- "russula compacta" or
-    # "RUSSULA COMPACTA", as field slips are often filled in -- fails
-    # to parse and so never reaches a lookup, even though the row is
-    # sitting there under a case-insensitive collation. Only after the
-    # ordinary lookup has come up empty, so a name that resolves today
-    # cannot start resolving differently, and the extra queries fall
-    # on the path that was about to fail anyway.
-    def retry_in_canonical_case(user, corrected)
-      recased = Name.canonical_name_string(corrected)
-      return [corrected, @names] if recased == corrected
+    # Field slips are written by hand, and two habits keep an otherwise
+    # findable name from ever reaching a lookup: one case throughout
+    # ("russula compacta", "RUSSULA COMPACTA"), and a question mark
+    # marking the recorder's doubt ("russula?"). Both fail to parse.
+    # Only after the ordinary lookup has come up empty, so a name that
+    # resolves today cannot start resolving differently, and the extra
+    # queries fall on the path that was about to fail anyway.
+    def retry_relaxed(user, corrected)
+      relaxed = Name.canonical_name_string(strip_uncertainty(corrected))
+      return [corrected, @names] if relaxed == corrected
 
-      [recased, Name.find_names_filling_in_authors(user, recased)]
+      [relaxed, Name.find_names_filling_in_authors(user, relaxed)]
+    end
+
+    # No name in MO contains a question mark, so dropping it can never
+    # steal a match from a real name.
+    def strip_uncertainty(str)
+      str.tr("?", " ").strip_squeeze
     end
 
     # Convenience method returning a hash for mass ivar assignment

--- a/test/models/naming/name_resolver_test.rb
+++ b/test/models/naming/name_resolver_test.rb
@@ -67,6 +67,38 @@ class Naming::NameResolverTest < UnitTestCase
     assert_nil(resolver.name)
   end
 
+  # A slip reading "coprinus comatus?" records the writer's doubt about
+  # the name, not a different name. No name in MO holds a question
+  # mark, so the mark only ever blocks a match.
+  def test_resolves_a_name_written_with_a_question_mark
+    resolver = resolve("#{@name.text_name}?")
+
+    assert(resolver.success)
+    assert_equal(@name, resolver.name)
+  end
+
+  def test_resolves_a_name_written_with_a_detached_question_mark
+    resolver = resolve("#{@name.text_name} ?")
+
+    assert(resolver.success)
+    assert_equal(@name, resolver.name)
+  end
+
+  # Both hand-writing habits at once -- the common field-slip case.
+  def test_resolves_a_lower_case_name_written_with_a_question_mark
+    resolver = resolve("#{@name.text_name.downcase}?")
+
+    assert(resolver.success)
+    assert_equal(@name, resolver.name)
+  end
+
+  def test_leaves_an_unknown_name_with_a_question_mark_unresolved
+    resolver = resolve("xyzzy plughia?")
+
+    assert_not(resolver.success)
+    assert_nil(resolver.name)
+  end
+
   # Only reached once the ordinary lookup comes up empty, so a name
   # that already resolves cannot start resolving to something else.
   def test_canonical_case_lookup_is_skipped_when_the_name_resolves

--- a/test/models/naming/name_resolver_test.rb
+++ b/test/models/naming/name_resolver_test.rb
@@ -99,6 +99,34 @@ class Naming::NameResolverTest < UnitTestCase
     assert_nil(resolver.name)
   end
 
+  # Dropping the mark has to land on the *deprecated* branch -- offering
+  # the accepted synonym -- rather than resolving the deprecated name
+  # silently or falling through as an unknown name.
+  def test_deprecated_name_with_a_question_mark_still_offers_its_synonyms
+    deprecated = names(:petigera)
+    assert(deprecated.deprecated, "fixture must be deprecated")
+    approved = deprecated.approved_synonyms.map(&:text_name)
+    assert(approved.any?, "fixture must have an approved synonym")
+
+    resolver = resolve("#{deprecated.text_name.downcase}?")
+
+    assert_not(resolver.success)
+    assert_nil(resolver.name)
+    assert_equal(approved, resolver.valid_names.map(&:text_name))
+  end
+
+  # The mark changes nothing about the outcome, which is the whole claim.
+  def test_a_question_mark_does_not_change_a_deprecated_name_outcome
+    deprecated = names(:petigera)
+
+    plain = resolve(deprecated.text_name)
+    marked = resolve("#{deprecated.text_name}?")
+
+    assert_equal(plain.success, marked.success)
+    assert_equal(plain.valid_names.map(&:text_name),
+                 marked.valid_names.map(&:text_name))
+  end
+
   # Only reached once the ordinary lookup comes up empty, so a name
   # that already resolves cannot start resolving to something else.
   def test_canonical_case_lookup_is_skipped_when_the_name_resolves


### PR DESCRIPTION
Field slips frequently record the writer's doubt as `russula?`. That string fails to parse, so it never reaches a lookup at all — even though `Russula` is sitting right there in the table. Zero names in MO contain a question mark, so dropping it before the retry can never steal a match from a real name.

This folds the strip into the post-failure retry added in #4999 for hand-written capitalization, rather than adding a second retry. Both are the same kind of problem — a hand-writing habit that keeps an otherwise findable name from ever being looked up — and combining them means `russula?` gets the question mark dropped *and* gets recased to `Russula` in one pass, which the two habits appearing together on a real slip requires.

The retry still only runs after the ordinary lookup has come up empty, so a name that resolves today cannot start resolving differently, and the extra queries fall on the path that was about to fail anyway.

```ruby
def retry_relaxed(user, corrected)
  relaxed = Name.canonical_name_string(strip_uncertainty(corrected))
  return [corrected, @names] if relaxed == corrected

  [relaxed, Name.find_names_filling_in_authors(user, relaxed)]
end

def strip_uncertainty(str)
  str.tr("?", " ").strip_squeeze
end
```

Verified against the production data set: no `Name` row has a question mark in `text_name`.

## Test plan

Nothing to set up. On an observation, use "Propose a Name" and type a name with a trailing question mark:

- `russula?` → resolves to `Russula`
- `Russula ?` (detached) → resolves to `Russula`
- `russula compacta?` → resolves to `Russula compacta`
- `xyzzy plughia?` → still unresolved, and still offers spelling suggestions

A deprecated name with a question mark (`amanita muscaria var. flavivolvata?`) should behave the same as without one — it asks you to choose the accepted synonym rather than resolving silently.
