### PR TITLE
Fix QR slip detection in production: probe the direct disk path (`FieldSlip::QRDecoder`)

### DIFF
--- a/app/classes/field_slip/qr_decoder.rb
+++ b/app/classes/field_slip/qr_decoder.rb
@@ -64,13 +64,27 @@ class FieldSlip
       return [] unless available?
 
       SIZES.each do |size|
-        path = Image::LocalFile.path(image, size)
+        path = local_file(image, size)
         next unless path
 
         codes = scan(path)
         return codes if codes.any?
       end
       []
+    end
+
+    # The precedence-resolved URL stops pointing at the local copy the
+    # moment an image transfers (production resolves transferred images
+    # to the image server), but the file itself stays on this machine's
+    # disk until cleanup -- so probe the direct path too, or a fresh
+    # upload becomes unreadable within a second of arriving.
+    def self.local_file(image, size)
+      Image::LocalFile.path(image, size) || direct_path(image, size)
+    end
+
+    def self.direct_path(image, size)
+      path = image.full_filepath(size)
+      path if path && File.exist?(path)
     end
 
     # -Sdisable -Sqrcode.enable: QR only, so a stray barcode elsewhere

--- a/test/classes/field_slip/qr_decoder_test.rb
+++ b/test/classes/field_slip/qr_decoder_test.rb
@@ -76,6 +76,28 @@ class FieldSlip::QRDecoderTest < UnitTestCase
     end
   end
 
+  # Production resolves a transferred image's URL to the image server,
+  # so the URL-based lookup goes nil within a second of upload -- but
+  # the file is still on this machine's disk, and the direct path
+  # finds it.
+  def test_falls_back_to_the_direct_disk_path_when_the_url_goes_remote
+    image = images(:in_situ_image)
+    path = image.full_filepath(:full_size)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.binwrite(path, "jpegbytes")
+
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      Image::LocalFile.stub(:path, nil) do
+        FieldSlip::QRDecoder.stub(:scan, ["OPEN-0219"]) do
+          assert_equal("OPEN-0219",
+                       FieldSlip::QRDecoder.slip_code_in(image))
+        end
+      end
+    end
+  ensure
+    FileUtils.rm_f(path)
+  end
+
   # ---------- zbarimg plumbing ----------
 
   def test_scan_parses_zbar_output


### PR DESCRIPTION
Fixes the production failure where Create went straight to Observation Show instead of the slip review (e.g. obs 664001), and QR auto-attach never fired.

Production's `image_precedence` is `[:mycolab, :local]`, and `TransferImagesJob` marks an image transferred within ~1s of upload — from that moment `image_url` resolves to `https://mushroomobserver.org/images/...`, so the URL-based `Image::LocalFile` lookup returns nil, `FieldSlip::QRDecoder` finds no file to scan, and every downstream feature (auto-attach, extraction chaining, the Create→review redirect) silently no-ops. Development never transfers images, so `:local` always won there and everything worked — which is why this only surfaced in production.

The file itself remains on the web server's disk until cleanup, so the decoder now falls back to probing `Image#full_filepath(size)` directly when the resolved URL isn't local. No change to the Gemini extraction path — it already had its own remote-fetch fallback, which is why the "Read Field Slip" button kept working.

## Test plan

- [x] Decoder, QR-job, and Create-redirect tests (23) + RuboCop
- After deploy: create an observation with a slip photo → should land on "Reading the field slip…" and then the review form.
- For obs 664001 specifically (created before the fix), re-trigger detection once deployed:
  ```
  bin/rails runner 'DetectFieldSlipQRJob.perform_now(664001, Observation.find(664001).images.first.id)'
  ```
  (adjust the image if the slip photo isn't the first), or attach the code via the observation edit form and press Read Field Slip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)