### PR TITLE
Keep line breaks in multi-line field slip values through review (`textarea` for multi-line rows)

### DIFF
--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -48,8 +48,10 @@ class FieldSlip
       # An iNat id is stored as the link the field slip form writes, so
       # an observation reads back the same whichever route entered it.
       # Already-linked values pass through rather than nesting.
+      # CRLF from a textarea submit normalizes to bare newlines, so a
+      # multi-line Notes value stores the same shape however it arrived.
       def value_for(field, value)
-        text = value.to_s.strip
+        text = value.to_s.gsub("\r\n", "\n").strip
         return text unless field == @template.inat_codes_field
         return text unless @inat_code
         return text if FieldSlipNotesBuilder.inat_link?(text)

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -62,12 +62,26 @@ module Views::Controllers::Images::FieldSlipExtracts
     # correcting it is the whole point of the step.
     def render_extracted_cell(row)
       if row.editable
-        text_field("value[#{row.field}]", value: row.extracted, label: false)
+        render_extracted_input(row)
       else
         plain(row.extracted.to_s)
       end
       render_inat_flag(row)
       render_confidence(row)
+    end
+
+    # A slip's Notes box is often several lines, and a single-line
+    # input silently drops the newlines from its value -- the browser
+    # strips them, gluing "Phenolic odor\nYellow staining" into
+    # "Phenolic odorYellow staining" on save. A textarea keeps them.
+    def render_extracted_input(row)
+      value = row.extracted.to_s
+      unless value.include?("\n")
+        return text_field("value[#{row.field}]", value: value, label: false)
+      end
+
+      textarea_field("value[#{row.field}]", value: value, label: false,
+                                            rows: value.count("\n") + 1)
     end
 
     # A value holding an iNaturalist observation id ticks itself and

--- a/test/classes/field_slip/extractor/applier_test.rb
+++ b/test/classes/field_slip/extractor/applier_test.rb
@@ -33,6 +33,16 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
     assert_equal("N26-0290", @obs.notes[:MycoMap_Voucher_Number])
   end
 
+  # A multi-line Notes value keeps its line breaks, with a textarea's
+  # CRLF normalized to bare newlines.
+  def test_multiline_notes_keep_their_line_breaks
+    apply_fields({ "Notes" =>
+                   "Phenolic odor\r\nYellow staining\r\nYellow in KOH" })
+
+    assert_equal("Phenolic odor\nYellow staining\nYellow in KOH",
+                 @obs.notes[:Other])
+  end
+
   # Several notes fields in one pass have to merge, not overwrite each
   # other -- and must not drop notes the observation already had.
   def test_notes_writes_merge_with_existing_notes

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -43,6 +43,22 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_no_html(html, "input[name='value[Substrate]']")
     end
 
+    # A single-line input drops the newlines from its value, gluing a
+    # slip's multi-line Notes together on save; a textarea keeps them.
+    def test_multiline_values_render_a_textarea
+      html = render_page(fields: {
+                           "Notes" => "Phenolic odor\nYellow staining",
+                           "Collector" => "Scott Shapiro"
+                         })
+
+      assert_html(html, "textarea[name='value[Notes]']", text: "Phenolic odor")
+      assert_html(html, "textarea[name='value[Notes]']",
+                  text: "Yellow staining")
+      assert_html(html, "input[name='value[Collector]']",
+                  count: 1)
+      assert_no_html(html, "textarea[name='value[Collector]']")
+    end
+
     # The name gets an autocompleter, which only renders its dropdown
     # and hidden id field when it has a real label -- `label: false`
     # silently drops the append slot they live in.


### PR DESCRIPTION
## Summary

Fixes multi-line field slip values getting glued together on review (seen on production image 2067907: a three-line Notes box saved as "Phenolic odorYellow stainingYellow in KOH").

The extraction model returns the lines with newlines intact, but the review form rendered every extracted value in a single-line `text_field` — and browsers strip newlines from a single-line input's `value`, so submitting the form concatenated the lines with no separator at all. Two changes:

- `Views::Controllers::Images::FieldSlipExtracts::Form#render_extracted_input`: a value containing a newline renders in a `textarea_field` sized to its line count; single-line values keep the plain input.
- `FieldSlip::Extractor::Applier#value_for`: normalizes the `\r\n` a textarea submits to bare `\n`, so the stored note has clean lines regardless of how the value arrived.

The saved note now keeps the slip's own line structure ("Phenolic odor\nYellow staining\nYellow in KOH").

## Test plan

- [x] `bin/rails test test/views/controllers/images/field_slip_extracts/edit_test.rb test/classes/field_slip/extractor/applier_test.rb test/controllers/images/field_slip_extracts_controller_test.rb`
- Re-extract the slip on image 2067907 (or any slip whose Notes box has several lines), review, save: the Notes row shows a textarea with the lines intact, and the saved observation note keeps them as separate lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
