### PR TITLE
Index `names.text_name` and `names.search_name`

### DIFF
--- a/db/migrate/20260809175755_add_name_lookup_indexes.rb
+++ b/db/migrate/20260809175755_add_name_lookup_indexes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddNameLookupIndexes < ActiveRecord::Migration[7.2]
+  # `names` had no index on either lookup column, so every exact-match
+  # in name resolution -- run several times per naming proposal, plus
+  # the alternate-spelling sweep's prefix guesses -- was a full table
+  # scan at ~30-50ms each.
+  def change
+    add_index(:names, :text_name)
+    add_index(:names, :search_name)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_31_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_09_175755) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -115,6 +115,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_31_120000) do
     t.json "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "complete", null: false
     t.index ["image_id"], name: "index_field_slip_extracts_on_image_id", unique: true
     t.index ["user_id"], name: "index_field_slip_extracts_on_user_id"
   end
@@ -552,7 +553,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_31_120000) do
     t.string "lifeform", limit: 1024, default: " ", null: false
     t.boolean "locked", default: false, null: false
     t.integer "icn_id"
+    t.index ["search_name"], name: "index_names_on_search_name"
     t.index ["synonym_id"], name: "synonym_index"
+    t.index ["text_name"], name: "index_names_on_text_name"
   end
 
   create_table "naming_reasons", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,7 +115,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_09_175755) do
     t.json "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status", default: "complete", null: false
     t.index ["image_id"], name: "index_field_slip_extracts_on_image_id", unique: true
     t.index ["user_id"], name: "index_field_slip_extracts_on_user_id"
   end


### PR DESCRIPTION
The `names` table had no index on either lookup column (only `synonym_id`), so every exact-match query in name resolution — several per naming proposal, plus the alternate-spelling sweep's prefix guesses — was a full table scan at ~30–50ms each against the ~70k-row production table.

Surfaced while profiling the field slip review flow (#5024), where a single unknown name cost ~0.8s of Name scans per page render and ~1.3s per save — but the cost applies to every naming proposal site-wide, not just field slips. With the indexes, the same lookups run in ~0.2ms warm against a production-sized local table.

Schema-only migration; both columns are short varchars (100 / 221), well within InnoDB index limits, so plain full-column indexes.

## Test plan

- [x] Migration runs against a production-sized dev DB (~0.2s total)
- [x] `bin/rails test test/models/name_test.rb` (185 tests)
- After deploy + migrate: a naming proposal with an unknown/misspelled name should render its feedback noticeably faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)