### PR TITLE
Read a handwritten MycoMap voucher number

### DIFF
--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -28,6 +28,11 @@ class FieldSlip
     #      invented from the prompt's own alias tables); a null that
     #      was written but could not be read is listed in `unreadable`,
     #      separating it from a box the collector left empty
+    #   4  the voucher number is identified by where it sits -- the
+    #      upper-right region, around the logo rather than beside it --
+    #      instead of by being printed, so a handwritten one is read
+    #      too (extracts at v3 or earlier hold no voucher number for
+    #      any slip filled in after the printed stickers ran out)
     PROMPT_VERSION = "4"
 
     # The slip's fields, in the order they appear on the printed form,

--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -28,7 +28,7 @@ class FieldSlip
     #      invented from the prompt's own alias tables); a null that
     #      was written but could not be read is listed in `unreadable`,
     #      separating it from a box the collector left empty
-    PROMPT_VERSION = "3"
+    PROMPT_VERSION = "4"
 
     # The slip's fields, in the order they appear on the printed form,
     # mapped to where each one lands on the Observation. `nil` means the

--- a/app/classes/field_slip/extractor/prompt.rb
+++ b/app/classes/field_slip/extractor/prompt.rb
@@ -73,16 +73,19 @@ class FieldSlip
             verbatim.
           - Substrate and Habit are often circled from a printed list
             rather than written. Report the circled word(s).
-          - "MycoMap Voucher Number" is whatever occupies the slip's
-            top-right corner, printed or handwritten. It is usually a
-            printed sticker like N26-0290, but when the stickers ran
-            out it was written in by hand, often as a bare number with
-            the prefix left off. Give it exactly as written -- do not
-            add a prefix a bare number does not carry. It is not the
-            field slip code. Identify it by that corner, not by
-            whether it is printed: anything written in another box
-            belongs to that box's field, and "Other Codes" is only
-            what a person wrote in the Other Codes box.
+          - "MycoMap Voucher Number" sits in the slip's upper-right
+            region, printed or handwritten. It is usually a printed
+            sticker like N26-0290; when the stickers ran out it was
+            written in by hand, often as a bare number with the prefix
+            left off. A logo usually occupies that corner, and a
+            handwritten number may be above it or to its left rather
+            than beside it, so read the whole upper-right area. Give
+            it exactly as written -- do not add a prefix a bare number
+            does not carry. It is not the field slip code. Identify it
+            by that region, not by whether it is printed: anything
+            written in another box belongs to that box's field, and
+            "Other Codes" is only what a person wrote in the Other
+            Codes box.
         RULES
       end
 

--- a/app/classes/field_slip/extractor/prompt.rb
+++ b/app/classes/field_slip/extractor/prompt.rb
@@ -60,6 +60,12 @@ class FieldSlip
             box the collector left empty is not unreadable. Getting
             this right decides whether another photo is worth
             consulting for that field.
+          #{per_field_rules}
+        RULES
+      end
+
+      def per_field_rules
+        <<~RULES.strip
           - "Field Slip Code" is printed, not handwritten, and looks
             like #{code_example}. It also appears in the QR code.
           - "ID" is the name written by the collector. It may be a
@@ -67,10 +73,16 @@ class FieldSlip
             verbatim.
           - Substrate and Habit are often circled from a printed list
             rather than written. Report the circled word(s).
-          - "MycoMap Voucher Number" is the PRINTED code in the slip's
-            top-right corner, like N26-0290. It is not handwritten and
-            is not the field slip code. Do not put it in "Other Codes";
-            "Other Codes" is only what a person wrote in that box.
+          - "MycoMap Voucher Number" is whatever occupies the slip's
+            top-right corner, printed or handwritten. It is usually a
+            printed sticker like N26-0290, but when the stickers ran
+            out it was written in by hand, often as a bare number with
+            the prefix left off. Give it exactly as written -- do not
+            add a prefix a bare number does not carry. It is not the
+            field slip code. Identify it by that corner, not by
+            whether it is printed: anything written in another box
+            belongs to that box's field, and "Other Codes" is only
+            what a person wrote in the Other Codes box.
         RULES
       end
 

--- a/test/classes/field_slip/extractor/prompt_test.rb
+++ b/test/classes/field_slip/extractor/prompt_test.rb
@@ -29,6 +29,24 @@ class FieldSlip::Extractor::PromptTest < UnitTestCase
     assert_includes(text, "JSON")
   end
 
+  # NEMF 2026 ran out of printed voucher stickers partway through and
+  # wrote the rest by hand, often as a bare number. Identifying the
+  # field by "printed" dropped every one of those.
+  def test_accepts_a_handwritten_voucher_number
+    text = prompt
+
+    assert_includes(text, "MycoMap Voucher Number")
+    assert_includes(text, "printed or handwritten")
+    assert_includes(text, "top-right corner")
+  end
+
+  # A bare number must come back bare. The prefix belongs to a
+  # particular event, so inventing one here would put an unverifiable
+  # value into the notes of every slip that was written by hand.
+  def test_does_not_ask_the_model_to_invent_a_voucher_prefix
+    assert_includes(prompt, "add a prefix a bare number does not carry")
+  end
+
   # An observation's other photos go through the same prompt, and the
   # alias tables below are a standing invitation to answer from them
   # rather than from the image.

--- a/test/classes/field_slip/extractor/prompt_test.rb
+++ b/test/classes/field_slip/extractor/prompt_test.rb
@@ -37,14 +37,25 @@ class FieldSlip::Extractor::PromptTest < UnitTestCase
 
     assert_includes(text, "MycoMap Voucher Number")
     assert_includes(text, "printed or handwritten")
-    assert_includes(text, "top-right corner")
+    assert_includes(text, "upper-right")
+  end
+
+  # The corner already holds a logo, and the hand-written numbers were
+  # fitted around it -- above or to the left as often as beside it.
+  def test_looks_past_the_logo_in_the_voucher_corner
+    text = prompt
+
+    assert_includes(text, "logo")
+    assert_includes(text.squish, "read the whole upper-right area")
   end
 
   # A bare number must come back bare. The prefix belongs to a
   # particular event, so inventing one here would put an unverifiable
   # value into the notes of every slip that was written by hand.
   def test_does_not_ask_the_model_to_invent_a_voucher_prefix
-    assert_includes(prompt, "add a prefix a bare number does not carry")
+    # squish so a rewrap of the prompt does not fail the assertion
+    assert_includes(prompt.squish,
+                    "do not add a prefix a bare number does not carry")
   end
 
   # An observation's other photos go through the same prompt, and the


### PR DESCRIPTION
NEMF 2026 ran out of printed voucher stickers partway through the foray and the rest were written in by hand, usually as a bare number with the prefix left off — a handwritten `9089` meaning `N26-9089` (image 2051589 is an example).

The rule made that unreadable by construction:

> "MycoMap Voucher Number" is the PRINTED code in the slip's top-right corner, like N26-0290. **It is not handwritten** and is not the field slip code.

So every handwritten voucher was dropped, and the instruction to keep it out of "Other Codes" meant it was not captured anywhere else either.

This identifies the field by **where it sits** — the slip's top-right corner — rather than by whether it happens to be printed.

## The value comes back exactly as written

A bare `9089` returns as `9089`, not `N26-9089`. The `N26` prefix belongs to one particular event and the prompt has no way to know it is right; asking the model to supply it would write an unverifiable value into the notes of every hand-written slip. Whatever consumes the extract knows which event it came from and can expand it there. The prompt says so explicitly, and there is a test pinning it, because that is exactly the kind of "helpful" behaviour a later prompt edit might reintroduce.

`PROMPT_VERSION` goes to `4`. That field is recorded on each `FieldSlipExtract` but is not used to invalidate anything, so no existing extract is re-read and the bump costs nothing — it just makes it possible to tell later which reads could have seen a handwritten voucher. Current spread is 87 at v1, 207 at v2, 1402 at v3.

`field_rules` went one line over `Metrics/MethodLength`, so the per-field rules moved into their own `per_field_rules` method rather than the cop being disabled.

## Test plan

Nothing to set up; the change is prompt text.

- `bin/rails test test/classes/field_slip/extractor/prompt_test.rb` — 24 tests green, two of them new.
- To check it against a real slip, open a NEMF 2026 image whose voucher was hand-written (image 2051589) in the field slip extract UI and re-run the extraction. Before this change the "MycoMap Voucher Number" field comes back null; after it, `9089`.
- A slip with a printed sticker should be unaffected and still return `N26-0290`.
