### PR TITLE
Add `zbar` to setup docs, dev-setup scripts, and `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
       libjpeg-dev \
       libjpeg-progs \
       libimage-exiftool-perl \
+      zbar-tools \
       chromium \
       mariadb-client \
       bsdextrautils \

--- a/README_DEV_SETUP_MACOSX.md
+++ b/README_DEV_SETUP_MACOSX.md
@@ -105,8 +105,10 @@ continuing. See footnote 1.<sup id="a1">[1](#f1)</sup>**
 
 
 ```sh
-brew install git mysql exiftool libjpeg shared-mime-info openssl imagemagick findutils
+brew install git mysql exiftool libjpeg shared-mime-info openssl imagemagick findutils zbar
 ```
+
+`zbar` provides `zbarimg`, which MO uses to read field slip QR codes out of uploaded photos (see `FieldSlip::QRDecoder`). Everything else works without it; that one feature just stays off.
 
 ## Bash
 

--- a/README_PRODUCTION_INSTALL
+++ b/README_PRODUCTION_INSTALL
@@ -101,10 +101,13 @@ root> swapon /swap
 root> echo '/swap none swap sw 0 0' | tee -a /etc/fstab
 
 # Install most of the modules that we will need (except ruby).
+# zbar-tools provides zbarimg, used to read field slip QR codes out of
+# uploaded photos (see FieldSlip::QRDecoder); MO runs fine without it,
+# that one feature just stays off.
 root> apt-get install -y mysql-server mysql-client libmysqlclient-dev \
           libcurl4-openssl-dev libssl-dev git nginx-extras libyaml-dev \
           imagemagick libmagickcore-dev libmagickwand-dev libjpeg-dev \
-          exiftool mrtg
+          exiftool mrtg zbar-tools
 # (it's saying several services need to be restarted so rebooting
 # sounded like a good idea at this point)
 root> reboot

--- a/script/dev_setup/ubuntu_root.sh
+++ b/script/dev_setup/ubuntu_root.sh
@@ -78,7 +78,7 @@ EOF
         libmysqlclient-dev libcurl4-openssl-dev libssl-dev libapr1-dev \
         libaprutil1-dev libreadline-dev zlib1g-dev imagemagick \
         libmagickcore-dev libmagickwand-dev libjpeg-dev libjpeg-progs \
-        libimage-exiftool-perl
+        libimage-exiftool-perl zbar-tools
 
     cd /tmp || exit 1
     rm -rf build

--- a/script/dev_setup_macos
+++ b/script/dev_setup_macos
@@ -70,7 +70,7 @@ if command -v mysql >/dev/null 2>&1; then
 fi
 
 echo "Installing Homebrew packages..."
-brew install git mysql exiftool libjpeg shared-mime-info openssl imagemagick findutils
+brew install git mysql exiftool libjpeg shared-mime-info openssl imagemagick findutils zbar
 
 echo "Starting MySQL..."
 brew services start mysql


### PR DESCRIPTION
## Summary

Follow-up to #5029: documents the zbar dependency (`zbarimg`, used by `FieldSlip::QRDecoder` to read field slip QR codes out of uploaded photos) everywhere environments get provisioned. Production already has it installed; this records it so the next rebuild does too. MO runs fine without the package — the QR auto-attach feature just stays off.

- `README_DEV_SETUP_MACOSX.md` + `script/dev_setup_macos` — `zbar` added to the brew install list, with a one-line note in the README about what it's for.
- `script/dev_setup/ubuntu_root.sh` — `zbar-tools` added to the apt list (this script is what `README_DEV_SETUP_UBUNTU.md` drives, so the Ubuntu dev docs are covered through it).
- `README_PRODUCTION_INSTALL` — `zbar-tools` added to the apt-get line, matching what is now installed on the production server.
- `Dockerfile` — `zbar-tools` added to the image.

CI (`ci_rails.yml`) is deliberately unchanged: the test environment has `field_slip_qr_detection` off and the decoder tests stub the shell-out, so installing zbar there would only slow the build.

## Test plan

- [x] `bin/rails test test/classes/field_slip/qr_decoder_test.rb` (unchanged behavior, no zbar required)
- Docs/provisioning only; a fresh `dev_setup_macos` / `dev_setup_ubuntu` run installs the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
