### PR TITLE
Run slip extraction in the background (`ExtractFieldSlipJob`); land Create on the review page

### DIFF
--- a/app/classes/field_slip/extractor/gemini.rb
+++ b/app/classes/field_slip/extractor/gemini.rb
@@ -22,11 +22,19 @@ class FieldSlip
       IMAGE_SIZE = :huge
       TIMEOUT = 60
 
+      # The model that will be asked for, credentials override first --
+      # also what a pending/failed extract stamps as provenance before
+      # any response reports the concrete model that answered.
+      def self.configured_model
+        creds = Rails.application.credentials.gemini || {}
+        creds[:model].presence || DEFAULT_MODEL
+      end
+
       # `credentials.gemini` is an OrderedOptions, i.e. a Hash -- so
       # `.key` resolves to `Hash#key` and raises ArgumentError rather
       # than returning the API key. Subscript, not dot.
       def initialize(model: nil, api_key: nil)
-        @model = model || credentials[:model].presence || DEFAULT_MODEL
+        @model = model || self.class.configured_model
         @api_key = api_key || credentials[:key]
       end
 

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -16,19 +16,23 @@ module Images
     before_action :find_image!
     before_action :permission_required
 
+    # Enqueues the read (see ExtractFieldSlipJob) and lands on the
+    # review page, which shows its progress -- the ~15s provider call
+    # used to run right here behind a spinnerless request. Also the
+    # retry path when a read failed.
     def create
-      result = FieldSlip::Extractor.default.extract(@image, context: context)
-      FieldSlipExtract.record(
-        image: @image, user: @user, result: result,
-        prompt_version: FieldSlip::Extractor::PROMPT_VERSION
-      )
+      ExtractFieldSlipJob.request(image: @image, user: @user)
       redirect_to(edit_image_field_slip_extract_path(@image.id))
-    rescue StandardError => e
-      flash_error(:field_slip_extract_failed.t(error: e.message))
-      redirect_to(image_path(@image.id))
     end
 
+    # Three states: a completed extract renders the review form; a
+    # pending or failed one renders the self-refreshing Status page;
+    # no extract at all is only worth waiting on when the caller said
+    # so (`await=1`, set by the observation-create redirect while the
+    # QR jobs are still attaching the slip and starting the read).
     def edit
+      @extract = FieldSlipExtract.find_by(image_id: @image.id)
+      return render_status unless @extract&.complete?
       return unless extract_or_redirect!
 
       # No `layout:` option -- `Views::FullPageBase#around_template`
@@ -64,9 +68,23 @@ module Images
       return unless @image
       return if FieldSlipExtract.permitted?(image: @image, user: @user,
                                             site_admin: in_admin_mode?)
+      return if awaiting_own_upload?
 
       flash_error(:permission_denied.t)
       redirect_to(image_path(@image.id))
+    end
+
+    # The observation-create redirect can land here BEFORE the QR jobs
+    # have filed the observation into its project -- at which point
+    # `permitted?` has no project to check against. Waiting on your own
+    # freshly uploaded photo shows nothing but a status panel, so it
+    # only needs ownership; the review form itself stays behind
+    # `permitted?`, which holds by the time the extract completes.
+    def awaiting_own_upload?
+      return false unless request.get?
+      return false if FieldSlipExtract.find_by(image_id: @image.id)&.complete?
+
+      @image.observations.any? { |obs| obs.user_id == @user.id }
     end
 
     def find_image!
@@ -79,8 +97,19 @@ module Images
       nil
     end
 
-    def context
-      FieldSlip::Extractor::Context.for_image(@image)
+    # A pending or failed extract always shows its status; a missing
+    # one only does while the create redirect said to wait for the QR
+    # jobs -- otherwise a bare visit keeps today's "nothing to review"
+    # behavior.
+    def render_status
+      if @extract.nil? && params[:await].blank?
+        flash_error(:field_slip_extract_missing.t)
+        return redirect_to(image_path(@image.id))
+      end
+
+      render(Views::Controllers::Images::FieldSlipExtracts::Status.new(
+               image: @image, extract: @extract, user: @user
+             ))
     end
 
     # The extract and the observation it would be written to. Both have

--- a/app/controllers/observations_controller/create.rb
+++ b/app/controllers/observations_controller/create.rb
@@ -240,12 +240,79 @@ module ObservationsController::Create
   end
 
   def redirect_to_next_page
+    return if redirected_to_field_slip_review?
+
     if @observation.location_id.nil?
       redirect_to(new_location_path(where: @observation.place_name(@user),
                                     set_observation: @observation.id))
     else
       redirect_to(permanent_observation_path(@observation.id))
     end
+  end
+
+  # After Create, a slip reviewer lands straight on the review of the
+  # photographed slip: the extraction is usually already running by
+  # then (the QR jobs chain it on attach -- see DetectFieldSlipQRJob),
+  # and the review page shows its progress until the read is done.
+  # Decode-only here -- attaching the slip is the QR jobs' business --
+  # so this adds no writes to the request.
+  def redirected_to_field_slip_review?
+    image = field_slip_review_image
+    return false unless image
+
+    redirect_to(edit_image_field_slip_extract_path(image.id, await: 1))
+    true
+  end
+
+  # The first new photo whose QR names a slip this user reviews.
+  # Gated to admins of the code's own prefix project, so ordinary
+  # uploads never pay for the scan or get detoured. When the
+  # observation already HAS the matching slip -- created by scanning
+  # or typing the code, which makes the QR jobs skip it -- the read is
+  # started from here instead.
+  def field_slip_review_image
+    return nil unless FieldSlip::QRDecoder.available?
+    return nil unless reviews_field_slips?
+
+    @observation.images.each do |image|
+      code = FieldSlip::QRDecoder.slip_code_in(image)
+      next unless code && reviewable_slip_code?(code)
+
+      start_extraction_for_linked_slip(image, code)
+      return image
+    end
+    nil
+  end
+
+  # A slip already linked to the observation only counts when the
+  # photographed code IS that slip's -- reviewing some other slip's
+  # photo into this observation is never an automatic act.
+  def reviewable_slip_code?(code)
+    slip = @observation.field_slip
+    return false if slip && slip.code != code
+    return true if in_admin_mode?
+
+    prefix = FieldSlip.prefix_for_code(code)
+    project = prefix && Project.find_by(field_slip_prefix: prefix)
+    project.present? && project.is_admin?(@user)
+  end
+
+  # The QR jobs only read slips they themselves attach; a slip that
+  # was already linked during this create gets its read started here.
+  # Never when an extract exists -- re-photographing a slip must not
+  # silently re-read one somebody may have reviewed.
+  def start_extraction_for_linked_slip(image, code)
+    return unless @observation.field_slip&.code == code
+    return if FieldSlipExtract.exists?(image_id: image.id)
+
+    ExtractFieldSlipJob.request(image: image, user: @user)
+  end
+
+  # Cheap gate so ordinary uploads never run the QR scan at all: only
+  # admins of a project with a field-slip prefix photograph slips.
+  def reviews_field_slips?
+    Project.where.not(field_slip_prefix: nil).
+      exists?(admin_group_id: @user.user_group_ids)
   end
 
   def reload_new_form(reasons)

--- a/app/javascript/controllers/reload-poll_controller.js
+++ b/app/javascript/controllers/reload-poll_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Reloads the page on an interval, for pages that are waiting on a
+// background job (e.g. a field slip extraction) and re-render
+// themselves into their finished state once the work lands.
+// Connects to data-controller="reload-poll"
+export default class extends Controller {
+  static values = { interval: { type: Number, default: 4000 } }
+
+  connect() {
+    this.element.dataset.reloadPoll = "connected";
+    this.timer = setInterval(() => location.reload(), this.intervalValue)
+  }
+
+  disconnect() {
+    if (this.timer != null) {
+      clearInterval(this.timer)
+    }
+  }
+}

--- a/app/jobs/detect_field_slip_qr_job.rb
+++ b/app/jobs/detect_field_slip_qr_job.rb
@@ -29,5 +29,14 @@ class DetectFieldSlipQRJob < ApplicationJob
       "DetectFieldSlipQRJob: #{code} -> #{result} " \
       "(observation #{observation.id}, image #{image.id})"
     )
+    return unless result == :attached
+
+    # This image just proved itself to be a slip photo, so read it now
+    # -- the ~15s provider call runs while the collector is still
+    # photographing, and the review page finds the extract waiting.
+    # Chained only on a fresh attach: adding more photos to an already-
+    # linked observation never re-reads a slip somebody may have
+    # reviewed (those runs exit above on the occurrence check).
+    ExtractFieldSlipJob.request(image: image, user: observation.user)
   end
 end

--- a/app/jobs/extract_field_slip_job.rb
+++ b/app/jobs/extract_field_slip_job.rb
@@ -34,6 +34,13 @@ class ExtractFieldSlipJob < ApplicationJob
       prompt_version: FieldSlip::Extractor::PROMPT_VERSION
     )
   rescue StandardError => e
+    # Not re-raised -- the failed extract row IS the retry mechanism
+    # (the review page's Try Again button) -- so the details have to be
+    # logged here or they exist nowhere.
+    Rails.logger.error(
+      "ExtractFieldSlipJob failed on image #{image.id}: " \
+      "#{e.class}: #{e.message}\n#{e.backtrace&.first(10)&.join("\n")}"
+    )
     FieldSlipExtract.fail!(image: image, user: user, error: e.message)
   end
 end

--- a/app/jobs/extract_field_slip_job.rb
+++ b/app/jobs/extract_field_slip_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Machine-reads one field slip photo in the background (see
+# FieldSlip::Extractor), so the ~15-second provider call runs while the
+# collector is still photographing instead of behind a spinner. The
+# review page shows the extract's status: pending while this runs,
+# failed (with the error and a retry button) if the provider chokes,
+# the review form once `record` lands.
+class ExtractFieldSlipJob < ApplicationJob
+  queue_as :default
+
+  # The one entry point: writes the pending row first, so the review
+  # page has a status to show from the moment the job is queued.
+  def self.request(image:, user:)
+    FieldSlipExtract.start!(image: image, user: user)
+    perform_later(image.id, user.id)
+  end
+
+  def perform(image_id, user_id)
+    image = Image.find_by(id: image_id)
+    user = User.find_by(id: user_id)
+    return unless image && user
+
+    extract(image, user)
+  end
+
+  private
+
+  def extract(image, user)
+    context = FieldSlip::Extractor::Context.for_image(image)
+    result = FieldSlip::Extractor.default.extract(image, context: context)
+    FieldSlipExtract.record(
+      image: image, user: user, result: result,
+      prompt_version: FieldSlip::Extractor::PROMPT_VERSION
+    )
+  rescue StandardError => e
+    FieldSlipExtract.fail!(image: image, user: user, error: e.message)
+  end
+end

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -51,7 +51,7 @@ class FieldSlipExtract < AbstractModel
   def self.start!(image:, user:)
     extract = find_or_initialize_by(image_id: image.id)
     extract.update!(user: user, status: "pending", provider: "gemini",
-                    model: FieldSlip::Extractor::Gemini::DEFAULT_MODEL,
+                    model: FieldSlip::Extractor::Gemini.configured_model,
                     prompt_version: FieldSlip::Extractor::PROMPT_VERSION)
     extract
   end
@@ -75,7 +75,7 @@ class FieldSlipExtract < AbstractModel
     extract = find_or_initialize_by(image_id: image.id)
     extract.user ||= user
     extract.provider ||= "gemini"
-    extract.model ||= FieldSlip::Extractor::Gemini::DEFAULT_MODEL
+    extract.model ||= FieldSlip::Extractor::Gemini.configured_model
     extract.status = "failed"
     extract.data = extract.data.to_h.merge("error" => error.to_s)
     extract.save!

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -36,12 +36,32 @@ class FieldSlipExtract < AbstractModel
     end
   end
 
+  # An extraction has a lifecycle now that it runs in the background:
+  # `start!` writes the pending row (so the review page has something
+  # to show while the provider is thinking), `record` completes it,
+  # `fail!` keeps the error where the reviewer will actually see it --
+  # a failed read used to leave nothing behind but a log line.
+  STATUSES = %w[pending complete failed].freeze
+
+  validates :status, inclusion: { in: STATUSES }
+
+  # Replaces any previous read of this image. The provider/model here
+  # are what will be asked; `record` overwrites them with what actually
+  # answered.
+  def self.start!(image:, user:)
+    extract = find_or_initialize_by(image_id: image.id)
+    extract.update!(user: user, status: "pending", provider: "gemini",
+                    model: FieldSlip::Extractor::Gemini::DEFAULT_MODEL,
+                    prompt_version: FieldSlip::Extractor::PROMPT_VERSION)
+    extract
+  end
+
   # Replaces any previous read of this image.
   def self.record(image:, user:, result:, prompt_version:)
     extract = find_or_initialize_by(image_id: image.id)
     extract.update!(
       user: user, provider: result.provider, model: result.model,
-      prompt_version: prompt_version,
+      prompt_version: prompt_version, status: "complete",
       data: { "fields" => result.fields, "confidence" => result.confidence,
               "template" => result.template,
               "slip_present" => result.slip_present,
@@ -50,6 +70,24 @@ class FieldSlipExtract < AbstractModel
     )
     extract
   end
+
+  def self.fail!(image:, user:, error:)
+    extract = find_or_initialize_by(image_id: image.id)
+    extract.user ||= user
+    extract.provider ||= "gemini"
+    extract.model ||= FieldSlip::Extractor::Gemini::DEFAULT_MODEL
+    extract.status = "failed"
+    extract.data = extract.data.to_h.merge("error" => error.to_s)
+    extract.save!
+    extract
+  end
+
+  def pending? = status == "pending"
+  def failed? = status == "failed"
+  def complete? = status == "complete"
+
+  # What went wrong, for the review page's failed state.
+  def error = data.to_h["error"]
 
   def fields = data.to_h["fields"] || {}
   def confidence = data.to_h["confidence"] || {}

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Where the review page waits for a background extraction (see
+# ExtractFieldSlipJob): a self-refreshing "reading..." panel while the
+# job runs (or is about to -- the QR jobs may still be attaching the
+# slip), and the error with a retry button when the provider failed.
+# Once the extract completes, the reload lands on the review form.
+module Views::Controllers::Images::FieldSlipExtracts
+  class Status < Views::FullPageBase
+    prop :image, ::Image
+    prop :extract, _Nilable(::FieldSlipExtract), default: nil
+    prop :user, ::User
+
+    def view_template
+      add_page_title(:field_slip_extract_status_title.t)
+
+      if @extract&.failed?
+        render_failed
+      else
+        render_pending
+      end
+      render_observation_link
+    end
+
+    private
+
+    def render_pending
+      div(data: { controller: "reload-poll" }) do
+        render(Components::Panel.new(
+                 panel_id: "field_slip_extract_pending"
+               )) do |p|
+          p.with_body do
+            span(class: "spinner-right mx-2")
+            plain(:field_slip_extract_pending.t)
+          end
+        end
+      end
+    end
+
+    def render_failed
+      Alert(level: :danger) do
+        plain(:field_slip_extract_failed.t(error: @extract.error.to_s))
+      end
+      Button(type: :post, name: :field_slip_extract_retry.l,
+             target: image_field_slip_extract_path(@image.id))
+    end
+
+    def render_observation_link
+      observation = @image.observations.first
+      return unless observation
+
+      p do
+        Link(type: :get, name: :field_slip_extract_observation_link.l,
+             target: permanent_observation_path(observation.id))
+      end
+    end
+  end
+end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2596,6 +2596,10 @@
   field_slip_extract_saved: Saved the selected field slip values.
   field_slip_extract_missing: That image has no field slip data to review yet.
   field_slip_extract_failed: "Could not read the field slip: [error]"
+  field_slip_extract_status_title: Reading Field Slip
+  field_slip_extract_pending: Reading the field slip. This usually takes about 15 seconds; this page refreshes itself and will show the results when they are ready.
+  field_slip_extract_retry: Try Again
+  field_slip_extract_observation_link: Go to the observation
   field_slip_extract_add_alias: Add this abbreviation
   field_slip_extract_code_mismatch: "The slip in this photo reads [read], but the observation is attached to field slip [attached]. Check that this is the right photo before saving."
   field_slip_extract_unknown_alias: "No project abbreviation is defined for [name], so the location was left as written."

--- a/db/migrate/20260809164716_add_status_to_field_slip_extracts.rb
+++ b/db/migrate/20260809164716_add_status_to_field_slip_extracts.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddStatusToFieldSlipExtracts < ActiveRecord::Migration[7.2]
+  def change
+    # "complete" so every existing row -- all recorded from successful
+    # reads -- keeps meaning what it meant.
+    add_column(:field_slip_extracts, :status, :string,
+               null: false, default: "complete")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_31_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_09_164716) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -115,6 +115,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_31_120000) do
     t.json "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "complete", null: false
     t.index ["image_id"], name: "index_field_slip_extracts_on_image_id", unique: true
     t.index ["user_id"], name: "index_field_slip_extracts_on_user_id"
   end

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -4,6 +4,8 @@ require("test_helper")
 
 module Images
   class FieldSlipExtractsControllerTest < FunctionalTestCase
+    include ActiveJob::TestHelper
+
     def setup
       super
       @obs = observations(:minimal_unknown_obs)
@@ -83,40 +85,21 @@ module Images
 
     # ---------- create ----------
 
-    def test_create_records_the_extract_and_redirects_to_review
+    # The provider call runs in a job now (see ExtractFieldSlipJob);
+    # the button's request just queues it and lands on the review page,
+    # which shows the pending state.
+    def test_create_enqueues_the_read_and_redirects_to_review
       login_as_site_admin
-      result = FieldSlip::Extractor::Result.new(
-        provider: "gemini", model: "gemini-3.6-flash", raw: { "x" => 1 },
-        fields: { "Collector" => "Scott Shapiro" }, confidence: {},
-        template: "mo"
-      )
 
-      FieldSlip::Extractor.stub(:default, fake_extractor(result)) do
+      assert_enqueued_with(job: ExtractFieldSlipJob,
+                           args: [@image.id, rolf.id]) do
         post(:create, params: { image_id: @image.id })
       end
 
       assert_redirected_to(edit_image_field_slip_extract_path(@image.id))
       extract = FieldSlipExtract.find_by(image_id: @image.id)
 
-      assert_equal("Scott Shapiro", extract.value_for("Collector"))
-      assert_equal("gemini-3.6-flash", extract.model)
-      # Stamped from the constant, not a literal: a read is only
-      # attributable to the prompt that produced it if these agree.
-      assert_equal(FieldSlip::Extractor::PROMPT_VERSION,
-                   extract.prompt_version)
-    end
-
-    # A provider failure has to land as a flash, not a 500 -- the button
-    # is one click and the network is not reliable.
-    def test_create_reports_a_provider_failure
-      login_as_site_admin
-
-      FieldSlip::Extractor.stub(:default, failing_extractor) do
-        post(:create, params: { image_id: @image.id })
-      end
-
-      assert_redirected_to(image_path(@image.id))
-      assert_flash_error
+      assert(extract.pending?, "the review page needs a status to show")
     end
 
     def test_create_with_an_unknown_image_redirects
@@ -132,6 +115,80 @@ module Images
 
     def test_edit_without_an_extract_redirects
       login_as_site_admin
+
+      get(:edit, params: { image_id: @image.id })
+
+      assert_redirected_to(image_path(@image.id))
+      assert_flash_error
+    end
+
+    def test_edit_shows_a_pending_read_with_self_refresh
+      FieldSlipExtract.start!(image: @image, user: rolf)
+      login_as_site_admin
+
+      get(:edit, params: { image_id: @image.id })
+
+      assert_response(:success)
+      assert_select("[data-controller='reload-poll']")
+    end
+
+    def test_edit_shows_a_failed_read_with_a_retry_button
+      FieldSlipExtract.fail!(image: @image, user: rolf, error: "quota")
+      login_as_site_admin
+
+      get(:edit, params: { image_id: @image.id })
+
+      assert_response(:success)
+      assert_select(".alert-danger", text: /quota/)
+      assert_select(
+        "form[action='#{image_field_slip_extract_path(@image.id)}']"
+      )
+      assert_select("[data-controller='reload-poll']", count: 0)
+    end
+
+    # The observation-create redirect arrives before the QR jobs have
+    # attached anything; `await=1` is what makes an extract-less page
+    # wait instead of bouncing.
+    def test_edit_awaits_detection_when_asked
+      login_as_site_admin
+
+      get(:edit, params: { image_id: @image.id, await: 1 })
+
+      assert_response(:success)
+      assert_select("[data-controller='reload-poll']")
+    end
+
+    # ...and can land before the observation is even in its project,
+    # when `permitted?` has nothing to check against. Waiting on your
+    # own upload needs only ownership; the review form still needs
+    # project admin-ship.
+    def test_owner_may_wait_on_their_own_upload_before_project_filing
+      owner = @obs.user
+      login(owner.login)
+
+      assert_not(
+        FieldSlipExtract.permitted?(image: @image.reload, user: owner),
+        "premise: ownership alone, no project admin-ship"
+      )
+
+      FieldSlipExtract.start!(image: @image, user: owner)
+
+      get(:edit, params: { image_id: @image.id })
+
+      assert_response(:success)
+      assert_select("[data-controller='reload-poll']")
+    end
+
+    def test_owner_alone_may_not_review_a_completed_extract
+      owner = @obs.user
+      login(owner.login)
+
+      assert_not(
+        FieldSlipExtract.permitted?(image: @image.reload, user: owner),
+        "premise: ownership alone, no project admin-ship"
+      )
+
+      record_extract(fields: { "Collector" => "A" })
 
       get(:edit, params: { image_id: @image.id })
 
@@ -343,22 +400,6 @@ module Images
       put(:update, params: { image_id: @image.id })
 
       assert_redirected_to(image_path(@image.id))
-    end
-
-    private
-
-    def fake_extractor(result)
-      extractor = Object.new
-      extractor.define_singleton_method(:extract) { |_image, **| result }
-      extractor
-    end
-
-    def failing_extractor
-      extractor = Object.new
-      extractor.define_singleton_method(:extract) do |_image, **|
-        raise(FieldSlip::Extractor::Gemini::BadResponse.new("nope"))
-      end
-      extractor
     end
   end
 end

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -1902,7 +1902,101 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert_flash_warning
   end
 
+  # --------------------------------------------------------------------
+  #  Landing on the slip review straight from Create (#5024)
+  # --------------------------------------------------------------------
+
+  # A reviewer whose new photo is a slip lands on the review page,
+  # which waits out the QR jobs and the background read.
+  def test_create_redirects_a_slip_reviewer_to_the_review_page
+    image = images(:in_situ_image)
+    make_slip_project_admin(rolf)
+    login("rolf")
+
+    with_decoded_slip_code("OPEN-0219") do
+      post(:create, params: slip_photo_params(image))
+    end
+
+    assert_redirected_to(
+      edit_image_field_slip_extract_path(image.id, await: 1)
+    )
+  end
+
+  # A slip attached during this create (typed or scanned code -- the
+  # QR jobs skip linked observations) gets its read started here.
+  def test_create_with_matching_field_code_starts_the_read
+    image = images(:in_situ_image)
+    make_slip_project_admin(rolf)
+    login("rolf")
+
+    with_decoded_slip_code("OPEN-0777") do
+      post(:create,
+           params: slip_photo_params(image).merge(field_code: "OPEN-0777"))
+    end
+
+    assert_redirected_to(
+      edit_image_field_slip_extract_path(image.id, await: 1)
+    )
+    assert(FieldSlipExtract.find_by(image_id: image.id).pending?,
+           "the read starts here; the QR jobs skip linked observations")
+  end
+
+  # A photographed code for some OTHER slip than the attached one is
+  # never auto-reviewed into this observation.
+  def test_create_ignores_a_code_that_mismatches_the_attached_slip
+    image = images(:in_situ_image)
+    make_slip_project_admin(rolf)
+    login("rolf")
+
+    with_decoded_slip_code("OPEN-0219") do
+      post(:create,
+           params: slip_photo_params(image).merge(field_code: "OPEN-0777"))
+    end
+
+    assert_response(:redirect)
+    assert_no_match(/field_slip_extract/, @response.location.to_s)
+    assert_nil(FieldSlipExtract.find_by(image_id: image.id))
+  end
+
+  # Ordinary uploads never pay for the scan or get detoured: the gate
+  # is admin-ship of a project with a field-slip prefix.
+  def test_create_does_not_detour_ordinary_uploads
+    login("katrina")
+
+    assert_not(
+      Project.where.not(field_slip_prefix: nil).
+        exists?(admin_group_id: katrina.user_group_ids),
+      "premise: katrina reviews no slip projects"
+    )
+
+    with_decoded_slip_code("OPEN-0219") do
+      post(:create,
+           params: modified_generic_params({ naming: { vote: {} } }, katrina))
+    end
+
+    assert_response(:redirect)
+    assert_no_match(/field_slip_extract/, @response.location.to_s)
+  end
+
   private
+
+  def make_slip_project_admin(user)
+    project = projects(:open_membership_project)
+    project.admin_group.users << user unless project.is_admin?(user)
+  end
+
+  def slip_photo_params(image)
+    modified_generic_params(
+      { observation: { good_image_ids: image.id.to_s },
+        naming: { vote: {} } }, rolf
+    )
+  end
+
+  def with_decoded_slip_code(code, &block)
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:slip_code_in, code, &block)
+    end
+  end
 
   def stub_update_field_slip(status)
     @controller.define_singleton_method(:update_field_slip) { |*| status }

--- a/test/jobs/detect_field_slip_qr_job_test.rb
+++ b/test/jobs/detect_field_slip_qr_job_test.rb
@@ -26,6 +26,30 @@ class DetectFieldSlipQRJobTest < ActiveJob::TestCase
                     @obs)
   end
 
+  # The image just proved itself to be a slip photo, so the read
+  # starts right away -- by the time a reviewer arrives, the extract
+  # is usually waiting.
+  def test_a_fresh_attach_chains_the_extraction
+    assert_enqueued_with(job: ExtractFieldSlipJob,
+                         args: [@image.id, @obs.user.id]) do
+      perform_with_code("OPEN-0219")
+    end
+
+    assert(FieldSlipExtract.find_by(image_id: @image.id).pending?)
+  end
+
+  # Adding photos to an already-linked observation never re-reads a
+  # slip somebody may have reviewed.
+  def test_no_extraction_chained_when_nothing_was_attached
+    slip = FieldSlip.find_or_create_by_code("OPEN-0800", @obs.user)
+    @obs.field_slip = slip
+    @obs.save!
+
+    assert_no_enqueued_jobs(only: ExtractFieldSlipJob) do
+      perform_with_code("OPEN-0219")
+    end
+  end
+
   def test_leaves_the_observation_alone_when_the_photo_has_no_code
     perform_with_code(nil)
 

--- a/test/jobs/extract_field_slip_job_test.rb
+++ b/test/jobs/extract_field_slip_job_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class ExtractFieldSlipJobTest < ActiveJob::TestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @image = images(:in_situ_image)
+    @obs.images << @image unless @obs.images.include?(@image)
+  end
+
+  def result
+    FieldSlip::Extractor::Result.new(
+      provider: "gemini", model: "gemini-3.6-flash", raw: {},
+      fields: { "Collector" => "A. W. Wilson" }, confidence: {},
+      template: "mo"
+    )
+  end
+
+  def fake_extractor(res)
+    extractor = Object.new
+    extractor.define_singleton_method(:extract) { |_image, **| res }
+    extractor
+  end
+
+  def failing_extractor
+    extractor = Object.new
+    extractor.define_singleton_method(:extract) do |_image, **|
+      raise(FieldSlip::Extractor::Gemini::BadResponse.new("no JSON today"))
+    end
+    extractor
+  end
+
+  # `request` writes the pending row before the job runs, so the
+  # review page has a status to show from the first moment.
+  def test_request_marks_pending_and_enqueues
+    assert_enqueued_with(job: ExtractFieldSlipJob,
+                         args: [@image.id, users(:rolf).id]) do
+      ExtractFieldSlipJob.request(image: @image, user: users(:rolf))
+    end
+
+    assert(FieldSlipExtract.find_by(image_id: @image.id).pending?)
+  end
+
+  def test_perform_records_a_completed_extract
+    ExtractFieldSlipJob.request(image: @image, user: users(:rolf))
+
+    FieldSlip::Extractor.stub(:default, fake_extractor(result)) do
+      ExtractFieldSlipJob.perform_now(@image.id, users(:rolf).id)
+    end
+
+    extract = FieldSlipExtract.find_by(image_id: @image.id)
+
+    assert(extract.complete?)
+    assert_equal("A. W. Wilson", extract.value_for("Collector"))
+    assert_equal(FieldSlip::Extractor::PROMPT_VERSION,
+                 extract.prompt_version)
+  end
+
+  # A provider failure used to leave nothing behind but a log line;
+  # now the row says what went wrong, where the retry button can see
+  # it.
+  def test_perform_records_a_failure_with_its_error
+    ExtractFieldSlipJob.request(image: @image, user: users(:rolf))
+
+    FieldSlip::Extractor.stub(:default, failing_extractor) do
+      ExtractFieldSlipJob.perform_now(@image.id, users(:rolf).id)
+    end
+
+    extract = FieldSlipExtract.find_by(image_id: @image.id)
+
+    assert(extract.failed?)
+    assert_match(/no JSON today/, extract.error)
+  end
+
+  # A failed read retries into a fresh pending row and can complete.
+  def test_a_failed_read_can_be_retried
+    FieldSlipExtract.fail!(image: @image, user: users(:rolf), error: "quota")
+    ExtractFieldSlipJob.request(image: @image, user: users(:rolf))
+
+    assert(FieldSlipExtract.find_by(image_id: @image.id).pending?)
+
+    FieldSlip::Extractor.stub(:default, fake_extractor(result)) do
+      ExtractFieldSlipJob.perform_now(@image.id, users(:rolf).id)
+    end
+
+    assert(FieldSlipExtract.find_by(image_id: @image.id).complete?)
+  end
+
+  def test_survives_vanished_records
+    ExtractFieldSlipJob.perform_now(-1, users(:rolf).id)
+    ExtractFieldSlipJob.perform_now(@image.id, -1)
+
+    assert_nil(FieldSlipExtract.find_by(image_id: @image.id))
+  end
+end

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -62,6 +62,47 @@ class FieldSlipExtractTest < UnitTestCase
     assert_equal({ "ok" => true }, extract.data["raw"])
   end
 
+  # ---------- lifecycle ----------
+
+  # Existing rows (and every `record`) read as complete; only the
+  # background-extraction path ever writes the other two.
+  def test_record_is_complete
+    extract = record(fields: { "Collector" => "A" })
+
+    assert(extract.complete?)
+    assert_not(extract.pending?)
+  end
+
+  def test_start_marks_pending_and_record_completes_it
+    started = FieldSlipExtract.start!(image: @image, user: rolf)
+
+    assert(started.pending?)
+
+    completed = record(fields: { "Collector" => "A" })
+
+    assert_equal(started.id, completed.id, "same one-row-per-image slot")
+    assert(completed.complete?)
+  end
+
+  def test_fail_keeps_the_error_for_the_reviewer
+    extract = FieldSlipExtract.fail!(image: @image, user: rolf,
+                                     error: "429 quota exceeded")
+
+    assert(extract.failed?)
+    assert_equal("429 quota exceeded", extract.error)
+  end
+
+  # A failure after a completed read must not orphan the row's
+  # provider provenance (they are NOT NULL columns).
+  def test_fail_over_an_existing_row_keeps_its_provenance
+    record(fields: { "Collector" => "A" })
+    extract = FieldSlipExtract.fail!(image: @image, user: rolf,
+                                     error: "boom")
+
+    assert(extract.failed?)
+    assert_equal("m", extract.model, "provenance of the last real read")
+  end
+
   # ---------- template ----------
 
   def test_record_stores_which_template_was_read

--- a/test/models/image/local_file_test.rb
+++ b/test/models/image/local_file_test.rb
@@ -46,10 +46,25 @@ class Image::LocalFileTest < UnitTestCase
     end
   end
 
+  # Exercises the image_url plumbing end to end. Writes the file it
+  # expects to find rather than asserting on the ambient filesystem --
+  # other tests (image uploads, the Gemini adapter's) leave files
+  # behind the very URL this image resolves to, so "no file there"
+  # depends on test order.
   def test_path_resolves_through_image_url
-    # The test env resolves images to file:// URLs with no files behind
-    # them, so this exercises the image_url plumbing end to end.
-    assert_nil(Image::LocalFile.path(images(:in_situ_image), :huge))
+    image = images(:in_situ_image)
+    resolved = image.image_url(:huge).url.sub(/\?\d+\z/, "")
+    expected = Image::LocalFile.file_url_path(resolved) ||
+               Image::LocalFile.web_path_on_disk(resolved)
+
+    assert(expected.present?, "premise: test env resolves images locally")
+
+    FileUtils.mkdir_p(File.dirname(expected))
+    File.binwrite(expected, "jpegbytes")
+
+    assert_equal(expected, Image::LocalFile.path(image, :huge))
+  ensure
+    FileUtils.rm_f(expected) if expected
   end
 
   private

--- a/test/views/controllers/images/field_slip_extracts/status_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/status_test.rb
@@ -30,8 +30,14 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_html(html, "[data-controller='reload-poll']")
       assert_html(html, "#field_slip_extract_pending",
                   text: :field_slip_extract_pending.t.as_displayed[0, 40])
-      assert_html(html,
-                  "a[href='#{routes.permanent_observation_path(@obs.id)}']")
+      # The view links image.observations.first -- the fixture image
+      # hangs off several observations, so pin whichever IS first
+      # rather than assuming an association order.
+      linked = @image.reload.observations.first
+
+      assert_html(
+        html, "a[href='#{routes.permanent_observation_path(linked.id)}']"
+      )
     end
 
     # No extract yet -- the QR jobs are still attaching -- looks the

--- a/test/views/controllers/images/field_slip_extracts/status_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/status_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Views::Controllers::Images::FieldSlipExtracts
+  class StatusTest < ComponentTestCase
+    # A proxy, not an include: including url_helpers makes MiniTest
+    # pick up route helpers named test_* as test methods.
+    def routes
+      Rails.application.routes.url_helpers
+    end
+
+    def setup
+      super
+      @user = users(:rolf)
+      @obs = observations(:minimal_unknown_obs)
+      @image = images(:in_situ_image)
+      @obs.images << @image unless @obs.images.include?(@image)
+    end
+
+    def render_status(extract: nil)
+      render(Status.new(image: @image, extract: extract, user: @user))
+    end
+
+    def test_pending_read_self_refreshes
+      extract = FieldSlipExtract.start!(image: @image, user: @user)
+
+      html = render_status(extract: extract)
+
+      assert_html(html, "[data-controller='reload-poll']")
+      assert_html(html, "#field_slip_extract_pending",
+                  text: :field_slip_extract_pending.t.as_displayed[0, 40])
+      assert_html(html,
+                  "a[href='#{routes.permanent_observation_path(@obs.id)}']")
+    end
+
+    # No extract yet -- the QR jobs are still attaching -- looks the
+    # same as pending: something is happening, keep refreshing.
+    def test_awaiting_detection_self_refreshes_too
+      html = render_status
+
+      assert_html(html, "[data-controller='reload-poll']")
+    end
+
+    def test_failed_read_shows_the_error_and_a_retry_button
+      extract = FieldSlipExtract.fail!(image: @image, user: @user,
+                                       error: "429 quota exceeded")
+
+      html = render_status(extract: extract)
+
+      assert_html(html, ".alert-danger", text: "429 quota exceeded")
+      assert_html(
+        html,
+        "form[action='#{routes.image_field_slip_extract_path(@image.id)}'] " \
+        "button[type='submit']"
+      )
+      assert_no_html(html, "[data-controller='reload-poll']")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Part of #5024, from the performance review of the fair workflow: the ~15s Gemini call was 76% of the workflow's machine time and ran synchronously behind the "Read Field Slip" button, and a provider failure vanished into a log line. This PR moves extraction into the background, starts it as early as possible, lands Create directly on the review page, and gives failures a visible retry.

**Extraction lifecycle.** `FieldSlipExtract` gains a `status` column (`pending` / `complete` / `failed`; existing rows default to complete). `ExtractFieldSlipJob.request` writes the pending row and enqueues the read; a provider failure records `failed` with the error message in `data`, where the review page shows it with a **Try Again** button. The "Read Field Slip" button now enqueues instead of blocking, and doubles as the retry path.

**Pre-extraction.** `DetectFieldSlipQRJob` chains the read the moment a QR attach proves an image is a slip photo — the provider call runs while the collector is still photographing, so by the time a reviewer opens the page the extract is usually waiting. Chained only on a fresh attach: adding photos to an already-linked observation never re-reads a slip somebody may have reviewed.

**Create → review.** After creating an observation, a slip reviewer lands straight on the review page instead of navigating there by hand. The redirect decision is a read-only QR decode in the request (attaching stays the QR jobs' business), gated twice so ordinary uploads never pay for the scan or get detoured: the user must admin some project with a field-slip prefix, and then admin the decoded code's own prefix project. The review page (`Views::…::FieldSlipExtracts::Status`) self-refreshes (new `reload-poll` Stimulus controller, 4s) through "reading…" until the extract completes and the form renders; a failed read shows the error + retry instead of polling.

**Scan-first flows get the same speedup.** When the slip was attached during the create itself — a typed or scanned code (the NEMF workflow), which the QR jobs skip — the create flow starts the read for the photo whose QR matches the attached slip. A photographed code that *mismatches* the attached slip is ignored, and a read is never started when an extract already exists.

**Permissions.** The Create redirect can land before the QR jobs have filed the observation into its project, when `permitted?` has nothing to check against — so waiting on your *own* freshly uploaded photo requires only ownership. The review form itself (and the extract-triggering POST) stay behind the existing project-admin gate, which holds by the time the extract completes.

## Test plan

- [x] `bin/rails test` on the extract model/jobs/controller/views + full `observations_controller_create_test.rb` (196 tests)
- On a machine with zbar + a Gemini key: create an observation with a CMS slip photo among the images → land on "Reading the field slip…" → page refreshes into the review form without touching anything.
- Kill the network (or use a bad key), retry the flow → the review page shows the error with a Try Again button; press it → pending → complete.
- Type a field slip code into the observation form with the slip's photo attached (scan-first flow) → same landing.
- Create an ordinary observation with no slip photo → normal redirect, no detour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
