### PR TITLE
Convert Phlex `initialize`s to Literal props; add 4 custom cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ require:
   - ./lib/rubocop/cop/mo/dry_test_render_helper
   - ./lib/rubocop/cop/mo/initialize_without_prop
   - ./lib/rubocop/cop/mo/lowercase_translation_tag
+  - ./lib/rubocop/cop/mo/no_active_record_relation_prop
   - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
   - ./lib/rubocop/cop/mo/no_resolved_errors_add_type
 
@@ -83,6 +84,17 @@ MO/LowercaseTranslationTag:
     lowercase -- see lib/rubocop/cop/mo/lowercase_translation_tag.rb
     and GH issue #4843.
   Enabled: true
+
+MO/NoActiveRecordRelationProp:
+  Description: >-
+    Phlex `prop` types must not reference ActiveRecord::Relation --
+    materialize with .to_a at the call site and use _Array(<Model>)
+    instead, so the element type is checked too -- see
+    lib/rubocop/cop/mo/no_active_record_relation_prop.rb.
+  Enabled: true
+  Include:
+    - "app/components/**/*.rb"
+    - "app/views/**/*.rb"
 
 MO/NoResolvedErrorsAddType:
   Description: >-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,16 @@ MO/InitializeWithoutProp:
     # left as manual initialize.
     - "app/components/application_form.rb"
     - "app/components/application_form/**/*.rb"
+    # TEMPORARY, remove once #5020 merges/rebases in: the Link::*/
+    # Button::* prop conversions live exclusively on #5020, not here,
+    # per an explicit decision to keep this branch's diff to the
+    # non-Link/Button sweep. Excluded so this branch's CI stays green
+    # in the meantime rather than flagging files this PR isn't
+    # touching.
+    - "app/components/button.rb"
+    - "app/components/button/**/*.rb"
+    - "app/components/link.rb"
+    - "app/components/link/**/*.rb"
 
 MO/LowercaseTranslationTag:
   Description: >-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ plugins:
 
 require:
   - ./lib/rubocop/cop/mo/dry_test_render_helper
+  - ./lib/rubocop/cop/mo/initialize_without_prop
   - ./lib/rubocop/cop/mo/lowercase_translation_tag
   - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
   - ./lib/rubocop/cop/mo/no_resolved_errors_add_type
@@ -52,6 +53,17 @@ MO/DryTestRenderHelper:
   Include:
     - "test/components/**/*_test.rb"
     - "test/views/**/*_test.rb"
+
+MO/InitializeWithoutProp:
+  Description: >-
+    A Phlex class defining `initialize` with hand-assigned `@ivar =`
+    state and no `prop` of its own should use Literal props instead --
+    see lib/rubocop/cop/mo/initialize_without_prop.rb and the #5020
+    prop-conversion sweep.
+  Enabled: true
+  Include:
+    - "app/components/**/*.rb"
+    - "app/views/**/*.rb"
 
 MO/LowercaseTranslationTag:
   Description: >-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,8 +17,10 @@ require:
   - ./lib/rubocop/cop/mo/initialize_without_prop
   - ./lib/rubocop/cop/mo/lowercase_translation_tag
   - ./lib/rubocop/cop/mo/no_active_record_relation_prop
+  - ./lib/rubocop/cop/mo/no_raw_bootstrap_component
   - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
   - ./lib/rubocop/cop/mo/no_resolved_errors_add_type
+  - ./lib/rubocop/cop/mo/prefer_kit_syntax
 
 AllCops:
   NewCops: enable
@@ -104,6 +106,40 @@ MO/NoResolvedErrorsAddType:
     and #4901/#4920.
   Enabled: true
 
+MO/NoRawBootstrapComponent:
+  Description: >-
+    Phlex views/components must not hand-roll the markup for a
+    top-level Bootstrap UI component MO already has a Components::*
+    wrapper for (Alert, Modal, Dropdown, ListGroup, NavTabs, Panel,
+    Navbar, Carousel, InputGroup, ButtonGroup) -- see
+    lib/rubocop/cop/mo/no_raw_bootstrap_component.rb.
+  Enabled: true
+  Include:
+    - "app/components/**/*.rb"
+    - "app/views/**/*.rb"
+  Exclude:
+    # Superform-based field classes (Components::Form::Input <
+    # Superform::Rails::Components::Input) don't share an inheritance
+    # line with Components::Base, so they have no Kit-sugar/Components
+    # infrastructure to swap into -- see app/components/form/input.rb's
+    # own comment. autocompleter_field.rb's `.dropdown-menu` div is a
+    # Stimulus-driven autocomplete pulldown reusing the class for
+    # styling only, not Bootstrap's actual toggle-button JS behavior.
+    - "app/components/application_form/**/*.rb"
+    # NavTabs' own implementation -- legitimately builds the
+    # `<ul class="nav nav-tabs">` this cop exists to make everyone
+    # else use NavTabs(...) for instead.
+    - "app/components/nav_tabs.rb"
+    # Deliberate: the sidebar's `.list-group` wrapper holds several
+    # independently `cache(...)`-wrapped sections that render
+    # Components::ListGroup::Item/LinkItem directly, not via a
+    # `ListGroup(...) do |list| ... end` builder block -- swapping in
+    # Components::ListGroup here would route those renders through
+    # `vanish`/deferred registration, which silently breaks fragment
+    # caching (see list_group.rb's own docs, which name this file as
+    # the deliberate exception).
+    - "app/views/layouts/sidebar.rb"
+
 MO/NoRawLinkOrButtonTo:
   Description: >-
     Phlex views/components must use Components::Link/Components::Button
@@ -131,6 +167,16 @@ MO/NoRawLinkOrButtonTo:
     # is .btn-family styling/variants, which doesn't fit a badge.
     # Genuinely a different primitive, not a bypass of Button.
     - "app/components/id_badge.rb"
+
+MO/PreferKitSyntax:
+  Description: >-
+    Phlex views/components should call Foo(...) (Kit syntax) rather
+    than render(Components::Foo.new(...)) for a single-level
+    Components class -- see lib/rubocop/cop/mo/prefer_kit_syntax.rb.
+  Enabled: true
+  Include:
+    - "app/components/**/*.rb"
+    - "app/views/**/*.rb"
 
 Gemspec:
   # Not relevent (MO is not a gem)

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,18 @@ MO/InitializeWithoutProp:
   Include:
     - "app/components/**/*.rb"
     - "app/views/**/*.rb"
+  Exclude:
+    # Every field class here takes a Superform::Field or FieldProxy --
+    # both are duck-typed, so the only prop type available is a vague
+    # _Interface(:dom, :value), not a concrete class; `wrapper_options`/
+    # `attributes` are already-generic Hash catch-alls. Converting
+    # doesn't buy real type safety here the way it does elsewhere, and
+    # several files subclass Superform's own component classes
+    # directly (third-party initialize signatures, positional `field`
+    # args, no dedicated test coverage). Not worth the risk/reward;
+    # left as manual initialize.
+    - "app/components/application_form.rb"
+    - "app/components/application_form/**/*.rb"
 
 MO/LowercaseTranslationTag:
   Description: >-

--- a/app/components/alert/link.rb
+++ b/app/components/alert/link.rb
@@ -1,19 +1,17 @@
 # frozen_string_literal: true
 
 class Components::Alert::Link < Components::Base
-  def initialize(text, href, class: nil, **attrs)
-    super()
-    @text = text
-    @href = href
-    @html_class = grab(class:)
-    @attrs = attrs
-  end
+  prop :text, String
+  prop :href, String
+  # Catch-all for class:, data:, aria:, and any other HTML attrs on
+  # the rendered link -- matches Accordion/Icon/Collapsible's pattern.
+  prop :attributes, _Hash(Symbol, _Any?), :**
 
   def view_template
     Link(type: :get,
          name: @text,
          target: @href,
-         class: class_names("alert-link", @html_class),
-         **@attrs)
+         class: class_names("alert-link", @attributes[:class]),
+         **@attributes.except(:class))
   end
 end

--- a/app/components/content_padded.rb
+++ b/app/components/content_padded.rb
@@ -15,14 +15,11 @@
 #     class: "shadow-sm", data: { controller: "modal" }
 #   ) { ... }
 class Components::ContentPadded < Components::Base
-  # @param attrs [Hash] HTML attrs forwarded verbatim to the `<div>`.
-  #   `class:` is composed with the default `"p-3"`.
-  def initialize(**attrs)
-    super()
-    @attrs = attrs
-  end
+  # HTML attrs forwarded verbatim to the `<div>`. `class:` is
+  # composed with the default `"p-3"`.
+  prop :attributes, _Hash(Symbol, _Any?), :**
 
   def view_template(&block)
-    div(**mix({ class: "p-3" }, @attrs), &block)
+    div(**mix({ class: "p-3" }, @attributes), &block)
   end
 end

--- a/app/components/form/location_feedback.rb
+++ b/app/components/form/location_feedback.rb
@@ -18,10 +18,8 @@ class Components::Form::LocationFeedback < Components::Base
   def view_template
     return unless @dubious_where_reasons&.any?
 
-    render(
-      Components::Alert.new(
-        level: :warning, class: "my-3", id: "dubious_location_messages"
-      )
+    Alert(
+      level: :warning, class: "my-3", id: "dubious_location_messages"
     ) do
       div do
         @dubious_where_reasons.each_with_index do |reason, index|

--- a/app/components/form/location_map.rb
+++ b/app/components/form/location_map.rb
@@ -49,8 +49,7 @@ class Components::Form::LocationMap < Components::Base
   end
 
   def render_button_group
-    div(class: "btn-group my-3", role: "group",
-        data: { map_target: "controlWrap" }) do
+    ButtonGroup(class: "my-3", data: { map_target: "controlWrap" }) do
       render_toggle_button
       render_clear_button
     end

--- a/app/components/list_group.rb
+++ b/app/components/list_group.rb
@@ -70,27 +70,25 @@
 #     end
 #   end
 class Components::ListGroup < Components::Base
-  # @param id [String] `id=` for the container element. Use to make
-  #   the container a Turbo Stream target.
-  # @param flush [Boolean] add `list-group-flush` for borderless
-  #   nesting inside a Panel body. Defaults to false.
-  # @param element [Symbol] container element — `:div` (default) or
-  #   `:ul`. Items take the matching child element (`:div` → `<div>`,
-  #   `:ul` → `<li>`).
-  # @param class [String] CSS classes appended to the default
-  #   `list-group` (+ `list-group-flush` when `flush: true`).
-  # @param attributes [Hash] arbitrary HTML attrs forwarded to the
-  #   container element (`data:` for Stimulus, ARIA, etc.).
-  def initialize(id: nil, flush: false, element: :div,
-                 class: nil, attributes: {})
-    super()
-    @html_id = id
-    @flush = flush
-    @element = element
-    @html_class = grab(class:)
-    @attributes = attributes
+  # `id=` for the container element. Use to make the container a
+  # Turbo Stream target.
+  prop :id, _Nilable(String), default: nil
+  # Adds `list-group-flush` for borderless nesting inside a Panel body.
+  prop :flush, _Boolean, default: false
+  # Container element — `:div` (default) or `:ul`. Items take the
+  # matching child element (`:div` → `<div>`, `:ul` → `<li>`).
+  prop :element, _Union(:div, :ul), default: :div
+  # Catch-all for class:, data:, aria:, and any other HTML attrs on
+  # the container element -- matches Icon/Collapsible's pattern.
+  prop :attributes, _Hash(Symbol, _Any?), :**
+
+  # `@items`/`@empty_block` are builder-accumulated state (populated
+  # by `item`/`link_item`/`empty` during `vanish`), not constructor
+  # props -- see the class docs above.
+  def initialize(**)
     @items = []
     @empty_block = nil
+    super
   end
 
   def view_template(&block)
@@ -170,9 +168,9 @@ class Components::ListGroup < Components::Base
 
   def container_attrs
     classes = class_names(
-      "list-group", ("list-group-flush" if @flush), @html_class
+      "list-group", ("list-group-flush" if @flush), @attributes[:class]
     )
-    { class: classes, id: @html_id }.compact.merge(@attributes)
+    { class: classes, id: @id }.compact.merge(@attributes.except(:class))
   end
 
   def item_element
@@ -183,7 +181,7 @@ class Components::ListGroup < Components::Base
     if item[:wrap]
       render(Item.new(
                element: item_element, class: item[:class],
-               id: item[:id], attributes: item[:attrs]
+               id: item[:id], **item[:attrs]
              ), &item[:block])
     else
       render(LinkItem.new(class: item[:class]), &item[:block])

--- a/app/components/list_group/item.rb
+++ b/app/components/list_group/item.rb
@@ -20,26 +20,22 @@
 #     # inner content (e.g. a CommentItem view)
 #   end
 class Components::ListGroup::Item < Components::Base
-  # @param element [Symbol] `:div` (default, matches `<div class="list-group">`)
-  #   or `:li` (matches `<ul class="list-group">`).
-  # @param class [String] appended to the default `list-group-item`.
-  #   Falsy values are skipped.
-  # @param id [String, nil] `id=` attribute. Required for Turbo Stream
-  #   `update` / `replace` / `remove` targets to find the row.
-  # @param attributes [Hash] arbitrary HTML attrs (data:, aria-*, etc.).
-  def initialize(element: :div, class: nil, id: nil, attributes: {})
-    super()
-    @element = element
-    @html_class = grab(class:)
-    @html_id = id
-    @attributes = attributes
-  end
+  # `:div` (default, matches `<div class="list-group">`) or `:li`
+  # (matches `<ul class="list-group">`).
+  prop :element, _Union(:div, :li), default: :div
+  # `id=` attribute. Required for Turbo Stream `update` / `replace` /
+  # `remove` targets to find the row.
+  prop :id, _Nilable(String), default: nil
+  # Catch-all for class:, data:, aria:, and any other HTML attrs --
+  # matches Icon/Collapsible's pattern. `class:` is appended to the
+  # default `list-group-item`.
+  prop :attributes, _Hash(Symbol, _Any?), :**
 
   def view_template(&block)
     send(@element,
-         class: class_names("list-group-item", @html_class),
-         id: @html_id,
-         **@attributes,
+         class: class_names("list-group-item", @attributes[:class]),
+         id: @id,
+         **@attributes.except(:class),
          &block)
   end
 end

--- a/app/components/list_group/link_item.rb
+++ b/app/components/list_group/link_item.rb
@@ -37,12 +37,10 @@
 #     Link(type: :active, content: title, path: url, class: css_class)
 #   end
 class Components::ListGroup::LinkItem < Components::Base
-  def initialize(class: nil)
-    super()
-    @html_class = grab(class:)
-  end
+  # Catch-all for class: -- matches Icon/Collapsible's pattern.
+  prop :attributes, _Hash(Symbol, _Any?), :**
 
   def view_template(&block)
-    yield(class_names("list-group-item", @html_class))
+    yield(class_names("list-group-item", @attributes[:class]))
   end
 end

--- a/app/components/map.rb
+++ b/app/components/map.rb
@@ -157,8 +157,7 @@ class Components::Map < Components::Base
     return if @observations_loaded_count.nil? ||
               @observations_total_count.nil?
 
-    div(id: "map_cap_banner", class: "alert alert-warning mt-2",
-        style: (@capped ? nil : "display:none")) do
+    Alert(**cap_banner_attrs) do
       trusted_html(
         :map_cap_banner.t(
           loaded: @observations_loaded_count.to_fs(:delimited),
@@ -166,6 +165,12 @@ class Components::Map < Components::Base
         )
       )
     end
+  end
+
+  def cap_banner_attrs
+    attrs = { level: :warning, id: "map_cap_banner", class: "mt-2" }
+    attrs[:style] = "display:none" unless @capped
+    attrs
   end
 
   # --------------------------------------------------------------

--- a/app/components/nav_tabs.rb
+++ b/app/components/nav_tabs.rb
@@ -44,22 +44,27 @@
 #     end
 #   end
 class Components::NavTabs < Components::Base
-  # @param current [String, Symbol, nil] tab key marked `.active`
-  # @param link_class [String, nil] extra CSS classes appended to
-  #   every tab's `<a class="nav-link …">` (e.g. `"mt-3"`)
-  # @param attributes [Hash] arbitrary HTML attrs forwarded to the
-  #   `<ul>` element (`data:`, ARIA, etc.). The `class:` is always
-  #   `"nav nav-tabs"` and is not overridable from here.
+  # Tab key marked `.active`.
+  prop :current, _Nilable(_Union(String, Symbol)), default: nil
+  # Extra CSS classes appended to every tab's `<a class="nav-link …">`
+  # (e.g. `"mt-3"`).
+  prop :link_class, _Nilable(String), default: nil
+  # Catch-all for arbitrary HTML attrs forwarded to the `<ul>` element
+  # (`data:`, ARIA, etc.) -- matches Icon/Collapsible's pattern. The
+  # `class:` is always `"nav nav-tabs"` and is not overridable here.
+  prop :attributes, _Hash(Symbol, _Any?), :**
+
+  # `@tabs` is builder-accumulated state (populated by `tab`/`add_all`
+  # during `vanish`, plus any pre-seeded `tabs:` collection below),
+  # not a constructor prop -- see the class docs above.
+  #
   # @param tabs [Tab::Collection, Enumerable<Tab::Base>, nil]
   #   pre-built tabs to render. Any block passed to `view_template`
   #   runs *after* these, so a Collection + ad-hoc `tabs.tab(...)`
   #   calls compose cleanly.
-  def initialize(current: nil, link_class: nil, attributes: {}, tabs: nil)
-    super()
-    @current = current
-    @link_class = link_class
-    @attributes = attributes
+  def initialize(tabs: nil, **)
     @tabs = []
+    super(**)
     Array(tabs).each { |t| tab(t) } if tabs
   end
 

--- a/app/components/table.rb
+++ b/app/components/table.rb
@@ -24,9 +24,9 @@
 #   rooted layout shell with mixed-shape rows. `rows` arg is
 #   unused / can be nil in this mode.
 #
-# Table-level HTML attrs (`data:`, `cols:`, ARIA attrs, etc.) go in
-# the `attributes:` Hash. `class:` and `id:` are first-class init
-# args.
+# Table-level HTML attrs (`class:`, `data:`, `cols:`, ARIA attrs,
+# etc.) are all plain kwargs forwarded to the `<table>` element.
+# `id:` is a first-class init arg.
 #
 # @example Column mode (uniform rows)
 #   Table(@users, variant: :striped) do |t|
@@ -53,7 +53,7 @@
 # @example Body mode (table-level data attrs + mixed rows)
 #   Table(
 #     class: "name-lister",
-#     attributes: { data: { controller: "name-list" } }
+#     data: { controller: "name-list" }
 #   ) do |t|
 #     t.column(:name.ti, width: "20%")
 #     t.column(:options.ti, width: "80%")
@@ -63,38 +63,38 @@
 #     end
 #   end
 class Components::Table < Components::Base
-  # @param rows [Enumerable, nil] rows passed to each column/row
-  #   block (unused in body mode)
-  # @param class [String] extra CSS classes appended after the
-  #   component-managed classes
-  # @param id [String] `id=` for the `<table>` element
-  # @param show_headers [Boolean] render the `<thead>` (default true)
-  # @param tbody_id [String] `id=` for the `<tbody>` element (use to
-  #   make the tbody a Turbo Stream target)
-  # @param attributes [Hash] arbitrary HTML attrs forwarded to the
-  #   `<table>` element (`data:`, `cols:`, ARIA attrs, etc.)
-  # @param variant [Symbol, Array<Symbol>] Bootstrap table modifier(s)
-  #   (:striped, :condensed, :hover, :bordered) → adds "table-striped"
-  #   etc. to the class list
-  # @param identifier [String] stable identifier slug → adds
-  #   "table-{identifier}" class for test/JS targeting
-  #   (e.g. `identifier: "location-help"` → `class="… table-location-help"`)
-  def initialize(rows = nil, class: nil, id: nil, show_headers: true, # rubocop:disable Metrics/ParameterLists
-                 tbody_id: nil, attributes: {}, variant: nil, identifier: nil)
-    super()
-    @rows = rows
+  # Rows passed to each column/row block (unused in body mode).
+  prop :rows, _Nilable(_Interface(:each)), :positional, default: nil
+  # `id=` for the `<table>` element.
+  prop :id, _Nilable(String), default: nil
+  # Render the `<thead>`.
+  prop :show_headers, _Boolean, default: true
+  # `id=` for the `<tbody>` element (use to make the tbody a Turbo
+  # Stream target).
+  prop :tbody_id, _Nilable(String), default: nil
+  # Bootstrap table modifier(s) (:striped, :condensed, :hover,
+  # :bordered) — adds "table-striped" etc. to the class list.
+  prop :variant, _Nilable(_Union(Symbol, _Array(Symbol))), default: nil
+  # Stable identifier slug — adds "table-{identifier}" class for
+  # test/JS targeting (e.g. `identifier: "location-help"` →
+  # `class="… table-location-help"`).
+  prop :identifier, _Nilable(String), default: nil
+  # Catch-all for class:, data:, cols:, ARIA attrs, and any other
+  # HTML attrs forwarded to the `<table>` element -- matches
+  # Icon/Collapsible's pattern.
+  prop :attributes, _Hash(Symbol, _Any?), :**
+
+  # `@columns`/`@row_block`/`@body_blocks`/`@heading_block`/
+  # `@heading_attrs` are builder-accumulated state (populated by
+  # `column`/`row`/`body`/`heading` during `vanish`), not constructor
+  # props -- see the class docs above.
+  def initialize(*, **)
     @columns = []
     @row_block = nil
     @body_blocks = []
     @heading_block = nil
     @heading_attrs = {}
-    @show_headers = show_headers
-    @tbody_id = tbody_id
-    @html_class = grab(class:)
-    @html_id = id
-    @attributes = attributes
-    @variant = variant
-    @identifier = identifier
+    super
   end
 
   def view_template(&block)
@@ -183,10 +183,10 @@ class Components::Table < Components::Base
   private
 
   def table_attributes
-    attrs = @attributes.dup
+    attrs = @attributes.except(:class)
     attrs[:class] = class_names("table", variant_classes, identifier_class,
-                                @html_class)
-    attrs[:id] = @html_id if @html_id
+                                @attributes[:class])
+    attrs[:id] = @id if @id
     attrs
   end
 

--- a/app/controllers/application_controller/authentication.rb
+++ b/app/controllers/application_controller/authentication.rb
@@ -225,7 +225,7 @@ module ApplicationController::Authentication
   # Is the current User in admin mode?  Returns true or false.  (*NOTE*: this
   # is available to views.)
   def in_admin_mode?
-    session[:admin]
+    session[:admin] == true
   end
   # helper_method :in_admin_mode?
 

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -197,9 +197,14 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
     @herbarium.place_name         = @herbarium.location.try(&:name)
     @herbarium.personal           = @herbarium.personal_user_id.present?
     @herbarium.personal_user_name = @herbarium.personal_user.try(&:login)
-    return unless in_admin_mode?
+    set_top_users_for_reload
+  end
 
-    @top_users = User.top_users_for_herbarium(@herbarium)
+  # Needed both by the initial edit GET and by #update's
+  # validation-failure re-render (reload_form), so it doesn't silently
+  # drop the top-users list the second time around.
+  def set_top_users_for_reload
+    @top_users = User.top_users_for_herbarium(@herbarium) if in_admin_mode?
   end
 
   def render_modal_herbarium_form
@@ -258,10 +263,7 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
     return unless (@herbarium = find_or_goto_index(Herbarium, params[:id]))
     return unless make_sure_can_edit!
 
-    @herbarium.attributes = herbarium_params
-    normalize_parameters
-    create_location_object_if_new(@herbarium)
-    try_to_save_location_if_new(@herbarium)
+    prepare_herbarium_update
     return reload_form(:edit) unless validate_herbarium! && !@any_errors
 
     unless @herbarium.save
@@ -269,6 +271,14 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
       return reload_form(:edit)
     end
     redirect_to_create_location_or_referrer_or_show_location
+  end
+
+  def prepare_herbarium_update
+    set_top_users_for_reload
+    @herbarium.attributes = herbarium_params
+    normalize_parameters
+    create_location_object_if_new(@herbarium)
+    try_to_save_location_if_new(@herbarium)
   end
 
   def destroy

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -203,7 +203,7 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   # Needed both by the initial edit GET and by #update's
   # validation-failure re-render (reload_form), so it doesn't silently
   # drop the top-users list the second time around.
-  def set_top_users_for_reload
+  private def set_top_users_for_reload
     @top_users = User.top_users_for_herbarium(@herbarium) if in_admin_mode?
   end
 

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -80,133 +80,6 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
     end
   end
 
-  private
-
-  def prepare_herbarium_update
-    set_top_users_for_reload
-    @herbarium.attributes = herbarium_params
-    normalize_parameters
-    create_location_object_if_new(@herbarium)
-    try_to_save_location_if_new(@herbarium)
-  end
-
-  def modal_title
-    case action_name
-    when "new", "create"
-      :new_object.t(type: :herbarium)
-    when "edit", "update"
-      render_to_string(Views::Layouts::Header::ObjectTitle.new(
-                         object: @herbarium, mode: :edit,
-                         title: :herbarium_record.ti
-                       ))
-    end
-  end
-
-  def modal_identifier
-    case action_name
-    when "new", "create"
-      "herbarium"
-    when "edit", "update"
-      "herbarium_#{@herbarium.id}"
-    end
-  end
-
-  def render_modal_herbarium_form
-    render(Components::Modal.new(
-             type: :turbo_form,
-             identifier: modal_identifier,
-             title: modal_title,
-             user: @user,
-             model: @herbarium,
-             form_locals: { user: @user,
-                            location: @herbarium.location,
-                            top_users: @top_users }
-           ), layout: false)
-  end
-
-  def set_up_herbarium_for_edit
-    @herbarium.place_name = @herbarium.location.try(&:name)
-    @herbarium.personal           = @herbarium.personal_user_id.present?
-    @herbarium.personal_user_name = @herbarium.personal_user.try(&:login)
-    set_top_users_for_reload
-  end
-
-  def render_herbarium_show
-    @canonical_url = herbarium_url(params[:id])
-    return unless (@herbarium = find_or_goto_index(Herbarium, params[:id]))
-
-    render(Views::Controllers::Herbaria::Show.new(herbarium: @herbarium))
-  end
-
-  # Needed both by the initial edit GET and by #update's
-  # validation-failure re-render (reload_form), so it doesn't silently
-  # drop the top-users list the second time around.
-  def set_top_users_for_reload
-    @top_users = User.top_users_for_herbarium(@herbarium) if in_admin_mode?
-  end
-
-  # Phlex action template — explicit render per the conversion rule.
-  def render_index_view
-    render(Views::Controllers::Herbaria::Index.new(
-             query: @query, pagination_data: @pagination_data,
-             objects: @objects, merge: @merge
-           ))
-  end
-
-  def full_index_sort_options
-    [
-      ["records",    :sort_by_records.t],
-      ["curator",    :sort_by_curator.t],
-      ["code",       :sort_by_code.t],
-      ["name",       :sort_by_name.t],
-      ["user",       :sort_by_user.t],
-      ["created_at", :sort_by_created_at.t],
-      ["updated_at", :sort_by_updated_at.t]
-    ].freeze
-  end
-
-  # Nonpersonal variant is the full list minus `user` only (NOT
-  # `curator` — institutional herbaria can still have curators,
-  # so sorting by curator is meaningful in the nonpersonal view).
-  # Matches the legacy `nonpersonal_herbaria_index_sorts` exactly.
-  def nonpersonal_index_sort_options
-    # rubocop:disable Style/HashExcept
-    # `except` mistakenly suggested here — this is an Array of
-    # [key, label] tuples, not a Hash. `reject` is correct.
-    full_index_sort_options.reject { |key, _| key == "user" }.freeze
-    # rubocop:enable Style/HashExcept
-  end
-
-  # If user clicks "merge" on an herbarium, it reloads the page and asks
-  # them to click on the destination herbarium to merge it with.
-  def set_merge_ivar
-    @merge = Herbarium.safe_find(params[:merge])
-  end
-
-  def default_sort_order
-    ::Query::Herbaria.default_order # :records
-  end
-
-  def index_active_params
-    [:pattern, :nonpersonal, :by, :q, :id].freeze
-  end
-
-  def nonpersonal
-    store_location
-    query = create_query(
-      :Herbarium, nonpersonal: true, order_by: :code_then_name
-    )
-    [query, { always_index: true }]
-  end
-
-  def index_display_opts(opts, _query)
-    { letters: true,
-      num_per_page: 100,
-      include: [:curators, :herbarium_records, :personal_user] }.merge(opts)
-  end
-
-  public
-
   ##############################################################################
   #
   # Display a single herbarium, based on :flow params
@@ -298,6 +171,139 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   private
 
   include Herbaria::SharedPrivateMethods
+
+  # ---------- Index helpers ----------------------------------------------
+
+  # Phlex action template — explicit render per the conversion rule.
+  def render_index_view
+    render(Views::Controllers::Herbaria::Index.new(
+             query: @query, pagination_data: @pagination_data,
+             objects: @objects, merge: @merge
+           ))
+  end
+
+  def full_index_sort_options
+    [
+      ["records",    :sort_by_records.t],
+      ["curator",    :sort_by_curator.t],
+      ["code",       :sort_by_code.t],
+      ["name",       :sort_by_name.t],
+      ["user",       :sort_by_user.t],
+      ["created_at", :sort_by_created_at.t],
+      ["updated_at", :sort_by_updated_at.t]
+    ].freeze
+  end
+
+  # Nonpersonal variant is the full list minus `user` only (NOT
+  # `curator` — institutional herbaria can still have curators,
+  # so sorting by curator is meaningful in the nonpersonal view).
+  # Matches the legacy `nonpersonal_herbaria_index_sorts` exactly.
+  def nonpersonal_index_sort_options
+    # rubocop:disable Style/HashExcept
+    # `except` mistakenly suggested here — this is an Array of
+    # [key, label] tuples, not a Hash. `reject` is correct.
+    full_index_sort_options.reject { |key, _| key == "user" }.freeze
+    # rubocop:enable Style/HashExcept
+  end
+
+  # If user clicks "merge" on an herbarium, it reloads the page and asks
+  # them to click on the destination herbarium to merge it with.
+  def set_merge_ivar
+    @merge = Herbarium.safe_find(params[:merge])
+  end
+
+  def default_sort_order
+    ::Query::Herbaria.default_order # :records
+  end
+
+  def index_active_params
+    [:pattern, :nonpersonal, :by, :q, :id].freeze
+  end
+
+  def nonpersonal
+    store_location
+    query = create_query(
+      :Herbarium, nonpersonal: true, order_by: :code_then_name
+    )
+    [query, { always_index: true }]
+  end
+
+  def index_display_opts(opts, _query)
+    { letters: true,
+      num_per_page: 100,
+      include: [:curators, :herbarium_records, :personal_user] }.merge(opts)
+  end
+
+  # ---------- Show helper --------------------------------------------------
+
+  def render_herbarium_show
+    @canonical_url = herbarium_url(params[:id])
+    return unless (@herbarium = find_or_goto_index(Herbarium, params[:id]))
+
+    render(Views::Controllers::Herbaria::Show.new(herbarium: @herbarium))
+  end
+
+  # ---------- New/Edit form helpers ----------------------------------------
+
+  def set_up_herbarium_for_edit
+    @herbarium.place_name         = @herbarium.location.try(&:name)
+    @herbarium.personal           = @herbarium.personal_user_id.present?
+    @herbarium.personal_user_name = @herbarium.personal_user.try(&:login)
+    set_top_users_for_reload
+  end
+
+  # Needed both by the initial edit GET and by #update's
+  # validation-failure re-render (reload_form), so it doesn't silently
+  # drop the top-users list the second time around.
+  def set_top_users_for_reload
+    @top_users = User.top_users_for_herbarium(@herbarium) if in_admin_mode?
+  end
+
+  def render_modal_herbarium_form
+    render(Components::Modal.new(
+             type: :turbo_form,
+             identifier: modal_identifier,
+             title: modal_title,
+             user: @user,
+             model: @herbarium,
+             form_locals: { user: @user,
+                            location: @herbarium.location,
+                            top_users: @top_users }
+           ), layout: false)
+  end
+
+  def modal_identifier
+    case action_name
+    when "new", "create"
+      "herbarium"
+    when "edit", "update"
+      "herbarium_#{@herbarium.id}"
+    end
+  end
+
+  def modal_title
+    case action_name
+    when "new", "create"
+      :new_object.t(type: :herbarium)
+    when "edit", "update"
+      render_to_string(Views::Layouts::Header::ObjectTitle.new(
+                         object: @herbarium, mode: :edit,
+                         title: :herbarium_record.ti
+                       ))
+    end
+  end
+
+  # ---------- Update helper -------------------------------------------------
+
+  def prepare_herbarium_update
+    set_top_users_for_reload
+    @herbarium.attributes = herbarium_params
+    normalize_parameters
+    create_location_object_if_new(@herbarium)
+    try_to_save_location_if_new(@herbarium)
+  end
+
+  # ---------- Shared validation / persistence helpers -----------------------
 
   def make_sure_can_edit!
     return true if in_admin_mode? || @herbarium.can_edit?(@user)

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -82,6 +82,69 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
 
   private
 
+  def prepare_herbarium_update
+    set_top_users_for_reload
+    @herbarium.attributes = herbarium_params
+    normalize_parameters
+    create_location_object_if_new(@herbarium)
+    try_to_save_location_if_new(@herbarium)
+  end
+
+  def modal_title
+    case action_name
+    when "new", "create"
+      :new_object.t(type: :herbarium)
+    when "edit", "update"
+      render_to_string(Views::Layouts::Header::ObjectTitle.new(
+                         object: @herbarium, mode: :edit,
+                         title: :herbarium_record.ti
+                       ))
+    end
+  end
+
+  def modal_identifier
+    case action_name
+    when "new", "create"
+      "herbarium"
+    when "edit", "update"
+      "herbarium_#{@herbarium.id}"
+    end
+  end
+
+  def render_modal_herbarium_form
+    render(Components::Modal.new(
+             type: :turbo_form,
+             identifier: modal_identifier,
+             title: modal_title,
+             user: @user,
+             model: @herbarium,
+             form_locals: { user: @user,
+                            location: @herbarium.location,
+                            top_users: @top_users }
+           ), layout: false)
+  end
+
+  def set_up_herbarium_for_edit
+    @herbarium.place_name = @herbarium.location.try(&:name)
+    @herbarium.personal           = @herbarium.personal_user_id.present?
+    @herbarium.personal_user_name = @herbarium.personal_user.try(&:login)
+    set_top_users_for_reload
+  end
+
+  def render_herbarium_show
+    @canonical_url = herbarium_url(params[:id])
+    return unless (@herbarium = find_or_goto_index(Herbarium, params[:id]))
+
+    render(Views::Controllers::Herbaria::Show.new(herbarium: @herbarium))
+  end
+
+  # Needed both by the initial edit GET and by #update's
+  # validation-failure re-render (reload_form), so it doesn't silently
+  # drop the top-users list the second time around.
+  def set_top_users_for_reload
+    @top_users = User.top_users_for_herbarium(@herbarium) if in_admin_mode?
+  end
+
   # Phlex action template — explicit render per the conversion rule.
   def render_index_view
     render(Views::Controllers::Herbaria::Index.new(
@@ -157,13 +220,6 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
     render_herbarium_show
   end
 
-  def render_herbarium_show
-    @canonical_url = herbarium_url(params[:id])
-    return unless (@herbarium = find_or_goto_index(Herbarium, params[:id]))
-
-    render(Views::Controllers::Herbaria::Show.new(herbarium: @herbarium))
-  end
-
   # ---------- Actions to Display forms -- (new, edit, etc.) -------------------
 
   def new
@@ -190,54 +246,6 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
                  herbarium: @herbarium, user: @user, top_users: @top_users
                ))
       end
-    end
-  end
-
-  def set_up_herbarium_for_edit
-    @herbarium.place_name         = @herbarium.location.try(&:name)
-    @herbarium.personal           = @herbarium.personal_user_id.present?
-    @herbarium.personal_user_name = @herbarium.personal_user.try(&:login)
-    set_top_users_for_reload
-  end
-
-  # Needed both by the initial edit GET and by #update's
-  # validation-failure re-render (reload_form), so it doesn't silently
-  # drop the top-users list the second time around.
-  private def set_top_users_for_reload
-    @top_users = User.top_users_for_herbarium(@herbarium) if in_admin_mode?
-  end
-
-  def render_modal_herbarium_form
-    render(Components::Modal.new(
-             type: :turbo_form,
-             identifier: modal_identifier,
-             title: modal_title,
-             user: @user,
-             model: @herbarium,
-             form_locals: { user: @user,
-                            location: @herbarium.location,
-                            top_users: @top_users }
-           ), layout: false)
-  end
-
-  def modal_identifier
-    case action_name
-    when "new", "create"
-      "herbarium"
-    when "edit", "update"
-      "herbarium_#{@herbarium.id}"
-    end
-  end
-
-  def modal_title
-    case action_name
-    when "new", "create"
-      :new_object.t(type: :herbarium)
-    when "edit", "update"
-      render_to_string(Views::Layouts::Header::ObjectTitle.new(
-                         object: @herbarium, mode: :edit,
-                         title: :herbarium_record.ti
-                       ))
     end
   end
 
@@ -271,14 +279,6 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
       return reload_form(:edit)
     end
     redirect_to_create_location_or_referrer_or_show_location
-  end
-
-  def prepare_herbarium_update
-    set_top_users_for_reload
-    @herbarium.attributes = herbarium_params
-    normalize_parameters
-    create_location_object_if_new(@herbarium)
-    try_to_save_location_if_new(@herbarium)
   end
 
   def destroy

--- a/app/controllers/inat_imports_controller/form_builders.rb
+++ b/app/controllers/inat_imports_controller/form_builders.rb
@@ -49,7 +49,7 @@ module InatImportsController::FormBuilders
       Views::Controllers::InatImports::New.new(
         form: build_new_form(submitted),
         super_importer: InatImport.super_importer?(@user),
-        admin: in_admin_mode?,
+        admin: in_admin_mode? == true,
         has_prior_imports: InatImport.exists?(user: @user)
       )
     )

--- a/app/controllers/inat_imports_controller/form_builders.rb
+++ b/app/controllers/inat_imports_controller/form_builders.rb
@@ -49,7 +49,7 @@ module InatImportsController::FormBuilders
       Views::Controllers::InatImports::New.new(
         form: build_new_form(submitted),
         super_importer: InatImport.super_importer?(@user),
-        admin: in_admin_mode? == true,
+        admin: in_admin_mode?,
         has_prior_imports: InatImport.exists?(user: @user)
       )
     )

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -301,7 +301,7 @@ class NamesController < ApplicationController
     # Third query (maybe combine with second)
     @obss = Name::Observations.new(@name)
     # This initiates a query for the images of only the most confident obs
-    @best_images = @obss.best_images
+    @best_images = @obss.best_images.to_a
 
     # Save a lookup in comments_for_object
     @comments = @name.comments&.sort_by(&:created_at)&.reverse

--- a/app/controllers/projects/aliases_controller.rb
+++ b/app/controllers/projects/aliases_controller.rb
@@ -14,7 +14,7 @@ module Projects
     def index
       @project = Project.find(params[:project_id])
       @project_aliases = ProjectAlias.index_includes.
-                         where(project: @project).order(name: :asc)
+                         where(project: @project).order(name: :asc).to_a
       respond_to do |format|
         format.html do
           render(Views::Controllers::Projects::Aliases::Index.new(
@@ -59,6 +59,7 @@ module Projects
 
     def create
       @project_alias = ProjectAlias.new(project_alias_params)
+      @project = @project_alias.project
       err = resolve_verify_target_error(
         @project_alias.verify_target(params[:project_alias][:term])
       )
@@ -96,6 +97,7 @@ module Projects
     end
 
     def update
+      @project = @project_alias.project
       respond_to do |format|
         if @project_alias.update(project_alias_params)
           format.turbo_stream do
@@ -153,7 +155,8 @@ module Projects
     # `projects/aliases/_target_update.erb` partial. Emits four
     # turbo_stream actions.
     def render_project_alias_target_change(project)
-      project_aliases = project.aliases.includes(:target).order(name: :asc)
+      project_aliases = project.aliases.includes(:target).order(name: :asc).
+                        to_a
       render(turbo_stream: [
                replace_target_alias_widget,
                replace_aliases_table(project_aliases),

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -20,7 +20,7 @@ module Projects
     def index
       return unless find_project!
 
-      users = @project.user_group.users.includes(:image)
+      users = @project.user_group.users.includes(:image).to_a
       project_member = ProjectMember.new(project: @project)
       render(Views::Controllers::Projects::Members::Index.new(
                project: @project, users: users,

--- a/app/controllers/projects/updates_controller.rb
+++ b/app/controllers/projects/updates_controller.rb
@@ -93,7 +93,7 @@ module Projects
       scope.
         offset(pagination.from).
         limit(pagination.num_per_page).
-        includes(Observation.matrix_box_includes)
+        includes(Observation.matrix_box_includes).to_a
     end
 
     def require_admin

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -252,13 +252,13 @@ class ProjectsController < ApplicationController
     @drafts = NameDescription.joins(:admin_groups).
               where("name_description_admins.user_group_id":
                     @project.admin_group_id).
-              includes(:name, :user)
+              includes(:name, :user).to_a
     # Save a lookup in comments_for_object
     @comments = @project.comments&.sort_by(&:created_at)&.reverse
     # Matches for the list-search autocompleter
     @object_names = @project.observations.joins(:name).
                     select(Name[:text_name], Name[:id]).distinct.
-                    order(Name[:text_name])
+                    order(Name[:text_name]).to_a
   end
 
   def upload_image_if_present

--- a/app/controllers/projects_controller/creation.rb
+++ b/app/controllers/projects_controller/creation.rb
@@ -85,6 +85,7 @@ module ProjectsController::Creation
     admin_group&.destroy
     user_group&.destroy
     @project = Project.new
+    @project_dates_any = true
     image_ivars
     render_new_form
   end

--- a/app/controllers/species_lists/shared_private_methods.rb
+++ b/app/controllers/species_lists/shared_private_methods.rb
@@ -84,7 +84,7 @@ module SpeciesLists
       names = sorter.multiple_names.uniq.sort_by(&:search_name)
 
       names.map do |name|
-        [name, name.other_authors.includes([:observations])]
+        [name, name.other_authors.includes([:observations]).to_a]
       end
     end
 

--- a/app/controllers/species_lists/write_in_controller.rb
+++ b/app/controllers/species_lists/write_in_controller.rb
@@ -23,9 +23,6 @@ module SpeciesLists
 
     private
 
-    # MO doesn't wire `Phlex::Rails::Resolver`, so a bare `render(:new)`
-    # can't resolve the Phlex action view at `species_lists/write_in/new.rb`.
-    # Construct it explicitly with the instance state the ERB used to read.
     def render_new_page
       render(
         Views::Controllers::SpeciesLists::WriteIn::New.new(

--- a/app/controllers/species_lists/write_in_controller.rb
+++ b/app/controllers/species_lists/write_in_controller.rb
@@ -217,8 +217,14 @@ module SpeciesLists
     end
 
     def calculated_member_vars_for_reload(member_params)
-      # cannot leave @member_notes == nil because view expects a hash
-      @member_notes = member_params[:notes] || Observation.no_notes
+      # cannot leave @member_notes == nil because view expects a hash.
+      # `member_params[:notes]`, when submitted, is a nested
+      # ActionController::Parameters (dynamic "Other"/template-header
+      # keys, not fixed Strong Params attributes) -- matches
+      # ObservationsController::SharedFormMethods#notes_to_sym_and_compact's
+      # conversion for the same shape of field.
+      @member_notes = member_params[:notes]&.to_unsafe_h&.symbolize_keys ||
+                      Observation.no_notes
       @member_is_collection_location =
         member_params[:is_collection_location].to_s == "1"
       @member_specimen = member_params[:specimen].to_s == "1"

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -213,7 +213,7 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
     # Matches for the list-search autocompleter
     @object_names = @species_list.observations.joins(:name).
                     select(Name[:text_name], Name[:id]).distinct.
-                    order(Name[:text_name])
+                    order(Name[:text_name]).to_a
   end
 
   ##############################################################################

--- a/app/models/external_site.rb
+++ b/app/models/external_site.rb
@@ -107,6 +107,6 @@ class ExternalSite < AbstractModel
       all
     else
       user_is_site_project_member(user.id)
-    end
+    end.to_a
   end
 end

--- a/app/views/controllers/account/api_keys/table.rb
+++ b/app/views/controllers/account/api_keys/table.rb
@@ -6,10 +6,7 @@ module Views::Controllers::Account::APIKeys
   # Shared between the index page render and the post-CUD
   # turbo_stream response (which replaces just this block).
   class Table < Views::Base
-    def initialize(user:)
-      super()
-      @user = user
-    end
+    prop :user, ::User
 
     def view_template
       render_keys_table

--- a/app/views/controllers/checklists/contents.rb
+++ b/app/views/controllers/checklists/contents.rb
@@ -5,11 +5,8 @@ module Views::Controllers::Checklists
   # #checklist_contents so the target-names turbo-stream can replace
   # the whole block when a target is added or removed.
   class Contents < ::Components::Base
-    def initialize(data:, context:)
-      super()
-      @data = data
-      @context = context
-    end
+    prop :data, ::Checklist
+    prop :context, ::Views::Controllers::Checklists::Context
 
     def view_template
       div(id: "checklist_contents") do

--- a/app/views/controllers/checklists/panel.rb
+++ b/app/views/controllers/checklists/panel.rb
@@ -8,15 +8,17 @@ module Views::Controllers::Checklists
   # Every taxon row, its display content, link path, and the optional
   # "remove target name" button live here as private methods.
   class Panel < ::Components::Base
-    def initialize(data:, context:, taxa: nil,
-                   panel_id: "checklist_panel",
-                   link_to_name_page: false)
-      super()
-      @data = data
-      @context = context
-      @taxa = taxa || data.taxa
-      @panel_id = panel_id
-      @link_to_name_page = link_to_name_page
+    prop :data, ::Checklist
+    prop :context, ::Views::Controllers::Checklists::Context
+    prop :taxa, _Array(Array)
+    prop :panel_id, String, default: "checklist_panel"
+    prop :link_to_name_page, _Boolean, default: false
+
+    # taxa: defaults to the full checklist when the caller doesn't
+    # pass a filtered subset (see Checklists::Contents#render_panel_
+    # section, which passes species_level_observed_taxa etc).
+    def initialize(data:, taxa: nil, **)
+      super(data: data, taxa: taxa || data.taxa, **)
     end
 
     def view_template

--- a/app/views/controllers/checklists/show.rb
+++ b/app/views/controllers/checklists/show.rb
@@ -3,11 +3,8 @@
 # Phlex view for the checklist page.
 module Views::Controllers::Checklists
   class Show < Views::FullPageBase
-    def initialize(data:, context:)
-      super()
-      @data = data
-      @context = context
-    end
+    prop :data, ::Checklist
+    prop :context, ::Views::Controllers::Checklists::Context
 
     def view_template
       render_page_chrome

--- a/app/views/controllers/field_slips/index.rb
+++ b/app/views/controllers/field_slips/index.rb
@@ -69,13 +69,13 @@ module Views::Controllers::FieldSlips
     end
 
     def render_no_prefix_nudge
-      div(class: "alert alert-info mt-3",
-          id: "field_slip_no_prefix_nudge") do
+      Alert(level: :info, id: "field_slip_no_prefix_nudge",
+            class: "mt-3") do
         plain(:show_project_field_slip_no_prefix.t)
         whitespace
         render(Components::Alert::Link.new(
-                 :show_project_field_slip_set_prefix.t,
-                 project_admin_path(project_id: @project.id)
+                 text: :show_project_field_slip_set_prefix.t,
+                 href: project_admin_path(project_id: @project.id)
                ))
       end
     end

--- a/app/views/controllers/herbaria/curator_requests/new.rb
+++ b/app/views/controllers/herbaria/curator_requests/new.rb
@@ -3,11 +3,8 @@
 module Views::Controllers::Herbaria::CuratorRequests
   # Action view for the herbarium curator-request form.
   class New < Views::FullPageBase
-    def initialize(herbarium:, back: nil)
-      super()
-      @herbarium = herbarium
-      @back = back
-    end
+    prop :herbarium, ::Herbarium
+    prop :back, _Nilable(String), default: nil
 
     def view_template
       add_page_title(:show_herbarium_curator_request.t)

--- a/app/views/controllers/herbaria/edit.rb
+++ b/app/views/controllers/herbaria/edit.rb
@@ -3,12 +3,11 @@
 module Views::Controllers::Herbaria
   # Action view for the edit herbarium form page.
   class Edit < Views::FullPageBase
-    def initialize(herbarium:, user:, top_users:)
-      super()
-      @herbarium = herbarium
-      @user = user
-      @top_users = top_users
-    end
+    prop :herbarium, ::Herbarium
+    prop :user, ::User
+    # nil for non-admins -- set_up_herbarium_for_edit only computes
+    # this `if in_admin_mode?`.
+    prop :top_users, _Nilable(_Array(::User))
 
     def view_template
       add_edit_title(@herbarium)

--- a/app/views/controllers/herbaria/new.rb
+++ b/app/views/controllers/herbaria/new.rb
@@ -3,11 +3,8 @@
 module Views::Controllers::Herbaria
   # Action view for the new herbarium form page.
   class New < Views::FullPageBase
-    def initialize(herbarium:, user:)
-      super()
-      @herbarium = herbarium
-      @user = user
-    end
+    prop :herbarium, ::Herbarium
+    prop :user, ::User
 
     def view_template
       add_new_title(:new_object, :herbarium)

--- a/app/views/controllers/herbaria/search/new.rb
+++ b/app/views/controllers/herbaria/search/new.rb
@@ -3,12 +3,9 @@
 module Views::Controllers::Herbaria::Search
   # Action view for the herbaria search form page.
   class New < Views::FullPageBase
-    def initialize(search:, controller:, local:)
-      super()
-      @search = search
-      @controller = controller
-      @local = local
-    end
+    prop :search, ::Query
+    prop :controller, ::Herbaria::SearchController
+    prop :local, _Boolean
 
     def view_template
       add_new_title(:search_object, :herbaria)

--- a/app/views/controllers/images/field_slip_extracts/edit.rb
+++ b/app/views/controllers/images/field_slip_extracts/edit.rb
@@ -108,9 +108,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     end
 
     def render_slip_photo
-      render(Components::InteractiveImage.new(
-               image: @extract.image, user: @user, votes: false
-             ))
+      InteractiveImage(image: @extract.image, user: @user, votes: false)
     end
 
     def render_form

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -33,9 +33,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     # the observation-scoped scan page's job (linked below), since
     # which photo shows the slip is a decision about the observation.
     def render_unscanned
-      render(Components::Panel.new(
-               panel_id: "field_slip_extract_none"
-             )) do |p|
+      Panel(panel_id: "field_slip_extract_none") do |p|
         p.with_body do
           plain(:field_slip_extract_none_yet.l)
         end

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -57,9 +57,7 @@ module Views::Controllers::Images::FieldSlipExtracts
 
     def render_pending
       div(data: { controller: "reload-poll" }) do
-        render(Components::Panel.new(
-                 panel_id: "field_slip_extract_pending"
-               )) do |p|
+        Panel(panel_id: "field_slip_extract_pending") do |p|
           p.with_body do
             span(class: "spinner-right mx-2")
             plain(:field_slip_extract_pending.l)

--- a/app/views/controllers/inat_imports/new.rb
+++ b/app/views/controllers/inat_imports/new.rb
@@ -5,14 +5,10 @@ module Views::Controllers::InatImports
   # Sets page title and context nav, then renders the
   # form component.
   class New < Views::FullPageBase
-    def initialize(form:, super_importer: false, admin: false,
-                   has_prior_imports: false)
-      super()
-      @form = form
-      @super_importer = super_importer
-      @admin = admin
-      @has_prior_imports = has_prior_imports
-    end
+    prop :form, ::FormObject::InatImport
+    prop :super_importer, _Boolean, default: false
+    prop :admin, _Boolean, default: false
+    prop :has_prior_imports, _Boolean, default: false
 
     def view_template
       add_page_title(:inat_import_create_title.l)

--- a/app/views/controllers/info/textile_sandbox.rb
+++ b/app/views/controllers/info/textile_sandbox.rb
@@ -16,12 +16,9 @@ module Views::Controllers::Info
     # @param textile_sandbox [FormObject::TextileSandbox] the model
     # @param show_result [Boolean] whether to show rendered result
     # @param submit_type [String] the submit button clicked
-    def initialize(textile_sandbox:, show_result:, submit_type:)
-      super()
-      @textile_sandbox = textile_sandbox
-      @show_result = show_result
-      @submit_type = submit_type
-    end
+    prop :textile_sandbox, ::FormObject::TextileSandbox
+    prop :show_result, _Boolean
+    prop :submit_type, _Nilable(String)
 
     def view_template
       add_page_title(:sandbox_title.t)

--- a/app/views/controllers/locations/show/coordinates.rb
+++ b/app/views/controllers/locations/show/coordinates.rb
@@ -8,9 +8,7 @@ module Views::Controllers::Locations
       prop :location, ::Location
 
       def view_template
-        render(
-          ::Components::Panel.new(panel_id: "location_coordinates")
-        ) do |panel|
+        Panel(panel_id: "location_coordinates") do |panel|
           panel.with_heading { :coordinates.ti }
           links = heading_links
           panel.with_heading_links { trusted_html(links) } if links.present?

--- a/app/views/controllers/names/show.rb
+++ b/app/views/controllers/names/show.rb
@@ -20,12 +20,8 @@ module Views::Controllers::Names
   class Show < Views::FullPageBase
     prop :name, ::Name
     prop :user, _Nilable(::User), default: nil
-    # `best_images` comes from `Name::Observations#best_images` —
-    # an `ActiveRecord::Relation` of `Image` in production; accept
-    # plain `Array` for tests that pass a stubbed list.
-    prop :best_images,
-         _Nilable(_Union(Array, ::ActiveRecord::Relation)),
-         default: nil
+    # Matches Views::Controllers::Users::Show's own best_images prop.
+    prop :best_images, _Array(_Nilable(::Image)), default: -> { [] }
     # The `Description` record (eager-loaded via
     # `Name.show_includes`). Forwarded to `BestDescriptionPanel`,
     # which derives both the body text and the permission gates
@@ -84,7 +80,7 @@ module Views::Controllers::Names
 
     def render_left_column
       div(class: content_for(:left_columns).to_s) do
-        render_best_images_carousel if @best_images&.length&.positive?
+        render_best_images_carousel if @best_images.length.positive?
         render(Show::BestDescriptionPanel.new(
                  name: @name, description: @description, user: @user
                ))

--- a/app/views/controllers/observations/field_slip_scans/show.rb
+++ b/app/views/controllers/observations/field_slip_scans/show.rb
@@ -13,9 +13,7 @@ module Views::Controllers::Observations::FieldSlipScans
     def view_template
       add_page_title(:field_slip_scan_title.t(id: @observation.id))
 
-      render(Components::Panel.new(
-               panel_id: "field_slip_scan_photos"
-             )) do |p|
+      Panel(panel_id: "field_slip_scan_photos") do |p|
         p.with_body do
           plain(:field_slip_scan_help.l)
           div(class: "d-flex flex-wrap mt-3") do
@@ -30,8 +28,8 @@ module Views::Controllers::Observations::FieldSlipScans
 
     def render_photo(image)
       div(class: "mr-4 mb-3 text-center") do
-        render(Components::InteractiveImage.new(image: image, user: @user,
-                                                size: :small, votes: false))
+        InteractiveImage(image: image, user: @user, size: :small,
+                         votes: false)
         div { render_photo_state(image) }
       end
     end

--- a/app/views/controllers/observations/namings/edit.rb
+++ b/app/views/controllers/observations/namings/edit.rb
@@ -5,20 +5,14 @@
 # back into the same Form component.
 module Views::Controllers::Observations::Namings
   class Edit < Views::FullPageBase
-    # rubocop:disable Metrics/ParameterLists
-    # See sibling `New#initialize` for the same param-list rationale.
-    def initialize(observation:, naming:, vote:, given_name:, reasons:,
-                   user: nil, feedback: {})
-      super()
-      @observation = observation
-      @user = user
-      @naming = naming
-      @vote = vote
-      @given_name = given_name
-      @reasons = reasons
-      @feedback = feedback
-    end
-    # rubocop:enable Metrics/ParameterLists
+    prop :observation, ::Observation
+    prop :naming, ::Naming
+    # nil when this user hasn't voted on this naming yet.
+    prop :vote, _Nilable(::Vote)
+    prop :given_name, String
+    prop :reasons, _Hash(Integer, ::Naming::Reason)
+    prop :user, _Nilable(::User), default: nil
+    prop :feedback, Hash, default: -> { {} }
 
     def view_template
       add_chrome

--- a/app/views/controllers/observations/namings/new.rb
+++ b/app/views/controllers/observations/namings/new.rb
@@ -5,23 +5,16 @@
 # form, and a right column with the observation's images.
 module Views::Controllers::Observations::Namings
   class New < Views::FullPageBase
-    # rubocop:disable Metrics/ParameterLists
     # Forwards every prop the Form component needs — `observation`
     # for chrome (title + context-nav + observation_details +
-    # images), the rest for the Form itself. Not a candidate for
-    # the parameter-list refactor lever; this is the form's data.
-    def initialize(observation:, naming:, vote:, given_name:, reasons:,
-                   user: nil, feedback: {})
-      super()
-      @observation = observation
-      @user = user
-      @naming = naming
-      @vote = vote
-      @given_name = given_name
-      @reasons = reasons
-      @feedback = feedback
-    end
-    # rubocop:enable Metrics/ParameterLists
+    # images), the rest for the Form itself.
+    prop :observation, ::Observation
+    prop :naming, ::Naming
+    prop :vote, ::Vote
+    prop :given_name, String
+    prop :reasons, _Hash(Integer, ::Naming::Reason)
+    prop :user, _Nilable(::User), default: nil
+    prop :feedback, Hash, default: -> { {} }
 
     def view_template
       add_chrome

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -20,25 +20,24 @@
 # obs-title chain in `observations_helper.rb`.
 module Views::Controllers::Observations
   class Show < Views::FullPageBase
-    # rubocop:disable Metrics/ParameterLists
-    # The show page consumes every obs-derived ivar the controller
-    # builds; the param list mirrors the controller's `@ivar`s.
-    def initialize(observation:, user: nil, consensus: nil,
-                   comments: [], images: [], other_sites: nil,
-                   sibling_observations: nil, occurrence: nil,
-                   owner_name: nil)
-      super()
-      @observation = observation
-      @user = user
-      @consensus = consensus
-      @comments = comments
-      @images = images
-      @other_sites = other_sites
-      @sibling_observations = sibling_observations || []
-      @occurrence = occurrence
-      @owner_name = owner_name
+    prop :observation, ::Observation
+    prop :user, _Nilable(::User), default: nil
+    prop :consensus, _Nilable(::Observation::NamingConsensus), default: nil
+    prop :comments, _Array(::Comment), default: -> { [] }
+    prop :images, _Array(::Image), default: -> { [] }
+    prop :other_sites,
+         _Nilable(_Union(_Array(::ExternalSite), ::ActiveRecord::Relation)),
+         default: nil
+    prop :sibling_observations, _Array(::Observation)
+    prop :occurrence, _Nilable(::Occurrence), default: nil
+    prop :owner_name, _Nilable(::Name), default: nil
+
+    # sibling_observations: only gets computed by the controller when
+    # there's an @occurrence -- normalize nil to [] here so callers
+    # (and this class's own methods) never need a nil-guard.
+    def initialize(sibling_observations: nil, **)
+      super(sibling_observations: sibling_observations || [], **)
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def view_template
       add_chrome

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -25,9 +25,7 @@ module Views::Controllers::Observations
     prop :consensus, _Nilable(::Observation::NamingConsensus), default: nil
     prop :comments, _Array(::Comment), default: -> { [] }
     prop :images, _Array(::Image), default: -> { [] }
-    prop :other_sites,
-         _Nilable(_Union(_Array(::ExternalSite), ::ActiveRecord::Relation)),
-         default: nil
+    prop :other_sites, _Nilable(_Array(::ExternalSite)), default: nil
     prop :sibling_observations, _Array(::Observation)
     prop :occurrence, _Nilable(::Occurrence), default: nil
     prop :owner_name, _Nilable(::Name), default: nil
@@ -96,7 +94,7 @@ module Views::Controllers::Observations
     def render_right_column
       render(Details.new(
                obs: @observation, consensus: @consensus, user: @user,
-               sites: @other_sites&.to_a, siblings: @sibling_observations
+               sites: @other_sites, siblings: @sibling_observations
              ))
       return unless @user
 

--- a/app/views/controllers/occurrences/edit.rb
+++ b/app/views/controllers/occurrences/edit.rb
@@ -4,15 +4,13 @@
 # Optionally overlays a project membership confirmation modal.
 module Views::Controllers::Occurrences
   class Edit < Views::FullPageBase
-    def initialize(occurrence:, observations:, candidates:,
-                   user:, project_gaps: nil)
-      super()
-      @occurrence = occurrence
-      @observations = observations
-      @candidates = candidates
-      @user = user
-      @project_gaps = project_gaps
-    end
+    prop :occurrence, ::Occurrence
+    prop :observations, _Array(::Observation)
+    prop :candidates, _Array(::Observation)
+    prop :user, ::User
+    # nil on the plain `edit` GET -- only #update's redirect-back-to-
+    # edit path (when gaps remain) computes this first.
+    prop :project_gaps, _Nilable(Hash), default: nil
 
     def view_template
       container_class(:wide)

--- a/app/views/controllers/occurrences/new.rb
+++ b/app/views/controllers/occurrences/new.rb
@@ -5,14 +5,10 @@
 # Optionally overlays a project membership confirmation modal.
 module Views::Controllers::Occurrences
   class New < Views::FullPageBase
-    def initialize(source_obs:, recent_observations:, user:,
-                   project_confirm: {})
-      super()
-      @source_obs = source_obs
-      @recent_observations = recent_observations
-      @user = user
-      @project_confirm = project_confirm
-    end
+    prop :source_obs, ::Observation
+    prop :recent_observations, _Array(::Observation)
+    prop :user, ::User
+    prop :project_confirm, Hash, default: -> { {} }
 
     def view_template
       container_class(:full)

--- a/app/views/controllers/occurrences/show.rb
+++ b/app/views/controllers/occurrences/show.rb
@@ -4,12 +4,9 @@
 # Displays observations in matrix boxes with the primary first.
 module Views::Controllers::Occurrences
   class Show < Views::FullPageBase
-    def initialize(occurrence:, observations:, user:)
-      super()
-      @occurrence = occurrence
-      @observations = observations
-      @user = user
-    end
+    prop :occurrence, ::Occurrence
+    prop :observations, _Array(::Observation)
+    prop :user, ::User
 
     def view_template
       container_class(:wide)

--- a/app/views/controllers/projects/admin/show.rb
+++ b/app/views/controllers/projects/admin/show.rb
@@ -7,13 +7,10 @@ module Views::Controllers::Projects::Admin
   # the form so the user can swap to Members or Aliases without
   # leaving the Admin context.
   class Show < Views::FullPageBase
-    def initialize(project:, user:, dates_any:, upload_params:)
-      super()
-      @project = project
-      @user = user
-      @dates_any = dates_any
-      @upload_params = upload_params
-    end
+    prop :project, ::Project
+    prop :user, ::User
+    prop :dates_any, _Boolean
+    prop :upload_params, Hash
 
     def view_template
       add_project_banner(@project)

--- a/app/views/controllers/projects/admin_requests/new.rb
+++ b/app/views/controllers/projects/admin_requests/new.rb
@@ -3,10 +3,7 @@
 module Views::Controllers::Projects::AdminRequests
   # Phlex view for the admin request form page.
   class New < Views::FullPageBase
-    def initialize(project:)
-      super()
-      @project = project
-    end
+    prop :project, ::Project
 
     def view_template
       add_page_title(

--- a/app/views/controllers/projects/admin_subtabs.rb
+++ b/app/views/controllers/projects/admin_subtabs.rb
@@ -10,11 +10,8 @@
 # root rather than nested under a sub-controller's directory.
 module Views::Controllers::Projects
   class AdminSubtabs < Views::Base
-    def initialize(project:, current_subtab:)
-      super()
-      @project = project
-      @current_subtab = current_subtab
-    end
+    prop :project, ::Project
+    prop :current_subtab, _Union("details", "members", "aliases")
 
     def view_template
       Row do

--- a/app/views/controllers/projects/aliases/edit.rb
+++ b/app/views/controllers/projects/aliases/edit.rb
@@ -3,12 +3,9 @@
 module Views::Controllers::Projects::Aliases
   # Phlex view for the edit project alias form page.
   class Edit < Views::FullPageBase
-    def initialize(project_alias:, project:, user:)
-      super()
-      @project_alias = project_alias
-      @project = project
-      @user = user
-    end
+    prop :project_alias, ::ProjectAlias
+    prop :project, ::Project
+    prop :user, ::User
 
     def view_template
       add_project_banner(@project)

--- a/app/views/controllers/projects/aliases/index.rb
+++ b/app/views/controllers/projects/aliases/index.rb
@@ -3,11 +3,8 @@
 # Phlex view for the project aliases index page.
 module Views::Controllers::Projects::Aliases
   class Index < Views::FullPageBase
-    def initialize(project:, project_aliases:)
-      super()
-      @project = project
-      @project_aliases = project_aliases
-    end
+    prop :project, ::Project
+    prop :project_aliases, _Array(::ProjectAlias)
 
     def view_template
       add_project_banner(@project)

--- a/app/views/controllers/projects/aliases/new.rb
+++ b/app/views/controllers/projects/aliases/new.rb
@@ -3,12 +3,9 @@
 module Views::Controllers::Projects::Aliases
   # Phlex view for the new project alias form page.
   class New < Views::FullPageBase
-    def initialize(project_alias:, project:, user:)
-      super()
-      @project_alias = project_alias
-      @project = project
-      @user = user
-    end
+    prop :project_alias, ::ProjectAlias
+    prop :project, ::Project
+    prop :user, ::User
 
     def view_template
       add_project_banner(@project)

--- a/app/views/controllers/projects/aliases/show.rb
+++ b/app/views/controllers/projects/aliases/show.rb
@@ -3,11 +3,8 @@
 module Views::Controllers::Projects::Aliases
   # Phlex view for the project alias show page.
   class Show < Views::FullPageBase
-    def initialize(project:, project_alias:)
-      super()
-      @project = project
-      @project_alias = project_alias
-    end
+    prop :project, ::Project
+    prop :project_alias, ::ProjectAlias
 
     def view_template
       add_project_banner(@project)

--- a/app/views/controllers/projects/aliases/table.rb
+++ b/app/views/controllers/projects/aliases/table.rb
@@ -15,10 +15,7 @@ module Views::Controllers::Projects::Aliases
     # `Link(type: :get, name: ..., target: alias_.target)` cell
     # doesn't trigger N+1 queries. The `Projects::AliasesController`
     # paths supply that.
-    def initialize(project_aliases:)
-      super()
-      @project_aliases = project_aliases
-    end
+    prop :project_aliases, _Array(::ProjectAlias)
 
     # Must stay `render(::Components::Table.new(...))`, not bare
     # `Table(...)` Kit syntax -- this view class is itself named

--- a/app/views/controllers/projects/aliases/widget.rb
+++ b/app/views/controllers/projects/aliases/widget.rb
@@ -7,11 +7,8 @@
 # alongside the action views (edit, index, new, show).
 module Views::Controllers::Projects::Aliases
   class Widget < Views::Base
-    def initialize(project:, target:)
-      super()
-      @project = project
-      @target = target
-    end
+    prop :project, ::Project
+    prop :target, _Union(::User, ::Location)
 
     def view_template
       div(id: "target_project_alias_#{@target.id}") do

--- a/app/views/controllers/projects/field_slips/new.rb
+++ b/app/views/controllers/projects/field_slips/new.rb
@@ -3,13 +3,10 @@
 module Views::Controllers::Projects::FieldSlips
   # Phlex view for the field slips form page.
   class New < Views::FullPageBase
-    def initialize(project:, user:, field_slip_max:, trackers:)
-      super()
-      @project = project
-      @user = user
-      @field_slip_max = field_slip_max
-      @trackers = trackers
-    end
+    prop :project, ::Project
+    prop :user, ::User
+    prop :field_slip_max, Integer
+    prop :trackers, _Array(::FieldSlipJobTracker)
 
     def view_template
       add_page_title(page_title)

--- a/app/views/controllers/projects/field_slips/tracker_row.rb
+++ b/app/views/controllers/projects/field_slips/tracker_row.rb
@@ -7,11 +7,8 @@
 # reference this view by its full namespace.
 module Views::Controllers::Projects::FieldSlips
   class TrackerRow < Views::Base
-    def initialize(tracker:, user:)
-      super()
-      @tracker = tracker
-      @user = user
-    end
+    prop :tracker, ::FieldSlipJobTracker
+    prop :user, ::User
 
     def view_template
       tr(id: dom_id(@tracker), **tracker_data) do

--- a/app/views/controllers/projects/list_item.rb
+++ b/app/views/controllers/projects/list_item.rb
@@ -7,10 +7,7 @@
 # meta column).
 module Views::Controllers::Projects
   class ListItem < Views::Base
-    def initialize(project:)
-      super()
-      @project = project
-    end
+    prop :project, ::Project
 
     def view_template
       div(class: "text-larger") do

--- a/app/views/controllers/projects/locations/tables.rb
+++ b/app/views/controllers/projects/locations/tables.rb
@@ -6,16 +6,12 @@
 #
 module Views::Controllers::Projects::Locations
   class Tables < Views::Base
-    def initialize(project:, grouped_data:,
-                   ungrouped_locations:, obs_counts:,
-                   user: nil)
-      super()
-      @project = project
-      @grouped_data = grouped_data
-      @ungrouped_locations = ungrouped_locations
-      @obs_counts = obs_counts
-      @user = user
-    end
+    prop :project, ::Project
+    # Each element: { target: ::Location, sub_locations: Array(::Location) }
+    prop :grouped_data, _Array(Hash)
+    prop :ungrouped_locations, _Array(::Location)
+    prop :obs_counts, _Hash(Integer, Integer)
+    prop :user, _Nilable(::User), default: nil
 
     def view_template
       div(id: "locations_table") do

--- a/app/views/controllers/projects/members/add_obs_modal.rb
+++ b/app/views/controllers/projects/members/add_obs_modal.rb
@@ -8,13 +8,10 @@ module Views::Controllers::Projects::Members
   # Submit button row in `.modal-footer`. Renders nothing in the
   # body when count is zero except the "none match" message.
   class AddObsModal < Views::Base
-    def initialize(project:, candidate:, count:, batch_limit:)
-      super()
-      @project = project
-      @candidate = candidate
-      @count = count
-      @batch_limit = batch_limit
-    end
+    prop :project, ::Project
+    prop :candidate, ::User
+    prop :count, Integer
+    prop :batch_limit, Integer
 
     def view_template
       Modal(id: "modal_add_obs",

--- a/app/views/controllers/projects/members/edit.rb
+++ b/app/views/controllers/projects/members/edit.rb
@@ -3,12 +3,9 @@
 module Views::Controllers::Projects::Members
   # Phlex view for the change member status page.
   class Edit < Views::FullPageBase
-    def initialize(project:, project_member:, user:)
-      super()
-      @project = project
-      @project_member = project_member
-      @user = user
-    end
+    prop :project, ::Project
+    prop :project_member, ::ProjectMember
+    prop :user, ::User
 
     def view_template
       add_page_title(

--- a/app/views/controllers/projects/members/groups.rb
+++ b/app/views/controllers/projects/members/groups.rb
@@ -4,11 +4,8 @@
 # `Projects::MembersController#edit`.
 module Views::Controllers::Projects::Members
   class Groups < Views::Base
-    def initialize(project:, user:)
-      super()
-      @project = project
-      @user = user
-    end
+    prop :project, ::Project
+    prop :user, ::User
 
     def view_template
       render_group(:change_member_status_members,

--- a/app/views/controllers/projects/members/index.rb
+++ b/app/views/controllers/projects/members/index.rb
@@ -3,14 +3,10 @@
 module Views::Controllers::Projects::Members
   # Phlex view for the project members index page.
   class Index < Views::FullPageBase
-    def initialize(project:, users:, project_member:,
-                   user:)
-      super()
-      @project = project
-      @users = users
-      @project_member = project_member
-      @user = user
-    end
+    prop :project, ::Project
+    prop :users, _Array(::User)
+    prop :project_member, ::ProjectMember
+    prop :user, ::User
 
     def view_template
       add_project_banner(@project)

--- a/app/views/controllers/projects/members/new.rb
+++ b/app/views/controllers/projects/members/new.rb
@@ -3,13 +3,10 @@
 module Views::Controllers::Projects::Members
   # Phlex view for the add members page.
   class New < Views::FullPageBase
-    def initialize(project:, users:, project_member:, user:)
-      super()
-      @project = project
-      @users = users
-      @project_member = project_member
-      @user = user
-    end
+    prop :project, ::Project
+    prop :users, _Array(::User)
+    prop :project_member, ::ProjectMember
+    prop :user, ::User
 
     def view_template
       add_page_title(

--- a/app/views/controllers/projects/new.rb
+++ b/app/views/controllers/projects/new.rb
@@ -3,12 +3,9 @@
 module Views::Controllers::Projects
   # Phlex view for the new project form page.
   class New < Views::FullPageBase
-    def initialize(project:, dates_any:, upload_params:)
-      super()
-      @project = project
-      @dates_any = dates_any
-      @upload_params = upload_params
-    end
+    prop :project, ::Project
+    prop :dates_any, _Boolean
+    prop :upload_params, Hash
 
     def view_template
       add_new_title(:create_object, :project)

--- a/app/views/controllers/projects/show.rb
+++ b/app/views/controllers/projects/show.rb
@@ -3,14 +3,14 @@
 module Views::Controllers::Projects
   # Phlex view for the project show page.
   class Show < Views::FullPageBase
-    def initialize(project:, user:, drafts:, comments:, object_names:)
-      super()
-      @project = project
-      @user = user
-      @drafts = drafts
-      @comments = comments
-      @object_names = object_names
-    end
+    prop :project, ::Project
+    prop :user, ::User
+    prop :drafts, _Array(::NameDescription)
+    prop :comments, _Array(::Comment)
+    # Despite selecting Name[:text_name]/Name[:id], the base relation
+    # is `@project.observations` -- these are Observation records
+    # (with those Name columns attached), not Name instances.
+    prop :object_names, _Array(::Observation)
 
     def view_template
       add_show_title(@project)

--- a/app/views/controllers/projects/updates/index.rb
+++ b/app/views/controllers/projects/updates/index.rb
@@ -2,16 +2,25 @@
 
 module Views::Controllers::Projects::Updates
   class Index < Views::FullPageBase
-    def initialize(project:, user:, results:, show_excluded:)
-      super()
-      @project = project
-      @user = user
-      @observations = results[:observations]
-      @pagination = results[:pagination]
-      @request_url = results[:request_url]
-      @form_action_url = results[:form_action_url]
-      @current_count = results[:current_count]
-      @show_excluded = show_excluded
+    prop :project, ::Project
+    prop :user, ::User
+    prop :observations, _Array(::Observation)
+    prop :pagination, ::PaginationData
+    prop :request_url, String
+    prop :form_action_url, String
+    prop :current_count, Integer
+    prop :show_excluded, _Boolean
+
+    # `results:` bundles five values the controller computes together
+    # (see Projects::UpdatesController#build_index_results) -- split
+    # them into individual props here so callers still pass one hash.
+    def initialize(results:, **)
+      super(observations: results[:observations],
+            pagination: results[:pagination],
+            request_url: results[:request_url],
+            form_action_url: results[:form_action_url],
+            current_count: results[:current_count],
+            **)
     end
 
     def view_template

--- a/app/views/controllers/projects/updates/obs_footer.rb
+++ b/app/views/controllers/projects/updates/obs_footer.rb
@@ -8,12 +8,9 @@
 # (which also un-excludes). Otherwise, both Add and Exclude are shown.
 module Views::Controllers::Projects::Updates
   class ObsFooter < Views::Base
-    def initialize(project:, obs:, show_excluded:)
-      super()
-      @project = project
-      @obs = obs
-      @show_excluded = show_excluded
-    end
+    prop :project, ::Project
+    prop :obs, ::Observation
+    prop :show_excluded, _Boolean
 
     def view_template
       div(id: "update_footer_#{@obs.id}", class: "text-center") do

--- a/app/views/controllers/projects/violations/target_location_modal.rb
+++ b/app/views/controllers/projects/violations/target_location_modal.rb
@@ -18,13 +18,10 @@ module Views::Controllers::Projects::Violations
   # one-controller-action modal wrappers — it isn't reusable, it's
   # the rendering of one specific controller action.
   class TargetLocationModal < Views::Base
-    def initialize(project:, obs:, user:, existing_locations:)
-      super()
-      @project = project
-      @obs = obs
-      @user = user
-      @existing_locations = existing_locations
-    end
+    prop :project, ::Project
+    prop :obs, ::Observation
+    prop :user, ::User
+    prop :existing_locations, _Hash(String, ::Location)
 
     def view_template
       Modal(id: TargetLocationForm.modal_id_for(@obs),

--- a/app/views/controllers/species_lists/details.rb
+++ b/app/views/controllers/species_lists/details.rb
@@ -5,11 +5,8 @@
 # with a download button in the header row.
 module Views::Controllers::SpeciesLists
   class Details < Views::Base
-    def initialize(species_list:, query:)
-      super()
-      @species_list = species_list
-      @query = query
-    end
+    prop :species_list, ::SpeciesList
+    prop :query, ::Query
 
     def view_template
       Panel(panel_id: "list_details",

--- a/app/views/controllers/species_lists/downloads/new.rb
+++ b/app/views/controllers/species_lists/downloads/new.rb
@@ -6,14 +6,11 @@
 # (`Views::Controllers::Observations::Downloads::Form`).
 module Views::Controllers::SpeciesLists::Downloads
   class New < Views::FullPageBase
-    def initialize(list:, query:, type:, format:, encoding:)
-      super()
-      @list = list
-      @query = query
-      @type = type
-      @format = format
-      @encoding = encoding
-    end
+    prop :list, ::SpeciesList
+    prop :query, ::Query
+    prop :type, String
+    prop :format, String
+    prop :encoding, String
 
     def view_template
       add_page_title(:species_list_download_title.t)

--- a/app/views/controllers/species_lists/edit.rb
+++ b/app/views/controllers/species_lists/edit.rb
@@ -5,15 +5,11 @@
 # shared `Form` Phlex class with `button: :update`.
 module Views::Controllers::SpeciesLists
   class Edit < Views::FullPageBase
-    def initialize(species_list:, projects:, dubious_where_reasons:,
-                   submitted_project_ids:, user:)
-      super()
-      @species_list = species_list
-      @projects = projects
-      @dubious_where_reasons = dubious_where_reasons
-      @submitted_project_ids = submitted_project_ids
-      @user = user
-    end
+    prop :species_list, ::SpeciesList
+    prop :projects, _Array(::Project)
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash)))
+    prop :submitted_project_ids, _Nilable(_Array(String))
+    prop :user, ::User
 
     def view_template
       add_edit_title(@species_list)

--- a/app/views/controllers/species_lists/index.rb
+++ b/app/views/controllers/species_lists/index.rb
@@ -5,13 +5,10 @@
 # container width), then renders a list of `Listing` rows.
 module Views::Controllers::SpeciesLists
   class Index < Views::FullPageBase
-    def initialize(query:, pagination_data:, objects:, project: nil)
-      super()
-      @query = query
-      @pagination_data = pagination_data
-      @objects = objects
-      @project = project
-    end
+    prop :query, ::Query
+    prop :pagination_data, ::PaginationData
+    prop :objects, _Array(::SpeciesList)
+    prop :project, _Nilable(::Project), default: nil
 
     def view_template
       add_project_banner(@project) if @project

--- a/app/views/controllers/species_lists/listing.rb
+++ b/app/views/controllers/species_lists/listing.rb
@@ -12,15 +12,11 @@
 # wrapper of its own; the surrounding ListGroup item provides it.
 module Views::Controllers::SpeciesLists
   class Listing < Views::Base
-    def initialize(species_list:, observation: nil,
-                   remove: false, add: false, project: nil)
-      super()
-      @species_list = species_list
-      @observation = observation
-      @remove = remove
-      @add = add
-      @project = project
-    end
+    prop :species_list, ::SpeciesList
+    prop :observation, _Nilable(::Observation), default: nil
+    prop :remove, _Boolean, default: false
+    prop :add, _Boolean, default: false
+    prop :project, _Nilable(::Project), default: nil
 
     # Row contents only — the surrounding `<div class="list-group-item
     # d-flex justify-content-between align-items-start">` is emitted by

--- a/app/views/controllers/species_lists/name_lists/new.rb
+++ b/app/views/controllers/species_lists/name_lists/new.rb
@@ -41,7 +41,7 @@ module Views::Controllers::SpeciesLists::NameLists
     def render_lister_table
       Table(
         class: "name-lister mt-3 w-100",
-        attributes: { cols: "3", data: lister_data }
+        cols: "3", data: lister_data
       ) do |t|
         t.column(:name_lister_genera.t, width: "20%")
         t.column(:name_lister_species.t, width: "40%")

--- a/app/views/controllers/species_lists/name_lists/new.rb
+++ b/app/views/controllers/species_lists/name_lists/new.rb
@@ -14,11 +14,8 @@
 # `attributes:`.
 module Views::Controllers::SpeciesLists::NameLists
   class New < Views::FullPageBase
-    def initialize(name_strings:, user:)
-      super()
-      @name_strings = name_strings
-      @user = user
-    end
+    prop :name_strings, _Array(String)
+    prop :user, ::User
 
     def view_template
       add_page_title(:name_lister_title.t)

--- a/app/views/controllers/species_lists/new.rb
+++ b/app/views/controllers/species_lists/new.rb
@@ -8,22 +8,12 @@
 # pre-populates from another species_list.
 module Views::Controllers::SpeciesLists
   class New < Views::FullPageBase
-    # rubocop:disable Metrics/ParameterLists
-    # See `Edit#initialize` — action views forward whatever the form
-    # needs; `ParameterLists` isn't on the CLAUDE.md "always refactor"
-    # list and the alternatives (hash collapse, pre-built form) hurt
-    # readability.
-    def initialize(species_list:, projects:, dubious_where_reasons:,
-                   submitted_project_ids:, user:, clone_id: nil)
-      super()
-      @species_list = species_list
-      @projects = projects
-      @dubious_where_reasons = dubious_where_reasons
-      @submitted_project_ids = submitted_project_ids
-      @user = user
-      @clone_id = clone_id
-    end
-    # rubocop:enable Metrics/ParameterLists
+    prop :species_list, ::SpeciesList
+    prop :projects, _Array(::Project)
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash)))
+    prop :submitted_project_ids, _Nilable(_Array(String))
+    prop :user, ::User
+    prop :clone_id, _Nilable(String), default: nil
 
     def view_template
       add_new_title(:create_object, :species_list)

--- a/app/views/controllers/species_lists/observation.rb
+++ b/app/views/controllers/species_lists/observation.rb
@@ -6,15 +6,11 @@
 # gated "Remove" button sits in the top-right.
 module Views::Controllers::SpeciesLists
   class Observation < Views::Base
-    def initialize(observation:, user:, species_list:,
-                   image: false, remove: false)
-      super()
-      @observation = observation
-      @user = user
-      @species_list = species_list
-      @image = image
-      @remove = remove
-    end
+    prop :observation, ::Observation
+    prop :user, ::User
+    prop :species_list, ::SpeciesList
+    prop :image, _Boolean, default: false
+    prop :remove, _Boolean, default: false
 
     def view_template
       Row do

--- a/app/views/controllers/species_lists/observations/edit.rb
+++ b/app/views/controllers/species_lists/observations/edit.rb
@@ -6,11 +6,8 @@
 # current query of observations.
 module Views::Controllers::SpeciesLists::Observations
   class Edit < Views::FullPageBase
-    def initialize(prefill_value:, num_results:)
-      super()
-      @prefill_value = prefill_value
-      @num_results = num_results
-    end
+    prop :prefill_value, String
+    prop :num_results, Integer
 
     def view_template
       add_page_title(:species_list_add_remove_title.t)

--- a/app/views/controllers/species_lists/projects/edit.rb
+++ b/app/views/controllers/species_lists/projects/edit.rb
@@ -4,13 +4,10 @@
 # chrome plus the inline `Form`.
 module Views::Controllers::SpeciesLists::Projects
   class Edit < Views::FullPageBase
-    def initialize(list:, projects:, object_states:, project_states:)
-      super()
-      @list = list
-      @projects = projects
-      @object_states = object_states
-      @project_states = project_states
-    end
+    prop :list, ::SpeciesList
+    prop :projects, _Array(::Project)
+    prop :object_states, _Hash(Symbol, _Boolean)
+    prop :project_states, _Hash(Integer, _Boolean)
 
     def view_template
       add_page_title(:species_list_projects_title.t(list: @list.title))

--- a/app/views/controllers/species_lists/search/new.rb
+++ b/app/views/controllers/species_lists/search/new.rb
@@ -5,12 +5,9 @@ module Views::Controllers::SpeciesLists
     # Search form for species_lists. Wraps `Components::Form::Search`
     # with the page chrome (title, container width).
     class New < Views::FullPageBase
-      def initialize(search:, controller:, local: nil)
-        super()
-        @search = search
-        @controller = controller
-        @local = local
-      end
+      prop :search, ::Query
+      prop :controller, ::SpeciesLists::SearchController
+      prop :local, _Nilable(_Boolean), default: nil
 
       def view_template
         add_new_title(:search_object, :species_lists)

--- a/app/views/controllers/species_lists/show.rb
+++ b/app/views/controllers/species_lists/show.rb
@@ -7,23 +7,14 @@
 # search box, observations list, comments, object footer.
 module Views::Controllers::SpeciesLists
   class Show < Views::FullPageBase
-    # rubocop:disable Metrics/ParameterLists
-    # See `Edit#initialize` — action views forward whatever the page
-    # needs; `ParameterLists` isn't on the CLAUDE.md "always refactor"
-    # list.
-    def initialize(species_list:, user:, query:, pagination_data:,
-                   objects:, comments:, object_names:, project: nil)
-      super()
-      @species_list = species_list
-      @user = user
-      @query = query
-      @pagination_data = pagination_data
-      @objects = objects
-      @comments = comments
-      @object_names = object_names
-      @project = project
-    end
-    # rubocop:enable Metrics/ParameterLists
+    prop :species_list, ::SpeciesList
+    prop :user, ::User
+    prop :query, ::Query
+    prop :pagination_data, ::PaginationData
+    prop :objects, _Array(::Observation)
+    prop :comments, _Array(::Comment)
+    prop :object_names, ::ActiveRecord::Relation
+    prop :project, _Nilable(::Project), default: nil
 
     def view_template
       add_chrome

--- a/app/views/controllers/species_lists/show.rb
+++ b/app/views/controllers/species_lists/show.rb
@@ -13,7 +13,10 @@ module Views::Controllers::SpeciesLists
     prop :pagination_data, ::PaginationData
     prop :objects, _Array(::Observation)
     prop :comments, _Array(::Comment)
-    prop :object_names, ::ActiveRecord::Relation
+    # Despite selecting Name[:text_name]/Name[:id], the base relation
+    # is `@species_list.observations` -- these are Observation
+    # records (with those Name columns attached), not Name instances.
+    prop :object_names, _Array(::Observation)
     prop :project, _Nilable(::Project), default: nil
 
     def view_template

--- a/app/views/controllers/species_lists/uploads/new.rb
+++ b/app/views/controllers/species_lists/uploads/new.rb
@@ -4,10 +4,7 @@
 # inline `Form` that posts the file under `species_list[file]`.
 module Views::Controllers::SpeciesLists::Uploads
   class New < Views::FullPageBase
-    def initialize(species_list:)
-      super()
-      @species_list = species_list
-    end
+    prop :species_list, ::SpeciesList
 
     def view_template
       add_page_title(:species_list_upload_title.t)

--- a/app/views/controllers/species_lists/write_in/new.rb
+++ b/app/views/controllers/species_lists/write_in/new.rb
@@ -14,8 +14,7 @@ module Views::Controllers::SpeciesLists::WriteIn
     # touches them, so they're nil there.
     prop :new_names, _Nilable(_Array(String))
     prop :deprecated_names, _Nilable(_Array(::Name))
-    prop :multiple_names,
-         _Nilable(_Array(_Tuple(::Name, ::ActiveRecord::Relation)))
+    prop :multiple_names, _Nilable(_Array(_Tuple(::Name, _Array(::Name))))
     prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash)))
     prop :list_members, _Nilable(String)
     prop :place_name, _Nilable(String)

--- a/app/views/controllers/species_lists/write_in/new.rb
+++ b/app/views/controllers/species_lists/write_in/new.rb
@@ -5,13 +5,28 @@ module Views::Controllers::SpeciesLists::WriteIn
   # re-rendered by the `create` action on validation failure).
   # Sets the page chrome and delegates to the Phlex `Form`.
   class New < Views::FullPageBase
-    def initialize(species_list:, user:, button:, **state)
-      super()
-      @species_list = species_list
-      @user = user
-      @button = button
-      @state = state
-    end
+    prop :species_list, ::SpeciesList
+    prop :user, ::User
+    prop :button, Symbol
+    # new_names/deprecated_names/multiple_names/list_members/place_name
+    # only get set on the create action's validation-failure re-render
+    # (init_name_vars_from_sorter) -- the initial #new GET never
+    # touches them, so they're nil there.
+    prop :new_names, _Nilable(_Array(String))
+    prop :deprecated_names, _Nilable(_Array(::Name))
+    prop :multiple_names,
+         _Nilable(_Array(_Tuple(::Name, ::ActiveRecord::Relation)))
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash)))
+    prop :list_members, _Nilable(String)
+    prop :place_name, _Nilable(String)
+    prop :member_vote, _Union(Integer, String)
+    prop :member_notes, Hash
+    prop :member_notes_parts, _Array(String)
+    prop :member_lat, _Nilable(String)
+    prop :member_lng, _Nilable(String)
+    prop :member_alt, _Nilable(String)
+    prop :member_is_collection_location, _Boolean
+    prop :member_specimen, _Boolean
 
     def view_template
       add_page_title(
@@ -23,7 +38,21 @@ module Views::Controllers::SpeciesLists::WriteIn
       render(Form.new(@species_list,
                       user: @user,
                       button: @button,
-                      **@state))
+                      new_names: @new_names,
+                      deprecated_names: @deprecated_names,
+                      multiple_names: @multiple_names,
+                      dubious_where_reasons: @dubious_where_reasons,
+                      list_members: @list_members,
+                      place_name: @place_name,
+                      member_vote: @member_vote,
+                      member_notes: @member_notes,
+                      member_notes_parts: @member_notes_parts,
+                      member_lat: @member_lat,
+                      member_lng: @member_lng,
+                      member_alt: @member_alt,
+                      member_is_collection_location:
+                        @member_is_collection_location,
+                      member_specimen: @member_specimen))
     end
   end
 end

--- a/app/views/layouts/sidebar/context_nav.rb
+++ b/app/views/layouts/sidebar/context_nav.rb
@@ -28,9 +28,13 @@ class Views::Layouts::Sidebar::ContextNav < Views::Base
   # prop.
   CSS_CLASSES = ::Views::Layouts::Sidebar::CSS_CLASSES
 
+  prop :links, _Array(Array)
+
+  # links: arrives as `[text, url, args]` tuples (see
+  # Views::FullPageBase::ContextNav#add_context_nav) -- compact here
+  # is a defensive extra pass, not a transform callers rely on.
   def initialize(links:)
-    super()
-    @links = links.compact
+    super(links: links.compact)
   end
 
   def view_template

--- a/lib/rubocop/cop/mo/initialize_without_prop.rb
+++ b/lib/rubocop/cop/mo/initialize_without_prop.rb
@@ -61,6 +61,22 @@ module RuboCop
         PHLEX_SUPERCLASS_PREFIXES = ["Components::", "Views::"].freeze
         PHLEX_SUPERCLASSES = ["Phlex::HTML", "Phlex::SGML"].freeze
 
+        # `Components::ApplicationForm` extends Superform::Rails::Form
+        # (a gem class) and its own hand-written `initialize` sets up
+        # `@namespace`/`@model`/`@action`/`@method` -- state every
+        # Superform field helper depends on. Verified empirically: a
+        # direct subclass that declares its own `prop` hits the same
+        # "child's new props make super skip the parent's initialize
+        # body" gotcha documented above, except here the skipped logic
+        # is core Superform state, not just a validation call, so
+        # there's no safe explicit-call workaround (there's no single
+        # method to call -- it's the whole initialize). Matches
+        # `application_form/**/*.rb`'s exclusion for the same family
+        # of reasons; this covers the OTHER direct subclasses of
+        # ApplicationForm that live outside that directory (most
+        # `views/controllers/**/form.rb` files).
+        NON_PROP_COMPATIBLE_SUPERCLASSES = ["Components::ApplicationForm"].freeze
+
         def on_class(class_node)
           return unless phlex_subclass?(class_node)
 
@@ -79,6 +95,8 @@ module RuboCop
           return false unless superclass
 
           name = superclass.source.delete_prefix("::")
+          return false if NON_PROP_COMPATIBLE_SUPERCLASSES.include?(name)
+
           PHLEX_SUPERCLASSES.include?(name) ||
             PHLEX_SUPERCLASS_PREFIXES.any? { |prefix| name.start_with?(prefix) }
         end

--- a/lib/rubocop/cop/mo/initialize_without_prop.rb
+++ b/lib/rubocop/cop/mo/initialize_without_prop.rb
@@ -46,7 +46,24 @@ module RuboCop
               "class declares no `prop` of its own -- use Literal props " \
               "instead (see .claude/rules/phlex_reference.md)."
 
+        # Literal type-builder methods (`prop`, `_Nilable`, `_Union`,
+        # etc.) only exist on a class whose ancestry runs through
+        # `Phlex::HTML` -- MO's own hierarchy roots are
+        # `Components::*`/`Views::*` (both ultimately `Phlex::HTML`
+        # subclasses), so checking the literal superclass name against
+        # those prefixes is a cheap, reliable proxy for "this class
+        # can actually use props" without needing to load the app.
+        # This is a static, lexical check (RuboCop has no runtime
+        # class table) -- a class that renames its superclass to
+        # something outside these prefixes while still ultimately
+        # being Phlex-based would be missed, but that's not a pattern
+        # this codebase uses.
+        PHLEX_SUPERCLASS_PREFIXES = ["Components::", "Views::"].freeze
+        PHLEX_SUPERCLASSES = ["Phlex::HTML", "Phlex::SGML"].freeze
+
         def on_class(class_node)
+          return unless phlex_subclass?(class_node)
+
           init_def = direct_initialize(class_node)
           return unless init_def
           return unless assigns_own_ivar?(init_def)
@@ -56,6 +73,15 @@ module RuboCop
         end
 
         private
+
+        def phlex_subclass?(class_node)
+          superclass = class_node.children[1]
+          return false unless superclass
+
+          name = superclass.source.delete_prefix("::")
+          PHLEX_SUPERCLASSES.include?(name) ||
+            PHLEX_SUPERCLASS_PREFIXES.any? { |prefix| name.start_with?(prefix) }
+        end
 
         def direct_initialize(class_node)
           class_node.each_descendant(:def).find do |def_node|

--- a/lib/rubocop/cop/mo/initialize_without_prop.rb
+++ b/lib/rubocop/cop/mo/initialize_without_prop.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Flags a class that defines `initialize` with hand-rolled
+      # `@ivar = value` assignments but declares no Literal `prop` of
+      # its own -- MO's Phlex convention is Literal props (see
+      # .claude/rules/phlex_reference.md's "ALWAYS use concrete prop
+      # types" section and the #5020 prop-conversion sweep), not
+      # manually-assigned instance state.
+      #
+      # A class whose `initialize` does nothing but COMPUTE a value
+      # and forward it via `super(...)` (no `@ivar =` of its own) is
+      # the legitimate "hybrid pattern" for a prop whose default
+      # depends on another prop's value -- see
+      # Components::Link::Edit/New/Download for the canonical
+      # example. That shape is intentionally NOT flagged; only a
+      # class that assigns its own ivars by hand, bypassing props
+      # entirely, is.
+      #
+      # @example
+      #   # bad
+      #   class Components::Foo < Components::Base
+      #     def initialize(name:, path:)
+      #       @name = name
+      #       @path = path
+      #     end
+      #   end
+      #
+      #   # good
+      #   class Components::Foo < Components::Base
+      #     prop :name, String
+      #     prop :path, String
+      #   end
+      #
+      #   # good -- hybrid pattern, no ivars of its own, forwards to super
+      #   class Components::Foo::Edit < Components::Foo
+      #     def initialize(name: nil, target: nil, **opts)
+      #       name ||= default_name(target)
+      #       super(name: name, target: target, **opts)
+      #     end
+      #   end
+      class InitializeWithoutProp < Base
+        MSG = "`initialize` hand-assigns instance variables but this " \
+              "class declares no `prop` of its own -- use Literal props " \
+              "instead (see .claude/rules/phlex_reference.md)."
+
+        def on_class(class_node)
+          init_def = direct_initialize(class_node)
+          return unless init_def
+          return unless assigns_own_ivar?(init_def)
+          return if declares_prop?(class_node)
+
+          add_offense(init_def)
+        end
+
+        private
+
+        def direct_initialize(class_node)
+          class_node.each_descendant(:def).find do |def_node|
+            def_node.method?(:initialize) && owned_by?(def_node, class_node)
+          end
+        end
+
+        # A node belongs to `class_node` only if `class_node` is its
+        # NEAREST enclosing class/sclass -- excludes a nested class's
+        # own `initialize`/`prop` from being attributed to the outer
+        # class.
+        def owned_by?(node, class_node)
+          node.each_ancestor(:class, :sclass).first.equal?(class_node)
+        end
+
+        def assigns_own_ivar?(def_node)
+          def_node.each_descendant(:ivasgn).any?
+        end
+
+        def declares_prop?(class_node)
+          class_node.each_descendant(:send).any? do |send_node|
+            send_node.method?(:prop) && send_node.receiver.nil? &&
+              owned_by?(send_node, class_node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mo/no_active_record_relation_prop.rb
+++ b/lib/rubocop/cop/mo/no_active_record_relation_prop.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Phlex `prop` declarations must not reference `ActiveRecord::
+      # Relation` as (or within) the type -- a bare Relation carries no
+      # element type, so Literal's construction-time check can't catch a
+      # caller passing the wrong model's records (or the right model via
+      # the wrong query). Materialize with `.to_a` at the call site and
+      # declare `_Array(<Model>)` instead -- this doesn't drop whatever
+      # `.includes`/`.joins` eager-loading is already on the relation,
+      # it just changes when the query executes (immediately, instead
+      # of on first enumeration).
+      #
+      # @example
+      #   # bad
+      #   prop :objects, ::ActiveRecord::Relation
+      #   prop :objects, _Nilable(::ActiveRecord::Relation)
+      #   prop :objects, _Union(_Array(::Foo), ::ActiveRecord::Relation)
+      #
+      #   # good
+      #   prop :objects, _Array(::Foo)
+      #   prop :objects, _Nilable(_Array(::Foo))
+      class NoActiveRecordRelationProp < Base
+        MSG = "Don't use ActiveRecord::Relation as a prop type -- it " \
+              "carries no element type, so Literal can't catch a caller " \
+              "passing the wrong model's records. Materialize with " \
+              "`.to_a` at the call site and use `_Array(<Model>)` " \
+              "instead."
+
+        RESTRICT_ON_SEND = [:prop].freeze
+
+        def on_send(node)
+          type_arg = node.arguments[1]
+          return unless type_arg
+          return unless type_arg.source.include?("ActiveRecord::Relation")
+
+          add_offense(type_arg)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mo/no_raw_bootstrap_component.rb
+++ b/lib/rubocop/cop/mo/no_raw_bootstrap_component.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Phlex views/components must not hand-roll the markup for a
+      # top-level Bootstrap UI component MO already has a
+      # `Components::*` wrapper for -- e.g. `div(class: "alert
+      # alert-info")` instead of `Alert(level: :info)`. Detects a
+      # `div`/`ul`/`nav` tag call whose `class:` value is a string
+      # literal containing one of the known Bootstrap root classes
+      # below, and suggests the corresponding component.
+      #
+      # Scoped via this cop's Include/Exclude in .rubocop.yml -- the
+      # Exclude list covers each mapped component's own implementation
+      # file(s), which legitimately emit the raw markup to BUILD the
+      # abstraction every other Phlex file is required to use instead
+      # (same shape as MO/NoRawLinkOrButtonTo's exclusion of
+      # button.rb/link.rb).
+      #
+      # @example
+      #   # bad
+      #   div(class: "alert alert-info") { ... }
+      #   div(class: "modal fade", id: "x") { ... }
+      #
+      #   # good
+      #   Alert(level: :info) { ... }
+      #   Modal(id: "x") { ... }
+      class NoRawBootstrapComponent < Base
+        MSG = "Don't hand-roll `.%<css_class>s` markup -- use " \
+              "`%<component>s(...)` (Components::%<component>s) instead."
+
+        RESTRICT_ON_SEND = [:div, :ul, :nav].freeze
+
+        ROOT_CLASS_TO_COMPONENT = {
+          "alert" => "Alert",
+          "modal" => "Modal",
+          "dropdown" => "Dropdown",
+          "dropdown-menu" => "Dropdown",
+          "list-group" => "ListGroup",
+          "navbar" => "Navbar",
+          "nav-tabs" => "NavTabs",
+          "panel" => "Panel",
+          "carousel" => "Carousel",
+          "input-group" => "InputGroup",
+          "btn-group" => "ButtonGroup"
+        }.freeze
+
+        def on_send(node)
+          return unless bare_call?(node)
+
+          class_arg = class_keyword_value(node)
+          return unless class_arg&.str_type?
+
+          root = matching_root_class(class_arg.value)
+          return unless root
+          return if application_form_subclass?(node)
+
+          component = ROOT_CLASS_TO_COMPONENT[root]
+          add_offense(node,
+                      message: format(MSG, css_class: root,
+                                           component: component))
+        end
+
+        private
+
+        def bare_call?(node)
+          node.receiver.nil? || node.receiver.self_type?
+        end
+
+        # `Components::ApplicationForm` is a class, not a module, so
+        # Phlex::Kit's `const_added` hook never fires for its
+        # subclasses -- see phlex_reference.md's "Kit sugar doesn't
+        # reach app/components/application_form/*". Any raw Bootstrap
+        # markup here (e.g. a Stimulus-driven autocomplete pulldown
+        # reusing `.dropdown-menu` for styling only, not Bootstrap's
+        # actual toggle-button JS behavior) can't be swapped for a
+        # bare Kit-syntax call regardless of which root class matched.
+        def application_form_subclass?(node)
+          class_node = node.each_ancestor(:class).first
+          return false unless class_node
+
+          superclass = class_node.children[1]
+          return false unless superclass
+
+          superclass.source.delete_prefix("::").end_with?("ApplicationForm")
+        end
+
+        def class_keyword_value(node)
+          hash = node.arguments.find(&:hash_type?)
+          return nil unless hash
+
+          pair = hash.pairs.find do |p|
+            p.key.sym_type? && p.key.value == :class
+          end
+          pair&.value
+        end
+
+        def matching_root_class(class_string)
+          tokens = class_string.to_s.split(/\s+/)
+          ROOT_CLASS_TO_COMPONENT.keys.find { |root| tokens.include?(root) }
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mo/prefer_kit_syntax.rb
+++ b/lib/rubocop/cop/mo/prefer_kit_syntax.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Phlex views/components should call `Foo(...)` (Kit syntax)
+      # rather than `render(Components::Foo.new(...))` when `Foo` sits
+      # directly under `Components` -- Phlex::Kit generates a bare
+      # instance method for every such class (see
+      # .claude/rules/phlex_reference.md's "Kit syntax" section), so
+      # the verbose `render(...)` form is never necessary for a
+      # single-level Components class.
+      #
+      # Three real, already-encountered exceptions are detected and
+      # skipped automatically (no `.rubocop.yml` file lists needed):
+      #
+      # 1. **Self-name collision**: a class named the same as the Kit
+      #    method it would call (e.g. `Components::Matrix::Carousel`
+      #    calling `Carousel(...)`, or a view class named `Table`
+      #    calling `Table(...)`) breaks -- Kit's method resolution
+      #    recurses into the caller's own class instead of resolving
+      #    `Components::Carousel`/`Components::Table`. Confirmed by two
+      #    existing bug-fix comments (commit 33fdc952e5).
+      #    `render(Components::X.new(...))` is the correct, permanent
+      #    form here, not a workaround to eventually remove.
+      #
+      # 2. **Mixin modules**: a `module Components::X` meant to be
+      #    `include`d at varying nesting depths (e.g.
+      #    `Components::IconWithText`, included by deeply-dispatched
+      #    subclasses like `Components::Button::Edit`) can't reliably
+      #    assume Kit sugar is mixed in that far down the ancestor
+      #    chain. Any `render(...)` whose nearest enclosing definition
+      #    is a bare `module` (not a `class`) is skipped.
+      #
+      # 3. **`ApplicationForm` subclasses**: `Components::ApplicationForm`
+      #    is a class, not a module, so Phlex::Kit's `const_added` hook
+      #    never fires for its subclasses (see phlex_reference.md's
+      #    "Kit sugar doesn't reach app/components/application_form/*").
+      #    A class whose direct superclass name ends in `ApplicationForm`
+      #    is skipped.
+      #
+      # @example
+      #   # bad
+      #   render(Components::Alert.new(level: :info)) { ... }
+      #
+      #   # good
+      #   Alert(level: :info) { ... }
+      #
+      #   # good -- self-name collision (exception 1 above)
+      #   class Components::Matrix::Carousel < Components::Base
+      #     def view_template
+      #       render(Components::Carousel.new(...)) { ... }
+      #     end
+      #   end
+      class PreferKitSyntax < Base
+        MSG = "Use bare `%<name>s(...)` (Kit syntax) instead of " \
+              "`render(Components::%<name>s.new(...))`."
+
+        RESTRICT_ON_SEND = [:render].freeze
+
+        def on_send(node)
+          return unless bare_call?(node)
+
+          ctor = component_constructor(node)
+          return unless ctor
+
+          name = single_level_components_class(ctor)
+          return unless name
+          return if inside_module?(node)
+          return if application_form_subclass?(node)
+          return if enclosing_class_named?(node, name)
+
+          add_offense(node, message: format(MSG, name: name))
+        end
+
+        private
+
+        def bare_call?(node)
+          node.receiver.nil? || node.receiver.self_type?
+        end
+
+        def component_constructor(node)
+          arg = node.arguments.first
+          return nil unless arg&.send_type? && arg.method?(:new)
+
+          arg
+        end
+
+        def single_level_components_class(ctor_node)
+          receiver = ctor_node.receiver
+          return nil unless receiver&.const_type?
+
+          full_name = receiver.const_name
+          return nil unless full_name
+
+          parts = full_name.delete_prefix("::").split("::")
+          return nil unless parts.length == 2 && parts.first == "Components"
+
+          parts.last
+        end
+
+        def inside_module?(node)
+          enclosing = node.each_ancestor(:class, :module).first
+          enclosing&.module_type? || false
+        end
+
+        def application_form_subclass?(node)
+          class_node = node.each_ancestor(:class).first
+          return false unless class_node
+
+          superclass = class_node.children[1]
+          return false unless superclass
+
+          superclass.source.delete_prefix("::").end_with?("ApplicationForm")
+        end
+
+        def enclosing_class_named?(node, name)
+          class_node = node.each_ancestor(:class).first
+          return false unless class_node
+
+          own_name = class_node.children[0]&.const_name
+          return false unless own_name
+
+          own_name.split("::").last == name
+        end
+      end
+    end
+  end
+end

--- a/test/components/alert/link_test.rb
+++ b/test/components/alert/link_test.rb
@@ -25,7 +25,8 @@ class Components::Alert::LinkTest < ComponentTestCase
   private
 
   def render_link(**)
-    render(Components::Alert::Link.new("Set prefix", "/projects/1/admin",
-                                       **))
+    render(Components::Alert::Link.new(
+             text: "Set prefix", href: "/projects/1/admin", **
+           ))
   end
 end

--- a/test/components/list_group/item_test.rb
+++ b/test/components/list_group/item_test.rb
@@ -34,7 +34,7 @@ class ListGroupItemTest < ComponentTestCase
   end
 
   def test_arbitrary_attributes_forwarded
-    html = render_item(attributes: { data: { role: "row" } }) { "x" }
+    html = render_item(data: { role: "row" }) { "x" }
 
     assert_html(html, "div.list-group-item",
                 attribute: { "data-role" => "row" })
@@ -55,11 +55,10 @@ class ListGroupItemTest < ComponentTestCase
 
   private
 
-  def render_item(element: :div, class: nil, id: nil, attributes: {}, &block)
+  def render_item(element: :div, class: nil, id: nil, **attrs, &block)
     extra_class = binding.local_variable_get(:class)
     render(Components::ListGroup::Item.new(
-             element: element, class: extra_class, id: id,
-             attributes: attributes
+             element: element, class: extra_class, id: id, **attrs
            ), &block)
   end
 end

--- a/test/components/list_group_test.rb
+++ b/test/components/list_group_test.rb
@@ -101,7 +101,7 @@ class ListGroupTest < ComponentTestCase
 
   def test_container_data_attributes_pass_through
     html = render_list(
-      attributes: { data: { controller: "section-update" } }
+      data: { controller: "section-update" }
     ) do |list|
       list.item { "x" }
     end

--- a/test/components/nav_tabs_test.rb
+++ b/test/components/nav_tabs_test.rb
@@ -57,8 +57,7 @@ class NavTabsTest < ComponentTestCase
   end
 
   def test_attributes_forwarded_to_ul
-    html = render_with(attributes: { id: "my_tabs",
-                                     data: { x: "v" } }) do |tabs|
+    html = render_with(id: "my_tabs", data: { x: "v" }) do |tabs|
       tabs.tab("One", "/one")
     end
 

--- a/test/components/table_test.rb
+++ b/test/components/table_test.rb
@@ -169,13 +169,13 @@ class TableTest < ComponentTestCase
     rows = [TestRow.new(name: "Alice")]
 
     html = render_table(
-      rows, attributes: { cols: "1", data: { controller: "name-list" } }
+      rows, cols: "1", data: { controller: "name-list" }
     ) do |t|
       t.column("Name", &:name)
     end
 
-    # `attributes:` Hash forwards arbitrary HTML attrs to the
-    # `<table>` element (table-level Stimulus root etc.).
+    # Arbitrary kwargs forward to the `<table>` element (table-level
+    # Stimulus root etc.).
     assert_html(html, "table[cols='1'][data-controller='name-list']")
   end
 

--- a/test/controllers/projects/aliases_controller_test.rb
+++ b/test/controllers/projects/aliases_controller_test.rb
@@ -172,6 +172,10 @@ module Projects
             })
 
       assert_response(:success)
+      # Regression: #update didn't set @project before re-rendering the
+      # edit page on validation failure, so the project banner (which
+      # renders nothing at all without a project) silently disappeared.
+      assert_select("#project_tabs")
     end
 
     def test_update_can_use_turbo_to_modify_project_alias

--- a/test/views/controllers/checklists/contents_test.rb
+++ b/test/views/controllers/checklists/contents_test.rb
@@ -78,13 +78,22 @@ module Views::Controllers::Checklists
     # panel. We deliberately leave taxa arrays empty so
     # `render_panel_section` skips both observed panels — this test is
     # about the summary line, not panel rendering.
-    ChecklistDataStub = Struct.new(
-      :num_species_observed, :num_higher_level_observed,
-      :species_level_observed_taxa, :higher_level_observed_taxa,
-      :unobserved_target_taxa, :duplicate_synonyms,
-      :any_deprecated_flag,
-      keyword_init: true
-    ) do
+    #
+    # Subclasses `Checklist` (rather than a bare Struct) so it still
+    # satisfies `Contents`' `prop :data, ::Checklist` -- overrides
+    # `initialize` entirely, so none of the real DB-driven calculation
+    # in the base class runs.
+    class ChecklistDataStub < Checklist
+      attr_accessor :num_species_observed, :num_higher_level_observed,
+                    :species_level_observed_taxa,
+                    :higher_level_observed_taxa, :unobserved_target_taxa,
+                    :duplicate_synonyms, :any_deprecated_flag
+
+      def initialize(**attrs)
+        super()
+        attrs.each { |key, value| public_send(:"#{key}=", value) }
+      end
+
       def any_deprecated?
         any_deprecated_flag
       end

--- a/test/views/controllers/projects/aliases/table_test.rb
+++ b/test/views/controllers/projects/aliases/table_test.rb
@@ -39,7 +39,7 @@ module Views::Controllers::Projects::Aliases
     end
 
     def test_empty_alias_list_renders_just_headers
-      html = render_table(project_aliases: ProjectAlias.none)
+      html = render_table(project_aliases: [])
 
       assert_html(html, "table##{Table::TABLE_ID}")
       assert_html(html, "th", text: :name.ti)
@@ -49,7 +49,7 @@ module Views::Controllers::Projects::Aliases
 
     private
 
-    def render_table(project_aliases: @project.aliases)
+    def render_table(project_aliases: @project.aliases.to_a)
       render(Table.new(project_aliases: project_aliases))
     end
   end

--- a/test/views/controllers/projects/members/index_test.rb
+++ b/test/views/controllers/projects/members/index_test.rb
@@ -14,7 +14,8 @@ module Views::Controllers::Projects::Members
     # view's table column.
     def test_member_status
       project = projects(:eol_project)
-      view = Index.new(project: project, users: [], project_member: nil,
+      view = Index.new(project: project, users: [],
+                       project_member: ProjectMember.new(project: project),
                        user: @user)
 
       assert_equal(:owner.ti, view.send(:member_status, project.user))


### PR DESCRIPTION
CC on autopilot at some point forgot all about Phlex typed props, and just started calling `initialize` — and I didn't notice. Once there are enough bad examples in the codebase, it's a crapshoot whether it follows good examples or bad. 

This sweep gets rid of most of the bad examples, and adds a cop to stop the behavior. The rest of the "violations" will get cleaned up in #5020, the icon PR, and a future PR addressing #5022.

## Summary

- Converts `app/views/controllers/` and `app/components/` (except `Link::`/`Button::`, which live on #5020) from hand-rolled `initialize` to Literal `prop` declarations.
- Adds four custom cops: `MO/InitializeWithoutProp` (flags hand-rolled `initialize`), `MO/NoActiveRecordRelationProp` (bans `ActiveRecord::Relation` prop types), `MO/NoRawBootstrapComponent` (bans hand-rolled Bootstrap markup MO already has a component for), `MO/PreferKitSyntax` (prefers bare `Foo(...)` over `render(Components::Foo.new(...))`).
- Fixes a bug the sweep surfaced: `SpeciesLists::WriteInController` was handing a strictly-typed `member_notes: Hash` prop a raw `ActionController::Parameters`.

## Scope note

`.rubocop.yml` temporarily excludes `app/components/button*`/`link*` from `MO/InitializeWithoutProp`, since those conversions live only on #5020 — remove once that merges.

## Follow-up

#5048 tracks introducing a proper `Notes` PORO to replace the bare `Hash` prop type this sweep introduced for `member_notes`.

## Test plan

- [x] Full `bin/rails test`
- [x] `bundle exec rubocop --parallel`
