### PR TITLE
Auto-attach observations to field slips via QR codes in uploaded photos (`FieldSlip::QRDecoder`)

### DIFF
--- a/app/classes/field_slip/attacher.rb
+++ b/app/classes/field_slip/attacher.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class FieldSlip
+  # Attaches a slip-less observation to the field slip a code names --
+  # the silent counterpart of the observation form's field_code path
+  # (ObservationsController::FieldSlips#assign_field_slip), for
+  # photo-first observations where the code arrives as pixels in an
+  # uploaded photo rather than as a scan or a typed field.
+  #
+  # Deliberately narrower than the interactive path, because nobody is
+  # watching: it acts only when the observation has no occurrence and
+  # the code's slip is unused, so it can never move an observation,
+  # join one to somebody else's collection, or override a choice a
+  # person made on a form.
+  class Attacher
+    def self.attach(observation:, code:, user:)
+      new(observation: observation, code: code, user: user).attach
+    end
+
+    def initialize(observation:, code:, user:)
+      @observation = observation
+      @code = code.to_s.strip.upcase
+      @user = user
+    end
+
+    # Returns what happened, for the caller's log line.
+    def attach
+      return :already_linked if @observation.occurrence_id
+
+      existing = FieldSlip.find_by(code: @code)
+      return :in_use if existing&.occurrence
+      return :closed_project if barred?(existing)
+
+      slip = existing || FieldSlip.find_or_create_by_code(@code, @user)
+      return :invalid unless slip
+
+      link(slip)
+      :attached
+    end
+
+    private
+
+    # An existing slip already in a project the user can neither join
+    # nor is a member of: attaching would put the observation in that
+    # project against invariant 4 (see #4932). A NEW code never lands
+    # here -- `FieldSlip#update_project` declines to set a project the
+    # user can't add to, so the slip just comes out project-less.
+    def barred?(slip)
+      project = slip&.project
+      project && !project.member?(@user) && !project.can_join?(@user)
+    end
+
+    def link(slip)
+      @observation.field_slip = slip
+      @observation.save!
+      slip.adopt_user_from(@observation)
+      refresh_occurrence
+      apply_project(slip.project)
+    end
+
+    # The bookkeeping every attach path owes the occurrence. No
+    # activity-log entry: the occurrence is freshly created for this
+    # one observation, whose own creation entry already says it all.
+    def refresh_occurrence
+      occ = @observation.occurrence
+      occ.reload
+      occ.recompute_has_specimen!
+      occ.recalculate_consensus!(@user)
+    end
+
+    # Using a slip for an open-membership project enrolls the user, the
+    # way scanning one always has -- that is what a printed prefix
+    # means. The observation then joins the project too, unless it
+    # violates the project's constraints, in which case the slip is
+    # being used as a spare and the observation stays out.
+    def apply_project(project)
+      return unless project
+
+      project.join(@user)
+      return unless project.member?(@user)
+      return if project.violates_constraints?(@observation)
+
+      project.add_observation(@observation)
+    end
+  end
+end

--- a/app/classes/field_slip/extractor/gemini.rb
+++ b/app/classes/field_slip/extractor/gemini.rb
@@ -91,13 +91,15 @@ class FieldSlip
         Base64.strict_encode64(image_bytes(image))
       end
 
+      # Recognizing the on-disk shapes matters here: RestClient raises
+      # on anything that isn't an HTTP URI.
       def image_bytes(image)
         url = image.image_url(IMAGE_SIZE)
-        path = local_path(url)
+        path = Image::LocalFile.path_from_url(url)
         return File.binread(path) if path
 
         resolved = url.url
-        # A file:// URL that got past `local_path` means the file MO
+        # A file:// URL with no file behind it means the file MO
         # expects is not there. Say so, rather than handing RestClient
         # something it rejects with a bare "not an HTTP URI".
         raise(MissingImage.new(resolved)) unless resolved.start_with?("http")
@@ -105,34 +107,6 @@ class FieldSlip
         RestClient::Request.execute(method: :get, url: resolved,
                                     timeout: TIMEOUT,
                                     raw_response: true).file.read
-      end
-
-      # A resolved image URL is on disk in two different shapes, and
-      # both have to be recognized or RestClient is handed something
-      # that isn't an HTTP URI and raises.
-      #
-      #   "/images/1280/42.jpg?v"   the local source's `read` spec is a
-      #                             WEB path, not a filesystem one, so
-      #                             it maps onto MO.local_image_files.
-      #   "file:///…/42.jpg?v"      other sources (the test env's
-      #                             `remote1`) do use a file:// URL.
-      def local_path(url)
-        resolved = url.url.sub(/\?\d+\z/, "")
-        path = file_url_path(resolved) || web_path_on_disk(resolved)
-        path if path && File.exist?(path)
-      end
-
-      def file_url_path(resolved)
-        return nil unless resolved.start_with?("file://")
-
-        resolved.delete_prefix("file://")
-      end
-
-      def web_path_on_disk(resolved)
-        prefix = MO.image_sources.dig(:local, :read).to_s
-        return nil if prefix.blank? || !resolved.start_with?("#{prefix}/")
-
-        File.join(MO.local_image_files, resolved.delete_prefix("#{prefix}/"))
       end
 
       # The model is asked for JSON and told not to fence it, but a

--- a/app/classes/field_slip/qr_decoder.rb
+++ b/app/classes/field_slip/qr_decoder.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require("open3")
+
+class FieldSlip
+  # Reads a field slip code out of a photo's QR code, using the zbar
+  # command-line tool (`zbarimg`). DBG-style voucher slips encode the
+  # bare code ("2026-CMS-0219"); MO's own slips encode a /qr/ URL. Both
+  # forms are recognized.
+  #
+  # Inert when zbarimg is not installed (`brew install zbar` /
+  # `apt-get install zbar-tools`): callers check `available?` first, so
+  # an environment without the binary simply has no QR detection.
+  module QRDecoder
+    # Full size first: the QR occupies a small corner of the photo, and
+    # downscaling can cost it the resolution it needs to decode.
+    SIZES = [:full_size, :huge].freeze
+
+    MO_QR_URL = %r{\Ahttps?://(?:www\.)?mushroomobserver\.org/qr/(\S+)\z}i
+
+    # The general shape of a printed slip code ("2026-CMS-0219",
+    # "NEMF-10222"): one token, letters somewhere (FieldSlip's own
+    # validation requires a non-digit character), bounded length.
+    CODE_SHAPE = /\A[A-Z0-9][A-Z0-9._-]{3,30}\z/
+
+    def self.available?
+      MO.field_slip_qr_detection && zbarimg?
+    end
+
+    def self.zbarimg?
+      return @zbarimg unless @zbarimg.nil?
+
+      @zbarimg = system("which", "zbarimg", out: File::NULL,
+                                            err: File::NULL) || false
+    end
+
+    # The slip code in the image's QR code, or nil: no local file, no
+    # QR, or QR content that isn't a slip code.
+    def self.slip_code_in(image)
+      raw_codes(image).filter_map { |text| slip_code_from(text) }.first
+    end
+
+    # A bare code is only believed when its prefix names a project --
+    # photos contain all kinds of QR codes (product labels, wifi
+    # passes), and the project prefix is what separates a slip from
+    # noise. An MO /qr/ URL is explicit enough on its own.
+    def self.slip_code_from(text)
+      text = text.to_s.strip
+      url_code = text[MO_QR_URL, 1]
+      return url_code.upcase if url_code
+
+      code = text.upcase
+      return nil unless code.match?(CODE_SHAPE) && code.match?(/[^\d.-]/)
+
+      prefix = FieldSlip.prefix_for_code(code)
+      code if prefix && Project.exists?(field_slip_prefix: prefix)
+    end
+
+    # Every QR payload zbar finds, largest available file first,
+    # stopping at the first size that decodes anything.
+    def self.raw_codes(image)
+      return [] unless available?
+
+      SIZES.each do |size|
+        path = Image::LocalFile.path(image, size)
+        next unless path
+
+        codes = scan(path)
+        return codes if codes.any?
+      end
+      []
+    end
+
+    # -Sdisable -Sqrcode.enable: QR only, so a stray barcode elsewhere
+    # in the photo can't answer.
+    def self.scan(path)
+      out, _err, status = Open3.capture3(
+        "zbarimg", "--quiet", "--raw", "-Sdisable", "-Sqrcode.enable", path
+      )
+      # zbarimg exits 4 when it finds nothing -- not an error here.
+      return [] unless status.success?
+
+      out.split("\n").map(&:strip).compact_blank
+    end
+  end
+end

--- a/app/classes/field_slip/qr_decoder.rb
+++ b/app/classes/field_slip/qr_decoder.rb
@@ -16,7 +16,9 @@ class FieldSlip
     # downscaling can cost it the resolution it needs to decode.
     SIZES = [:full_size, :huge].freeze
 
-    MO_QR_URL = %r{\Ahttps?://(?:www\.)?mushroomobserver\.org/qr/(\S+)\z}i
+    # The code is the path segment alone -- MO's own /qr/ URLs can
+    # carry query params (e.g. ?project=...), which are not part of it.
+    MO_QR_URL = %r{\Ahttps?://(?:www\.)?mushroomobserver\.org/qr/([^?#/\s]+)}i
 
     # The general shape of a printed slip code ("2026-CMS-0219",
     # "NEMF-10222"): one token, letters somewhere (FieldSlip's own

--- a/app/jobs/detect_field_slip_qr_job.rb
+++ b/app/jobs/detect_field_slip_qr_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Scans a slip-less observation's photos for a field slip QR code and,
+# when one names a slip the observation can take, attaches it (see
+# FieldSlip::QRDecoder and FieldSlip::Attacher).
+#
+# This restores the scan-first flow's automatic project filing for
+# photo-first observations: DBG-style voucher slips (#5024) encode only
+# the bare code, which a phone's camera app can't act on, so the first
+# place MO ever sees the code may be the uploaded photo itself.
+class DetectFieldSlipQRJob < ApplicationJob
+  queue_as :default
+
+  def perform(observation_id)
+    observation = Observation.find_by(id: observation_id)
+    return unless observation && observation.occurrence_id.nil?
+    return unless FieldSlip::QRDecoder.available?
+
+    observation.images.order(:id).each do |image|
+      break if attach(observation, image) == :attached
+    end
+  end
+
+  private
+
+  def attach(observation, image)
+    code = FieldSlip::QRDecoder.slip_code_in(image)
+    return nil unless code
+
+    result = FieldSlip::Attacher.attach(observation: observation,
+                                        code: code, user: observation.user)
+    Rails.logger.info(
+      "DetectFieldSlipQRJob: #{code} -> #{result} " \
+      "(observation #{observation.id}, image #{image.id})"
+    )
+    result
+  end
+end

--- a/app/jobs/detect_field_slip_qr_job.rb
+++ b/app/jobs/detect_field_slip_qr_job.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
-# Scans a slip-less observation's photos for a field slip QR code and,
-# when one names a slip the observation can take, attaches it (see
-# FieldSlip::QRDecoder and FieldSlip::Attacher).
+# Scans one newly attached photo for a field slip QR code and, when it
+# names a slip the observation can take, attaches it (see
+# FieldSlip::QRDecoder and FieldSlip::Attacher). One job per photo (see
+# ObservationImage), so a multi-photo upload costs one scan per image;
+# once any photo attaches the slip, the rest no-op on the occurrence
+# check.
 #
 # This restores the scan-first flow's automatic project filing for
 # photo-first observations: DBG-style voucher slips (#5024) encode only
@@ -11,21 +14,14 @@
 class DetectFieldSlipQRJob < ApplicationJob
   queue_as :default
 
-  def perform(observation_id)
+  def perform(observation_id, image_id)
     observation = Observation.find_by(id: observation_id)
-    return unless observation && observation.occurrence_id.nil?
+    image = Image.find_by(id: image_id)
+    return unless observation && image && observation.occurrence_id.nil?
     return unless FieldSlip::QRDecoder.available?
 
-    observation.images.order(:id).each do |image|
-      break if attach(observation, image) == :attached
-    end
-  end
-
-  private
-
-  def attach(observation, image)
     code = FieldSlip::QRDecoder.slip_code_in(image)
-    return nil unless code
+    return unless code
 
     result = FieldSlip::Attacher.attach(observation: observation,
                                         code: code, user: observation.user)
@@ -33,6 +29,5 @@ class DetectFieldSlipQRJob < ApplicationJob
       "DetectFieldSlipQRJob: #{code} -> #{result} " \
       "(observation #{observation.id}, image #{image.id})"
     )
-    result
   end
 end

--- a/app/models/image/local_file.rb
+++ b/app/models/image/local_file.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Image
+  # Resolves the on-disk file behind an image at a given size, when this
+  # machine holds one. A resolved image URL is on disk in two different
+  # shapes, and both have to be recognized:
+  #
+  #   "/images/1280/42.jpg?v"   the local source's `read` spec is a WEB
+  #                             path, not a filesystem one, so it maps
+  #                             onto MO.local_image_files.
+  #   "file:///…/42.jpg?v"      other sources (the test env's `remote1`)
+  #                             do use a file:// URL.
+  #
+  # Returns nil when the resolved location is remote or the file is not
+  # actually there.
+  module LocalFile
+    def self.path(image, size)
+      path_from_url(image.image_url(size))
+    end
+
+    def self.path_from_url(url)
+      resolved = url.url.sub(/\?\d+\z/, "")
+      path = file_url_path(resolved) || web_path_on_disk(resolved)
+      path if path && File.exist?(path)
+    end
+
+    def self.file_url_path(resolved)
+      return nil unless resolved.start_with?("file://")
+
+      resolved.delete_prefix("file://")
+    end
+
+    def self.web_path_on_disk(resolved)
+      prefix = MO.image_sources.dig(:local, :read).to_s
+      return nil if prefix.blank? || !resolved.start_with?("#{prefix}/")
+
+      File.join(MO.local_image_files, resolved.delete_prefix("#{prefix}/"))
+    end
+  end
+end

--- a/app/models/observation_image.rb
+++ b/app/models/observation_image.rb
@@ -4,4 +4,20 @@
 class ObservationImage < ApplicationRecord
   belongs_to :observation
   belongs_to :image
+
+  # A newly attached photo may carry a field slip QR code that tells MO
+  # which slip -- and so which project -- the observation belongs to
+  # (see DetectFieldSlipQRJob). Only worth asking while the observation
+  # has no occurrence, and only where zbar is installed, so environments
+  # without it enqueue nothing.
+  after_create_commit :detect_field_slip_qr
+
+  private
+
+  def detect_field_slip_qr
+    return unless FieldSlip::QRDecoder.available?
+    return if observation.nil? || observation.occurrence_id
+
+    DetectFieldSlipQRJob.perform_later(observation.id)
+  end
 end

--- a/app/models/observation_image.rb
+++ b/app/models/observation_image.rb
@@ -18,6 +18,6 @@ class ObservationImage < ApplicationRecord
     return unless FieldSlip::QRDecoder.available?
     return if observation.nil? || observation.occurrence_id
 
-    DetectFieldSlipQRJob.perform_later(observation.id)
+    DetectFieldSlipQRJob.perform_later(observation.id, image_id)
   end
 end

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -136,6 +136,11 @@ MushroomObserver::Application.configure do
   # Default locale when nothing sets it explicitly.
   config.default_locale = "en"
 
+  # Scan uploaded photos for field slip QR codes and auto-attach the
+  # observation to the slip (and so its project). Also requires the
+  # zbar tool (zbarimg) on the machine -- see FieldSlip::QrDecoder.
+  config.field_slip_qr_detection = true
+
   # I18n namespace all our app-specific translations are kept in
   # inside localization files.
   config.locale_namespace = "mo"

--- a/config/consts.rb
+++ b/config/consts.rb
@@ -138,7 +138,7 @@ MushroomObserver::Application.configure do
 
   # Scan uploaded photos for field slip QR codes and auto-attach the
   # observation to the slip (and so its project). Also requires the
-  # zbar tool (zbarimg) on the machine -- see FieldSlip::QrDecoder.
+  # zbar tool (zbarimg) on the machine -- see FieldSlip::QRDecoder.
   config.field_slip_qr_detection = true
 
   # I18n namespace all our app-specific translations are kept in

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,7 +20,8 @@ MushroomObserver::Application.configure do
   config.image_fallback_source = :remote1
 
   # Off so suite behavior never depends on whether zbar happens to be
-  # installed; tests that want the pipeline stub QrDecoder.available?.
+  # installed; tests that want the pipeline stub
+  # FieldSlip::QRDecoder.available?.
   config.field_slip_qr_detection = false
 
   config.robots_dot_text_file = "#{config.root}/test/fixtures/robots.txt"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,6 +19,10 @@ MushroomObserver::Application.configure do
   }
   config.image_fallback_source = :remote1
 
+  # Off so suite behavior never depends on whether zbar happens to be
+  # installed; tests that want the pipeline stub QrDecoder.available?.
+  config.field_slip_qr_detection = false
+
   config.robots_dot_text_file = "#{config.root}/test/fixtures/robots.txt"
 
   config.water_users = []

--- a/test/classes/field_slip/attacher_test.rb
+++ b/test/classes/field_slip/attacher_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlip::AttacherTest < UnitTestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @obs.update!(occurrence: nil)
+    # Prefix OPEN, open_membership true.
+    @project = projects(:open_membership_project)
+  end
+
+  def attach(code:, user: @obs.user, obs: @obs)
+    FieldSlip::Attacher.attach(observation: obs, code: code, user: user)
+  end
+
+  def test_attaches_a_new_slip_and_files_into_the_prefix_project
+    user = @obs.user
+
+    assert_not(@project.member?(user), "premise: not yet a member")
+
+    result = attach(code: "OPEN-0219")
+
+    assert_equal(:attached, result)
+    @obs.reload
+
+    assert_equal("OPEN-0219", @obs.field_slip.code)
+    assert_equal(user, @obs.field_slip.user, "slip adopts the observer")
+    assert(@project.member?(user), "using the slip enrolls the user")
+    assert_includes(@project.observations.reload, @obs,
+                    "the observation files into the prefix project")
+  end
+
+  def test_reuses_an_existing_unused_slip
+    slip = FieldSlip.find_or_create_by_code("OPEN-0311", @obs.user)
+
+    assert_equal(:attached, attach(code: "open-0311"))
+    assert_equal(slip, @obs.reload.field_slip)
+  end
+
+  # Nobody is watching, so nothing that would move an observation or
+  # claim another collector's slip is ever done automatically.
+  def test_never_touches_an_observation_that_has_an_occurrence
+    other = observations(:minimal_unknown_obs)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0400", other.user)
+    other.field_slip = slip
+    other.save!
+
+    assert_equal(:already_linked, attach(obs: other.reload, code: "OPEN-0401"))
+    assert_equal("OPEN-0400", other.reload.field_slip.code)
+  end
+
+  def test_never_joins_a_slip_already_in_use
+    other = observations(:coprinus_comatus_obs)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0500", other.user)
+    other.update!(occurrence: nil)
+    other.field_slip = slip
+    other.save!
+
+    assert_equal(:in_use, attach(code: "OPEN-0500"))
+    assert_nil(@obs.reload.occurrence)
+  end
+
+  # An existing slip in a project the user can neither join nor is a
+  # member of: attaching would put the observation there against
+  # invariant 4 (#4932).
+  def test_skips_an_existing_slip_for_a_closed_project
+    closed = projects(:bolete_project)
+
+    assert_not(closed.open_membership, "premise: closed to self-joining")
+
+    owner = closed.user_group.users.first
+    slip = FieldSlip.find_or_create_by_code("BLT-0600", owner)
+
+    assert_equal(closed, slip.project, "premise: slip landed in the project")
+
+    stranger = users(:zero_user)
+
+    assert_not(closed.member?(stranger), "premise: not a member")
+
+    @obs.update!(user: stranger)
+
+    assert_equal(:closed_project, attach(code: "BLT-0600", user: stranger))
+    assert_nil(@obs.reload.occurrence)
+  end
+
+  # A NEW code for a closed project comes out as a spare: the slip is
+  # created project-less (FieldSlip#update_project declines a project
+  # the user can't add to), so the observation links to the slip but
+  # joins no project. Same as typing the code into the observation form.
+  def test_a_new_code_for_a_closed_project_becomes_a_spare_slip
+    closed = projects(:bolete_project)
+    stranger = users(:zero_user)
+    @obs.update!(user: stranger)
+
+    assert_equal(:attached, attach(code: "BLT-0700", user: stranger))
+    @obs.reload
+
+    assert_equal("BLT-0700", @obs.field_slip.code)
+    assert_nil(@obs.field_slip.project)
+    assert_not_includes(closed.observations.reload, @obs)
+  end
+
+  def test_an_unusable_code_is_invalid
+    assert_equal(:invalid, attach(code: "12345"),
+                 "all digits fails FieldSlip's code validation")
+    assert_nil(@obs.reload.occurrence)
+  end
+end

--- a/test/classes/field_slip/qr_decoder_test.rb
+++ b/test/classes/field_slip/qr_decoder_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class FieldSlip::QRDecoderTest < UnitTestCase
+  # ---------- what counts as a slip code ----------
+
+  # A bare code is believed only when its prefix names a project: photos
+  # contain all kinds of QR codes, and the prefix separates a slip from
+  # noise. (open_membership_project's prefix is OPEN.)
+  def test_bare_code_with_a_known_project_prefix
+    assert_equal("OPEN-0219", FieldSlip::QRDecoder.slip_code_from("open-0219"))
+  end
+
+  def test_bare_code_with_an_unknown_prefix_is_noise
+    assert_nil(FieldSlip::QRDecoder.slip_code_from("2099-XYZ-0001"))
+  end
+
+  def test_mo_qr_urls_are_explicit_enough_on_their_own
+    assert_equal("NEMF-10222",
+                 FieldSlip::QRDecoder.slip_code_from(
+                   "https://mushroomobserver.org/qr/nemf-10222"
+                 ))
+    assert_nil(FieldSlip::QRDecoder.slip_code_from(
+                 "https://example.com/qr/OPEN-0219"
+               ),
+               "someone else's /qr/ URL is not MO's")
+  end
+
+  def test_noise_is_rejected
+    assert_nil(FieldSlip::QRDecoder.slip_code_from("WIFI:T:WPA;S:cafe;;"))
+    assert_nil(FieldSlip::QRDecoder.slip_code_from("12345"),
+               "all digits fails FieldSlip's own code validation")
+    assert_nil(FieldSlip::QRDecoder.slip_code_from(""))
+    assert_nil(FieldSlip::QRDecoder.slip_code_from("a" * 40))
+  end
+
+  # ---------- the pipeline ----------
+
+  def test_slip_code_in_reads_the_first_recognizable_code
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      Image::LocalFile.stub(:path, "/tmp/fake.jpg") do
+        FieldSlip::QRDecoder.stub(:scan,
+                                  ["https://example.com", "OPEN-0219"]) do
+          assert_equal("OPEN-0219",
+                       FieldSlip::QRDecoder.slip_code_in(images(:in_situ_image)))
+        end
+      end
+    end
+  end
+
+  def test_slip_code_in_nil_when_detection_is_unavailable
+    FieldSlip::QRDecoder.stub(:available?, false) do
+      assert_nil(FieldSlip::QRDecoder.slip_code_in(images(:in_situ_image)))
+    end
+  end
+
+  def test_slip_code_in_nil_without_a_local_file
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      Image::LocalFile.stub(:path, nil) do
+        assert_nil(FieldSlip::QRDecoder.slip_code_in(images(:in_situ_image)))
+      end
+    end
+  end
+
+  # ---------- zbarimg plumbing ----------
+
+  def test_scan_parses_zbar_output
+    ok = Struct.new(:success?).new(true)
+    Open3.stub(:capture3, ["OPEN-1\nOPEN-2\n\n", "", ok]) do
+      assert_equal(%w[OPEN-1 OPEN-2], FieldSlip::QRDecoder.scan("/x.jpg"))
+    end
+  end
+
+  # zbarimg exits nonzero when it finds no symbols; that is an empty
+  # answer, not an error.
+  def test_scan_empty_when_zbar_finds_nothing
+    none = Struct.new(:success?).new(false)
+    Open3.stub(:capture3, ["", "", none]) do
+      assert_empty(FieldSlip::QRDecoder.scan("/x.jpg"))
+    end
+  end
+
+  # The config flag gates detection regardless of the binary (it is off
+  # in the test environment, so nothing here depends on zbar being
+  # installed).
+  def test_available_requires_the_config_flag
+    assert_not(FieldSlip::QRDecoder.available?)
+    assert_includes([true, false], FieldSlip::QRDecoder.zbarimg?)
+  end
+end

--- a/test/classes/field_slip/qr_decoder_test.rb
+++ b/test/classes/field_slip/qr_decoder_test.rb
@@ -27,6 +27,19 @@ class FieldSlip::QRDecoderTest < UnitTestCase
                "someone else's /qr/ URL is not MO's")
   end
 
+  # MO's own /qr/ URLs can carry query params (AddDispatchController
+  # appends ?project=...); the code is the path segment alone.
+  def test_mo_qr_url_query_params_are_not_part_of_the_code
+    assert_equal("OPEN-0219",
+                 FieldSlip::QRDecoder.slip_code_from(
+                   "https://mushroomobserver.org/qr/OPEN-0219?project=405"
+                 ))
+    assert_equal("OPEN-0219",
+                 FieldSlip::QRDecoder.slip_code_from(
+                   "https://mushroomobserver.org/qr/OPEN-0219#top"
+                 ))
+  end
+
   def test_noise_is_rejected
     assert_nil(FieldSlip::QRDecoder.slip_code_from("WIFI:T:WPA;S:cafe;;"))
     assert_nil(FieldSlip::QRDecoder.slip_code_from("12345"),

--- a/test/jobs/detect_field_slip_qr_job_test.rb
+++ b/test/jobs/detect_field_slip_qr_job_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class DetectFieldSlipQRJobTest < ActiveJob::TestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @obs.update!(occurrence: nil)
+    @image = images(:in_situ_image)
+    @obs.images << @image unless @obs.images.include?(@image)
+  end
+
+  def perform_with_code(code)
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:slip_code_in, code) do
+        DetectFieldSlipQRJob.perform_now(@obs.id)
+      end
+    end
+  end
+
+  def test_attaches_the_decoded_slip_code
+    perform_with_code("OPEN-0219")
+
+    assert_equal("OPEN-0219", @obs.reload.field_slip.code)
+    assert_includes(projects(:open_membership_project).observations.reload,
+                    @obs)
+  end
+
+  def test_leaves_the_observation_alone_when_no_photo_decodes
+    perform_with_code(nil)
+
+    assert_nil(@obs.reload.occurrence)
+  end
+
+  def test_noop_when_the_observation_is_already_linked
+    slip = FieldSlip.find_or_create_by_code("OPEN-0800", @obs.user)
+    @obs.field_slip = slip
+    @obs.save!
+
+    perform_with_code("OPEN-0219")
+
+    assert_equal("OPEN-0800", @obs.reload.field_slip.code)
+  end
+
+  def test_noop_when_detection_is_unavailable
+    FieldSlip::QRDecoder.stub(:available?, false) do
+      DetectFieldSlipQRJob.perform_now(@obs.id)
+    end
+
+    assert_nil(@obs.reload.occurrence)
+  end
+
+  def test_survives_a_vanished_observation
+    DetectFieldSlipQRJob.perform_now(-1)
+  end
+end

--- a/test/jobs/detect_field_slip_qr_job_test.rb
+++ b/test/jobs/detect_field_slip_qr_job_test.rb
@@ -13,7 +13,7 @@ class DetectFieldSlipQRJobTest < ActiveJob::TestCase
   def perform_with_code(code)
     FieldSlip::QRDecoder.stub(:available?, true) do
       FieldSlip::QRDecoder.stub(:slip_code_in, code) do
-        DetectFieldSlipQRJob.perform_now(@obs.id)
+        DetectFieldSlipQRJob.perform_now(@obs.id, @image.id)
       end
     end
   end
@@ -26,7 +26,7 @@ class DetectFieldSlipQRJobTest < ActiveJob::TestCase
                     @obs)
   end
 
-  def test_leaves_the_observation_alone_when_no_photo_decodes
+  def test_leaves_the_observation_alone_when_the_photo_has_no_code
     perform_with_code(nil)
 
     assert_nil(@obs.reload.occurrence)
@@ -44,13 +44,16 @@ class DetectFieldSlipQRJobTest < ActiveJob::TestCase
 
   def test_noop_when_detection_is_unavailable
     FieldSlip::QRDecoder.stub(:available?, false) do
-      DetectFieldSlipQRJob.perform_now(@obs.id)
+      DetectFieldSlipQRJob.perform_now(@obs.id, @image.id)
     end
 
     assert_nil(@obs.reload.occurrence)
   end
 
-  def test_survives_a_vanished_observation
-    DetectFieldSlipQRJob.perform_now(-1)
+  def test_survives_vanished_records
+    DetectFieldSlipQRJob.perform_now(-1, @image.id)
+    DetectFieldSlipQRJob.perform_now(@obs.id, -1)
+
+    assert_nil(@obs.reload.occurrence)
   end
 end

--- a/test/models/image/local_file_test.rb
+++ b/test/models/image/local_file_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Image::LocalFileTest < UnitTestCase
+  URL = Struct.new(:url)
+
+  def test_resolves_a_file_url_when_the_file_exists
+    Tempfile.create(["local_file", ".jpg"]) do |file|
+      assert_equal(file.path,
+                   Image::LocalFile.path_from_url(
+                     URL.new("file://#{file.path}?123")
+                   ))
+    end
+  end
+
+  def test_nil_for_a_file_url_with_nothing_behind_it
+    assert_nil(Image::LocalFile.path_from_url(
+                 URL.new("file:///no/such/file.jpg")
+               ))
+  end
+
+  def test_nil_for_a_remote_url
+    assert_nil(Image::LocalFile.path_from_url(
+                 URL.new("https://images.mushroomobserver.org/1280/1.jpg")
+               ))
+  end
+
+  # The local source's `read` spec is a web path, mapped onto
+  # MO.local_image_files.
+  def test_web_path_maps_onto_local_image_files
+    sources = MO.image_sources.deep_dup
+    sources[:local] ||= {}
+    sources[:local][:read] = "/images"
+    with_image_sources(sources) do
+      FileUtils.mkdir_p(File.join(MO.local_image_files, "1280"))
+      path = File.join(MO.local_image_files, "1280", "42.jpg")
+      FileUtils.touch(path)
+
+      assert_equal(path,
+                   Image::LocalFile.path_from_url(URL.new("/images/1280/42.jpg?7")))
+      assert_nil(Image::LocalFile.path_from_url(URL.new("/elsewhere/42.jpg")),
+                 "a web path outside the local read prefix is not ours")
+    ensure
+      FileUtils.rm_f(path)
+    end
+  end
+
+  def test_path_resolves_through_image_url
+    # The test env resolves images to file:// URLs with no files behind
+    # them, so this exercises the image_url plumbing end to end.
+    assert_nil(Image::LocalFile.path(images(:in_situ_image), :huge))
+  end
+
+  private
+
+  # MO.image_sources reads through IMAGE_CONFIG_DATA, so stub the
+  # reader itself rather than assigning config.
+  def with_image_sources(sources, &block)
+    MO.stub(:image_sources, sources, &block)
+  end
+end

--- a/test/models/observation_image_test.rb
+++ b/test/models/observation_image_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class ObservationImageTest < UnitTestCase
+  include ActiveJob::TestHelper
+
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @image = images(:turned_over_image)
+  end
+
+  def attach_image
+    ObservationImage.create!(observation: @obs, image: @image)
+  end
+
+  def test_attaching_a_photo_enqueues_qr_detection
+    @obs.update!(occurrence: nil)
+
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      assert_enqueued_with(job: DetectFieldSlipQRJob, args: [@obs.id]) do
+        attach_image
+      end
+    end
+  end
+
+  # An observation already in an occurrence has nothing to gain from a
+  # decoded code -- the attacher would refuse anyway.
+  def test_no_enqueue_when_the_observation_is_already_linked
+    assert_not_nil(@obs.occurrence_id, "premise: fixture is slip-linked")
+
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      assert_no_enqueued_jobs(only: DetectFieldSlipQRJob) { attach_image }
+    end
+  end
+
+  def test_no_enqueue_when_detection_is_unavailable
+    @obs.update!(occurrence: nil)
+
+    assert_no_enqueued_jobs(only: DetectFieldSlipQRJob) { attach_image }
+  end
+end

--- a/test/models/observation_image_test.rb
+++ b/test/models/observation_image_test.rb
@@ -18,7 +18,8 @@ class ObservationImageTest < UnitTestCase
     @obs.update!(occurrence: nil)
 
     FieldSlip::QRDecoder.stub(:available?, true) do
-      assert_enqueued_with(job: DetectFieldSlipQRJob, args: [@obs.id]) do
+      assert_enqueued_with(job: DetectFieldSlipQRJob,
+                           args: [@obs.id, @image.id]) do
         attach_image
       end
     end


### PR DESCRIPTION
## Summary

Part of #5024 ("Flow 2"). DBG-style voucher slips encode only the bare slip code in their QR, which a phone's native camera can't act on — so for photo-first observations (photos uploaded before any scan, including iNat-side workflows), the first place MO ever sees the code is the uploaded photo itself. This PR makes MO notice: when a photo is attached to a slip-less observation, the QR is decoded server-side and the observation is attached to the slip — and thereby filed into the project the code's prefix names — with the same semantics as scanning the code through MO's QR reader.

- `FieldSlip::QRDecoder` (`app/classes/field_slip/qr_decoder.rb`): decodes QR codes from the image's local file via `zbarimg` (QR symbology only), largest available size first. A bare code is believed only when its prefix matches a project's `field_slip_prefix` — photos contain all kinds of QR codes, and the known prefix is what separates a slip from noise. MO's own `/qr/` URLs are accepted as-is.
- `FieldSlip::Attacher` (`app/classes/field_slip/attacher.rb`): the silent counterpart of the observation form's `field_code` path. Creates/reuses the slip (`find_or_create_by_code`, so the project comes from the prefix), links via the occurrence, adopts the observer onto the slip, enrolls the user in an open-membership project (`Project#join`, same "a printed prefix is an invitation" rule), and files the observation into the project unless it violates constraints. Because nobody is watching, it is deliberately narrower than the interactive path: it acts only when the observation has **no occurrence** and the slip is **unused**, so it can never move an observation, claim another collector's slip, or override a choice made on a form. An existing slip in a closed project the user isn't in is skipped (invariant 4, #4932); a *new* code for a closed project becomes a project-less spare slip, matching the form's behavior.
- `DetectFieldSlipQRJob` + `ObservationImage#after_create_commit`: attaching a photo to a slip-less observation enqueues the job; the job scans the observation's photos and attaches on the first recognizable code, logging what it did.
- `Image::LocalFile` is extracted from the Gemini adapter's private local-path resolution so both features find an image's on-disk file the same way.

## Safety / rollout

Detection is double-gated: `MO.field_slip_qr_detection` (on by default, **off in the test environment** so suite behavior never depends on installed binaries) and the presence of `zbarimg`. With either missing, the hook enqueues nothing and the whole feature is inert.

**Deploy dependency**: `apt-get install zbar-tools` on the server (dev: `brew install zbar`). Nothing breaks without it — the feature just stays off.

No project picker anywhere: the slip's code decides the project, and permissions only validate (membership/joinability, exactly as the scan flow does). Field-level extraction review remains admin-gated and untouched by this PR.

## Test plan

Setup: `brew install zbar` locally; a project with a `field_slip_prefix` matching the slips (e.g. `2026-CMS` on project 405).

1. Create an observation with no field slip code, uploading one of the CMS slip photos from `projects/cms-2026` among the images. After the job runs, the observation should have field slip `2026-CMS-0218`/`0219`, the observation should be in the CMS project, and the uploader enrolled (if the project is open-membership).
2. Repeat with a photo containing no QR — nothing happens.
3. Repeat with an observation that already has a slip — nothing happens.
4. Scan one of the same codes through `/field_slips/qr_reader` and confirm the two routes produce the same linkage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
