### PR TITLE
Narrow icon-library checkouts to just `mo-icons.svg`

### DIFF
--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -50,7 +50,8 @@ jobs:
               https://github.com/MushroomObserver/icon-library.git \
               vendor/assets/images/icons
             source script/icon_library_narrow_checkout.sh
-            icon_library_narrow_checkout vendor/assets/images/icons
+            icon_library_narrow_checkout vendor/assets/images/icons ||
+              echo "::warning::Narrowing the icon-library checkout failed -- continuing with whatever was cloned."
             if [ -f vendor/assets/images/icons/mo-icons.svg ]; then
               echo "Cloned icon-library -- mo-icons.svg present."
             else

--- a/.github/workflows/ci_rails.yml
+++ b/.github/workflows/ci_rails.yml
@@ -49,6 +49,8 @@ jobs:
               clone --quiet --filter=blob:none --sparse \
               https://github.com/MushroomObserver/icon-library.git \
               vendor/assets/images/icons
+            source script/icon_library_narrow_checkout.sh
+            icon_library_narrow_checkout vendor/assets/images/icons
             if [ -f vendor/assets/images/icons/mo-icons.svg ]; then
               echo "Cloned icon-library -- mo-icons.svg present."
             else

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -15,85 +15,90 @@ if [ "$RAILS_ENV" != "production" ]; then
     exit 1
 fi
 
-# Manual, opt-in icon-library refresh -- deliberately NOT part of a
-# standard deploy (the icon-library repo has its own release cadence,
-# unrelated to app code). Exits here rather than falling through to
-# the code-deploy flow below, since none of that (git branch check,
-# maintenance page, puma/solidqueue stop, db:migrate, lang:update)
-# applies to a licensed-asset-only refresh.
-if [ "$1" = "--icons-only" ]; then
+# Icon-library refresh, shared by --icons-only (asset-only, no code
+# deploy) and --icons (bundled into a normal code deploy below).
+# Nothing else valid lives in $icons_dir, so a stale/broken checkout
+# is clobbered and re-cloned rather than pulled or preserved -- pull
+# can't recover from a non-git or wrong-remote directory, and this
+# way there's only one code path instead of pull-if-clean-else-abort.
+refresh_icon_library() {
     icons_dir="vendor/assets/images/icons"
 
-    if [ -d "$icons_dir/.git" ]; then
-        origin=$(git -C "$icons_dir" remote get-url origin 2>/dev/null)
-        case "$origin" in
-            *MushroomObserver/icon-library*)
-                echo Pulling latest icon-library... && git -C "$icons_dir" pull
-                ;;
-            *)
-                echo "$icons_dir exists but isn't a MushroomObserver/icon-library"
-                echo "checkout -- aborting rather than updating the wrong repo."
-                exit 1
-                ;;
-        esac
-    elif [ -d "$icons_dir" ]; then
-        echo "$icons_dir exists but isn't a git checkout -- aborting rather"
-        echo "than cloning into a non-empty directory."
-        exit 1
-    else
-        echo "$icons_dir isn't a checkout yet -- cloning..."
+    echo "Refreshing $icons_dir..."
+    rm -rf "$icons_dir"
+    git clone --filter=blob:none --sparse \
+        git@github.com:MushroomObserver/icon-library.git "$icons_dir" ||
         git clone --filter=blob:none --sparse \
-            git@github.com:MushroomObserver/icon-library.git "$icons_dir" ||
-            git clone --filter=blob:none --sparse \
-                https://github.com/MushroomObserver/icon-library.git "$icons_dir"
-    fi
+            https://github.com/MushroomObserver/icon-library.git "$icons_dir"
     if [ $? -ne 0 ]; then
-        echo Updating the icon library failed.
-        exit 1
+        echo Cloning the icon library failed.
+        return 1
     fi
 
     source script/icon_library_narrow_checkout.sh
     icon_library_narrow_checkout "$icons_dir"
     if [ $? -ne 0 ]; then
         echo Narrowing the icon-library checkout to mo-icons.svg failed.
-        exit 1
+        return 1
     fi
 
-    # A successful clone/pull doesn't guarantee mo-icons.svg itself is
+    # A successful clone doesn't guarantee mo-icons.svg itself is
     # there -- verify explicitly rather than trusting the command's
     # exit status alone. Production without icons is a real
     # regression (illegible site), not a tolerable degraded state
     # (contrast with the best-effort skip elsewhere for CI/dev), so
     # this is a hard failure.
     if [ ! -f "$icons_dir/mo-icons.svg" ]; then
-        echo "$icons_dir/mo-icons.svg is missing after the clone/pull --"
+        echo "$icons_dir/mo-icons.svg is missing after the clone --"
         echo "check icon-library's main branch. Aborting rather than"
         echo "precompiling and reloading without a working icon sprite."
-        exit 1
+        return 1
     fi
+}
 
-    # Assets are precompiled (config.assets.compile = false in
-    # production) and fingerprinted, so new icon files aren't live
-    # until recompiled. `service puma reload` sends SIGUSR2 (see
-    # config/etc/puma.service's ExecReload) -- Puma's hot restart,
-    # which re-execs and picks up the new manifest while keeping the
-    # listening socket, so this needs neither the maintenance page
-    # nor a full stop/start.
-    echo Precompiling assets... && rake assets:precompile
-    if [ $? -ne 0 ]; then
-        echo assets:precompile failed.
-        exit 1
-    fi
+# --icons-only is a manual, opt-in icon-library refresh -- deliberately
+# NOT part of a standard deploy (the icon-library repo has its own
+# release cadence, unrelated to app code). Exits here rather than
+# falling through to the code-deploy flow below, since none of that
+# (git branch check, maintenance page, puma/solidqueue stop,
+# db:migrate, lang:update) applies to a licensed-asset-only refresh.
+#
+# --icons bundles the same refresh into a normal code deploy (see the
+# icons_flag check further down, right before the single
+# assets:precompile that deploy already does) -- one precompile
+# instead of two separate ones from running --icons-only and a plain
+# deploy back to back.
+icons_flag=0
+case "$1" in
+    --icons-only)
+        refresh_icon_library || exit 1
 
-    echo Reloading puma... && sudo service puma reload
-    if [ $? -ne 0 ]; then
-        echo Puma reload failed.
-        exit 1
-    fi
+        # Assets are precompiled (config.assets.compile = false in
+        # production) and fingerprinted, so new icon files aren't live
+        # until recompiled. `service puma reload` sends SIGUSR2 (see
+        # config/etc/puma.service's ExecReload) -- Puma's hot restart,
+        # which re-execs and picks up the new manifest while keeping
+        # the listening socket, so this needs neither the maintenance
+        # page nor a full stop/start.
+        echo Precompiling assets... && rake assets:precompile
+        if [ $? -ne 0 ]; then
+            echo assets:precompile failed.
+            exit 1
+        fi
 
-    echo SUCCESS\!
-    exit 0
-fi
+        echo Reloading puma... && sudo service puma reload
+        if [ $? -ne 0 ]; then
+            echo Puma reload failed.
+            exit 1
+        fi
+
+        echo SUCCESS\!
+        exit 0
+        ;;
+    --icons)
+        icons_flag=1
+        ;;
+esac
 
 if [ "$(git branch | grep '^\*')" != "* main" ]; then
     echo Please switch to main branch.
@@ -195,6 +200,18 @@ if [ "$STASH_RESULT" != 'No local changes to save' ]; then
 	echo Restarting solidqueue... && sudo service solidqueue start
 	echo Resuming queues... && bundle exec rails runner script/resume_jobs.rb
 	exit 1
+    fi
+fi
+
+if [ "$icons_flag" = "1" ]; then
+    refresh_icon_library
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo "Deploy failed. Restarting puma and solidqueue with existing code..."
+        sudo service puma start
+        sudo service solidqueue start
+        echo Resuming queues... && bundle exec rails runner script/resume_jobs.rb
+        exit 1
     fi
 fi
 

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -41,15 +41,6 @@ if [ "$1" = "--icons-only" ]; then
         echo "than cloning into a non-empty directory."
         exit 1
     else
-        # Sparse-checkout: that repo's sources/ (the full GLYPHICONS
-        # 2.0 sprites/fonts the curated sprite is built from) is much
-        # larger than what production actually needs, which is just
-        # mo-icons.svg. `--sparse` alone (no further `sparse-checkout
-        # set` needed) defaults to cone mode's top-level-files-only
-        # checkout, which already excludes sources/ -- confirmed via
-        # a real clone that sources/ never lands on disk AND its
-        # blobs are never fetched (--filter=blob:none), not just
-        # hidden by the working-tree filter.
         echo "$icons_dir isn't a checkout yet -- cloning..."
         git clone --filter=blob:none --sparse \
             git@github.com:MushroomObserver/icon-library.git "$icons_dir" ||
@@ -58,6 +49,26 @@ if [ "$1" = "--icons-only" ]; then
     fi
     if [ $? -ne 0 ]; then
         echo Updating the icon library failed.
+        exit 1
+    fi
+
+    source script/icon_library_narrow_checkout.sh
+    icon_library_narrow_checkout "$icons_dir"
+    if [ $? -ne 0 ]; then
+        echo Narrowing the icon-library checkout to mo-icons.svg failed.
+        exit 1
+    fi
+
+    # A successful clone/pull doesn't guarantee mo-icons.svg itself is
+    # there -- verify explicitly rather than trusting the command's
+    # exit status alone. Production without icons is a real
+    # regression (illegible site), not a tolerable degraded state
+    # (contrast with the best-effort skip elsewhere for CI/dev), so
+    # this is a hard failure.
+    if [ ! -f "$icons_dir/mo-icons.svg" ]; then
+        echo "$icons_dir/mo-icons.svg is missing after the clone/pull --"
+        echo "check icon-library's main branch. Aborting rather than"
+        echo "precompiling and reloading without a working icon sprite."
         exit 1
     fi
 

--- a/script/dev_setup/sync_mo_icon_library.sh
+++ b/script/dev_setup/sync_mo_icon_library.sh
@@ -77,7 +77,10 @@ mo_sync_icon_library() {
     fi
 
     source script/icon_library_narrow_checkout.sh
-    icon_library_narrow_checkout "$clone_dir"
+    if ! icon_library_narrow_checkout "$clone_dir"; then
+        echo "WARNING: narrowing $clone_dir to mo-icons.svg failed -- extra"
+        echo "root files (Gemfile, README.md, etc.) may still be present."
+    fi
 
     if [ -f "$clone_dir/mo-icons.svg" ]; then
         mkdir -p "$(dirname "$dest_svg")"

--- a/script/dev_setup/sync_mo_icon_library.sh
+++ b/script/dev_setup/sync_mo_icon_library.sh
@@ -23,14 +23,9 @@
 # lands means that's never a problem, including if this directory
 # ever does start tracking something.
 #
-# Sparse-checkout, not a full clone: that repo's sources/ (the full
-# GLYPHICONS 2.0 sprites + fonts the curated sprite gets built from)
-# is much larger than what this needs, which is just the top-level
-# files. `--sparse` alone (no further `sparse-checkout set` needed)
-# defaults to cone mode's top-level-files-only checkout, which
-# already excludes sources/ -- confirmed via a real clone that
-# sources/ never lands on disk AND its blobs are never fetched
-# (--filter=blob:none), not just hidden by the working-tree filter.
+# Sparse-checkout, not a full clone -- see
+# script/icon_library_narrow_checkout.sh for why it's narrowed further
+# to just mo-icons.svg.
 #
 # Callable standalone via `script/dev_setup_macos --icons-only` or
 # `script/dev_setup_ubuntu --icons-only`, without running the rest of
@@ -80,6 +75,9 @@ mo_sync_icon_library() {
         echo "setup doesn't depend on it."
         return
     fi
+
+    source script/icon_library_narrow_checkout.sh
+    icon_library_narrow_checkout "$clone_dir"
 
     if [ -f "$clone_dir/mo-icons.svg" ]; then
         mkdir -p "$(dirname "$dest_svg")"

--- a/script/icon_library_narrow_checkout.sh
+++ b/script/icon_library_narrow_checkout.sh
@@ -3,5 +3,9 @@
 # README.md, etc). Shared by deploy.sh, ci_rails.yml, and
 # sync_mo_icon_library.sh. $1: the checkout directory.
 icon_library_narrow_checkout() {
+    if [ -z "$1" ]; then
+        echo "icon_library_narrow_checkout: missing directory argument" >&2
+        return 1
+    fi
     git -C "$1" sparse-checkout set --no-cone '/mo-icons.svg'
 }

--- a/script/icon_library_narrow_checkout.sh
+++ b/script/icon_library_narrow_checkout.sh
@@ -1,0 +1,7 @@
+# Narrows an icon-library checkout to just mo-icons.svg -- `--sparse`
+# alone at clone time still keeps every other root file (Gemfile,
+# README.md, etc). Shared by deploy.sh, ci_rails.yml, and
+# sync_mo_icon_library.sh. $1: the checkout directory.
+icon_library_narrow_checkout() {
+    git -C "$1" sparse-checkout set --no-cone '/mo-icons.svg'
+}


### PR DESCRIPTION
## Summary

Fixes `deploy.sh --icons-only` leaving stray root files in `vendor/assets/images/icons/`, adds a combined `--icons` flag that refreshes icons as part of a normal code deploy, and makes both icon-refresh paths clobber-and-reclone instead of pulling in place or aborting.

## Details

`--sparse` alone at clone time only gets cone mode's top-level-files-only default, which excludes `sources/` but keeps every other root file (`Gemfile`, `Gemfile.lock`, `README.md`, `sprite_map.yml`, `test_render.html`) — found this after a real `deploy.sh --icons-only` run left all of those sitting in `vendor/assets/images/icons/`, not just `mo-icons.svg`. `git sparse-checkout set --no-cone '/mo-icons.svg'` narrows an existing checkout down further, whether it's freshly cloned or already on disk. Deduped into `script/icon_library_narrow_checkout.sh` (one function, `icon_library_narrow_checkout <dir>`), sourced by `deploy.sh`, `ci_rails.yml`, and `sync_mo_icon_library.sh` rather than the same fix copy-pasted three times.

`deploy.sh` previously only supported `--icons-only` (icons alone, no code deploy) and required a plain deploy to refresh code without touching icons — running both back to back meant two separate `assets:precompile` calls. `--icons` now bundles the icon refresh into a normal code deploy, ahead of the single `assets:precompile` deploy already runs.

Both `--icons` and `--icons-only` now share one `refresh_icon_library` function that clobbers (`rm -rf`) and re-clones `vendor/assets/images/icons/` rather than pulling an existing git checkout in place or aborting when the directory exists but isn't a git checkout — nothing else valid lives in that directory, so a clean re-clone is simpler and more reliable than trying to recover a stale one.

## Test plan

- [x] Reproduced the original bug and verified the sparse-checkout fix locally against a throwaway repo with the same shape (multiple root files + a subdirectory) — plain `--sparse` clone kept all root files; `sparse-checkout set --no-cone '/mo-icons.svg'` narrowed an *already-checked-out* directory down to just that one file.
- [x] `bash -n` on all touched shell scripts, YAML validity check on `ci_rails.yml`
- [ ] Re-run `deploy.sh --icons-only` on production after merge to confirm it cleans up the currently-affected directory
- [ ] Exercise `deploy.sh --icons` on production (or a staging box) to confirm the bundled code+icons path works end to end
