### PR TITLE
Make the Geolocation checkbox on the observation form mean something

### DIFF
--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -5,6 +5,7 @@
 #    permitted_observation_args
 #    update_permitted_observation_attributes
 #    permitted_observation_params
+#    drop_unwanted_geolocation
 #    notes_to_sym_and_compact
 #    notes_param_present?
 #
@@ -51,7 +52,21 @@ module ObservationsController::SharedFormMethods
   def permitted_observation_params
     return unless params[:observation]
 
-    params[:observation].permit(permitted_observation_args).to_h
+    drop_unwanted_geolocation(
+      params[:observation].permit(permitted_observation_args).to_h
+    )
+  end
+
+  # The Geolocation checkbox is the observation's own statement about
+  # whether it has coordinates, but the map sits outside the section the
+  # checkbox collapses, so the inputs can still hold a point the user has
+  # said the observation does not have. Absent key means a caller that
+  # has no such checkbox (the API), which is left alone.
+  def drop_unwanted_geolocation(args)
+    return args unless params[:observation].key?(:has_geolocation)
+    return args if params[:observation][:has_geolocation].to_s == "1"
+
+    args.merge("lat" => nil, "lng" => nil, "alt" => nil)
   end
 
   # Symbolize keys and drop blank values -- except a blank on a key some

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -13,7 +13,7 @@ export default class extends GeocodeController {
     "eastInput", "highInput", "lowInput", "placeInput", "locationId",
     "getElevation", "mapClearBtn", "controlWrap", "toggleMapBtn",
     "latInput", "lngInput", "altInput", "showBoxBtn", "lockBoxBtn",
-    "editBoxBtn", "autocompleter"]
+    "editBoxBtn", "autocompleter", "geolocationCheck", "geolocationFields"]
 
   connect() {
     this.element.dataset.map = "connected"
@@ -181,6 +181,41 @@ export default class extends GeocodeController {
     if (!center) return
 
     this.sendPointChanged(center)
+  }
+
+  // The Geolocation checkbox is the observation's statement about whether
+  // it has coordinates at all, so unchecking it has to release the
+  // locality autocompleter from "localities containing this point" --
+  // otherwise the only localities on offer are the ones containing the
+  // point the user unchecked the box to get rid of.
+  geolocationToggled({ target }) {
+    if (!["observation", "hybrid"].includes(this.map_type)) return
+
+    if (!target.checked) {
+      this.sendPointChanged({ lat: null, lng: null })
+      return
+    }
+
+    const center = this.validateLatLngInputs(false)
+    if (center) this.sendPointChanged(center)
+  }
+
+  // Clicking the map or dragging the marker is the user asserting the
+  // observation has coordinates, so the checkbox has to agree: the
+  // server drops lat/lng when it is unchecked, and the map sits outside
+  // the section the box collapses, so a point set here would otherwise
+  // be discarded on save without ever having been visible.
+  //
+  // Deliberately hung off those two gestures rather than the inputs
+  // themselves -- writing lat/lng also happens programmatically, while
+  // EXIF is mid-way through opening the section itself.
+  assertGeolocation() {
+    if (!this.hasGeolocationCheckTarget) return
+    if (this.geolocationCheckTarget.checked) return
+
+    this.geolocationCheckTarget.checked = true
+    if (this.hasGeolocationFieldsTarget)
+      $(this.geolocationFieldsTarget).collapse('show')
   }
 
   // Lock rectangle so it's not editable, and show this state in the icon link
@@ -874,6 +909,7 @@ export default class extends GeocodeController {
           this.updateLatLngInputs(newPosition) // dispatches pointChanged
           // Moving the marker means we're no longer on the image lat/lng
           this.dispatch("reenableBtns")
+          if (eventName === "dragend") this.assertGeolocation()
         }
         // this.sampleElevationCenterOf(newPosition)
         this.getElevations([newPosition], "point")
@@ -1408,6 +1444,7 @@ export default class extends GeocodeController {
       this.map.panTo(location)
       // if (zoom < 15) { this.map.setZoom(zoom + 2) } // for incremental zoom
       this.updateFields(null, null, location)
+      this.assertGeolocation()
     });
   }
 

--- a/app/views/controllers/observations/form/details.rb
+++ b/app/views/controllers/observations/form/details.rb
@@ -160,7 +160,11 @@ class Views::Controllers::Observations::Form::Details < Views::Base
              attributes: {
                help: :form_observations_lat_long_help.t,
                help_collapse: true,
-               data: { form_exif_target: "collapseCheck" }
+               data: {
+                 form_exif_target: "collapseCheck",
+                 map_target: "geolocationCheck",
+                 action: "map#geolocationToggled"
+               }
              }
            ))
   end
@@ -169,7 +173,8 @@ class Views::Controllers::Observations::Form::Details < Views::Base
     Collapsible(
       id: "observation_geolocation",
       expanded: @observation.lat.present?,
-      data: { form_exif_target: "collapseFields" }
+      data: { form_exif_target: "collapseFields",
+              map_target: "geolocationFields" }
     ) do
       p { :form_observations_click_point.l }
       render_lat_lng_alt_row

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -72,6 +72,63 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
                   "[checked]", count: 0)
   end
 
+  # Unchecking the box has to release the locality autocompleter from
+  # "localities containing this point", so the box carries a map action
+  # as well as the EXIF one.
+  def test_edit_wires_the_geolocation_checkbox_to_the_map
+    obs = observations(:unknown_with_lat_lng)
+    login(obs.user.login)
+
+    get(:edit, params: { id: obs.id })
+
+    assert_select("input[name='observation[has_geolocation]']" \
+                  "[data-map-target='geolocationCheck']" \
+                  "[data-action~='map#geolocationToggled']")
+    assert_select("#observation_geolocation" \
+                  "[data-map-target='geolocationFields']")
+  end
+
+  # Unchecking Geolocation is the user saying the observation has no
+  # coordinates. The map sits outside the section the box collapses, so
+  # the inputs can still hold the very point being discarded.
+  def test_update_drops_coordinates_when_geolocation_is_unchecked
+    obs = observations(:unknown_with_lat_lng)
+    assert(obs.lat.present?, "fixture needs coordinates")
+    login(obs.user.login)
+
+    put(:update, params: geolocation_params(obs, has_geolocation: "0"))
+
+    obs.reload
+    assert_nil(obs.lat)
+    assert_nil(obs.lng)
+    assert_nil(obs.alt)
+  end
+
+  def test_update_keeps_coordinates_when_geolocation_is_checked
+    obs = observations(:unknown_with_lat_lng)
+    login(obs.user.login)
+
+    put(:update, params: geolocation_params(obs, has_geolocation: "1"))
+
+    obs.reload
+    assert_in_delta(34.1622, obs.lat.to_f)
+    assert_in_delta(-118.3521, obs.lng.to_f)
+    assert_equal(123, obs.alt, "the update itself should have gone through")
+  end
+
+  # A caller with no such checkbox -- the API -- must be left alone.
+  def test_update_keeps_coordinates_when_geolocation_is_not_submitted
+    obs = observations(:unknown_with_lat_lng)
+    login(obs.user.login)
+
+    put(:update, params: geolocation_params(obs))
+
+    obs.reload
+    assert_in_delta(34.1622, obs.lat.to_f)
+    assert_in_delta(-118.3521, obs.lng.to_f)
+    assert_equal(123, obs.alt)
+  end
+
   # Editing the primary of a multi-member occurrence, a sibling key it
   # doesn't store is an :inherit row -- a disabled textarea plus buttons
   # with Inherit active and the sibling value as an adopt button.
@@ -1069,5 +1126,16 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
       thumb_image_id: obs.thumb_image_id.to_s,
       good_image_ids: obs.image_ids.join(" ")
     }
+  end
+
+  # Resubmits the observation's own coordinates, so a kept lat/lng is
+  # unchanged rather than merely plausible. The altitude is new, which
+  # is what proves the update went through at all.
+  def geolocation_params(obs, has_geolocation: nil)
+    args = obs_params(obs).merge(
+      lat: obs.lat.to_s, lng: obs.lng.to_s, alt: "123"
+    )
+    args[:has_geolocation] = has_geolocation unless has_geolocation.nil?
+    { id: obs.id, observation: args }
   end
 end

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1176,6 +1176,31 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
                     "[data-type='location_containing']", wait: 6)
   end
 
+  # Unchecking Geolocation has to release the locality autocompleter from
+  # "localities containing this point". Otherwise correcting a bad point
+  # offers only the localities containing the very point being replaced,
+  # and the coordinates have to be cleared by hand first.
+  def test_unchecking_geolocation_releases_the_locality_autocompleter
+    obs = observations(:unknown_with_lat_lng)
+    assert(obs.lat.present?, "fixture needs coordinates")
+    login!(obs.user)
+
+    visit("/observations/#{obs.id}/edit")
+    assert_selector("#observation_form")
+    assert_selector("#observation_location_autocompleter" \
+                    "[data-type='location_containing']", wait: 6)
+
+    uncheck("observation_has_geolocation", allow_label_click: true)
+
+    assert_selector("#observation_location_autocompleter" \
+                    "[data-type='location']", wait: 6)
+
+    check("observation_has_geolocation", allow_label_click: true)
+
+    assert_selector("#observation_location_autocompleter" \
+                    "[data-type='location_containing']", wait: 6)
+  end
+
   def assert_geolocation_is_empty
     assert_field("observation_lat", with: "", visible: :all)
     assert_field("observation_lng", with: "", visible: :all)


### PR DESCRIPTION
Follow-on to #5002 / #5013. The Geolocation checkbox turned out to be entirely cosmetic — nothing in JS listened to it and no controller read `observation[has_geolocation]`, so it only ever drove the Bootstrap collapse.

That matters because `sendPointChanged` swaps the locality autocompleter to `location_containing` whenever lat and lng are set, restricting the dropdown to localities containing that point (the label changes to "Locality contains:"). With a bad point in the inputs — the ~230 NEMF observations stuck on the foray ID-table coordinates, for instance — the only localities on offer are the ones containing the point you are trying to get rid of. Unchecking the box did nothing about that, so correcting one meant unchecking the box *and* clearing lat/lng by hand.

Three changes make the checkbox mean what it says:

**Unchecking releases the autocompleter.** The box gains a `map#geolocationToggled` action which sends `{lat: null, lng: null}`, swapping back to unconstrained locality search. Re-checking re-sends the point.

**Unchecking drops the coordinates on save.** `permitted_observation_params` clears `lat`/`lng`/`alt` when the box is unchecked. An absent param means a caller that has no such checkbox — the API — and is left alone.

**Setting a point checks the box.** The map lives in the right-hand column, *outside* the section the checkbox collapses, so a point clicked there could otherwise be saved as nothing. Clicking the map or dragging the marker now checks the box and opens the section. This also fixes a pre-existing inconsistency in the other direction: today you can click a point with the box unchecked and the coordinates save anyway, contradicting what the box says.

The hook is deliberately on those two gestures rather than on `updateLatLngInputs`, which looks like the tidier single funnel but is not: it also runs on programmatic marker placement, including while `form-exif` is part-way through opening the section itself. Hooking it there made `test_manual_lat_lng_overrides_exif_location` fail roughly one run in three (verified: 4/4 clean on main, 1/3 failing with the hook in place, 4/4 clean once moved).

## Test plan

Setup: any observation with coordinates. A NEMF one stuck on the ID-table point (39.8416, -77.5443) is the motivating case.

1. **Edit an observation with coordinates.** The Geolocation box is checked and the section open. The locality field reads "Locality contains:".
2. **Uncheck the box.** The label should revert to "Where:" within a second or so, and typing should now offer localities anywhere — no need to clear lat/lng first.
3. **Pick a new locality and save.** The observation should keep the new locality and have *no* coordinates.
4. **Re-check the box before saving instead.** The coordinates should survive and the autocompleter should go back to "Locality contains:".
5. **New observation, box unchecked, open the map and click a point.** The box should tick itself and the section should open showing the coordinates. Save — the coordinates should persist.
6. **Drag the marker** with the box unchecked. Same result.
7. **Attach a geotagged photo.** Unchanged from today: coordinates fill in and the section opens.

The three failures in `observation_form_system_test.rb` (`post_edit_and_destroy_with_details_and_location`, `typing_location_overrides_exif_location`, `clearing_exif_lat_lng_allows_location_typing`) reproduce identically on `main` on a full-file run and are unrelated flakes.
