### PR TITLE
Attach a photographed field slip at Create; drop automatic extraction and the review redirect

### DIFF
--- a/app/classes/field_slip/qr_decoder.rb
+++ b/app/classes/field_slip/qr_decoder.rb
@@ -12,9 +12,12 @@ class FieldSlip
   # `apt-get install zbar-tools`): callers check `available?` first, so
   # an environment without the binary simply has no QR detection.
   module QRDecoder
-    # Full size first: the QR occupies a small corner of the photo, and
-    # downscaling can cost it the resolution it needs to decode.
-    SIZES = [:full_size, :huge].freeze
+    # The 1280px copy first: it decodes printed slip QRs reliably and
+    # zbar chews through it several times faster than a full-resolution
+    # original -- which matters when the scan runs inline in the
+    # observation-create request. Full size stays as the fallback for a
+    # QR too small or soft to survive the downscale.
+    SIZES = [:huge, :full_size].freeze
 
     # The code is the path segment alone -- MO's own /qr/ URLs can
     # carry query params (e.g. ?project=...), which are not part of it.

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -25,11 +25,8 @@ module Images
       redirect_to(edit_image_field_slip_extract_path(@image.id))
     end
 
-    # Three states: a completed extract renders the review form; a
-    # pending or failed one renders the self-refreshing Status page;
-    # no extract at all is only worth waiting on when the caller said
-    # so (`await=1`, set by the observation-create redirect while the
-    # QR jobs are still attaching the slip and starting the read).
+    # A completed extract renders the review form; a pending or failed
+    # one renders the self-refreshing Status page.
     def edit
       @extract = FieldSlipExtract.find_by(image_id: @image.id)
       return render_status unless @extract&.complete?
@@ -68,23 +65,9 @@ module Images
       return unless @image
       return if FieldSlipExtract.permitted?(image: @image, user: @user,
                                             site_admin: in_admin_mode?)
-      return if awaiting_own_upload?
 
       flash_error(:permission_denied.t)
       redirect_to(image_path(@image.id))
-    end
-
-    # The observation-create redirect can land here BEFORE the QR jobs
-    # have filed the observation into its project -- at which point
-    # `permitted?` has no project to check against. Waiting on your own
-    # freshly uploaded photo shows nothing but a status panel, so it
-    # only needs ownership; the review form itself stays behind
-    # `permitted?`, which holds by the time the extract completes.
-    def awaiting_own_upload?
-      return false unless request.get?
-      return false if FieldSlipExtract.find_by(image_id: @image.id)&.complete?
-
-      @image.observations.any? { |obs| obs.user_id == @user.id }
     end
 
     def find_image!
@@ -97,12 +80,10 @@ module Images
       nil
     end
 
-    # A pending or failed extract always shows its status; a missing
-    # one only does while the create redirect said to wait for the QR
-    # jobs -- otherwise a bare visit keeps today's "nothing to review"
-    # behavior.
+    # A pending or failed extract shows its status; a missing one has
+    # nothing to review.
     def render_status
-      if @extract.nil? && params[:await].blank?
+      if @extract.nil?
         flash_error(:field_slip_extract_missing.t)
         return redirect_to(image_path(@image.id))
       end

--- a/app/controllers/observations_controller/create.rb
+++ b/app/controllers/observations_controller/create.rb
@@ -268,10 +268,16 @@ module ObservationsController::Create
     end
   end
 
+  # "Created" or "attached", honestly: the slip may have existed as an
+  # unused spare before this observation claimed it.
   def attach_slip_by_code(code)
+    existed = FieldSlip.exists?(code: code.strip.upcase)
     result = FieldSlip::Attacher.attach(observation: @observation,
                                         code: code, user: @user)
-    flash_notice(:field_slip_created.t(code: code)) if result == :attached
+    return unless result == :attached
+
+    key = existed ? :field_slip_attached : :field_slip_created
+    flash_notice(key.t(code: code))
   end
 
   def reviewable_slip_code?(code)

--- a/app/controllers/observations_controller/create.rb
+++ b/app/controllers/observations_controller/create.rb
@@ -240,7 +240,7 @@ module ObservationsController::Create
   end
 
   def redirect_to_next_page
-    return if redirected_to_field_slip_review?
+    attach_photographed_field_slip
 
     if @observation.location_id.nil?
       redirect_to(new_location_path(where: @observation.place_name(@user),
@@ -250,62 +250,36 @@ module ObservationsController::Create
     end
   end
 
-  # After Create, a slip reviewer lands straight on the review of the
-  # photographed slip: the extraction is usually already running by
-  # then (the QR jobs chain it on attach -- see DetectFieldSlipQRJob),
-  # and the review page shows its progress until the read is done.
-  # Decode-only here -- attaching the slip is the QR jobs' business --
-  # so this adds no writes to the request.
-  def redirected_to_field_slip_review?
-    image = field_slip_review_image
-    return false unless image
-
-    redirect_to(edit_image_field_slip_extract_path(image.id, await: 1))
-    true
-  end
-
-  # The first new photo whose QR names a slip this user reviews.
-  # Gated to admins of the code's own prefix project, so ordinary
-  # uploads never pay for the scan or get detoured. When the
-  # observation already HAS the matching slip -- created by scanning
-  # or typing the code, which makes the QR jobs skip it -- the read is
-  # started from here instead.
-  def field_slip_review_image
-    return nil unless FieldSlip::QRDecoder.available?
-    return nil unless reviews_field_slips?
+  # A new photo whose QR names a slip this user reviews attaches it
+  # right here -- code -> slip -> project, same as typing the code into
+  # the form -- so the observation comes back already filed. Reading
+  # the slip is deliberately NOT started: that stays the reviewer's
+  # explicit act, the Read Field Slip button on the image.
+  def attach_photographed_field_slip
+    return unless FieldSlip::QRDecoder.available?
+    return unless @observation.occurrence_id.nil?
+    return unless reviews_field_slips?
 
     @observation.images.each do |image|
       code = FieldSlip::QRDecoder.slip_code_in(image)
       next unless code && reviewable_slip_code?(code)
 
-      start_extraction_for_linked_slip(image, code)
-      return image
+      return attach_slip_by_code(code)
     end
-    nil
   end
 
-  # A slip already linked to the observation only counts when the
-  # photographed code IS that slip's -- reviewing some other slip's
-  # photo into this observation is never an automatic act.
+  def attach_slip_by_code(code)
+    result = FieldSlip::Attacher.attach(observation: @observation,
+                                        code: code, user: @user)
+    flash_notice(:field_slip_created.t(code: code)) if result == :attached
+  end
+
   def reviewable_slip_code?(code)
-    slip = @observation.field_slip
-    return false if slip && slip.code != code
     return true if in_admin_mode?
 
     prefix = FieldSlip.prefix_for_code(code)
     project = prefix && Project.find_by(field_slip_prefix: prefix)
     project.present? && project.is_admin?(@user)
-  end
-
-  # The QR jobs only read slips they themselves attach; a slip that
-  # was already linked during this create gets its read started here.
-  # Never when an extract exists -- re-photographing a slip must not
-  # silently re-read one somebody may have reviewed.
-  def start_extraction_for_linked_slip(image, code)
-    return unless @observation.field_slip&.code == code
-    return if FieldSlipExtract.exists?(image_id: image.id)
-
-    ExtractFieldSlipJob.request(image: image, user: @user)
   end
 
   # Cheap gate so ordinary uploads never run the QR scan at all: only

--- a/app/jobs/detect_field_slip_qr_job.rb
+++ b/app/jobs/detect_field_slip_qr_job.rb
@@ -29,14 +29,8 @@ class DetectFieldSlipQRJob < ApplicationJob
       "DetectFieldSlipQRJob: #{code} -> #{result} " \
       "(observation #{observation.id}, image #{image.id})"
     )
-    return unless result == :attached
-
-    # This image just proved itself to be a slip photo, so read it now
-    # -- the ~15s provider call runs while the collector is still
-    # photographing, and the review page finds the extract waiting.
-    # Chained only on a fresh attach: adding more photos to an already-
-    # linked observation never re-reads a slip somebody may have
-    # reviewed (those runs exit above on the occurrence check).
-    ExtractFieldSlipJob.request(image: image, user: observation.user)
+    # Deliberately no extraction here: reading the slip is the
+    # reviewer's explicit act (the Read Field Slip button), not a side
+    # effect of attaching it.
   end
 end

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -2,19 +2,19 @@
 
 # Where the review page waits for a background extraction (see
 # ExtractFieldSlipJob): a self-refreshing "reading..." panel while the
-# job runs (or is about to -- the QR jobs may still be attaching the
-# slip), and the error with a retry button when the provider failed.
-# Once the extract completes, the reload lands on the review form.
+# job runs, and the error with a retry button when the provider
+# failed. Once the extract completes, the reload lands on the review
+# form.
 module Views::Controllers::Images::FieldSlipExtracts
   class Status < Views::FullPageBase
     prop :image, ::Image
-    prop :extract, _Nilable(::FieldSlipExtract), default: nil
+    prop :extract, ::FieldSlipExtract
     prop :user, ::User
 
     def view_template
       add_page_title(:field_slip_extract_status_title.t)
 
-      if @extract&.failed?
+      if @extract.failed?
         render_failed
       else
         render_pending

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2555,6 +2555,7 @@
   field_slip_constraint_violation: The selected observation violates one or more project constraints
   field_slip_project_not_member: You are not a member of the [title] project, so you cannot change which observations it contains.
   field_slip_created: Field slip [code] was successfully created.
+  field_slip_attached: Field slip [code] was attached to this observation.
   field_slip_create_obs: Create New Observation
   field_slip_quick_create_obs: Quick Create
   field_slip_creator: Creator

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -146,40 +146,7 @@ module Images
       assert_select("[data-controller='reload-poll']", count: 0)
     end
 
-    # The observation-create redirect arrives before the QR jobs have
-    # attached anything; `await=1` is what makes an extract-less page
-    # wait instead of bouncing.
-    def test_edit_awaits_detection_when_asked
-      login_as_site_admin
-
-      get(:edit, params: { image_id: @image.id, await: 1 })
-
-      assert_response(:success)
-      assert_select("[data-controller='reload-poll']")
-    end
-
-    # ...and can land before the observation is even in its project,
-    # when `permitted?` has nothing to check against. Waiting on your
-    # own upload needs only ownership; the review form still needs
-    # project admin-ship.
-    def test_owner_may_wait_on_their_own_upload_before_project_filing
-      owner = @obs.user
-      login(owner.login)
-
-      assert_not(
-        FieldSlipExtract.permitted?(image: @image.reload, user: owner),
-        "premise: ownership alone, no project admin-ship"
-      )
-
-      FieldSlipExtract.start!(image: @image, user: owner)
-
-      get(:edit, params: { image_id: @image.id })
-
-      assert_response(:success)
-      assert_select("[data-controller='reload-poll']")
-    end
-
-    def test_owner_alone_may_not_review_a_completed_extract
+    def test_owner_alone_may_not_review
       owner = @obs.user
       login(owner.login)
 

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -1903,12 +1903,14 @@ class ObservationsControllerCreateTest < FunctionalTestCase
   end
 
   # --------------------------------------------------------------------
-  #  Landing on the slip review straight from Create (#5024)
+  #  Attaching a photographed field slip at Create (#5024)
   # --------------------------------------------------------------------
 
-  # A reviewer whose new photo is a slip lands on the review page,
-  # which waits out the QR jobs and the background read.
-  def test_create_redirects_a_slip_reviewer_to_the_review_page
+  # A reviewer whose new photo is a slip gets it attached right in the
+  # create request -- slip, project, and enrollment -- and lands on the
+  # normal next page. Reading the slip stays the reviewer's explicit
+  # act (the Read Field Slip button), so no extract is started.
+  def test_create_attaches_a_photographed_slip_inline
     image = images(:in_situ_image)
     make_slip_project_admin(rolf)
     login("rolf")
@@ -1917,14 +1919,20 @@ class ObservationsControllerCreateTest < FunctionalTestCase
       post(:create, params: slip_photo_params(image))
     end
 
-    assert_redirected_to(
-      edit_image_field_slip_extract_path(image.id, await: 1)
-    )
+    assert_response(:redirect)
+    assert_no_match(/field_slip_extract/, @response.location.to_s)
+    obs = FieldSlip.find_by(code: "OPEN-0219").observation
+
+    assert_not_nil(obs, "the slip attaches during the create request")
+    assert_includes(projects(:open_membership_project).observations.reload,
+                    obs)
+    assert_nil(FieldSlipExtract.find_by(image_id: image.id),
+               "no automatic read")
   end
 
-  # A slip attached during this create (typed or scanned code -- the
-  # QR jobs skip linked observations) gets its read started here.
-  def test_create_with_matching_field_code_starts_the_read
+  # A slip attached during this create by a typed or scanned code needs
+  # nothing from the photo scan -- and still gets no automatic read.
+  def test_create_with_field_code_starts_no_read
     image = images(:in_situ_image)
     make_slip_project_admin(rolf)
     login("rolf")
@@ -1934,33 +1942,14 @@ class ObservationsControllerCreateTest < FunctionalTestCase
            params: slip_photo_params(image).merge(field_code: "OPEN-0777"))
     end
 
-    assert_redirected_to(
-      edit_image_field_slip_extract_path(image.id, await: 1)
-    )
-    assert(FieldSlipExtract.find_by(image_id: image.id).pending?,
-           "the read starts here; the QR jobs skip linked observations")
-  end
-
-  # A photographed code for some OTHER slip than the attached one is
-  # never auto-reviewed into this observation.
-  def test_create_ignores_a_code_that_mismatches_the_attached_slip
-    image = images(:in_situ_image)
-    make_slip_project_admin(rolf)
-    login("rolf")
-
-    with_decoded_slip_code("OPEN-0219") do
-      post(:create,
-           params: slip_photo_params(image).merge(field_code: "OPEN-0777"))
-    end
-
     assert_response(:redirect)
     assert_no_match(/field_slip_extract/, @response.location.to_s)
     assert_nil(FieldSlipExtract.find_by(image_id: image.id))
   end
 
-  # Ordinary uploads never pay for the scan or get detoured: the gate
-  # is admin-ship of a project with a field-slip prefix.
-  def test_create_does_not_detour_ordinary_uploads
+  # Ordinary uploads never pay for the scan: the gate is admin-ship of
+  # a project with a field-slip prefix.
+  def test_create_does_not_scan_ordinary_uploads
     login("katrina")
 
     assert_not(
@@ -1975,7 +1964,7 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     end
 
     assert_response(:redirect)
-    assert_no_match(/field_slip_extract/, @response.location.to_s)
+    assert_nil(FieldSlip.find_by(code: "OPEN-0219"))
   end
 
   private

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -1958,11 +1958,19 @@ class ObservationsControllerCreateTest < FunctionalTestCase
       "premise: katrina reviews no slip projects"
     )
 
-    with_decoded_slip_code("OPEN-0219") do
-      post(:create,
-           params: modified_generic_params({ naming: { vote: {} } }, katrina))
+    scanned = false
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:slip_code_in, lambda { |_image|
+        scanned = true
+        "OPEN-0219"
+      }) do
+        post(:create,
+             params: modified_generic_params({ naming: { vote: {} } },
+                                             katrina))
+      end
     end
 
+    assert_not(scanned, "the scan itself is skipped, not just its result")
     assert_response(:redirect)
     assert_nil(FieldSlip.find_by(code: "OPEN-0219"))
   end

--- a/test/jobs/detect_field_slip_qr_job_test.rb
+++ b/test/jobs/detect_field_slip_qr_job_test.rb
@@ -26,28 +26,14 @@ class DetectFieldSlipQRJobTest < ActiveJob::TestCase
                     @obs)
   end
 
-  # The image just proved itself to be a slip photo, so the read
-  # starts right away -- by the time a reviewer arrives, the extract
-  # is usually waiting.
-  def test_a_fresh_attach_chains_the_extraction
-    assert_enqueued_with(job: ExtractFieldSlipJob,
-                         args: [@image.id, @obs.user.id]) do
-      perform_with_code("OPEN-0219")
-    end
-
-    assert(FieldSlipExtract.find_by(image_id: @image.id).pending?)
-  end
-
-  # Adding photos to an already-linked observation never re-reads a
-  # slip somebody may have reviewed.
-  def test_no_extraction_chained_when_nothing_was_attached
-    slip = FieldSlip.find_or_create_by_code("OPEN-0800", @obs.user)
-    @obs.field_slip = slip
-    @obs.save!
-
+  # Reading the slip is the reviewer's explicit act (the Read Field
+  # Slip button), never a side effect of attaching it.
+  def test_attaching_starts_no_extraction
     assert_no_enqueued_jobs(only: ExtractFieldSlipJob) do
       perform_with_code("OPEN-0219")
     end
+
+    assert_nil(FieldSlipExtract.find_by(image_id: @image.id))
   end
 
   def test_leaves_the_observation_alone_when_the_photo_has_no_code

--- a/test/views/controllers/images/field_slip_extracts/status_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/status_test.rb
@@ -18,7 +18,7 @@ module Views::Controllers::Images::FieldSlipExtracts
       @obs.images << @image unless @obs.images.include?(@image)
     end
 
-    def render_status(extract: nil)
+    def render_status(extract:)
       render(Status.new(image: @image, extract: extract, user: @user))
     end
 
@@ -38,14 +38,6 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_html(
         html, "a[href='#{routes.permanent_observation_path(linked.id)}']"
       )
-    end
-
-    # No extract yet -- the QR jobs are still attaching -- looks the
-    # same as pending: something is happening, keep refreshing.
-    def test_awaiting_detection_self_refreshes_too
-      html = render_status
-
-      assert_html(html, "[data-controller='reload-poll']")
     end
 
     def test_failed_read_shows_the_error_and_a_retry_button


### PR DESCRIPTION
Per discussion on #5024's rollout: the Create-to-review flow (waiting page, background extraction chaining) is more moving parts than the fair needs, so this backs it out in favor of the simple, predictable version:

- **Create attaches the slip synchronously.** When a new photo's QR names a slip the user reviews (admin of the code's prefix project), the create request decodes it, attaches the slip via `FieldSlip::Attacher` (slip → project → enrollment), flashes "Created field slip <code>", and lands on the normal next page. The observation comes back already filed — immediate, visible, no detour.
- **No automatic extraction anywhere.** The chain in `DetectFieldSlipQRJob` and the create-flow extraction kick are removed. Reading a slip is the reviewer's explicit act: the **Read Field Slip** button, which keeps everything from #5032 that works — async job, "Reading…" status page with self-refresh, failed state with Try Again.
- The `await` mode on the review page and its ownership-based permission softening are removed with the redirect that needed them.
- `FieldSlip::QRDecoder` scans the 1280px copy before the full-resolution original (several times faster for zbar; printed slip QRs decode fine at that size), which keeps the inline scan's share of the Create request small.

Not touched: #5035 (global submit-button feedback) stays parked as its own PR — nothing here depends on it. If it merges later, the one-hunk overlap in `qr_decoder.rb` resolves trivially.

## Test plan

- [x] Extract/QR suites (204 tests), full `observations_controller_create_test.rb` (90)
- Create an observation with a slip photo → flash "Created field slip 2026-CMS-XXXX", observation page shows the slip and project, no redirect to a waiting page.
- Press **Read Field Slip** on the slip image → "Reading…" page self-refreshes into the review form; failures show Try Again.
- Ordinary observation with no slip photo → identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)