### PR TITLE
Add `FieldSlip::Template` layouts; read Andy Wilson's DBG voucher slips

### DIFF
--- a/app/classes/field_slip/extractor.rb
+++ b/app/classes/field_slip/extractor.rb
@@ -8,16 +8,17 @@ class FieldSlip
   # swapping providers -- or A/B-ing a new one against Gemini -- touches
   # nothing but this registry. An adapter owns its own request and
   # response parsing, and is asked -- through the shared `Prompt` -- for
-  # values keyed by the `FIELDS` labels below. Where each label lands on
-  # the Observation is `FIELDS`' business and `Applier`'s, so a new
-  # provider never restates the mapping.
+  # values keyed by the labels of the slip's `Template` (which layout a
+  # given photo uses comes from the project, via `Context`). Where each
+  # label lands on the Observation is the Template's business and
+  # `Applier`'s, so a new provider never restates the mapping.
   module Extractor
     PROVIDERS = { gemini: "FieldSlip::Extractor::Gemini" }.freeze
 
     # Bump when the prompt changes in a way that could change results.
     # Stored on the extract so a stale read is identifiable later --
     # which only works if this actually moves, so treat editing
-    # `Prompt` and bumping this as one act.
+    # `Prompt` (or a Template's rules) and bumping this as one act.
     #
     #   1  initial
     #   2  user aliases transcribed rather than expanded, so "dcs" stays
@@ -33,52 +34,12 @@ class FieldSlip
     #      instead of by being printed, so a handwritten one is read
     #      too (extracts at v3 or earlier hold no voucher number for
     #      any slip filled in after the printed stickers ran out)
-    PROMPT_VERSION = "4"
-
-    # The slip's fields, in the order they appear on the printed form,
-    # mapped to where each one lands on the Observation. `nil` means the
-    # value is reviewed but not saved directly: the code is a
-    # cross-check against the attached slip, and the ID becomes a
-    # proposed naming rather than a column.
-    FIELDS = {
-      "Field Slip Code" => nil,
-      "Collector" => :collector,
-      "Date" => :when,
-      "Location" => :place_name,
-      "Notes" => :"notes.Other",
-      "Odor/Taste" => :"notes.Odor/Taste",
-      "Trees/Shrubs" => :"notes.Trees/Shrubs",
-      "Substrate" => :"notes.Substrate",
-      "Habit" => :"notes.Habit",
-      "ID" => nil,
-      "ID By" => :"notes.Field_Slip_ID_By",
-      "Other Codes" => :"notes.Other_Codes",
-      "MycoMap Voucher Number" => :"notes.MycoMap_Voucher_Number"
-    }.freeze
-
-    # The slip's ID, which has no target column: it becomes a proposed
-    # naming, not an attribute. Editable all the same, and through a
-    # name autocompleter rather than a plain box -- what collectors
-    # write is often a common name ("Lumpy Bracket") or a genus, so the
-    # reviewer's job is to look up what it actually means rather than
-    # to correct a misreading.
-    NAME_FIELD = "ID"
-
-    # Also its own section, for the same reason: it is corrected through
-    # a location autocompleter, which needs a real label to work.
-    LOCATION_FIELD = "Location"
-
-    # "Other Codes" is free text, but in practice a purely numeric one
-    # is an iNaturalist observation id -- that is what collectors write
-    # in that box. Numeric values therefore default to being stored as
-    # an iNat link, the same shape the field slip form writes, with the
-    # reviewer able to untick it.
-    OTHER_CODES_FIELD = "Other Codes"
-    INAT_CODE_RE = /\A\d+\z/
-
-    def self.inat_code?(value)
-      value.to_s.strip.match?(INAT_CODE_RE)
-    end
+    #   5  the field list and reading rules come from the slip's
+    #      Template rather than being MO's slip always, and the
+    #      response reports template_matched, so a slip printed on a
+    #      layout the project doesn't use is rejected rather than its
+    #      boxes being force-fit onto the wrong field set
+    PROMPT_VERSION = "5"
 
     CONFIDENCE_LEVELS = %w[high medium low].freeze
 
@@ -87,17 +48,23 @@ class FieldSlip
     # behavior the slip_present flag exists to stop. Anything absent
     # from this table -- missing, "maybe", 1 -- normalizes to nil,
     # which means unreported rather than "no slip".
-    SLIP_PRESENT_VALUES = { true => true, false => false,
-                            "true" => true, "false" => false }.freeze
+    FLAG_VALUES = { true => true, false => false,
+                    "true" => true, "false" => false }.freeze
 
     # What one provider run produced: the raw response (stored verbatim
     # for provenance), the per-field values, the per-field confidence
-    # the model reported, and whether it saw a slip at all.
+    # the model reported, which template the slip was read as, whether
+    # the model saw a slip at all, and whether the slip it saw was
+    # printed on that template's layout.
     Result = Data.define(:provider, :model, :raw, :fields, :confidence,
-                         :slip_present, :unreadable) do
-      def initialize(slip_present: nil, unreadable: nil, **)
-        super(slip_present: SLIP_PRESENT_VALUES[normalize_flag(slip_present)],
-              unreadable: known_fields(unreadable), **)
+                         :template, :slip_present, :template_matched,
+                         :unreadable) do
+      def initialize(template:, slip_present: nil, template_matched: nil,
+                     unreadable: nil, **)
+        super(template: template.to_s,
+              slip_present: FLAG_VALUES[normalize_flag(slip_present)],
+              template_matched: FLAG_VALUES[normalize_flag(template_matched)],
+              unreadable: known_fields(unreadable, template), **)
       end
 
       def normalize_flag(value)
@@ -106,8 +73,8 @@ class FieldSlip
 
       # Names the model invented, or a bare string where a list was
       # asked for, must not travel any further than this.
-      def known_fields(value)
-        Array(value).map(&:to_s) & FIELDS.keys
+      def known_fields(value, template)
+        Array(value).map(&:to_s) & Template.for(template).fields.keys
       end
 
       def value_for(slip_field) = fields[slip_field]
@@ -120,6 +87,10 @@ class FieldSlip
       # Nil for a read from a provider (or a prompt version) that never
       # reported it -- only an explicit false means "no slip here".
       def no_slip? = slip_present == false
+
+      # A slip was seen, but printed on a different layout than this
+      # project's slips use, so nothing was read off it.
+      def template_mismatch? = !no_slip? && template_matched == false
 
       # Written on the slip but not recovered from this image, so
       # another photo of the same slip may still have it. Distinct

--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -12,6 +12,7 @@ class FieldSlip
     # name-creation and voting rules, so it is left to the caller.
     class Applier
       ID_BY_KEY = :Field_Slip_ID_By
+      COORD_TARGETS = [:lat, :lng].freeze
 
       # `chosen` is {slip field => edited value} for the ticked fields.
       # `template` maps each field to its Observation target.
@@ -30,7 +31,7 @@ class FieldSlip
       def apply
         assign_columns
         assign_notes
-        drop_unpaired_coordinate
+        enforce_coordinate_pair
         @observation.save!
         @observation
       end
@@ -125,21 +126,36 @@ class FieldSlip
       # reasoning as `assign_when`).
       def assign_lat(value)
         parsed = Location.parse_latitude(value)
-        @observation.lat = parsed if parsed
+        return unless parsed
+
+        @observation.lat = parsed
+        applied_coords << :lat
       end
 
       def assign_lng(value)
         parsed = Location.parse_longitude(value)
-        @observation.lng = parsed if parsed
+        return unless parsed
+
+        @observation.lng = parsed
+        applied_coords << :lng
       end
 
-      # Observation validates lat/lng as a pair, so a slip with only
-      # one coordinate recovered would fail the whole save. Better to
-      # save everything else than nothing: the half-pair reverts.
-      def drop_unpaired_coordinate
-        return if @observation.lat.present? == @observation.lng.present?
+      def applied_coords
+        @applied_coords ||= []
+      end
 
-        @observation.restore_attributes([:lat, :lng])
+      # Coordinates land as a pair or not at all: half a pair would
+      # fail Observation's own validation when the observation had
+      # none, and would silently mix a slip coordinate with one from
+      # another source when it did. Unless both were chosen and both
+      # parsed, whatever was assigned reverts -- the other fields
+      # still save.
+      def enforce_coordinate_pair
+        chosen = targets.count { |target, _| COORD_TARGETS.include?(target) }
+        return if chosen.zero?
+        return if chosen == 2 && applied_coords.size == 2
+
+        @observation.restore_attributes(COORD_TARGETS)
       end
 
       # A location the project aliases (or MO itself) know becomes a real

--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -14,19 +14,23 @@ class FieldSlip
       ID_BY_KEY = :Field_Slip_ID_By
 
       # `chosen` is {slip field => edited value} for the ticked fields.
-      # `inat_code` says whether "Other Codes" holds an iNaturalist
-      # observation id, which is stored as a link rather than as the
-      # bare number.
-      def initialize(observation:, chosen:, user:, inat_code: false)
+      # `template` maps each field to its Observation target.
+      # `inat_code` says whether the template's iNat-codes field holds
+      # an iNaturalist observation id, which is stored as a link rather
+      # than as the bare number.
+      def initialize(observation:, chosen:, user:, template:,
+                     inat_code: false)
         @observation = observation
         @chosen = chosen
         @user = user
+        @template = template
         @inat_code = inat_code
       end
 
       def apply
         assign_columns
         assign_notes
+        drop_unpaired_coordinate
         @observation.save!
         @observation
       end
@@ -35,7 +39,7 @@ class FieldSlip
 
       def targets
         @targets ||= @chosen.filter_map do |field, value|
-          target = Extractor::FIELDS[field]
+          target = @template.fields[field]
           [target, value_for(field, value)] if target && value.present?
         end
       end
@@ -45,11 +49,24 @@ class FieldSlip
       # Already-linked values pass through rather than nesting.
       def value_for(field, value)
         text = value.to_s.strip
-        return text unless field == Extractor::OTHER_CODES_FIELD
+        return text unless field == @template.inat_codes_field
         return text unless @inat_code
         return text if FieldSlipNotesBuilder.inat_link?(text)
 
-        FieldSlipNotesBuilder.inat_link(text)
+        inat_link_for(text)
+      end
+
+      # The box may hold more than the id ("10:29 388879492" -- a
+      # timestamp doubling as a checksum against the iNat record). The
+      # id becomes the link; the rest is kept beside it rather than
+      # dropped.
+      def inat_link_for(text)
+        code = @template.inat_code_in(text)
+        return text unless code
+
+        link = FieldSlipNotesBuilder.inat_link(code)
+        rest = text.sub(code, "").squish
+        rest.present? ? "#{link} (#{rest})" : link
       end
 
       def assign_columns
@@ -101,6 +118,28 @@ class FieldSlip
         @observation.when = Date.strptime(value, "%Y-%m-%d")
       rescue Date::Error
         nil
+      end
+
+      # Parsed the way the observation form does, so "39°07'N" works;
+      # a value that doesn't parse is skipped rather than saved (same
+      # reasoning as `assign_when`).
+      def assign_lat(value)
+        parsed = Location.parse_latitude(value)
+        @observation.lat = parsed if parsed
+      end
+
+      def assign_lng(value)
+        parsed = Location.parse_longitude(value)
+        @observation.lng = parsed if parsed
+      end
+
+      # Observation validates lat/lng as a pair, so a slip with only
+      # one coordinate recovered would fail the whole save. Better to
+      # save everything else than nothing: the half-pair reverts.
+      def drop_unpaired_coordinate
+        return if @observation.lat.present? == @observation.lng.present?
+
+        @observation.restore_attributes([:lat, :lng])
       end
 
       # A location the project aliases (or MO itself) know becomes a real

--- a/app/classes/field_slip/extractor/context.rb
+++ b/app/classes/field_slip/extractor/context.rb
@@ -26,6 +26,11 @@ class FieldSlip
         @project ||= observation&.projects&.first
       end
 
+      # Which printed layout this project's slips use.
+      def template
+        @template ||= FieldSlip::Template.for_project(project)
+      end
+
       def field_slip_code
         observation&.field_slip&.code
       end

--- a/app/classes/field_slip/extractor/gemini.rb
+++ b/app/classes/field_slip/extractor/gemini.rb
@@ -34,13 +34,7 @@ class FieldSlip
         raise(MissingKey) if @api_key.blank?
 
         raw = post(Prompt.new(context).to_s, image_data(image))
-        payload = parse(raw)
-        Result.new(provider: "gemini",
-                   model: raw["modelVersion"].presence || @model, raw: raw,
-                   fields: payload["fields"] || {},
-                   confidence: payload["confidence"] || {},
-                   slip_present: payload["slip_present"],
-                   unreadable: payload["unreadable"])
+        build_result(raw, parse(raw), context)
       end
 
       class MissingKey < StandardError
@@ -57,6 +51,17 @@ class FieldSlip
       end
 
       private
+
+      def build_result(raw, payload, context)
+        Result.new(provider: "gemini",
+                   model: raw["modelVersion"].presence || @model, raw: raw,
+                   fields: payload["fields"] || {},
+                   confidence: payload["confidence"] || {},
+                   template: context.template.key,
+                   slip_present: payload["slip_present"],
+                   template_matched: payload["template_matched"],
+                   unreadable: payload["unreadable"])
+      end
 
       def credentials
         Rails.application.credentials.gemini || {}

--- a/app/classes/field_slip/extractor/prompt.rb
+++ b/app/classes/field_slip/extractor/prompt.rb
@@ -4,6 +4,10 @@ class FieldSlip
   module Extractor
     # Builds the extraction instructions for one image.
     #
+    # The field list and layout-specific reading rules come from the
+    # slip's Template; the shared discipline (transcribe, don't invent,
+    # what "unreadable" means) lives here.
+    #
     # The abbreviation tables come from the project's own ProjectAliases
     # rather than being written into the prompt: a foray's walk numbers
     # and member initials already live there (see #4932), they change
@@ -15,6 +19,7 @@ class FieldSlip
 
       def initialize(context)
         @context = context
+        @template = context.template
       end
 
       def to_s
@@ -25,28 +30,34 @@ class FieldSlip
       private
 
       # The image may be a specimen photo rather than a slip: an
-      # observation carries several photos and only some show one.
-      # Without the escape hatch below, an image with no slip in it is
-      # still answered field by field, and the tables further down --
-      # there to help read handwriting -- become the source of the
-      # answer: a run has already returned a full location name lifted
-      # verbatim out of the location table for a photo containing no
-      # slip at all.
+      # observation carries several photos and only some show one. And
+      # a slip that IS there may be printed on some other event's form:
+      # without the mismatch escape hatch, its boxes get force-fit onto
+      # this template's field list. In either case the tables further
+      # down -- there to help read handwriting -- must not become the
+      # source of the answer: a run has already returned a full
+      # location name lifted verbatim out of the location table for a
+      # photo containing no slip at all.
       def preamble
         "Extract the data written on this mushroom field slip. The slip " \
           "is a printed form; most values are handwritten. Ignore the " \
           "specimen photographed beside it -- do not identify the " \
           "mushroom yourself, only transcribe what the slip says.\n\n" \
+          "The slip should be #{@template.layout}\n\n" \
           "If this image does not show a field slip, set \"slip_present\" " \
-          "to false and every field to null. Do not infer any value from " \
-          "the tables below -- they are reading aids for handwriting that " \
-          "is actually in the image, never a source of answers."
+          "to false and every field to null. If it shows a field slip " \
+          "printed on a DIFFERENT form than the one described above, set " \
+          "\"slip_present\" to true, \"template_matched\" to false, and " \
+          "every field to null -- do not map another form's boxes onto " \
+          "these fields. Do not infer any value from the tables below " \
+          "-- they are reading aids for handwriting that is actually in " \
+          "the image, never a source of answers."
       end
 
       def field_rules
         <<~RULES.strip
           Fields to extract, using exactly these keys:
-          #{Extractor::FIELDS.keys.map { |f| "  - #{f}" }.join("\n")}
+          #{@template.fields.keys.map { |f| "  - #{f}" }.join("\n")}
 
           Rules:
           - Transcribe what is written. Do not correct spelling or
@@ -60,32 +71,9 @@ class FieldSlip
             box the collector left empty is not unreadable. Getting
             this right decides whether another photo is worth
             consulting for that field.
-          #{per_field_rules}
-        RULES
-      end
-
-      def per_field_rules
-        <<~RULES.strip
-          - "Field Slip Code" is printed, not handwritten, and looks
-            like #{code_example}. It also appears in the QR code.
-          - "ID" is the name written by the collector. It may be a
-            scientific name, a common name, or a genus alone. Give it
-            verbatim.
-          - Substrate and Habit are often circled from a printed list
-            rather than written. Report the circled word(s).
-          - "MycoMap Voucher Number" sits in the slip's upper-right
-            region, printed or handwritten. It is usually a printed
-            sticker like N26-0290; when the stickers ran out it was
-            written in by hand, often as a bare number with the prefix
-            left off. A logo usually occupies that corner, and a
-            handwritten number may be above it or to its left rather
-            than beside it, so read the whole upper-right area. Give
-            it exactly as written -- do not add a prefix a bare number
-            does not carry. It is not the field slip code. Identify it
-            by that region, not by whether it is printed: anything
-            written in another box belongs to that box's field, and
-            "Other Codes" is only what a person wrote in the Other
-            Codes box.
+          - "#{@template.code_field}" is printed, not handwritten, and
+            looks like #{code_example}. It also appears in the QR code.
+          #{@template.field_rules}
         RULES
       end
 
@@ -98,9 +86,9 @@ class FieldSlip
         rows = alias_rows("Location")
         return nil if rows.empty?
 
-        "\"Location\" is usually a walk number or site abbreviation. " \
-          "Map it to the full location name using this table, and " \
-          "return the FULL NAME:\n#{rows}\n" \
+        "\"#{@template.location_field}\" is usually a walk number or " \
+          "site abbreviation. Map it to the full location name using " \
+          "this table, and return the FULL NAME:\n#{rows}\n" \
           "If the written value is not in the table, return it " \
           "verbatim -- do not guess which site was meant."
       end
@@ -148,6 +136,7 @@ class FieldSlip
 
           {
             "slip_present": true | false,
+            "template_matched": true | false,
             "fields": { <each key above>: <string or null> },
             "confidence": { <each key above>: "high" | "medium" | "low" },
             "unreadable": [ <keys written on the slip but not recoverable> ],

--- a/app/classes/field_slip/template.rb
+++ b/app/classes/field_slip/template.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  # A printed field slip layout: which fields the form carries, where
+  # each lands on the Observation, and how to read one from a photo
+  # (see FieldSlip::Extractor).
+  #
+  # Code-defined for now -- adding a layout is a subclass plus a
+  # registry entry here. The registry is expected to move to the
+  # database eventually, so event organizers can define and share
+  # layouts themselves (issue #5024).
+  module Template
+    REGISTRY = { "mo" => "FieldSlip::Template::Mo",
+                 "dbg" => "FieldSlip::Template::Dbg" }.freeze
+
+    # Which layout each project's slips are printed on, keyed by the
+    # project's field_slip_prefix (stable across environments, unlike
+    # ids). A project not listed uses the MO slip, so a photo of a slip
+    # on any other layout is rejected at review rather than misread.
+    PROJECT_TEMPLATES = {
+      "2025-NAMA" => "dbg",
+      "2026-CMS" => "dbg",
+      "2026-SMHF" => "dbg"
+    }.freeze
+
+    def self.for(key)
+      name = REGISTRY[key.to_s] ||
+             raise(ArgumentError.new("Unknown field slip template: #{key}"))
+      name.constantize.new
+    end
+
+    def self.default = self.for(:mo)
+
+    def self.for_project(project)
+      self.for(PROJECT_TEMPLATES[project&.field_slip_prefix] || "mo")
+    end
+  end
+end

--- a/app/classes/field_slip/template/base.rb
+++ b/app/classes/field_slip/template/base.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  module Template
+    # Interface for one slip layout. Subclasses define the field table
+    # and the layout-specific reading rules; everything shared between
+    # layouts (transcription discipline, alias tables, output format)
+    # lives in Extractor::Prompt.
+    class Base
+      def key = self.class.name.demodulize.underscore
+
+      # The slip's fields, in the order they appear on the printed
+      # form, mapped to where each one lands on the Observation. nil
+      # means the value is reviewed but not saved directly: a
+      # cross-check, or a component of another field.
+      def fields = raise(NotImplementedError)
+
+      # The field whose value becomes a proposed naming rather than an
+      # attribute. Edited through a name autocompleter: collectors
+      # often write a common name or a bare genus, so the reviewer's
+      # job is to look up what it means, not to correct a misreading.
+      def name_field = raise(NotImplementedError)
+
+      # The field corrected through a location autocompleter, which
+      # needs a real label to work.
+      def location_field = raise(NotImplementedError)
+
+      # The field whose value may hold an iNaturalist observation id,
+      # stored as an iNat link when it does (see #inat_code_in).
+      def inat_codes_field = raise(NotImplementedError)
+
+      # The printed code, present on every layout. Reviewed as a
+      # cross-check against the slip attached to the observation.
+      def code_field = "Field Slip Code"
+
+      # A one-sentence description of the printed layout, used to
+      # decide whether the photographed slip is this template at all.
+      def layout = raise(NotImplementedError)
+
+      # Layout-specific reading rules, appended to the shared rules in
+      # Extractor::Prompt.
+      def field_rules = raise(NotImplementedError)
+
+      # The iNaturalist observation id in a value read from
+      # `inat_codes_field`, or nil when the value doesn't hold one.
+      def inat_code_in(_value) = nil
+
+      def inat_code?(value) = inat_code_in(value).present?
+    end
+  end
+end

--- a/app/classes/field_slip/template/dbg.rb
+++ b/app/classes/field_slip/template/dbg.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  module Template
+    # Andy Wilson's voucher slip (Denver Botanic Gardens), used by the
+    # 2025 NAMA foray and the 2026 CMS fair / SMHF collections. The
+    # logo and the options printed in the Plants list vary per event;
+    # the layout is shared.
+    class Dbg < Base
+      FIELDS = {
+        "Field Slip Code" => nil,
+        "Voucher Number" => :"notes.Voucher_Number",
+        "Date" => :when,
+        "Collector" => :collector,
+        # State and County are components of the location; the
+        # reviewed place name carries them, so they are not stored
+        # separately.
+        "State" => nil,
+        "County" => nil,
+        "Location/Foray" => :place_name,
+        "Latitude" => :lat,
+        "Longitude" => :lng,
+        "Species" => nil,
+        "ID By" => :"notes.Field_Slip_ID_By",
+        "ID Date" => :"notes.Field_Slip_ID_Date",
+        "Notes" => :"notes.Other",
+        "Odor/Taste" => :"notes.Odor/Taste",
+        "Plants" => :"notes.Plants",
+        "Substrate" => :"notes.Substrate",
+        "Habit" => :"notes.Habit",
+        "iNaturalist" => :"notes.iNaturalist"
+      }.freeze
+
+      def fields = FIELDS
+      def name_field = "Species"
+      def location_field = "Location/Foray"
+      def inat_codes_field = "iNaturalist"
+
+      def layout
+        "a voucher slip with a ruler printed along its top edge and a " \
+          "header row holding a QR code, a large printed code (like " \
+          "2026-CMS-0219), and an event or herbarium logo. The left " \
+          "column has boxes labeled Date, Collector, State, County, " \
+          "Location/Foray, Latitude, Longitude, and Species, with ID " \
+          "by and ID date at the bottom. The right column has Notes, " \
+          "Odor/taste, a printed Plants list, a Substrate/Habit " \
+          "checklist, and an iNaturalist box, with the printed code " \
+          "repeated in the lower right."
+      end
+
+      def field_rules
+        <<~RULES.strip
+          - "Species" is the name written by the collector. It may be
+            a scientific name, a common name, or a genus alone. Give
+            it verbatim.
+          - "State" is usually a two-letter abbreviation. Give it as
+            written.
+          - "Plants" is a printed list of trees and shrubs; the
+            collector circles what applies. Report the circled
+            word(s), separated by commas.
+          - "Substrate" and "Habit" share one printed checklist headed
+            Substrate/Habit. The Substrate options (soil, wood,
+            litter) have a blank line beneath them for write-ins; the
+            Habit options are Solitary, Gregarious, and Caespitose.
+            Report checked, circled, or underlined words under their
+            own key, and anything handwritten on the blank line as
+            Substrate.
+          - "iNaturalist" is the box labeled iNaturalist. Collectors
+            write an observation number, a username, a timestamp, or a
+            combination. Transcribe the whole entry exactly as
+            written.
+          - "Voucher Number" is a specimen sticker in the slip's
+            upper-right region, on or near the logo, like CO26-0290.
+            Most slips have none. It may be handwritten. It is not the
+            field slip code. Give it exactly as written.
+        RULES
+      end
+
+      # The box is dedicated to iNaturalist, so any long digit run in
+      # it is the observation id -- even mixed with a username or
+      # timestamp ("10:29 388879492"). Five digits keeps clock times
+      # and dates from qualifying.
+      def inat_code_in(value)
+        value.to_s[/\d{5,}/]
+      end
+    end
+  end
+end

--- a/app/classes/field_slip/template/mo.rb
+++ b/app/classes/field_slip/template/mo.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  module Template
+    # Mushroom Observer's own printed slip.
+    class Mo < Base
+      FIELDS = {
+        "Field Slip Code" => nil,
+        "Collector" => :collector,
+        "Date" => :when,
+        "Location" => :place_name,
+        "Notes" => :"notes.Other",
+        "Odor/Taste" => :"notes.Odor/Taste",
+        "Trees/Shrubs" => :"notes.Trees/Shrubs",
+        "Substrate" => :"notes.Substrate",
+        "Habit" => :"notes.Habit",
+        "ID" => nil,
+        "ID By" => :"notes.Field_Slip_ID_By",
+        "Other Codes" => :"notes.Other_Codes",
+        "MycoMap Voucher Number" => :"notes.MycoMap_Voucher_Number"
+      }.freeze
+
+      def fields = FIELDS
+      def name_field = "ID"
+      def location_field = "Location"
+      def inat_codes_field = "Other Codes"
+
+      def layout
+        "Mushroom Observer's printed form: a QR code and printed " \
+          "field slip code at the top, then boxes labeled Collector, " \
+          "Date, Location, Notes, Odor/Taste, Trees/Shrubs, " \
+          "Substrate, Habit, ID, ID By, and Other Codes, with a " \
+          "MycoMap voucher sticker area in the upper-right region."
+      end
+
+      def field_rules
+        <<~RULES.strip
+          - "ID" is the name written by the collector. It may be a
+            scientific name, a common name, or a genus alone. Give it
+            verbatim.
+          - Substrate and Habit are often circled from a printed list
+            rather than written. Report the circled word(s).
+          - "MycoMap Voucher Number" sits in the slip's upper-right
+            region, printed or handwritten. It is usually a printed
+            sticker like N26-0290; when the stickers ran out it was
+            written in by hand, often as a bare number with the prefix
+            left off. A logo usually occupies that corner, and a
+            handwritten number may be above it or to its left rather
+            than beside it, so read the whole upper-right area. Give
+            it exactly as written -- do not add a prefix a bare number
+            does not carry. It is not the field slip code. Identify it
+            by that region, not by whether it is printed: anything
+            written in another box belongs to that box's field, and
+            "Other Codes" is only what a person wrote in the Other
+            Codes box.
+        RULES
+      end
+
+      # "Other Codes" is free text, but in practice a purely numeric
+      # one is an iNaturalist observation id -- that is what collectors
+      # write in that box.
+      def inat_code_in(value)
+        text = value.to_s.strip
+        text if text.match?(/\A\d+\z/)
+      end
+    end
+  end
+end

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -9,10 +9,10 @@
 # field labels rather than under this object's namespace: the labels are
 # the extract's keys ("Field Slip Code", "MycoMap Voucher Number"), not
 # attributes of anything, and keying the params by them keeps the
-# controller's read a straight lookup against `Extractor::FIELDS`.
+# controller's read a straight lookup against the extract's template.
 class FormObject::FieldSlipReview < FormObject::Base
   Row = Data.define(:field, :extracted, :current, :confidence, :savable,
-                    :editable) do
+                    :editable, :role) do
     # Nothing to decide when the model read nothing.
     def blank? = extracted.to_s.strip.empty?
 
@@ -35,8 +35,9 @@ class FormObject::FieldSlipReview < FormObject::Base
     # screen, so the decision is still in front of them.
     def default_use? = savable && present?
 
-    def name_row? = field == FieldSlip::Extractor::NAME_FIELD
-    def location_row? = field == FieldSlip::Extractor::LOCATION_FIELD
+    def name_row? = role == :name
+    def location_row? = role == :location
+    def inat_row? = role == :inat
 
     # Both get their own labelled section rather than a table cell: an
     # autocompleter only renders its dropdown and hidden id field when
@@ -52,32 +53,46 @@ class FormObject::FieldSlipReview < FormObject::Base
   # The Location the written abbreviation obviously means, when the
   # project is already using exactly one that matches.
   attribute :location_suggestion, default: nil
-  # Whether "Other Codes" looks like an iNaturalist observation id.
+  # Whether the template's iNat-codes field holds an iNaturalist
+  # observation id.
   attribute :inat_code, default: false
 
   def self.build(extract:, observation:, user: nil)
-    new(name_known: name_known?(extract, user),
+    template = extract.template
+    new(name_known: name_known?(extract, template, user),
         location_suggestion: extract.location_suggestion,
-        inat_code: FieldSlip::Extractor.inat_code?(
-          extract.value_for(FieldSlip::Extractor::OTHER_CODES_FIELD)
+        inat_code: template.inat_code?(
+          extract.value_for(template.inat_codes_field)
         ),
-        rows: FieldSlip::Extractor::FIELDS.map do |field, target|
-          Row.new(field: field, extracted: extract.value_for(field),
-                  current: current_value(observation, target),
-                  confidence: extract.confidence_for(field),
-                  savable: !target.nil?,
-                  editable: !target.nil? ||
-                            field == FieldSlip::Extractor::NAME_FIELD)
-        end)
+        rows: rows_for(extract, template, observation))
+  end
+
+  def self.rows_for(extract, template, observation)
+    template.fields.map do |field, target|
+      Row.new(field: field, extracted: extract.value_for(field),
+              current: current_value(observation, target),
+              confidence: extract.confidence_for(field),
+              savable: !target.nil?,
+              editable: !target.nil? || field == template.name_field,
+              role: role_for(template, field))
+    end
+  end
+
+  def self.role_for(template, field)
+    case field
+    when template.name_field then :name
+    when template.location_field then :location
+    when template.inat_codes_field then :inat
+    end
   end
 
   # Asks the resolver the same question saving will: would proposing
   # this right now succeed without a create-the-name round-trip? Pure
   # lookup -- the resolver only creates on an explicit approved_name.
-  def self.name_known?(extract, user)
+  def self.name_known?(extract, template, user)
     return false unless user
 
-    given = extract.value_for(FieldSlip::Extractor::NAME_FIELD).to_s.strip
+    given = extract.value_for(template.name_field).to_s.strip
     return false if given.blank?
 
     resolver = Naming::NameResolver.new(user, given_name: given)
@@ -85,7 +100,7 @@ class FormObject::FieldSlipReview < FormObject::Base
   end
 
   # What the observation holds today for the column or notes key this
-  # slip field maps to. nil for the two review-only fields.
+  # slip field maps to. nil for the review-only fields.
   def self.current_value(observation, target)
     return nil if target.nil?
 

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -95,11 +95,17 @@ module Images
       nil
     end
 
+    # The extract's template names the fields, so the same review works
+    # whichever layout the slip was printed on.
+    def name_field
+      @extract.template.name_field
+    end
+
     # Only when the reviewer ticked it. Unticked means "the slip says
     # this, don't propose it" -- the box starts clear for a name MO
     # doesn't hold, so creating one is always a deliberate choice.
     def propose_name
-      unless params.dig(:use, FieldSlip::Extractor::NAME_FIELD) == "1"
+      unless params.dig(:use, name_field) == "1"
         return FieldSlip::Extractor::NameProposer::Outcome.new(
           status: :none, naming: nil, feedback: {}
         )
@@ -108,7 +114,7 @@ module Images
       FieldSlip::Extractor::NameProposer.new(
         observation: @observation, user: @user, vote: params[:vote],
         name_params: {
-          given_name: params.dig(:value, FieldSlip::Extractor::NAME_FIELD),
+          given_name: params.dig(:value, name_field),
           approved_name: params[:approved_name],
           chosen_name: params.dig(:chosen_name, :name_id)
         }
@@ -129,15 +135,14 @@ module Images
       render(Views::Controllers::Images::FieldSlipExtracts::Edit.new(
                extract: @extract, observation: @observation, user: @user,
                name_feedback: outcome.feedback,
-               given_name: params.dig(:value,
-                                      FieldSlip::Extractor::NAME_FIELD).to_s
+               given_name: params.dig(:value, name_field).to_s
              ))
     end
 
     def apply_chosen_fields
       FieldSlip::Extractor::Applier.new(
         observation: @observation, chosen: chosen_fields, user: @user,
-        inat_code: params[:inat] == "1"
+        template: @extract.template, inat_code: params[:inat] == "1"
       ).apply
     end
 
@@ -147,8 +152,7 @@ module Images
     # a form submitted with nothing ticked arrives without `use` at all.
     def chosen_fields
       ticked = (params[:use]&.to_unsafe_h || {}).
-               select { |_k, v| v == "1" }.keys -
-               [FieldSlip::Extractor::NAME_FIELD]
+               select { |_k, v| v == "1" }.keys - [name_field]
       values = params[:value]&.to_unsafe_h || {}
       ticked.index_with { |field| values[field] }
     end

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -43,7 +43,9 @@ class FieldSlipExtract < AbstractModel
       user: user, provider: result.provider, model: result.model,
       prompt_version: prompt_version,
       data: { "fields" => result.fields, "confidence" => result.confidence,
+              "template" => result.template,
               "slip_present" => result.slip_present,
+              "template_matched" => result.template_matched,
               "unreadable" => result.unreadable, "raw" => result.raw }
     )
     extract
@@ -52,10 +54,23 @@ class FieldSlipExtract < AbstractModel
   def fields = data.to_h["fields"] || {}
   def confidence = data.to_h["confidence"] || {}
 
+  # The layout this photo was read as. Reads stored before templates
+  # existed were all of MO's own slip.
+  def template
+    @template ||= FieldSlip::Template.for(data.to_h["template"] || "mo")
+  end
+
   # True only when the read explicitly reported no slip in the image.
   # Reads stored before the provider reported it answer false, same as
   # a read that did see one -- absence of the flag is not evidence.
   def no_slip? = data.to_h["slip_present"] == false
+
+  # A slip was seen, but printed on a different layout than this
+  # project's slips use, so nothing was read off it. Same only-explicit-
+  # false reasoning as `no_slip?`.
+  def template_mismatch?
+    data.to_h["template_matched"] == false && !no_slip?
+  end
 
   # Fields written on the slip that this image could not recover, so
   # another photo of the same slip is worth consulting for them. A
@@ -80,7 +95,7 @@ class FieldSlipExtract < AbstractModel
   # this image is not the slip for this observation. nil when they
   # agree, when either is missing, or when there is no attached slip.
   def code_mismatch
-    read = value_for("Field Slip Code").to_s.strip
+    read = value_for(template.code_field).to_s.strip
     attached = observation&.field_slip&.code.to_s.strip
     return nil if read.blank? || attached.blank? || read == attached
 
@@ -92,7 +107,7 @@ class FieldSlipExtract < AbstractModel
   # alias fixes this slip and every later one, since the prompt is built
   # from the same table.
   def unknown_location_alias
-    written = value_for("Location").to_s.strip
+    written = value_for(template.location_field).to_s.strip
     return nil if written.blank?
     # A full MO location name is not an unknown abbreviation, whether or
     # not the project happens to alias it -- warning about one and
@@ -115,7 +130,7 @@ class FieldSlipExtract < AbstractModel
   # already uses, and only when exactly one of them matches, so a guess
   # can't quietly pick between two plausible sites.
   def location_suggestion
-    written = value_for("Location").to_s.strip
+    written = value_for(template.location_field).to_s.strip
     return nil if written.blank?
 
     matches = project_locations.select do |location|

--- a/app/views/controllers/images/field_slip_extracts/edit.rb
+++ b/app/views/controllers/images/field_slip_extracts/edit.rb
@@ -31,8 +31,21 @@ module Views::Controllers::Images::FieldSlipExtracts
     # The strongest signal that this image is not this observation's
     # slip: the printed code the model read is not the code attached.
     def render_flags
+      render_template_mismatch
       render_code_mismatch
       render_unknown_alias
+    end
+
+    # A slip was seen, but printed on a layout this project's slips
+    # don't use, so nothing was read off it. If the project should
+    # accept the layout, its entry in FieldSlip::Template needs
+    # updating -- then re-extract.
+    def render_template_mismatch
+      return unless @extract.template_mismatch?
+
+      Alert(level: :danger) do
+        plain(:field_slip_extract_template_mismatch.t)
+      end
     end
 
     def render_code_mismatch
@@ -111,6 +124,7 @@ module Views::Controllers::Images::FieldSlipExtracts
       small do
         plain(:field_slip_extract_provenance.t(
                 provider: @extract.provider, model: @extract.model,
+                template: @extract.template.key,
                 version: @extract.prompt_version.to_s,
                 time: @extract.updated_at.web_time
               ))

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -70,12 +70,12 @@ module Views::Controllers::Images::FieldSlipExtracts
       render_confidence(row)
     end
 
-    # A purely numeric "Other Codes" is an iNaturalist observation id in
-    # practice, so it ticks itself and gets stored as a link. Visible
-    # and overridable rather than silent, since the box is free text and
-    # someone will eventually write a herbarium number in it.
+    # A value holding an iNaturalist observation id ticks itself and
+    # gets stored as a link. Visible and overridable rather than
+    # silent, since the box is free text and someone will eventually
+    # write a herbarium number in it.
     def render_inat_flag(row)
-      return unless row.field == ::FieldSlip::Extractor::OTHER_CODES_FIELD
+      return unless row.inat_row?
 
       checkbox_field("inat", checked: @review.inat_code,
                              label: :field_slip_extract_inat.l)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2600,7 +2600,8 @@
   field_slip_extract_code_mismatch: "The slip in this photo reads [read], but the observation is attached to field slip [attached]. Check that this is the right photo before saving."
   field_slip_extract_unknown_alias: "No project abbreviation is defined for [name], so the location was left as written."
   field_slip_extract_id_help: Collectors often write a common name. Look up the scientific name here. Ticking the box proposes it, creating the name first if Mushroom Observer does not have it yet.
-  field_slip_extract_provenance: "Read by [provider] [model], prompt v[version], [time]."
+  field_slip_extract_provenance: "Read by [provider] [model], [template] template, prompt v[version], [time]."
+  field_slip_extract_template_mismatch: This photo shows a field slip, but not one printed on a layout this project's slips use, so no values were read. If the project should accept this slip type, its template needs updating first.
   field_slip_other_example: e.g., iNat ID
   field_slip_other_inat: Check if [:field_slip_other_codes] is an iNat ID
   field_slip_project_success: Field Slip will be associated with the [TITLE] Project

--- a/test/classes/field_slip/extractor/applier_test.rb
+++ b/test/classes/field_slip/extractor/applier_test.rb
@@ -9,10 +9,11 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
     @project.observations << @obs unless @project.observations.include?(@obs)
   end
 
-  def apply_fields(chosen, user: rolf, inat_code: false)
-    FieldSlip::Extractor::Applier.new(observation: @obs, chosen: chosen,
-                                      user: user,
-                                      inat_code: inat_code).apply
+  def apply_fields(chosen, user: rolf, inat_code: false, template: :mo)
+    FieldSlip::Extractor::Applier.new(
+      observation: @obs, chosen: chosen, user: user,
+      template: FieldSlip::Template.for(template), inat_code: inat_code
+    ).apply
     @obs.reload
   end
 
@@ -175,7 +176,7 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
     slip_before = @obs.field_slip&.code
 
     apply_fields({ "Field Slip Code" => "NEMF-99999",
-                   FieldSlip::Extractor::NAME_FIELD => "Coprinus comatus" })
+                   "ID" => "Coprinus comatus" })
 
     assert_equal_even_if_nil(slip_before, @obs.field_slip&.code)
     assert_equal(namings_before, @obs.namings.count,
@@ -188,5 +189,89 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
 
     assert_equal_even_if_nil(before["collector"], @obs.collector)
     assert_equal(before["when"], @obs.when)
+  end
+
+  # ---------- DBG template ----------
+
+  def test_dbg_fields_land_under_their_own_notes_keys
+    apply_fields({ "Plants" => "Spruce",
+                   "Voucher Number" => "CO26-0290",
+                   "ID Date" => "8/7" }, template: :dbg)
+
+    assert_equal("Spruce", @obs.notes[:Plants])
+    assert_equal("CO26-0290", @obs.notes[:Voucher_Number])
+    assert_equal("8/7", @obs.notes[:Field_Slip_ID_Date])
+  end
+
+  def test_dbg_coordinates_are_applied_as_a_pair
+    apply_fields({ "Latitude" => "38.8703",
+                   "Longitude" => "-105.0442" }, template: :dbg)
+
+    assert_in_delta(38.8703, @obs.lat)
+    assert_in_delta(-105.0442, @obs.lng)
+  end
+
+  # Observation validates lat/lng as a pair; half a pair must not sink
+  # the rest of the save.
+  def test_dbg_a_lone_coordinate_is_dropped_not_fatal
+    apply_fields({ "Latitude" => "38.8703",
+                   "Collector" => "A. W. Wilson" }, template: :dbg)
+
+    assert_nil(@obs.lat)
+    assert_equal("A. W. Wilson", @obs.collector)
+  end
+
+  def test_dbg_unparseable_coordinates_are_skipped
+    apply_fields({ "Latitude" => "somewhere",
+                   "Longitude" => "-105.0442" }, template: :dbg)
+
+    assert_nil(@obs.lat)
+    assert_nil(@obs.lng)
+  end
+
+  # The iNaturalist box often holds a timestamp beside the id ("10:29
+  # 388879492"); the id becomes the link and the rest is kept beside
+  # it as a checksum against the iNat record.
+  def test_dbg_inat_box_with_timestamp_links_the_id
+    apply_fields({ "iNaturalist" => "10:29 388879492" },
+                 template: :dbg, inat_code: true)
+
+    link = FieldSlipNotesBuilder.inat_link("388879492")
+
+    assert_equal("#{link} (10:29)", @obs.notes[:iNaturalist])
+  end
+
+  def test_dbg_bare_inat_number_links_without_leftover
+    apply_fields({ "iNaturalist" => "388879863" },
+                 template: :dbg, inat_code: true)
+
+    assert_equal(FieldSlipNotesBuilder.inat_link("388879863"),
+                 @obs.notes[:iNaturalist])
+  end
+
+  # Flagged but holding no id -- a username and clock time only -- the
+  # entry stays as written rather than becoming a broken link.
+  def test_dbg_inat_box_without_an_id_left_bare
+    apply_fields({ "iNaturalist" => "someuser 10:29" },
+                 template: :dbg, inat_code: true)
+
+    assert_equal("someuser 10:29", @obs.notes[:iNaturalist])
+  end
+
+  def test_dbg_location_foray_resolves_through_a_project_alias
+    ProjectAlias.create!(project: @project, name: "Crags Creek #2",
+                         target: locations(:albion))
+
+    apply_fields({ "Location/Foray" => "Crags Creek #2" }, template: :dbg)
+
+    assert_equal(locations(:albion), @obs.location)
+  end
+
+  # State and County are components of the reviewed place name, never
+  # stored on their own.
+  def test_dbg_state_and_county_are_review_only
+    apply_fields({ "State" => "CO", "County" => "Teller" }, template: :dbg)
+
+    assert_empty(@obs.notes.to_h.values & %w[CO Teller])
   end
 end

--- a/test/classes/field_slip/extractor/applier_test.rb
+++ b/test/classes/field_slip/extractor/applier_test.rb
@@ -229,6 +229,37 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
     assert_nil(@obs.lng)
   end
 
+  # A half-pair against existing coordinates would silently mix a slip
+  # coordinate with one from another source (photo EXIF, the form), so
+  # both keep their old values.
+  def test_dbg_one_chosen_coordinate_never_mixes_with_existing_ones
+    @obs.update!(lat: 40.0, lng: -100.0)
+    apply_fields({ "Latitude" => "38.8703",
+                   "Collector" => "A. W. Wilson" }, template: :dbg)
+
+    assert_in_delta(40.0, @obs.lat)
+    assert_in_delta(-100.0, @obs.lng)
+    assert_equal("A. W. Wilson", @obs.collector, "other fields still save")
+  end
+
+  def test_dbg_a_failed_parse_reverts_the_whole_pair
+    @obs.update!(lat: 40.0, lng: -100.0)
+    apply_fields({ "Latitude" => "38.8703",
+                   "Longitude" => "unreadable" }, template: :dbg)
+
+    assert_in_delta(40.0, @obs.lat)
+    assert_in_delta(-100.0, @obs.lng)
+  end
+
+  def test_dbg_a_full_pair_replaces_existing_coordinates
+    @obs.update!(lat: 40.0, lng: -100.0)
+    apply_fields({ "Latitude" => "38.8703",
+                   "Longitude" => "-105.0442" }, template: :dbg)
+
+    assert_in_delta(38.8703, @obs.lat)
+    assert_in_delta(-105.0442, @obs.lng)
+  end
+
   # The iNaturalist box often holds a timestamp beside the id ("10:29
   # 388879492"); the id becomes the link and the rest is kept beside
   # it as a checksum against the iNat record.

--- a/test/classes/field_slip/extractor/gemini_test.rb
+++ b/test/classes/field_slip/extractor/gemini_test.rb
@@ -143,6 +143,27 @@ class FieldSlip::Extractor::GeminiTest < UnitTestCase
     assert_not(extract.no_slip?)
   end
 
+  # The result records which layout the prompt asked for, and whether
+  # the model said the photographed slip was that layout at all.
+  def test_reports_the_template_and_a_mismatch
+    stub_gemini(json_payload(fields: {}, slip_present: true,
+                             template_matched: "false"))
+
+    result = extract
+
+    assert_equal(@context.template.key, result.template)
+    assert(result.template_mismatch?)
+  end
+
+  def test_missing_template_matched_is_not_a_mismatch
+    stub_gemini(json_payload(fields: { "Collector" => "Scott Shapiro" }))
+
+    result = extract
+
+    assert_nil(result.template_matched)
+    assert_not(result.template_mismatch?)
+  end
+
   def test_a_stringified_true_is_understood_too
     stub_gemini(json_payload(fields: {}, slip_present: "TRUE"))
 

--- a/test/classes/field_slip/extractor/prompt_test.rb
+++ b/test/classes/field_slip/extractor/prompt_test.rb
@@ -14,9 +14,14 @@ class FieldSlip::Extractor::PromptTest < UnitTestCase
     FieldSlip::Extractor::Prompt.new(context).to_s
   end
 
+  def dbg_prompt
+    @project.update!(field_slip_prefix: "2026-CMS")
+    prompt
+  end
+
   def test_asks_for_every_field_by_its_exact_key
     text = prompt
-    FieldSlip::Extractor::FIELDS.each_key do |field|
+    FieldSlip::Template.for(:mo).fields.each_key do |field|
       assert_includes(text, field, "prompt must name #{field}")
     end
   end
@@ -145,6 +150,37 @@ class FieldSlip::Extractor::PromptTest < UnitTestCase
 
   def test_tells_the_model_not_to_identify_the_mushroom
     assert_match(/do not identify/i, prompt)
+  end
+
+  # A slip printed on another event's form must be reported, not
+  # force-fit onto this template's field list.
+  def test_tells_the_model_how_to_report_a_template_mismatch
+    text = prompt
+
+    assert_includes(text, "template_matched")
+    assert_includes(text, "DIFFERENT form")
+  end
+
+  # The project's prefix picks the layout, and the whole field list
+  # follows it.
+  def test_dbg_project_gets_the_dbg_field_list
+    text = dbg_prompt
+    FieldSlip::Template.for(:dbg).fields.each_key do |field|
+      assert_includes(text, field, "prompt must name #{field}")
+    end
+
+    assert_not_includes(text, "MycoMap Voucher Number")
+    assert_includes(text, "Location/Foray")
+    assert_includes(text, "iNaturalist")
+  end
+
+  # The alias-table instructions have to name the template's own
+  # location field, or the model maps the wrong box through the table.
+  def test_dbg_location_table_names_the_location_foray_field
+    ProjectAlias.create!(project: @project, name: "EB2",
+                         target: locations(:albion))
+
+    assert_includes(dbg_prompt, "\"Location/Foray\" is usually")
   end
 
   # No project, no aliases: the prompt still has to be usable.

--- a/test/classes/field_slip/extractor_test.rb
+++ b/test/classes/field_slip/extractor_test.rb
@@ -24,28 +24,40 @@ class FieldSlip::ExtractorTest < UnitTestCase
   # otherwise fail silently at save time.
   def test_field_targets_are_reachable
     obs = observations(:minimal_unknown_obs)
-    FieldSlip::Extractor::FIELDS.each do |field, target|
-      next if target.nil?
+    FieldSlip::Template::REGISTRY.each_key do |key|
+      FieldSlip::Template.for(key).fields.each do |field, target|
+        next if target.nil?
 
-      key = target.to_s
-      if key.start_with?("notes.")
-        assert(key.delete_prefix("notes.").present?, "#{field}: empty key")
-      else
-        assert_respond_to(obs, target, "#{field}: no such attribute")
+        assert_target_reachable(obs, key, field, target)
       end
     end
   end
 
+  def assert_target_reachable(obs, template, field, target)
+    key = target.to_s
+    if key.start_with?("notes.")
+      assert(key.delete_prefix("notes.").present?,
+             "#{template}/#{field}: empty key")
+    else
+      assert_respond_to(obs, target, "#{template}/#{field}: no attribute")
+    end
+  end
+
   def test_name_field_is_review_only
-    assert_nil(FieldSlip::Extractor::FIELDS[FieldSlip::Extractor::NAME_FIELD],
-               "the ID becomes a naming, never an attribute write")
+    FieldSlip::Template::REGISTRY.each_key do |key|
+      template = FieldSlip::Template.for(key)
+
+      assert_nil(template.fields[template.name_field],
+                 "#{key}: the ID becomes a naming, never an attribute write")
+    end
   end
 
   # ---------- Result ----------
 
-  def result(fields: {}, confidence: {})
+  def result(fields: {}, confidence: {}, template: "mo", **flags)
     FieldSlip::Extractor::Result.new(provider: "gemini", model: "m", raw: {},
-                                     fields: fields, confidence: confidence)
+                                     fields: fields, confidence: confidence,
+                                     template: template, **flags)
   end
 
   def test_result_reads_values_and_confidence
@@ -63,5 +75,31 @@ class FieldSlip::ExtractorTest < UnitTestCase
 
     assert_equal("low", res.confidence_for("Date"))
     assert_equal("low", res.confidence_for("Missing"))
+  end
+
+  # Stringified booleans normalize; anything else is unreported.
+  def test_result_normalizes_flags
+    assert(result(slip_present: "False").no_slip?)
+    assert_not(result(slip_present: "maybe").no_slip?)
+    assert(result(template_matched: "false").template_mismatch?)
+    assert_not(result(template_matched: nil).template_mismatch?)
+  end
+
+  # No slip at all is not a layout mismatch -- the two states get
+  # different messages and different fixes.
+  def test_result_no_slip_is_not_a_template_mismatch
+    res = result(slip_present: false, template_matched: false)
+
+    assert(res.no_slip?)
+    assert_not(res.template_mismatch?)
+  end
+
+  # Unreadable-field names the model invented (or from the wrong
+  # template) must not travel further.
+  def test_result_unreadable_filtered_by_template
+    res = result(template: "dbg",
+                 unreadable: ["Species", "Trees/Shrubs", "Made Up"])
+
+    assert_equal(["Species"], res.unreadable)
   end
 end

--- a/test/classes/field_slip/template_test.rb
+++ b/test/classes/field_slip/template_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlip::TemplateTest < UnitTestCase
+  def test_for_returns_the_named_template
+    assert_instance_of(FieldSlip::Template::Mo, FieldSlip::Template.for(:mo))
+    assert_instance_of(FieldSlip::Template::Dbg,
+                       FieldSlip::Template.for("dbg"))
+  end
+
+  def test_for_rejects_an_unknown_template
+    assert_raises(ArgumentError) { FieldSlip::Template.for(:nemf) }
+  end
+
+  def test_default_is_the_mo_slip
+    assert_instance_of(FieldSlip::Template::Mo, FieldSlip::Template.default)
+  end
+
+  def test_keys_match_the_registry
+    FieldSlip::Template::REGISTRY.each_key do |key|
+      assert_equal(key, FieldSlip::Template.for(key).key)
+    end
+  end
+
+  # Selection is by the project's field_slip_prefix, so it holds in
+  # every environment regardless of ids.
+  def test_for_project_uses_the_prefix
+    project = projects(:bolete_project)
+    project.field_slip_prefix = "2026-CMS"
+
+    assert_instance_of(FieldSlip::Template::Dbg,
+                       FieldSlip::Template.for_project(project))
+  end
+
+  def test_for_project_defaults_to_the_mo_slip
+    assert_instance_of(FieldSlip::Template::Mo,
+                       FieldSlip::Template.for_project(
+                         projects(:bolete_project)
+                       ))
+    assert_instance_of(FieldSlip::Template::Mo,
+                       FieldSlip::Template.for_project(nil))
+  end
+
+  # The special fields every template names must be in its own field
+  # table -- a label typo here would quietly break the review form.
+  def test_special_fields_exist_in_each_template
+    FieldSlip::Template::REGISTRY.each_key do |key|
+      template = FieldSlip::Template.for(key)
+      labels = template.fields.keys
+
+      assert_includes(labels, template.name_field, key)
+      assert_includes(labels, template.location_field, key)
+      assert_includes(labels, template.inat_codes_field, key)
+      assert_includes(labels, template.code_field, key)
+    end
+  end
+
+  # ---------- iNat code detection ----------
+
+  # MO's Other Codes box is free text, so only a purely numeric value
+  # is treated as an iNat id.
+  def test_mo_inat_code_requires_purely_numeric
+    template = FieldSlip::Template.for(:mo)
+
+    assert_equal("12345678", template.inat_code_in(" 12345678 "))
+    assert_nil(template.inat_code_in("DBG-12345"))
+    assert_nil(template.inat_code_in("10:29 388879492"))
+    assert_not(template.inat_code?(nil))
+  end
+
+  # The DBG slip's box is dedicated to iNaturalist, so the id is
+  # recognized even mixed with a username or timestamp; short digit
+  # runs (clock times, dates) don't qualify.
+  def test_dbg_inat_code_found_in_mixed_text
+    template = FieldSlip::Template.for(:dbg)
+
+    assert_equal("388879492", template.inat_code_in("10:29 388879492"))
+    assert_equal("388879863", template.inat_code_in("388879863"))
+    assert_nil(template.inat_code_in("10:29 am"))
+    assert_nil(template.inat_code_in("someuser 8/6"))
+  end
+end

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -9,12 +9,12 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
     @obs.images << @image unless @obs.images.include?(@image)
   end
 
-  def build(fields: {}, confidence: {}, user: rolf)
+  def build(fields: {}, confidence: {}, user: rolf, template: "mo")
     extract = FieldSlipExtract.record(
       image: @image, user: rolf, prompt_version: "1",
       result: FieldSlip::Extractor::Result.new(
         provider: "g", model: "m", raw: {}, fields: fields,
-        confidence: confidence
+        confidence: confidence, template: template
       )
     )
     FormObject::FieldSlipReview.build(extract: extract, observation: @obs,
@@ -28,7 +28,8 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
   def test_builds_one_row_per_field
     review = build
 
-    assert_equal(FieldSlip::Extractor::FIELDS.keys, review.rows.map(&:field))
+    assert_equal(FieldSlip::Template.for(:mo).fields.keys,
+                 review.rows.map(&:field))
   end
 
   # Nothing read means nothing to review, so the table stays short.
@@ -41,16 +42,16 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
   # The ID needs a real label to render its autocompleter, which a table
   # cell has no room for, so it is pulled out of the table.
   def test_rows_to_show_excludes_the_name_row
-    review = build(fields: { FieldSlip::Extractor::NAME_FIELD => "Boletus",
+    review = build(fields: { "ID" => "Boletus",
                              "Collector" => "Scott Shapiro" })
 
     assert_not_includes(review.rows_to_show.map(&:field),
-                        FieldSlip::Extractor::NAME_FIELD)
-    assert_equal(FieldSlip::Extractor::NAME_FIELD, review.name_row.field)
+                        "ID")
+    assert_equal("ID", review.name_row.field)
   end
 
   def test_name_row_is_editable_but_not_savable
-    review = build(fields: { FieldSlip::Extractor::NAME_FIELD => "Boletus" })
+    review = build(fields: { "ID" => "Boletus" })
     row = review.name_row
 
     assert(row.editable, "the reviewer looks the real name up here")
@@ -128,14 +129,14 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
   # Ticked by default only when saving would succeed without a
   # create-the-name round-trip.
   def test_name_known_for_a_name_mo_holds
-    review = build(fields: { FieldSlip::Extractor::NAME_FIELD =>
+    review = build(fields: { "ID" =>
                              "Coprinus comatus" })
 
     assert(review.name_known)
   end
 
   def test_name_not_known_for_a_common_name
-    review = build(fields: { FieldSlip::Extractor::NAME_FIELD =>
+    review = build(fields: { "ID" =>
                              "Lumpy Bracket" })
 
     assert_not(review.name_known)
@@ -143,7 +144,7 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
 
   def test_name_not_known_when_blank_or_userless
     assert_not(build(fields: {}).name_known)
-    assert_not(build(fields: { FieldSlip::Extractor::NAME_FIELD => "Boletus" },
+    assert_not(build(fields: { "ID" => "Boletus" },
                      user: nil).name_known,
                "no user means no resolver, so no default tick")
   end
@@ -153,5 +154,43 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
                    confidence: { "Date" => "low" })
 
     assert_equal("low", row_for(review, "Date").confidence)
+  end
+
+  # ---------- iNat flag ----------
+
+  def test_inat_code_detected_in_a_numeric_other_codes
+    assert(build(fields: { "Other Codes" => "386717373" }).inat_code)
+    assert_not(build(fields: { "Other Codes" => "DBG-123" }).inat_code)
+  end
+
+  def test_inat_flag_rides_on_the_templates_own_field
+    assert(row_for(build(fields: { "Other Codes" => "1" }),
+                   "Other Codes").inat_row?)
+  end
+
+  # ---------- DBG template ----------
+
+  # The rows follow the extract's own template, and the special rows
+  # (name, location, iNat) follow its labels.
+  def test_dbg_extract_builds_dbg_rows
+    review = build(template: "dbg",
+                   fields: { "Species" => "Thelephora",
+                             "Location/Foray" => "Crags Creek Trailhead",
+                             "iNaturalist" => "10:29 388879492" })
+
+    assert_equal(FieldSlip::Template.for(:dbg).fields.keys,
+                 review.rows.map(&:field))
+    assert_equal("Species", review.name_row.field)
+    assert_equal("Location/Foray", review.location_row.field)
+    assert(row_for(review, "iNaturalist").inat_row?)
+    assert(review.inat_code,
+           "the id counts even mixed with a timestamp")
+  end
+
+  def test_dbg_name_known_reads_the_species_field
+    review = build(template: "dbg",
+                   fields: { "Species" => "Coprinus comatus" })
+
+    assert(review.name_known)
   end
 end

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -12,12 +12,12 @@ module Images
       @project = projects(:eol_project)
     end
 
-    def record_extract(fields: {}, confidence: {})
+    def record_extract(fields: {}, confidence: {}, template: "mo")
       FieldSlipExtract.record(
         image: @image, user: rolf, prompt_version: "1",
         result: FieldSlip::Extractor::Result.new(
           provider: "g", model: "m", raw: {}, fields: fields,
-          confidence: confidence
+          confidence: confidence, template: template
         )
       )
     end
@@ -87,7 +87,8 @@ module Images
       login_as_site_admin
       result = FieldSlip::Extractor::Result.new(
         provider: "gemini", model: "gemini-3.6-flash", raw: { "x" => 1 },
-        fields: { "Collector" => "Scott Shapiro" }, confidence: {}
+        fields: { "Collector" => "Scott Shapiro" }, confidence: {},
+        template: "mo"
       )
 
       FieldSlip::Extractor.stub(:default, fake_extractor(result)) do
@@ -140,7 +141,7 @@ module Images
 
     def test_edit_renders_the_rows_and_the_name_section
       record_extract(fields: { "Collector" => "Scott Shapiro",
-                               FieldSlip::Extractor::NAME_FIELD => "Boletus" })
+                               "ID" => "Boletus" })
       login_as_site_admin
 
       get(:edit, params: { image_id: @image.id })
@@ -219,8 +220,40 @@ module Images
       assert_equal("386717373", @obs.reload.notes[:Other_Codes])
     end
 
+    # A dbg extract reviews and saves through its own field labels --
+    # the name lives in "Species", the iNat id in "iNaturalist", and
+    # the coordinates land as a pair.
+    def test_update_applies_a_dbg_extract
+      record_extract(template: "dbg",
+                     fields: { "Species" => "Coprinus comatus",
+                               "Latitude" => "38.8703",
+                               "Longitude" => "-105.0442",
+                               "iNaturalist" => "10:29 388879492" })
+      before = @obs.namings.count
+      login_as_site_admin
+
+      put(:update,
+          params: { image_id: @image.id, inat: "1",
+                    use: { "Species" => "1", "Latitude" => "1",
+                           "Longitude" => "1", "iNaturalist" => "1" },
+                    value: { "Species" => "Coprinus comatus",
+                             "Latitude" => "38.8703",
+                             "Longitude" => "-105.0442",
+                             "iNaturalist" => "10:29 388879492" } })
+
+      @obs.reload
+
+      assert_equal(before + 1, @obs.namings.count)
+      assert_in_delta(38.8703, @obs.lat)
+      assert_in_delta(-105.0442, @obs.lng)
+      link = FieldSlipNotesBuilder.inat_link("388879492")
+
+      assert_equal("#{link} (10:29)", @obs.notes[:iNaturalist])
+      assert_redirected_to(permanent_observation_path(@obs.id))
+    end
+
     def test_update_proposes_a_ticked_known_name
-      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+      record_extract(fields: { "ID" =>
                                "Coprinus comatus" })
       before = @obs.namings.count
       login_as_site_admin
@@ -233,7 +266,7 @@ module Images
     end
 
     def test_update_leaves_an_unticked_name_alone
-      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+      record_extract(fields: { "ID" =>
                                "Coprinus comatus" })
       before = @obs.namings.count
       login_as_site_admin
@@ -247,7 +280,7 @@ module Images
     # An unrecognized name comes back for confirmation rather than being
     # created off a machine reading.
     def test_update_asks_before_creating_an_unknown_name
-      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+      record_extract(fields: { "ID" =>
                                "Lumpy Bracket" })
       names_before = Name.count
       login_as_site_admin
@@ -264,7 +297,7 @@ module Images
     # does not mean re-doing the rest.
     def test_update_applies_fields_even_when_the_name_needs_approval
       record_extract(fields: { "Collector" => "Scott Shapiro",
-                               FieldSlip::Extractor::NAME_FIELD =>
+                               "ID" =>
                                "Lumpy Bracket" })
       login_as_site_admin
 
@@ -280,7 +313,7 @@ module Images
     # complete rather than bouncing to a confirmation page whose
     # feedback panel would render empty.
     def test_update_completes_when_the_id_is_a_placeholder
-      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+      record_extract(fields: { "ID" =>
                                "unknown" })
       login_as_site_admin
 
@@ -291,7 +324,7 @@ module Images
     end
 
     def test_update_creates_the_name_once_approved
-      record_extract(fields: { FieldSlip::Extractor::NAME_FIELD =>
+      record_extract(fields: { "ID" =>
                                "Lumpysomething bracketii" })
       names_before = Name.count
       login_as_site_admin

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -9,7 +9,7 @@ class FieldSlipExtractTest < UnitTestCase
     @obs.images << @image unless @obs.images.include?(@image)
   end
 
-  DEFAULT_RESULT = { provider: "gemini", model: "m",
+  DEFAULT_RESULT = { provider: "gemini", model: "m", template: "mo",
                      raw: { "ok" => true } }.freeze
 
   def result(fields: {}, confidence: {}, **overrides)
@@ -60,6 +60,46 @@ class FieldSlipExtractTest < UnitTestCase
     assert_equal("gemini-3.6-flash", extract.model)
     assert_equal("1", extract.prompt_version)
     assert_equal({ "ok" => true }, extract.data["raw"])
+  end
+
+  # ---------- template ----------
+
+  def test_record_stores_which_template_was_read
+    assert_instance_of(FieldSlip::Template::Dbg,
+                       record(template: "dbg").template)
+  end
+
+  # Reads stored before templates existed were all of MO's own slip.
+  def test_template_defaults_to_mo_for_old_rows
+    extract = record(fields: { "Collector" => "A" })
+    extract.update!(data: extract.data.except("template"))
+
+    assert_instance_of(FieldSlip::Template::Mo, extract.reload.template)
+  end
+
+  def test_template_mismatch_only_on_explicit_false
+    assert(record(slip_present: true, template_matched: false).
+           template_mismatch?)
+    assert_not(record(template_matched: true).template_mismatch?)
+    assert_not(record.template_mismatch?, "unreported is not evidence")
+  end
+
+  # No slip at all is not a layout mismatch -- different message,
+  # different fix.
+  def test_no_slip_is_not_a_template_mismatch
+    extract = record(slip_present: false, template_matched: false)
+
+    assert(extract.no_slip?)
+    assert_not(extract.template_mismatch?)
+  end
+
+  # The dbg slip names its fields differently; the helpers must follow
+  # the stored template's labels.
+  def test_location_helpers_follow_the_stored_template
+    extract = record(template: "dbg",
+                     fields: { "Location/Foray" => "EB2" })
+
+    assert_equal("EB2", extract.unknown_location_alias)
   end
 
   def test_confidence_defaults_to_low_when_unusable

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -13,12 +13,12 @@ module Views::Controllers::Images::FieldSlipExtracts
       @project = projects(:eol_project)
     end
 
-    def extract_with(fields: {}, confidence: {})
+    def extract_with(fields: {}, confidence: {}, template: "mo", **flags)
       FieldSlipExtract.record(
         image: @image, user: @user, prompt_version: "1",
         result: FieldSlip::Extractor::Result.new(
           provider: "gemini", model: "gemini-3.6-flash", raw: {},
-          fields: fields, confidence: confidence
+          fields: fields, confidence: confidence, template: template, **flags
         )
       )
     end
@@ -47,7 +47,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     # and hidden id field when it has a real label -- `label: false`
     # silently drops the append slot they live in.
     def test_name_row_renders_a_live_autocompleter
-      html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
+      html = render_page(fields: { "ID" =>
                                    "Coprinus comatus" })
 
       assert_html(html, "[data-controller='autocompleter--name']")
@@ -59,14 +59,14 @@ module Views::Controllers::Images::FieldSlipExtracts
     # Ticked only when the ID already resolves to a name MO holds, so
     # creating a Name is always a deliberate act.
     def test_name_tick_defaults_on_for_a_known_name
-      html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
+      html = render_page(fields: { "ID" =>
                                    "Coprinus comatus" })
 
       assert_html(html, "input[name='use[ID]'][checked]")
     end
 
     def test_name_tick_defaults_off_for_an_unknown_name
-      html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
+      html = render_page(fields: { "ID" =>
                                    "Lumpy Bracket" })
 
       assert_html(html, "input[name='use[ID]']")
@@ -76,7 +76,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     # Pins the SELECTED option, not just the menu's presence: a
     # type mismatch once left none selected (see `render_vote_field`).
     def test_name_section_defaults_the_vote_to_promising
-      html = render_page(fields: { FieldSlip::Extractor::NAME_FIELD =>
+      html = render_page(fields: { "ID" =>
                                    "Coprinus comatus" })
 
       assert_html(html, "select[name='vote']")
@@ -194,6 +194,42 @@ module Views::Controllers::Images::FieldSlipExtracts
       html = render_page(fields: { "Collector" => "Scott Shapiro" })
 
       assert_no_html(html, "input[name='inat']")
+    end
+
+    # ---------- template ----------
+
+    # A slip on another event's layout was seen but not read; the page
+    # says so instead of showing an empty table with no explanation.
+    def test_flags_a_template_mismatch
+      html = render_page(slip_present: true, template_matched: false)
+
+      assert_html(html, ".alert-danger",
+                  text: :field_slip_extract_template_mismatch.t.
+                        as_displayed[0, 40])
+    end
+
+    def test_no_mismatch_flag_for_a_matching_read
+      html = render_page(fields: { "Collector" => "A" },
+                         template_matched: true)
+
+      assert_no_html(html, ".alert-danger")
+    end
+
+    # A dbg extract reviews through its own labels: Species gets the
+    # name section, Location/Foray the locality section, iNaturalist
+    # the flag.
+    def test_dbg_extract_renders_its_own_fields
+      html = render_page(template: "dbg",
+                         fields: { "Species" => "Coprinus comatus",
+                                   "Location/Foray" => "Crags Creek",
+                                   "iNaturalist" => "10:29 388879492",
+                                   "Plants" => "Spruce" })
+
+      assert_html(html, "#field_slip_extract_name")
+      assert_html(html, "input[name='use[Species]'][checked]")
+      assert_html(html, "input[name='value[Location/Foray]']")
+      assert_html(html, "input[name='value[Plants]'][value='Spruce']")
+      assert_html(html, "input[name='inat'][checked]")
     end
 
     # ---------- locality ----------


### PR DESCRIPTION
## Summary

Fixes #5024. Adds slip-layout templates to the field slip extraction pipeline so Andy Wilson's DBG voucher slips (2025 NAMA, 2026 CMS fair, 2026 SMHF) can be machine-read and reviewed, alongside MO's own slips.

- New `FieldSlip::Template` registry (`app/classes/field_slip/template.rb`): each template owns its field list, per-field observation mapping, layout-specific prompt rules, a layout description for auto-detection, and iNat-id detection for its codes field. `Template::Mo` is the existing MO slip (field table moved out of `Extractor::FIELDS` unchanged); `Template::Dbg` is Andy's layout.
- Template selection is per-project, keyed by `field_slip_prefix` (`2025-NAMA`, `2026-CMS`, `2026-SMHF` → dbg; everything else → mo). Prefix keys are stable across environments, unlike project ids.
- The prompt now describes the expected layout and the response reports `template_matched`. A slip printed on a layout the project doesn't use is rejected — the review page shows an alert instead of values force-fit onto the wrong field set. `PROMPT_VERSION` bumped to 5; the extract stores which template it was read as.
- `Extractor::Applier`, `FormObject::FieldSlipReview`, the review form/view, and the controller are all template-driven now (name field, location field, iNat-codes field come from the extract's template instead of constants).

## The DBG template

Fields per the sample slips on the issue (and `projects/cms-2026`): State/County (review-only, components of the reviewed place name), Location/Foray (aliases + locality autocompleter, same as MO's Location), Latitude/Longitude → observation coordinates (parsed via `Location.parse_latitude`, applied only as a pair so a lone coordinate can't sink the save), Species → proposed naming, ID By / ID Date / Plants / Substrate / Habit / Notes / Odor-Taste → notes keys, and the iNaturalist box. A long digit run in that box becomes an iNat link even when written beside a timestamp (`10:29 388879492` → link + `(10:29)` kept as a checksum). "Voucher Number" covers the upcoming CO26-XXXX specimen stickers (upper-right, over the logo), stored under `notes.Voucher_Number`.

Templates are code-defined for now — adding one is a subclass plus a registry entry. The DB-defined self-serve version (organizers configuring a template from a scan) is the intended follow-up.

## Test plan

Setup: a project whose `field_slip_prefix` is `2026-CMS` or `2026-SMHF` (project 405 / the new SMHF 2026 project), with its foray locations entered as ProjectAliases, plus a Gemini key in credentials.

1. Attach one of the CMS slip photos to an observation in the project and press "Read Field Slip" on the image page. The review form should show the DBG field list (State, County, Location/Foray, Species, Plants, iNaturalist…), with the iNat flag ticked when the box holds an observation number.
2. Save with Latitude/Longitude filled in and confirm the observation gets coordinates; save the iNaturalist row and confirm the note renders as an iNat link with the timestamp in parens.
3. Read a photo of an MO slip attached to that same project and confirm the red "layout not accepted" alert appears with no values.
4. Read an MO slip in a non-prefixed project and confirm nothing changed from before (mo template, prompt v5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
