### PR TITLE
Attach the field slip from the extraction's read code (`ExtractFieldSlipJob`, review form, repair script)

### DIFF
--- a/app/classes/field_slip/extractor/context.rb
+++ b/app/classes/field_slip/extractor/context.rb
@@ -22,8 +22,14 @@ class FieldSlip
         @observation = observation
       end
 
+      # The attached slip's project is authoritative: an observation
+      # can sit in several projects (the obs form pre-checks the last
+      # one used), and picking `projects.first` read the wrong event's
+      # aliases and template for a slip that says exactly which project
+      # it belongs to.
       def project
-        @project ||= observation&.projects&.first
+        @project ||= observation&.field_slip&.project ||
+                     observation&.projects&.first
       end
 
       # Which printed layout this project's slips use.

--- a/app/classes/field_slip/qr_decoder.rb
+++ b/app/classes/field_slip/qr_decoder.rb
@@ -15,12 +15,11 @@ class FieldSlip
     # The 1280px copy first: it decodes printed slip QRs reliably and
     # zbar chews through it several times faster than a full-resolution
     # original -- which matters when the scan runs inline in the
-    # observation-create request. Full size is the fallback for a QR
-    # too small or soft to survive the downscale -- but only when the
-    # original is still on local disk. An archived original is never
-    # downloaded for a scan; it just counts as a miss, and the
-    # no-slip-detected flash points at the manual scan page.
+    # observation-create request. Full size stays as the fallback for a
+    # QR too small or soft to survive the downscale.
     SIZES = [:huge, :full_size].freeze
+
+    FETCH_TIMEOUT = 30
 
     # The code is the path segment alone -- MO's own /qr/ URLs can
     # carry query params (e.g. ?project=...), which are not part of it.
@@ -64,19 +63,21 @@ class FieldSlip
       code if prefix && Project.exists?(field_slip_prefix: prefix)
     end
 
-    # Every QR payload zbar finds, largest available file first,
-    # stopping at the first size that decodes anything.
+    # Every QR payload zbar finds, preferred size first, stopping at
+    # the first size that decodes anything.
     def self.raw_codes(image)
       return [] unless available?
 
       SIZES.each do |size|
-        path = local_file(image, size)
-        next unless path
-
-        codes = scan(path)
+        codes = codes_at(image, size)
         return codes if codes.any?
       end
       []
+    end
+
+    def self.codes_at(image, size)
+      path = local_file(image, size)
+      path ? scan(path) : remote_codes(image, size)
     end
 
     # The precedence-resolved URL stops pointing at the local copy the
@@ -91,6 +92,28 @@ class FieldSlip
     def self.direct_path(image, size)
       path = image.full_filepath(size)
       path if path && File.exist?(path)
+    end
+
+    # Transfer to the image server can outrun this scan -- the local
+    # copy may vanish within seconds of upload -- so a size no longer
+    # on this machine's disk is fetched from the image server. Any
+    # fetch failure is a plain miss, not an error: in particular, an
+    # archived original is gone from the image server deliberately and
+    # is never pulled out of the archive for a scan.
+    def self.remote_codes(image, size)
+      url = image.image_url(size).url
+      return [] unless url.start_with?("http")
+
+      response = RestClient::Request.execute(method: :get, url: url,
+                                             timeout: FETCH_TIMEOUT,
+                                             raw_response: true)
+      begin
+        scan(response.file.path)
+      ensure
+        response.file.close!
+      end
+    rescue RestClient::Exception, SocketError, SystemCallError
+      []
     end
 
     # -Sdisable -Sqrcode.enable: QR only, so a stray barcode elsewhere

--- a/app/classes/field_slip/qr_decoder.rb
+++ b/app/classes/field_slip/qr_decoder.rb
@@ -12,9 +12,12 @@ class FieldSlip
   # `apt-get install zbar-tools`): callers check `available?` first, so
   # an environment without the binary simply has no QR detection.
   module QRDecoder
-    # Full size first: the QR occupies a small corner of the photo, and
-    # downscaling can cost it the resolution it needs to decode.
-    SIZES = [:full_size, :huge].freeze
+    # The 1280px copy first: it decodes printed slip QRs reliably and
+    # zbar chews through it several times faster than a full-resolution
+    # original -- which matters when the scan runs inline in the
+    # observation-create request. Full size stays as the fallback for a
+    # QR too small or soft to survive the downscale.
+    SIZES = [:huge, :full_size].freeze
 
     # The code is the path segment alone -- MO's own /qr/ URLs can
     # carry query params (e.g. ?project=...), which are not part of it.

--- a/app/classes/field_slip/qr_decoder.rb
+++ b/app/classes/field_slip/qr_decoder.rb
@@ -15,8 +15,11 @@ class FieldSlip
     # The 1280px copy first: it decodes printed slip QRs reliably and
     # zbar chews through it several times faster than a full-resolution
     # original -- which matters when the scan runs inline in the
-    # observation-create request. Full size stays as the fallback for a
-    # QR too small or soft to survive the downscale.
+    # observation-create request. Full size is the fallback for a QR
+    # too small or soft to survive the downscale -- but only when the
+    # original is still on local disk. An archived original is never
+    # downloaded for a scan; it just counts as a miss, and the
+    # no-slip-detected flash points at the manual scan page.
     SIZES = [:huge, :full_size].freeze
 
     # The code is the path segment alone -- MO's own /qr/ URLs can

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -38,6 +38,7 @@ class FormObject::FieldSlipReview < FormObject::Base
     def name_row? = role == :name
     def location_row? = role == :location
     def inat_row? = role == :inat
+    def code_row? = role == :code
 
     # Both get their own labelled section rather than a table cell: an
     # autocompleter only renders its dropdown and hidden id field when
@@ -68,18 +69,31 @@ class FormObject::FieldSlipReview < FormObject::Base
   end
 
   def self.rows_for(extract, template, observation)
+    attachable = code_attachable?(extract, template, observation)
     template.fields.map do |field, target|
+      code = field == template.code_field
       Row.new(field: field, extracted: extract.value_for(field),
               current: current_value(observation, target),
               confidence: extract.confidence_for(field),
-              savable: !target.nil?,
-              editable: !target.nil? || field == template.name_field,
+              savable: !target.nil? || (code && attachable),
+              editable: !target.nil? || field == template.name_field ||
+                        (code && attachable),
               role: role_for(template, field))
     end
   end
 
+  # The read code can be applied -- ticking it attaches the slip --
+  # exactly when the observation has none. The background job usually
+  # already did this (see ExtractFieldSlipJob#attach_read_code), so
+  # this is the manual path for what it couldn't decide on its own.
+  def self.code_attachable?(extract, template, observation)
+    observation.occurrence_id.nil? &&
+      extract.value_for(template.code_field).present?
+  end
+
   def self.role_for(template, field)
     case field
+    when template.code_field then :code
     when template.name_field then :name
     when template.location_field then :location
     when template.inat_codes_field then :inat

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -99,16 +99,11 @@ module Images
       nil
     end
 
-    # A pending or failed extract always shows its status; a missing
-    # one only does while the create redirect said to wait for the QR
-    # jobs -- otherwise a bare visit keeps today's "nothing to review"
-    # behavior.
+    # A pending or failed extract shows its status; a missing one
+    # renders the same page in its not-scanned-yet state, whose scan
+    # button is how a zbar-missed slip photo gets read at all -- this
+    # is where the no-slip-detected flash on observation create links.
     def render_status
-      if @extract.nil? && params[:await].blank?
-        flash_error(:field_slip_extract_missing.t)
-        return redirect_to(image_path(@image.id))
-      end
-
       render(Views::Controllers::Images::FieldSlipExtracts::Status.new(
                image: @image, extract: @extract, user: @user
              ))

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -47,6 +47,7 @@ module Images
 
       attach_ticked_code
       apply_chosen_fields
+      rejoin_slip_project
       outcome = propose_name
       # An unrecognized or ambiguous name needs the reviewer to confirm
       # before a Name is created, so the page comes back with the
@@ -149,6 +150,32 @@ module Images
           chosen_name: params.dig(:chosen_name, :name_id)
         }
       ).propose
+    end
+
+    # The join decision at slip-attach time ran against the
+    # observation's PRE-review data -- the create form's default date
+    # and leftover locality -- and constraint violations silently kept
+    # it out of the slip's project. The review then applies the slip's
+    # real date and locality: exactly the fields the decision used, so
+    # re-evaluate. (Reported: an NEMF slip's observation stayed out of
+    # the NEMF project while carrying form defaults at attach time.)
+    def rejoin_slip_project
+      @observation.reload
+      project = @observation.field_slip&.project
+      return unless project
+      return if @observation.projects.include?(project)
+      return unless project.member?(@observation.user)
+
+      if project.violates_constraints?(@observation)
+        flash_warning(:field_slip_extract_project_blocked.t(
+                        title: project.title
+                      ))
+      else
+        project.add_observation(@observation)
+        flash_notice(:field_slip_extract_project_joined.t(
+                       title: project.title
+                     ))
+      end
     end
 
     def flash_extract_saved(outcome)

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -45,6 +45,7 @@ module Images
     def update
       return unless extract_or_redirect!
 
+      attach_ticked_code
       apply_chosen_fields
       outcome = propose_name
       # An unrecognized or ambiguous name needs the reviewer to confirm
@@ -173,6 +174,35 @@ module Images
         observation: @observation, chosen: chosen_fields, user: @user,
         template: @extract.template, inat_code: params[:inat] == "1"
       ).apply
+    end
+
+    # A ticked code row attaches the slip -- the manual path for what
+    # ExtractFieldSlipJob#attach_read_code couldn't decide on its own
+    # (an in-use slip resolved by hand, a corrected misread). Runs
+    # before the field writes so the observation joins its project
+    # first and the project's aliases apply to them.
+    def attach_ticked_code
+      code_field = @extract.template.code_field
+      return unless params.dig(:use, code_field) == "1"
+      return unless @observation.occurrence_id.nil?
+
+      code = params.dig(:value, code_field).to_s.strip
+      return if code.blank?
+
+      result = FieldSlip::Attacher.attach(observation: @observation,
+                                          code: code, user: @user)
+      flash_attach_result(code, result)
+    end
+
+    def flash_attach_result(code, result)
+      if result == :attached
+        flash_notice(:field_slip_created.t(code: code))
+        @observation.reload
+      else
+        flash_warning(:field_slip_extract_attach_failed.t(
+                        code: code, reason: result.to_s.tr("_", " ")
+                      ))
+      end
     end
 
     # Only the ticked rows, keyed by slip field, holding whatever text

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -211,14 +211,18 @@ module Images
       code = params.dig(:value, code_field).to_s.strip
       return if code.blank?
 
+      existed = FieldSlip.exists?(code: code.upcase)
       result = FieldSlip::Attacher.attach(observation: @observation,
                                           code: code, user: @user)
-      flash_attach_result(code, result)
+      flash_attach_result(code, result, existed)
     end
 
-    def flash_attach_result(code, result)
+    # "Created" or "attached", honestly: the code may have named a
+    # pre-existing spare slip.
+    def flash_attach_result(code, result, existed)
       if result == :attached
-        flash_notice(:field_slip_created.t(code: code))
+        key = existed ? :field_slip_attached : :field_slip_created
+        flash_notice(key.t(code: code))
         @observation.reload
       else
         flash_warning(:field_slip_extract_attach_failed.t(

--- a/app/controllers/observations/field_slip_scans_controller.rb
+++ b/app/controllers/observations/field_slip_scans_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Observations
+  # The observation-scoped scan page: every photo with its scan state
+  # -- a Read Field Slip button when unscanned, a link to the photo's
+  # review or status page otherwise. This is where the no-slip-detected
+  # flash lands (choosing which photo shows the slip is a decision
+  # about the observation, not any one image), and the way back to
+  # scanning later; #5041 links it from the field slip show page.
+  class FieldSlipScansController < ApplicationController
+    before_action :login_required
+    before_action :find_observation!
+    before_action :permission_required
+
+    def show
+      render(Views::Controllers::Observations::FieldSlipScans::Show.new(
+               observation: @observation, user: @user
+             ))
+    end
+
+    private
+
+    def find_observation!
+      @observation = Observation.safe_find(params[:id])
+      return @observation if @observation
+
+      flash_error(:runtime_object_not_found.t(type: :observation,
+                                              id: params[:id]))
+      redirect_to(observations_path)
+      nil
+    end
+
+    # Same gate as the per-image extract pages: site admins and admins
+    # of any project the observation belongs to (each scan costs an
+    # API call). A `before_action` halts the chain when it redirects.
+    def permission_required
+      return unless @observation
+      return if in_admin_mode?
+      return if @observation.projects.any? do |project|
+        project.is_admin?(@user)
+      end
+
+      flash_error(:permission_denied.t)
+      redirect_to(permanent_observation_path(@observation.id))
+    end
+  end
+end

--- a/app/controllers/observations/field_slip_scans_controller.rb
+++ b/app/controllers/observations/field_slip_scans_controller.rb
@@ -32,9 +32,9 @@ module Observations
 
     # Same gate as the per-image extract pages: site admins and admins
     # of any project the observation belongs to (each scan costs an
-    # API call). A `before_action` halts the chain when it redirects.
+    # API call). Runs only when `find_observation!` succeeded -- a
+    # `before_action` redirect halts the chain.
     def permission_required
-      return unless @observation
       return if in_admin_mode?
       return if @observation.projects.any? do |project|
         project.is_admin?(@user)

--- a/app/controllers/observations/field_slip_scans_controller.rb
+++ b/app/controllers/observations/field_slip_scans_controller.rb
@@ -13,8 +13,10 @@ module Observations
     before_action :permission_required
 
     def show
+      extracts = FieldSlipExtract.where(image_id: @observation.image_ids).
+                 index_by(&:image_id)
       render(Views::Controllers::Observations::FieldSlipScans::Show.new(
-               observation: @observation, user: @user
+               observation: @observation, user: @user, extracts: extracts
              ))
     end
 

--- a/app/controllers/observations_controller/create.rb
+++ b/app/controllers/observations_controller/create.rb
@@ -242,77 +242,13 @@ module ObservationsController::Create
   def redirect_to_next_page
     return if redirected_to_field_slip_review?
 
+    warn_no_field_slip_detected
     if @observation.location_id.nil?
       redirect_to(new_location_path(where: @observation.place_name(@user),
                                     set_observation: @observation.id))
     else
       redirect_to(permanent_observation_path(@observation.id))
     end
-  end
-
-  # After Create, a slip reviewer lands straight on the review of the
-  # photographed slip: the extraction is usually already running by
-  # then (the QR jobs chain it on attach -- see DetectFieldSlipQRJob),
-  # and the review page shows its progress until the read is done.
-  # Decode-only here -- attaching the slip is the QR jobs' business --
-  # so this adds no writes to the request.
-  def redirected_to_field_slip_review?
-    image = field_slip_review_image
-    return false unless image
-
-    redirect_to(edit_image_field_slip_extract_path(image.id, await: 1))
-    true
-  end
-
-  # The first new photo whose QR names a slip this user reviews.
-  # Gated to admins of the code's own prefix project, so ordinary
-  # uploads never pay for the scan or get detoured. When the
-  # observation already HAS the matching slip -- created by scanning
-  # or typing the code, which makes the QR jobs skip it -- the read is
-  # started from here instead.
-  def field_slip_review_image
-    return nil unless FieldSlip::QRDecoder.available?
-    return nil unless reviews_field_slips?
-
-    @observation.images.each do |image|
-      code = FieldSlip::QRDecoder.slip_code_in(image)
-      next unless code && reviewable_slip_code?(code)
-
-      start_extraction_for_linked_slip(image, code)
-      return image
-    end
-    nil
-  end
-
-  # A slip already linked to the observation only counts when the
-  # photographed code IS that slip's -- reviewing some other slip's
-  # photo into this observation is never an automatic act.
-  def reviewable_slip_code?(code)
-    slip = @observation.field_slip
-    return false if slip && slip.code != code
-    return true if in_admin_mode?
-
-    prefix = FieldSlip.prefix_for_code(code)
-    project = prefix && Project.find_by(field_slip_prefix: prefix)
-    project.present? && project.is_admin?(@user)
-  end
-
-  # The QR jobs only read slips they themselves attach; a slip that
-  # was already linked during this create gets its read started here.
-  # Never when an extract exists -- re-photographing a slip must not
-  # silently re-read one somebody may have reviewed.
-  def start_extraction_for_linked_slip(image, code)
-    return unless @observation.field_slip&.code == code
-    return if FieldSlipExtract.exists?(image_id: image.id)
-
-    ExtractFieldSlipJob.request(image: image, user: @user)
-  end
-
-  # Cheap gate so ordinary uploads never run the QR scan at all: only
-  # admins of a project with a field-slip prefix photograph slips.
-  def reviews_field_slips?
-    Project.where.not(field_slip_prefix: nil).
-      exists?(admin_group_id: @user.user_group_ids)
   end
 
   def reload_new_form(reasons)

--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -12,6 +12,92 @@
 module ObservationsController::FieldSlips
   private
 
+  # After Create, a slip reviewer lands straight on the review of the
+  # photographed slip: the extraction is usually already running by
+  # then (the QR jobs chain it on attach -- see DetectFieldSlipQRJob),
+  # and the review page shows its progress until the read is done.
+  # Decode-only here -- attaching the slip is the QR jobs' business --
+  # so this adds no writes to the request.
+  def redirected_to_field_slip_review?
+    image = field_slip_review_image
+    return false unless image
+
+    redirect_to(edit_image_field_slip_extract_path(image.id, await: 1))
+    true
+  end
+
+  # The first new photo whose QR names a slip this user reviews.
+  # Gated to admins of the code's own prefix project, so ordinary
+  # uploads never pay for the scan or get detoured. When the
+  # observation already HAS the matching slip -- created by scanning
+  # or typing the code, which makes the QR jobs skip it -- the read is
+  # started from here instead.
+  def field_slip_review_image
+    return nil unless FieldSlip::QRDecoder.available?
+    return nil unless reviews_field_slips?
+
+    @observation.images.each do |image|
+      code = FieldSlip::QRDecoder.slip_code_in(image)
+      next unless code && reviewable_slip_code?(code)
+
+      start_extraction_for_linked_slip(image, code)
+      return image
+    end
+    nil
+  end
+
+  # A slip already linked to the observation only counts when the
+  # photographed code IS that slip's -- reviewing some other slip's
+  # photo into this observation is never an automatic act.
+  def reviewable_slip_code?(code)
+    slip = @observation.field_slip
+    return false if slip && slip.code != code
+    return true if in_admin_mode?
+
+    prefix = FieldSlip.prefix_for_code(code)
+    project = prefix && Project.find_by(field_slip_prefix: prefix)
+    project.present? && project.is_admin?(@user)
+  end
+
+  # The QR jobs only read slips they themselves attach; a slip that
+  # was already linked during this create gets its read started here.
+  # Never when an extract exists -- re-photographing a slip must not
+  # silently re-read one somebody may have reviewed.
+  def start_extraction_for_linked_slip(image, code)
+    return unless @observation.field_slip&.code == code
+    return if FieldSlipExtract.exists?(image_id: image.id)
+
+    ExtractFieldSlipJob.request(image: image, user: @user)
+  end
+
+  # Most observations in a slip-prefix project eventually carry a
+  # slip, and a zbar miss is silent by design (no auto-escalation to
+  # the paid scan -- see #5041) -- so the person who could fix it gets
+  # told, with the scan page linked. Same gates as the scan itself, so
+  # this only fires when the scan actually ran and found nothing.
+  def warn_no_field_slip_detected
+    return unless FieldSlip::QRDecoder.available?
+    return unless @observation.occurrence_id.nil?
+    return unless reviews_field_slips?
+
+    image = @observation.images.first
+    return unless image
+    return if @observation.projects.none? do |proj|
+      proj.field_slip_prefix.present?
+    end
+
+    flash_warning(:observation_no_field_slip_detected.t(
+                    url: edit_image_field_slip_extract_path(image.id)
+                  ))
+  end
+
+  # Cheap gate so ordinary uploads never run the QR scan at all: only
+  # admins of a project with a field-slip prefix photograph slips.
+  def reviews_field_slips?
+    Project.where.not(field_slip_prefix: nil).
+      exists?(admin_group_id: @user.user_group_ids)
+  end
+
   # The submitted field-slip code, normalized. Used both to apply the change
   # and to build the caller's invalid-code message.
   def field_code

--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -79,15 +79,13 @@ module ObservationsController::FieldSlips
     return unless FieldSlip::QRDecoder.available?
     return unless @observation.occurrence_id.nil?
     return unless reviews_field_slips?
-
-    image = @observation.images.first
-    return unless image
+    return if @observation.images.none?
     return if @observation.projects.none? do |proj|
       proj.field_slip_prefix.present?
     end
 
     flash_warning(:observation_no_field_slip_detected.t(
-                    url: edit_image_field_slip_extract_path(image.id)
+                    url: field_slip_scan_observation_path(@observation.id)
                   ))
   end
 

--- a/app/jobs/extract_field_slip_job.rb
+++ b/app/jobs/extract_field_slip_job.rb
@@ -29,10 +29,12 @@ class ExtractFieldSlipJob < ApplicationJob
   def extract(image, user)
     context = FieldSlip::Extractor::Context.for_image(image)
     result = FieldSlip::Extractor.default.extract(image, context: context)
-    FieldSlipExtract.record(
+    extract = FieldSlipExtract.record(
       image: image, user: user, result: result,
       prompt_version: FieldSlip::Extractor::PROMPT_VERSION
     )
+    attach_read_code(image, user, extract)
+    extract
   rescue StandardError => e
     # Not re-raised -- the failed extract row IS the retry mechanism
     # (the review page's Try Again button) -- so the details have to be
@@ -42,5 +44,26 @@ class ExtractFieldSlipJob < ApplicationJob
       "#{e.class}: #{e.message}\n#{e.backtrace&.first(10)&.join("\n")}"
     )
     FieldSlipExtract.fail!(image: image, user: user, error: e.message)
+  end
+
+  # The read code is the fallback when the QR path missed: zbar failed
+  # to decode ~27% of the CMS fair's slip photos while the extraction
+  # read the printed code off nearly all of them -- and without this,
+  # the code the extraction knows goes nowhere. Attacher's own guards
+  # keep it safe for a background act: never an observation that has a
+  # slip, never somebody else's slip.
+  def attach_read_code(image, user, extract)
+    observation = image.observations.first
+    return unless observation && observation.occurrence_id.nil?
+
+    code = extract.value_for(extract.template.code_field).to_s.strip
+    return if code.blank?
+
+    result = FieldSlip::Attacher.attach(observation: observation,
+                                        code: code, user: user)
+    Rails.logger.info(
+      "ExtractFieldSlipJob: read code #{code} -> #{result} " \
+      "(observation #{observation.id}, image #{image.id})"
+    )
   end
 end

--- a/app/jobs/extract_field_slip_job.rb
+++ b/app/jobs/extract_field_slip_job.rb
@@ -53,8 +53,8 @@ class ExtractFieldSlipJob < ApplicationJob
   # keep it safe for a background act: never an observation that has a
   # slip, never somebody else's slip.
   def attach_read_code(image, user, extract)
-    observation = image.observations.first
-    return unless observation && observation.occurrence_id.nil?
+    observation = sole_slipless_observation(image)
+    return unless observation
 
     code = extract.value_for(extract.template.code_field).to_s.strip
     return if code.blank?
@@ -65,5 +65,16 @@ class ExtractFieldSlipJob < ApplicationJob
       "ExtractFieldSlipJob: read code #{code} -> #{result} " \
       "(observation #{observation.id}, image #{image.id})"
     )
+  end
+
+  # An image on several observations makes "whose slip is this?"
+  # ambiguous, and a background guess would consume the slip for the
+  # right one. Only the review's human decides those.
+  def sole_slipless_observation(image)
+    observations = image.observations.to_a
+    return unless observations.one?
+
+    observation = observations.first
+    observation if observation.occurrence_id.nil?
   end
 end

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -189,7 +189,7 @@ class FieldSlipExtract < AbstractModel
   # its aliases' targets, and its own -- which is a much better
   # candidate set than all of MO.
   def project_locations
-    project = observation&.projects&.first
+    project = slip_project
     return [] unless project
 
     from_observations = Location.joins(:observations).
@@ -204,5 +204,11 @@ class FieldSlipExtract < AbstractModel
     context = FieldSlip::Extractor::Context.new(observation: observation)
     context.aliases("Location").flatten +
       [observation&.location&.name].compact
+  end
+
+  # The attached slip's project wins over `projects.first` -- see
+  # FieldSlip::Extractor::Context#project.
+  def slip_project
+    observation&.field_slip&.project || observation&.projects&.first
   end
 end

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -200,10 +200,20 @@ class FieldSlipExtract < AbstractModel
     (from_observations + aliased + [project.location]).compact.uniq
   end
 
+  # Aliases from the slip's project AND every project the observation
+  # is in -- the same resolution `Extractor::Applier#project_alias`
+  # uses when saving, so the warning can't contradict what applying
+  # would actually do.
   def known_location_names
-    context = FieldSlip::Extractor::Context.new(observation: observation)
-    context.aliases("Location").flatten +
+    ProjectAlias.where(project_id: relevant_project_ids,
+                       target_type: "Location").
+      includes(:target).flat_map { |a| [a.name, a.target&.name] }.compact +
       [observation&.location&.name].compact
+  end
+
+  def relevant_project_ids
+    ([observation&.field_slip&.project_id] +
+     Array(observation&.project_ids)).compact.uniq
   end
 
   # The attached slip's project wins over `projects.first` -- see

--- a/app/models/image/dhash.rb
+++ b/app/models/image/dhash.rb
@@ -72,7 +72,8 @@ class Image
       # ignored on this basis in config/brakeman.ignore.)
       def grayscale_pixels(path)
         out, err, status = Open3.capture3(
-          "convert", "#{path}[0]", "-auto-orient", "-colorspace", "Gray",
+          magick_binary, "#{path}[0]", "-auto-orient",
+          "-colorspace", "Gray",
           "-resize", "#{WIDTH}x#{HEIGHT}!", "-depth", "8", "gray:-"
         )
         unless status.success? && out.bytesize == WIDTH * HEIGHT
@@ -81,6 +82,18 @@ class Image
         end
 
         out.bytes
+      end
+
+      # IMv7 renamed the CLI to `magick` (its `convert` shim prints a
+      # deprecation warning on every call); the production servers run
+      # IMv6, which has only `convert`.
+      def magick_binary
+        @magick_binary ||=
+          if system("which", "magick", out: File::NULL, err: File::NULL)
+            "magick"
+          else
+            "convert"
+          end
       end
     end
   end

--- a/app/views/controllers/images/field_slip_extracts/edit.rb
+++ b/app/views/controllers/images/field_slip_extracts/edit.rb
@@ -44,7 +44,7 @@ module Views::Controllers::Images::FieldSlipExtracts
       return unless @extract.template_mismatch?
 
       Alert(level: :danger) do
-        trusted_html(:field_slip_extract_template_mismatch.t)
+        plain(:field_slip_extract_template_mismatch.l)
       end
     end
 
@@ -53,8 +53,8 @@ module Views::Controllers::Images::FieldSlipExtracts
       return unless read
 
       Alert(level: :danger) do
-        trusted_html(:field_slip_extract_code_mismatch.t(read: read,
-                                                         attached: attached))
+        plain(:field_slip_extract_code_mismatch.l(read: read,
+                                                  attached: attached))
       end
     end
 
@@ -68,11 +68,11 @@ module Views::Controllers::Images::FieldSlipExtracts
       suggestion = @extract.location_suggestion
       Alert(level: :warning) do
         if suggestion
-          trusted_html(:field_slip_extract_location_guess.t(
-                         written: written, suggestion: suggestion.name
-                       ))
+          plain(:field_slip_extract_location_guess.l(
+                  written: written, suggestion: suggestion.name
+                ))
         else
-          trusted_html(:field_slip_extract_unknown_alias.t(name: written))
+          plain(:field_slip_extract_unknown_alias.l(name: written))
           whitespace
           render_alias_link
         end
@@ -126,12 +126,12 @@ module Views::Controllers::Images::FieldSlipExtracts
     # once extraction has moved on.
     def render_provenance
       small do
-        trusted_html(:field_slip_extract_provenance.t(
-                       provider: @extract.provider, model: @extract.model,
-                       template: @extract.template.key,
-                       version: @extract.prompt_version.to_s,
-                       time: @extract.updated_at.web_time
-                     ))
+        plain(:field_slip_extract_provenance.l(
+                provider: @extract.provider, model: @extract.model,
+                template: @extract.template.key,
+                version: @extract.prompt_version.to_s,
+                time: @extract.updated_at.web_time
+              ))
       end
     end
   end

--- a/app/views/controllers/images/field_slip_extracts/edit.rb
+++ b/app/views/controllers/images/field_slip_extracts/edit.rb
@@ -79,8 +79,12 @@ module Views::Controllers::Images::FieldSlipExtracts
       end
     end
 
+    # The attached slip's project, so the link defines the alias where
+    # the slip actually lives -- `projects.first` sent it to whichever
+    # other project the observation happened to be in.
     def render_alias_link
-      project = @observation.projects.first
+      project = @observation.field_slip&.project ||
+                @observation.projects.first
       return unless project
 
       Link(type: :get, name: :field_slip_extract_add_alias.l,

--- a/app/views/controllers/images/field_slip_extracts/edit.rb
+++ b/app/views/controllers/images/field_slip_extracts/edit.rb
@@ -44,7 +44,7 @@ module Views::Controllers::Images::FieldSlipExtracts
       return unless @extract.template_mismatch?
 
       Alert(level: :danger) do
-        plain(:field_slip_extract_template_mismatch.t)
+        trusted_html(:field_slip_extract_template_mismatch.t)
       end
     end
 
@@ -53,8 +53,8 @@ module Views::Controllers::Images::FieldSlipExtracts
       return unless read
 
       Alert(level: :danger) do
-        plain(:field_slip_extract_code_mismatch.t(read: read,
-                                                  attached: attached))
+        trusted_html(:field_slip_extract_code_mismatch.t(read: read,
+                                                         attached: attached))
       end
     end
 
@@ -68,11 +68,11 @@ module Views::Controllers::Images::FieldSlipExtracts
       suggestion = @extract.location_suggestion
       Alert(level: :warning) do
         if suggestion
-          plain(:field_slip_extract_location_guess.t(
-                  written: written, suggestion: suggestion.name
-                ))
+          trusted_html(:field_slip_extract_location_guess.t(
+                         written: written, suggestion: suggestion.name
+                       ))
         else
-          plain(:field_slip_extract_unknown_alias.t(name: written))
+          trusted_html(:field_slip_extract_unknown_alias.t(name: written))
           whitespace
           render_alias_link
         end
@@ -126,12 +126,12 @@ module Views::Controllers::Images::FieldSlipExtracts
     # once extraction has moved on.
     def render_provenance
       small do
-        plain(:field_slip_extract_provenance.t(
-                provider: @extract.provider, model: @extract.model,
-                template: @extract.template.key,
-                version: @extract.prompt_version.to_s,
-                time: @extract.updated_at.web_time
-              ))
+        trusted_html(:field_slip_extract_provenance.t(
+                       provider: @extract.provider, model: @extract.model,
+                       template: @extract.template.key,
+                       version: @extract.prompt_version.to_s,
+                       time: @extract.updated_at.web_time
+                     ))
       end
     end
   end

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -128,9 +128,24 @@ module Views::Controllers::Images::FieldSlipExtracts
       if row.savable
         checkbox_field("use[#{row.field}]", checked: row.default_use?,
                                             label: use_label(row))
+      elsif row.code_row?
+        render_code_check_state
       else
         small { plain(:field_slip_extract_check_only.l) }
       end
+    end
+
+    # A non-attachable code row only renders when the observation
+    # already has its slip (blank rows are dropped, slip-less ones get
+    # the attach tick), so say what the check FOUND rather than the
+    # generic "cross-check only" that read as "nothing was read".
+    def render_code_check_state
+      key = if @extract.code_mismatch
+              :field_slip_extract_code_differs
+            else
+              :field_slip_extract_code_matches
+            end
+      small { plain(key.l) }
     end
 
     def use_label(row)

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -122,13 +122,19 @@ module Views::Controllers::Images::FieldSlipExtracts
       end
     end
 
+    # The code row's tick is an attach, not a field write, so it says
+    # so -- everything else gets a bare box under the "Save" header.
     def render_use_cell(row)
       if row.savable
         checkbox_field("use[#{row.field}]", checked: row.default_use?,
-                                            label: false)
+                                            label: use_label(row))
       else
         small { plain(:field_slip_extract_check_only.l) }
       end
+    end
+
+    def use_label(row)
+      row.code_row? ? :field_slip_extract_attach_code.l : false
     end
 
     # Locality, like the ID, is corrected through an autocompleter and

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -28,17 +28,46 @@ module Views::Controllers::Images::FieldSlipExtracts
 
     private
 
-    # No polling: nothing is running until the button is pressed.
+    # No polling: nothing is running until a button is pressed. The
+    # observation's photos each get their own scan button -- zbar found
+    # no code anywhere, so only the person can say which photo shows
+    # the slip, and "scan the first image" was a coin toss on a
+    # multi-photo observation.
     def render_unscanned
+      images = scan_candidates
       render(Components::Panel.new(
                panel_id: "field_slip_extract_none"
              )) do |p|
         p.with_body do
-          trusted_html(:field_slip_extract_none_yet.t)
+          trusted_html(unscanned_prompt(images.size))
+          div(class: "d-flex flex-wrap mt-3") do
+            images.each { |image| render_scan_candidate(image) }
+          end
         end
       end
-      Button(type: :post, name: :field_slip_extract_button.l,
-             target: image_field_slip_extract_path(@image.id))
+    end
+
+    def scan_candidates
+      observation = @image.observations.first
+      observation ? observation.images.to_a : [@image]
+    end
+
+    def unscanned_prompt(count)
+      key = if count > 1
+              :field_slip_extract_choose_photo
+            else
+              :field_slip_extract_none_yet
+            end
+      key.t
+    end
+
+    def render_scan_candidate(image)
+      div(class: "mr-4 mb-3 text-center") do
+        render(Components::InteractiveImage.new(image: image, user: @user,
+                                                size: :small, votes: false))
+        Button(type: :post, name: :field_slip_extract_button.l,
+               target: image_field_slip_extract_path(image.id))
+      end
     end
 
     def render_pending

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -37,7 +37,7 @@ module Views::Controllers::Images::FieldSlipExtracts
                panel_id: "field_slip_extract_none"
              )) do |p|
         p.with_body do
-          trusted_html(:field_slip_extract_none_yet.t)
+          plain(:field_slip_extract_none_yet.l)
         end
       end
       Button(type: :post, name: :field_slip_extract_button.l,
@@ -62,7 +62,7 @@ module Views::Controllers::Images::FieldSlipExtracts
                )) do |p|
           p.with_body do
             span(class: "spinner-right mx-2")
-            trusted_html(:field_slip_extract_pending.t)
+            plain(:field_slip_extract_pending.l)
           end
         end
       end
@@ -70,7 +70,7 @@ module Views::Controllers::Images::FieldSlipExtracts
 
     def render_failed
       Alert(level: :danger) do
-        trusted_html(:field_slip_extract_failed.t(error: @extract.error.to_s))
+        plain(:field_slip_extract_failed.l(error: @extract.error.to_s))
       end
       Button(type: :post, name: :field_slip_extract_retry.l,
              target: image_field_slip_extract_path(@image.id))

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -28,45 +28,30 @@ module Views::Controllers::Images::FieldSlipExtracts
 
     private
 
-    # No polling: nothing is running until a button is pressed. The
-    # observation's photos each get their own scan button -- zbar found
-    # no code anywhere, so only the person can say which photo shows
-    # the slip, and "scan the first image" was a coin toss on a
-    # multi-photo observation.
+    # No polling: nothing is running until the button is pressed.
+    # Scans just THIS photo; picking among the observation's photos is
+    # the observation-scoped scan page's job (linked below), since
+    # which photo shows the slip is a decision about the observation.
     def render_unscanned
-      images = scan_candidates
       render(Components::Panel.new(
                panel_id: "field_slip_extract_none"
              )) do |p|
         p.with_body do
-          trusted_html(unscanned_prompt(images.size))
-          div(class: "d-flex flex-wrap mt-3") do
-            images.each { |image| render_scan_candidate(image) }
-          end
+          trusted_html(:field_slip_extract_none_yet.t)
         end
       end
+      Button(type: :post, name: :field_slip_extract_button.l,
+             target: image_field_slip_extract_path(@image.id))
+      render_all_photos_link
     end
 
-    def scan_candidates
+    def render_all_photos_link
       observation = @image.observations.first
-      observation ? observation.images.to_a : [@image]
-    end
+      return unless observation
 
-    def unscanned_prompt(count)
-      key = if count > 1
-              :field_slip_extract_choose_photo
-            else
-              :field_slip_extract_none_yet
-            end
-      key.t
-    end
-
-    def render_scan_candidate(image)
-      div(class: "mr-4 mb-3 text-center") do
-        render(Components::InteractiveImage.new(image: image, user: @user,
-                                                size: :small, votes: false))
-        Button(type: :post, name: :field_slip_extract_button.l,
-               target: image_field_slip_extract_path(image.id))
+      p(class: "mt-3") do
+        Link(type: :get, name: :field_slip_scan_all_photos.l,
+             target: field_slip_scan_observation_path(observation.id))
       end
     end
 

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-# Where the review page waits for a background extraction (see
-# ExtractFieldSlipJob): a self-refreshing "reading..." panel while the
-# job runs (or is about to -- the QR jobs may still be attaching the
-# slip), and the error with a retry button when the provider failed.
-# Once the extract completes, the reload lands on the review form.
+# The review page's non-form states (see ExtractFieldSlipJob): a
+# self-refreshing "reading..." panel while the job runs, the error
+# with a retry button when the provider failed, and a not-scanned-yet
+# panel with a scan button when no extract exists -- the landing spot
+# for the no-slip-detected flash, and how a zbar-missed slip photo
+# gets read at all. Once an extract completes, the reload (or the
+# next visit) lands on the review form.
 module Views::Controllers::Images::FieldSlipExtracts
   class Status < Views::FullPageBase
     prop :image, ::Image
@@ -14,7 +16,9 @@ module Views::Controllers::Images::FieldSlipExtracts
     def view_template
       add_page_title(:field_slip_extract_status_title.t)
 
-      if @extract&.failed?
+      if @extract.nil?
+        render_unscanned
+      elsif @extract.failed?
         render_failed
       else
         render_pending
@@ -23,6 +27,19 @@ module Views::Controllers::Images::FieldSlipExtracts
     end
 
     private
+
+    # No polling: nothing is running until the button is pressed.
+    def render_unscanned
+      render(Components::Panel.new(
+               panel_id: "field_slip_extract_none"
+             )) do |p|
+        p.with_body do
+          trusted_html(:field_slip_extract_none_yet.t)
+        end
+      end
+      Button(type: :post, name: :field_slip_extract_button.l,
+             target: image_field_slip_extract_path(@image.id))
+    end
 
     def render_pending
       div(data: { controller: "reload-poll" }) do

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -31,7 +31,7 @@ module Views::Controllers::Images::FieldSlipExtracts
                )) do |p|
           p.with_body do
             span(class: "spinner-right mx-2")
-            plain(:field_slip_extract_pending.t)
+            trusted_html(:field_slip_extract_pending.t)
           end
         end
       end
@@ -39,7 +39,7 @@ module Views::Controllers::Images::FieldSlipExtracts
 
     def render_failed
       Alert(level: :danger) do
-        plain(:field_slip_extract_failed.t(error: @extract.error.to_s))
+        trusted_html(:field_slip_extract_failed.t(error: @extract.error.to_s))
       end
       Button(type: :post, name: :field_slip_extract_retry.l,
              target: image_field_slip_extract_path(@image.id))

--- a/app/views/controllers/observations/field_slip_scans/show.rb
+++ b/app/views/controllers/observations/field_slip_scans/show.rb
@@ -8,6 +8,7 @@ module Views::Controllers::Observations::FieldSlipScans
   class Show < Views::FullPageBase
     prop :observation, ::Observation
     prop :user, ::User
+    prop :extracts, _Hash(Integer, ::FieldSlipExtract)
 
     def view_template
       add_page_title(:field_slip_scan_title.t(id: @observation.id))
@@ -36,7 +37,7 @@ module Views::Controllers::Observations::FieldSlipScans
     end
 
     def render_photo_state(image)
-      extract = FieldSlipExtract.find_by(image_id: image.id)
+      extract = @extracts[image.id]
       if extract.nil?
         Button(type: :post, name: :field_slip_extract_button.l,
                target: image_field_slip_extract_path(image.id))

--- a/app/views/controllers/observations/field_slip_scans/show.rb
+++ b/app/views/controllers/observations/field_slip_scans/show.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Every photo of the observation with its field-slip scan state: a
+# scan button for unscanned photos (zbar found no code, so only the
+# person can say which photo shows the slip), a link to the photo's
+# review or status page once a scan exists.
+module Views::Controllers::Observations::FieldSlipScans
+  class Show < Views::FullPageBase
+    prop :observation, ::Observation
+    prop :user, ::User
+
+    def view_template
+      add_page_title(:field_slip_scan_title.t(id: @observation.id))
+
+      render(Components::Panel.new(
+               panel_id: "field_slip_scan_photos"
+             )) do |p|
+        p.with_body do
+          trusted_html(:field_slip_scan_help.t)
+          div(class: "d-flex flex-wrap mt-3") do
+            @observation.images.each { |image| render_photo(image) }
+          end
+        end
+      end
+      render_observation_link
+    end
+
+    private
+
+    def render_photo(image)
+      div(class: "mr-4 mb-3 text-center") do
+        render(Components::InteractiveImage.new(image: image, user: @user,
+                                                size: :small, votes: false))
+        div { render_photo_state(image) }
+      end
+    end
+
+    def render_photo_state(image)
+      extract = FieldSlipExtract.find_by(image_id: image.id)
+      if extract.nil?
+        Button(type: :post, name: :field_slip_extract_button.l,
+               target: image_field_slip_extract_path(image.id))
+      else
+        Link(type: :get, name: state_label(extract),
+             target: edit_image_field_slip_extract_path(image.id))
+      end
+    end
+
+    def state_label(extract)
+      if extract.complete?
+        :field_slip_scan_review.l
+      elsif extract.failed?
+        :field_slip_scan_failed.l
+      else
+        :field_slip_scan_reading.l
+      end
+    end
+
+    def render_observation_link
+      p do
+        Link(type: :get, name: :field_slip_extract_observation_link.l,
+             target: permanent_observation_path(@observation.id))
+      end
+    end
+  end
+end

--- a/app/views/controllers/observations/field_slip_scans/show.rb
+++ b/app/views/controllers/observations/field_slip_scans/show.rb
@@ -17,7 +17,7 @@ module Views::Controllers::Observations::FieldSlipScans
                panel_id: "field_slip_scan_photos"
              )) do |p|
         p.with_body do
-          trusted_html(:field_slip_scan_help.t)
+          plain(:field_slip_scan_help.l)
           div(class: "d-flex flex-wrap mt-3") do
             @observation.images.each { |image| render_photo(image) }
           end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -94,13 +94,13 @@
     {
       "warning_type": "Command Injection",
       "warning_code": 14,
-      "fingerprint": "1c4dceb31ac90677da674e42525855dd50e3b289599e177ed7be5a7c174125cf",
+      "fingerprint": "968f1042f74deaf7c5c6c6c7a05580f8185a8fb9223e8ce90204ae3330026c2c",
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "app/models/image/dhash.rb",
       "line": 75,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "Open3.capture3(\"convert\", \"#{path}[0]\", \"-auto-orient\", \"-colorspace\", \"Gray\", \"-resize\", \"#{9}x#{8}!\", \"-depth\", \"8\", \"gray:-\")",
+      "code": "Open3.capture3(magick_binary, \"#{path}[0]\", \"-auto-orient\", \"-colorspace\", \"Gray\", \"-resize\", \"#{9}x#{8}!\", \"-depth\", \"8\", \"gray:-\")",
       "render_path": null,
       "location": {
         "type": "method",

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2589,7 +2589,7 @@
   field_slip_extract_apply: Save this to the observation
   field_slip_extract_inat: This is an iNaturalist observation id
   field_slip_extract_currently: "Currently: [value]"
-  field_slip_extract_location_guess: "The slip reads [written]. This project already uses [suggestion], which is filled in below -- check it before saving."
+  field_slip_extract_location_guess: "The slip reads [written]. This project already uses [suggestion], which is filled in below — check it before saving."
   field_slip_extract_name_proposed: "Proposed [name] as a name for this observation."
   field_slip_extract_name_needs_approval: The name needs confirming before it can be proposed. The other fields were saved.
   field_slip_extract_confidence: "[level] confidence"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2555,6 +2555,7 @@
   field_slip_constraint_violation: The selected observation violates one or more project constraints
   field_slip_project_not_member: You are not a member of the [title] project, so you cannot change which observations it contains.
   field_slip_created: Field slip [code] was successfully created.
+  field_slip_attached: Field slip [code] was attached to this observation.
   field_slip_create_obs: Create New Observation
   field_slip_quick_create_obs: Quick Create
   field_slip_creator: Creator

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2603,7 +2603,12 @@
   field_slip_extract_attach_code: attach this field slip
   field_slip_extract_code_matches: matches the attached field slip
   field_slip_extract_none_yet: This photo has not been scanned for field slip data yet.
-  field_slip_extract_choose_photo: No photo of this observation has been scanned for field slip data yet. Choose the one that shows the field slip and scan it.
+  field_slip_scan_title: "Field Slip Scans for Observation [id]"
+  field_slip_scan_help: Scan the photo that shows the field slip. Photos already scanned link to their results.
+  field_slip_scan_review: review scan results
+  field_slip_scan_reading: reading in progress
+  field_slip_scan_failed: scan failed - view / retry
+  field_slip_scan_all_photos: Choose among all of this observation's photos
   observation_no_field_slip_detected: 'No field slip code was automatically detected in the photos. If one of them shows a field slip, you can "scan it":[url].'
   field_slip_extract_code_differs: differs from the attached field slip!
   field_slip_extract_attach_failed: "Could not attach field slip [code]: [reason]."

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2602,6 +2602,8 @@
   field_slip_extract_observation_link: Go to the observation
   field_slip_extract_attach_code: attach this field slip
   field_slip_extract_code_matches: matches the attached field slip
+  field_slip_extract_none_yet: This photo has not been scanned for field slip data yet.
+  observation_no_field_slip_detected: 'No field slip code was automatically detected in the photos. If one of them shows a field slip, you can "scan it":[url].'
   field_slip_extract_code_differs: differs from the attached field slip!
   field_slip_extract_attach_failed: "Could not attach field slip [code]: [reason]."
   field_slip_extract_project_joined: Added the observation to [title], whose constraints it now satisfies.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2602,6 +2602,8 @@
   field_slip_extract_observation_link: Go to the observation
   field_slip_extract_attach_code: attach this field slip
   field_slip_extract_attach_failed: "Could not attach field slip [code]: [reason]."
+  field_slip_extract_project_joined: Added the observation to [title], whose constraints it now satisfies.
+  field_slip_extract_project_blocked: The observation is still not in [title] because it does not satisfy that project's constraints (location, dates, or species).
   field_slip_extract_add_alias: Add this abbreviation
   field_slip_extract_code_mismatch: "The slip in this photo reads [read], but the observation is attached to field slip [attached]. Check that this is the right photo before saving."
   field_slip_extract_unknown_alias: "No project abbreviation is defined for [name], so the location was left as written."

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2603,6 +2603,7 @@
   field_slip_extract_attach_code: attach this field slip
   field_slip_extract_code_matches: matches the attached field slip
   field_slip_extract_none_yet: This photo has not been scanned for field slip data yet.
+  field_slip_extract_choose_photo: No photo of this observation has been scanned for field slip data yet. Choose the one that shows the field slip and scan it.
   observation_no_field_slip_detected: 'No field slip code was automatically detected in the photos. If one of them shows a field slip, you can "scan it":[url].'
   field_slip_extract_code_differs: differs from the attached field slip!
   field_slip_extract_attach_failed: "Could not attach field slip [code]: [reason]."

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2601,6 +2601,8 @@
   field_slip_extract_retry: Try Again
   field_slip_extract_observation_link: Go to the observation
   field_slip_extract_attach_code: attach this field slip
+  field_slip_extract_code_matches: matches the attached field slip
+  field_slip_extract_code_differs: differs from the attached field slip!
   field_slip_extract_attach_failed: "Could not attach field slip [code]: [reason]."
   field_slip_extract_project_joined: Added the observation to [title], whose constraints it now satisfies.
   field_slip_extract_project_blocked: The observation is still not in [title] because it does not satisfy that project's constraints (location, dates, or species).

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2600,6 +2600,8 @@
   field_slip_extract_pending: Reading the field slip. This usually takes about 15 seconds; this page refreshes itself and will show the results when they are ready.
   field_slip_extract_retry: Try Again
   field_slip_extract_observation_link: Go to the observation
+  field_slip_extract_attach_code: attach this field slip
+  field_slip_extract_attach_failed: "Could not attach field slip [code]: [reason]."
   field_slip_extract_add_alias: Add this abbreviation
   field_slip_extract_code_mismatch: "The slip in this photo reads [read], but the observation is attached to field slip [attached]. Check that this is the right photo before saving."
   field_slip_extract_unknown_alias: "No project abbreviation is defined for [name], so the location was left as written."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -627,6 +627,7 @@ MushroomObserver::Application.routes.draw do
                 only: [:show, :new, :create, :edit, :update, :destroy],
                 shallow: true, controller: "observations/external_links"
 
+      get("field_slip_scan", to: "observations/field_slip_scans#show")
       get("map", to: "observations/maps#show")
       get("map_popup", to: "observations/maps#popup")
       get("suggestions", to: "observations/namings/suggestions#show",

--- a/script/attach_slips_from_extracts.rb
+++ b/script/attach_slips_from_extracts.rb
@@ -32,25 +32,28 @@ class SlipExtractRepairer
 
   def run
     puts(@apply ? "APPLYING changes." : "DRY RUN.")
-    candidates.each { |obs, image, extract| repair(obs, image, extract) }
+    # Streamed rather than loaded whole: every completed extract on
+    # the site flows through here.
+    FieldSlipExtract.where(status: "complete").includes(:image).
+      find_each do |extract|
+        obs, image = candidate_for(extract)
+        repair(obs, image, extract) if obs
+      end
     summarize
   end
 
   private
 
-  # Slip-less observations whose images carry a completed extract that
-  # read a code.
-  def candidates
-    FieldSlipExtract.where(status: "complete").includes(:image).
-      filter_map do |extract|
-        obs = extract.observation
-        next unless obs && obs.occurrence_id.nil?
+  # The slip-less observation behind an extract that read a code, or
+  # nil when there is nothing to repair.
+  def candidate_for(extract)
+    obs = extract.observation
+    return nil unless obs && obs.occurrence_id.nil?
 
-        code = extract.value_for(extract.template.code_field).to_s.strip
-        next if code.blank?
+    code = extract.value_for(extract.template.code_field).to_s.strip
+    return nil if code.blank?
 
-        [obs, extract.image, extract]
-      end
+    [obs, extract.image]
   end
 
   def repair(obs, image, extract)

--- a/script/attach_slips_from_extracts.rb
+++ b/script/attach_slips_from_extracts.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Attaches slip-less observations to the field slip their completed
+# extraction read, for observations the QR decode missed (zbar failed
+# on ~27% of the 2026 CMS fair's slip photos while the extraction read
+# the printed code off nearly all of them). One-time repair for
+# observations created before ExtractFieldSlipJob learned to do this
+# itself; safe to re-run -- already-linked observations are skipped.
+#
+#   bin/rails runner script/attach_slips_from_extracts.rb
+#   bin/rails runner script/attach_slips_from_extracts.rb --apply
+#
+# Uses FieldSlip::Attacher, so the guards hold: never an observation
+# that has a slip, never a slip already in use, never a closed
+# project's existing slip.
+class SlipExtractRepairer
+  USAGE = "Usage: bin/rails runner " \
+          "script/attach_slips_from_extracts.rb [--apply]"
+
+  def self.from_argv(argv)
+    apply = argv.delete("--apply").present?
+    abort("#{USAGE}\nUnrecognized: #{argv.join(" ")}") if argv.any?
+
+    new(apply: apply)
+  end
+
+  def initialize(apply:)
+    @apply = apply
+    @tally = Hash.new(0)
+  end
+
+  def run
+    puts(@apply ? "APPLYING changes." : "DRY RUN.")
+    candidates.each { |obs, image, extract| repair(obs, image, extract) }
+    summarize
+  end
+
+  private
+
+  # Slip-less observations whose images carry a completed extract that
+  # read a code.
+  def candidates
+    FieldSlipExtract.where(status: "complete").includes(:image).
+      filter_map do |extract|
+        obs = extract.observation
+        next unless obs && obs.occurrence_id.nil?
+
+        code = extract.value_for(extract.template.code_field).to_s.strip
+        next if code.blank?
+
+        [obs, extract.image, extract]
+      end
+  end
+
+  def repair(obs, image, extract)
+    code = extract.value_for(extract.template.code_field).to_s.strip
+    result =
+      if @apply
+        FieldSlip::Attacher.attach(observation: obs, code: code,
+                                   user: obs.user)
+      else
+        predicted_result(obs, code)
+      end
+    @tally[result] += 1
+    puts(format("  %-15s obs %-8d img %-8d %s",
+                result, obs.id, image.id, code))
+  end
+
+  # The same checks Attacher runs, minus the writes, so the dry run
+  # reports what apply would do.
+  def predicted_result(obs, code)
+    return :already_linked if obs.occurrence_id
+
+    existing = FieldSlip.find_by(code: code.upcase)
+    return :in_use if existing&.occurrence
+    return :closed_project if barred?(existing, obs.user)
+    return :invalid unless code.match?(/[^\d.-]/)
+
+    :attached
+  end
+
+  def barred?(slip, user)
+    project = slip&.project
+    project && !project.member?(user) && !project.can_join?(user)
+  end
+
+  def summarize
+    puts("Results: #{@tally.map { |k, v| "#{k}=#{v}" }.join(", ")}")
+    return if @apply
+
+    puts("Dry run - nothing written. To apply: bin/rails runner " \
+         "script/attach_slips_from_extracts.rb --apply")
+  end
+end
+
+SlipExtractRepairer.from_argv(ARGV).run

--- a/test/classes/field_slip/extractor/context_test.rb
+++ b/test/classes/field_slip/extractor/context_test.rb
@@ -28,6 +28,27 @@ class FieldSlip::Extractor::ContextTest < UnitTestCase
     assert_equal(@obs.field_slip&.code, context_for.field_slip_code)
   end
 
+  # An observation can sit in several projects (the obs form pre-checks
+  # the last one used); the attached slip says which event it belongs
+  # to, and the aliases and template must follow the slip. Reported
+  # against a NEMF slip reviewed through another project's aliases.
+  def test_project_prefers_the_attached_slips_project
+    join_project
+    other = projects(:open_membership_project)
+    # update_columns: a real project change cascades the observations
+    # along; the test needs the divergence.
+    @obs.field_slip.update_columns(project_id: other.id)
+
+    assert_equal(other, context_for(@obs.reload).project)
+  end
+
+  def test_project_falls_back_to_the_observations_first_project
+    join_project
+    @obs.field_slip.update_columns(project_id: nil)
+
+    assert_equal(@project, context_for(@obs.reload).project)
+  end
+
   # The abbreviation table is the project's own aliases rather than
   # anything written into the prompt -- that is what lets an alias added
   # during review improve the next slip.
@@ -67,7 +88,11 @@ class FieldSlip::Extractor::ContextTest < UnitTestCase
   end
 
   def test_aliases_empty_without_a_project
-    assert_empty(context_for.aliases("Location"))
+    # The fixture slip carries a project; "no project" now means the
+    # slip's is gone too.
+    @obs.field_slip.update_columns(project_id: nil)
+
+    assert_empty(context_for(@obs.reload).aliases("Location"))
   end
 
   # An alias whose target has been deleted would otherwise render as a

--- a/test/classes/field_slip/qr_decoder_test.rb
+++ b/test/classes/field_slip/qr_decoder_test.rb
@@ -68,10 +68,57 @@ class FieldSlip::QRDecoderTest < UnitTestCase
     end
   end
 
+  # The test env resolves image URLs to file:// -- nothing local and
+  # nothing fetchable means nil, with no fetch attempted.
   def test_slip_code_in_nil_without_a_local_file
     FieldSlip::QRDecoder.stub(:available?, true) do
       Image::LocalFile.stub(:path, nil) do
         assert_nil(FieldSlip::QRDecoder.slip_code_in(images(:in_situ_image)))
+      end
+    end
+  end
+
+  # A local copy can vanish within seconds of upload (transfer to the
+  # image server can outrun the scan); the size gets fetched from the
+  # image server instead.
+  def test_fetches_a_no_longer_local_size_from_the_image_server
+    image = images(:in_situ_image)
+    file = Tempfile.new(["qr", ".jpg"])
+    file.binmode
+    file.write("jpegbytes")
+    file.rewind
+    response = Struct.new(:file).new(file)
+    fake_url = Struct.new(:url).new("https://images.example.com/1280/1.jpg")
+
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:local_file, nil) do
+        image.stub(:image_url, fake_url) do
+          RestClient::Request.stub(:execute, response) do
+            FieldSlip::QRDecoder.stub(:scan, ["OPEN-0219"]) do
+              assert_equal("OPEN-0219",
+                           FieldSlip::QRDecoder.slip_code_in(image))
+            end
+          end
+        end
+      end
+    end
+  end
+
+  # An archived original is gone from the image server deliberately;
+  # the fetch 404s and the scan counts it as a miss, never reaching
+  # into the archive.
+  def test_a_failed_fetch_is_a_miss_not_an_error
+    image = images(:in_situ_image)
+    fake_url = Struct.new(:url).new("https://images.example.com/orig/1.jpg")
+    raise_404 = ->(*) { raise(RestClient::NotFound) }
+
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:local_file, nil) do
+        image.stub(:image_url, fake_url) do
+          RestClient::Request.stub(:execute, raise_404) do
+            assert_nil(FieldSlip::QRDecoder.slip_code_in(image))
+          end
+        end
       end
     end
   end

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -58,12 +58,39 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
     assert_not(row.savable, "it becomes a naming, not an attribute")
   end
 
-  def test_review_only_rows_are_neither_editable_nor_savable
+  # A linked observation has nothing to attach, so the code stays a
+  # cross-check.
+  def test_code_row_is_review_only_when_the_observation_has_a_slip
+    assert_not_nil(@obs.occurrence_id, "premise: fixture is slip-linked")
+
     review = build(fields: { "Field Slip Code" => "NEMF-10222" })
     row = row_for(review, "Field Slip Code")
 
     assert_not(row.editable)
     assert_not(row.savable)
+  end
+
+  # A slip-less observation's code row becomes the attach control: the
+  # background job usually attached already, so reaching review without
+  # a slip means a case needing human judgment.
+  def test_code_row_attaches_when_the_observation_has_no_slip
+    @obs.update!(occurrence: nil)
+
+    review = build(fields: { "Field Slip Code" => "NEMF-10222" })
+    row = row_for(review, "Field Slip Code")
+
+    assert(row.code_row?)
+    assert(row.editable, "a misread code gets corrected here")
+    assert(row.savable)
+    assert(row.default_use?)
+  end
+
+  def test_code_row_stays_review_only_when_nothing_was_read
+    @obs.update!(occurrence: nil)
+
+    review = build(fields: { "Collector" => "A" })
+
+    assert_not(row_for(review, "Field Slip Code").savable)
   end
 
   # ---------- current values ----------

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -427,6 +427,22 @@ module Images
                       @obs)
     end
 
+    # A pre-existing spare slip gets "attached", not "created".
+    def test_update_attaching_an_existing_spare_slip_says_attached
+      @obs.update!(occurrence: nil)
+      FieldSlip.find_or_create_by_code("OPEN-0219", @obs.user)
+      record_extract(fields: { "Field Slip Code" => "OPEN-0219" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Field Slip Code" => "1" },
+                             value: { "Field Slip Code" => "OPEN-0219" } })
+
+      assert_equal("OPEN-0219", @obs.reload.field_slip.code)
+      assert_flash([[:field_slip_attached, { code: "OPEN-0219" }],
+                    :field_slip_extract_saved])
+    end
+
     # The reviewer's edit wins here too: a misread code gets corrected
     # in the box and the corrected one attaches.
     def test_update_attaches_the_edited_code_not_the_read_one

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -450,6 +450,61 @@ module Images
       assert_flash_warning
     end
 
+    # The reported bug: the join decision at slip-attach time ran
+    # against the create form's default date and locality, silently
+    # keeping the observation out of its slip's project -- and the
+    # review then fixed exactly those fields. Re-evaluating after the
+    # apply joins the project.
+    def test_update_joins_the_slips_project_once_constraints_are_met
+      project = projects(:open_membership_project)
+      project.update!(location: locations(:albion),
+                      start_date: Date.parse("2026-07-30"),
+                      end_date: Date.parse("2026-08-02"))
+      project.join(@obs.user)
+      @obs.update!(occurrence: nil)
+      slip = FieldSlip.find_or_create_by_code("OPEN-0950", @obs.user)
+      @obs.field_slip = slip
+      @obs.save!
+
+      assert(project.violates_constraints?(@obs),
+             "premise: pre-review data violates the constraints")
+      assert_not_includes(project.observations, @obs)
+
+      record_extract(fields: { "Date" => "2026-08-01",
+                               "Location" => locations(:albion).name })
+      login_as_site_admin
+
+      put(:update,
+          params: { image_id: @image.id,
+                    use: { "Date" => "1", "Location" => "1" },
+                    value: { "Date" => "2026-08-01",
+                             "Location" => locations(:albion).name } })
+
+      assert_includes(project.observations.reload, @obs.reload)
+      assert_flash_success
+    end
+
+    def test_update_warns_when_the_review_still_violates_constraints
+      project = projects(:open_membership_project)
+      project.update!(location: locations(:albion),
+                      start_date: Date.parse("2026-07-30"),
+                      end_date: Date.parse("2026-08-02"))
+      project.join(@obs.user)
+      @obs.update!(occurrence: nil)
+      slip = FieldSlip.find_or_create_by_code("OPEN-0951", @obs.user)
+      @obs.field_slip = slip
+      @obs.save!
+      record_extract(fields: { "Collector" => "A. W. Wilson" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Collector" => "1" },
+                             value: { "Collector" => "A. W. Wilson" } })
+
+      assert_not_includes(project.observations.reload, @obs.reload)
+      assert_flash_warning
+    end
+
     def test_update_never_moves_a_linked_observation
       slip = FieldSlip.find_or_create_by_code("OPEN-0800", @obs.user)
       @obs.update!(occurrence: nil)

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -401,5 +401,68 @@ module Images
 
       assert_redirected_to(image_path(@image.id))
     end
+
+    # ---------- attaching the ticked code ----------
+
+    def test_update_attaches_a_ticked_code_to_a_slipless_observation
+      @obs.update!(occurrence: nil)
+      record_extract(fields: { "Field Slip Code" => "OPEN-0219" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Field Slip Code" => "1" },
+                             value: { "Field Slip Code" => "OPEN-0219" } })
+
+      assert_equal("OPEN-0219", @obs.reload.field_slip.code)
+      assert_includes(projects(:open_membership_project).observations.reload,
+                      @obs)
+    end
+
+    # The reviewer's edit wins here too: a misread code gets corrected
+    # in the box and the corrected one attaches.
+    def test_update_attaches_the_edited_code_not_the_read_one
+      @obs.update!(occurrence: nil)
+      record_extract(fields: { "Field Slip Code" => "OPEN-9999" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Field Slip Code" => "1" },
+                             value: { "Field Slip Code" => "OPEN-0220" } })
+
+      assert_equal("OPEN-0220", @obs.reload.field_slip.code)
+    end
+
+    def test_update_warns_when_the_ticked_code_cannot_attach
+      @obs.update!(occurrence: nil)
+      other = observations(:coprinus_comatus_obs)
+      other.update!(occurrence: nil)
+      slip = FieldSlip.find_or_create_by_code("OPEN-0500", other.user)
+      other.field_slip = slip
+      other.save!
+      record_extract(fields: { "Field Slip Code" => "OPEN-0500" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Field Slip Code" => "1" },
+                             value: { "Field Slip Code" => "OPEN-0500" } })
+
+      assert_nil(@obs.reload.occurrence)
+      assert_flash_warning
+    end
+
+    def test_update_never_moves_a_linked_observation
+      slip = FieldSlip.find_or_create_by_code("OPEN-0800", @obs.user)
+      @obs.update!(occurrence: nil)
+      @obs.field_slip = slip
+      @obs.save!
+      record_extract(fields: { "Field Slip Code" => "OPEN-0219" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Field Slip Code" => "1" },
+                             value: { "Field Slip Code" => "OPEN-0219" } })
+
+      assert_equal("OPEN-0800", @obs.reload.field_slip.code)
+    end
   end
 end

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -113,13 +113,21 @@ module Images
 
     # ---------- edit ----------
 
-    def test_edit_without_an_extract_redirects
+    # No extract renders the not-scanned-yet page with the scan button
+    # -- the landing spot for the no-slip-detected flash, and how a
+    # zbar-missed slip photo gets read at all. No polling: nothing is
+    # running until the button is pressed.
+    def test_edit_without_an_extract_offers_the_scan
       login_as_site_admin
 
       get(:edit, params: { image_id: @image.id })
 
-      assert_redirected_to(image_path(@image.id))
-      assert_flash_error
+      assert_response(:success)
+      assert_select(
+        "form[action='#{image_field_slip_extract_path(@image.id)}'] " \
+        "button[type='submit']"
+      )
+      assert_select("[data-controller='reload-poll']", count: 0)
     end
 
     def test_edit_shows_a_pending_read_with_self_refresh
@@ -149,13 +157,14 @@ module Images
     # The observation-create redirect arrives before the QR jobs have
     # attached anything; `await=1` is what makes an extract-less page
     # wait instead of bouncing.
-    def test_edit_awaits_detection_when_asked
+    # The create redirect appends await=1; the page renders the same
+    # meaningful state with or without it.
+    def test_edit_with_await_param_renders_the_same_page
       login_as_site_admin
 
       get(:edit, params: { image_id: @image.id, await: 1 })
 
       assert_response(:success)
-      assert_select("[data-controller='reload-poll']")
     end
 
     # ...and can land before the observation is even in its project,

--- a/test/controllers/observations/field_slip_scans_controller_test.rb
+++ b/test/controllers/observations/field_slip_scans_controller_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Observations
+  class FieldSlipScansControllerTest < FunctionalTestCase
+    def setup
+      super
+      @obs = observations(:minimal_unknown_obs)
+      @image = images(:in_situ_image)
+      @obs.images << @image unless @obs.images.include?(@image)
+      @project = projects(:eol_project)
+      @project.observations << @obs unless @project.observations.include?(@obs)
+    end
+
+    def test_show_requires_login
+      get(:show, params: { id: @obs.id })
+
+      assert_redirected_to(new_account_login_path)
+    end
+
+    def test_show_refused_for_an_ordinary_user
+      login("katrina")
+
+      get(:show, params: { id: @obs.id })
+
+      assert_redirected_to(permanent_observation_path(@obs.id))
+      assert_flash_error
+    end
+
+    # Every photo gets a scan button when unscanned; a photo with an
+    # extract links to its review/status page instead.
+    def test_show_offers_a_scan_button_per_unscanned_photo
+      login("mary")
+
+      assert(@project.is_admin?(mary), "premise: mary administers it")
+      get(:show, params: { id: @obs.id })
+
+      assert_response(:success)
+      @obs.images.each do |image|
+        assert_select(
+          "form[action='#{image_field_slip_extract_path(image.id)}'] " \
+          "button[type='submit']"
+        )
+      end
+    end
+
+    def test_show_links_scanned_photos_to_their_results
+      FieldSlipExtract.start!(image: @image, user: mary)
+      login("mary")
+
+      get(:show, params: { id: @obs.id })
+
+      assert_response(:success)
+      assert_select(
+        "a[href='#{edit_image_field_slip_extract_path(@image.id)}']"
+      )
+      assert_select(
+        "form[action='#{image_field_slip_extract_path(@image.id)}']",
+        count: 0
+      )
+    end
+
+    def test_show_with_an_unknown_observation_redirects
+      login("mary")
+
+      get(:show, params: { id: -1 })
+
+      assert_redirected_to(observations_path)
+      assert_flash_error
+    end
+  end
+end

--- a/test/controllers/observations/field_slip_scans_controller_test.rb
+++ b/test/controllers/observations/field_slip_scans_controller_test.rb
@@ -53,12 +53,42 @@ module Observations
 
       assert_response(:success)
       assert_select(
-        "a[href='#{edit_image_field_slip_extract_path(@image.id)}']"
+        "a[href='#{edit_image_field_slip_extract_path(@image.id)}']",
+        text: :field_slip_scan_reading.l
       )
       assert_select(
         "form[action='#{image_field_slip_extract_path(@image.id)}']",
         count: 0
       )
+    end
+
+    def test_show_labels_failed_and_completed_scans
+      FieldSlipExtract.fail!(image: @image, user: mary, error: "boom")
+      login("mary")
+
+      get(:show, params: { id: @obs.id })
+
+      assert_select("a", text: :field_slip_scan_failed.l)
+
+      FieldSlipExtract.record(
+        image: @image, user: mary, prompt_version: "1",
+        result: FieldSlip::Extractor::Result.new(
+          provider: "g", model: "m", raw: {}, template: "mo",
+          fields: { "Collector" => "A" }, confidence: {}
+        )
+      )
+      get(:show, params: { id: @obs.id })
+
+      assert_select("a", text: :field_slip_scan_review.l)
+    end
+
+    def test_show_allowed_for_a_site_admin
+      login("rolf")
+      make_admin
+
+      get(:show, params: { id: @obs.id })
+
+      assert_response(:success)
     end
 
     def test_show_with_an_unknown_observation_redirects

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -1958,6 +1958,41 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert_nil(FieldSlipExtract.find_by(image_id: image.id))
   end
 
+  # Most observations in a slip-prefix project eventually carry a
+  # slip, so a scan that found no code warns -- with a link to the
+  # scan page -- instead of staying silent (zbar missed ~27% of slip
+  # photos at the 2026 CMS fair).
+  def test_create_warns_when_no_slip_was_detected
+    image = images(:in_situ_image)
+    project = projects(:open_membership_project)
+    project.join(rolf)
+    make_slip_project_admin(rolf)
+    login("rolf")
+
+    params = slip_photo_params(image)
+    params[:observation] =
+      params[:observation].merge(project_ids: [project.id.to_s])
+    with_decoded_slip_code(nil) do
+      post(:create, params: params)
+    end
+
+    assert_response(:redirect)
+    assert_flash_warning
+  end
+
+  def test_create_does_not_warn_outside_prefix_projects
+    image = images(:in_situ_image)
+    make_slip_project_admin(rolf)
+    login("rolf")
+
+    with_decoded_slip_code(nil) do
+      post(:create, params: slip_photo_params(image))
+    end
+
+    assert_response(:redirect)
+    assert_flash_success
+  end
+
   # Ordinary uploads never pay for the scan or get detoured: the gate
   # is admin-ship of a project with a field-slip prefix.
   def test_create_does_not_detour_ordinary_uploads

--- a/test/jobs/extract_field_slip_job_test.rb
+++ b/test/jobs/extract_field_slip_job_test.rb
@@ -59,12 +59,15 @@ class ExtractFieldSlipJobTest < ActiveJob::TestCase
 
   # A provider failure used to leave nothing behind but a log line;
   # now the row says what went wrong, where the retry button can see
-  # it.
+  # it. The logger is stubbed because the test env logs errors to
+  # stdout, and this deliberate failure would print into the test run.
   def test_perform_records_a_failure_with_its_error
     ExtractFieldSlipJob.request(image: @image, user: users(:rolf))
 
     FieldSlip::Extractor.stub(:default, failing_extractor) do
-      ExtractFieldSlipJob.perform_now(@image.id, users(:rolf).id)
+      Rails.logger.stub(:error, nil) do
+        ExtractFieldSlipJob.perform_now(@image.id, users(:rolf).id)
+      end
     end
 
     extract = FieldSlipExtract.find_by(image_id: @image.id)

--- a/test/jobs/extract_field_slip_job_test.rb
+++ b/test/jobs/extract_field_slip_job_test.rb
@@ -103,10 +103,19 @@ class ExtractFieldSlipJobTest < ActiveJob::TestCase
     )
   end
 
+  # The fixture image hangs off several observations; the attach path
+  # only acts on an unambiguous one, so the attach tests isolate it.
+  def isolate_image_to_obs
+    (@image.observations.to_a - [@obs]).each do |other|
+      other.images.delete(@image)
+    end
+  end
+
   # zbar missed ~27% of the CMS fair's slip photos; the extraction read
   # the printed code off nearly all of them. A successful read now
   # attaches the slip when the observation has none.
   def test_a_read_code_attaches_the_slip_to_a_slipless_observation
+    isolate_image_to_obs
     @obs.update!(occurrence: nil)
 
     FieldSlip::Extractor.stub(:default,
@@ -120,6 +129,7 @@ class ExtractFieldSlipJobTest < ActiveJob::TestCase
   end
 
   def test_a_read_code_never_touches_a_linked_observation
+    isolate_image_to_obs
     @obs.update!(occurrence: nil)
     slip = FieldSlip.find_or_create_by_code("OPEN-0800", @obs.user)
     @obs.field_slip = slip
@@ -133,7 +143,25 @@ class ExtractFieldSlipJobTest < ActiveJob::TestCase
     assert_equal("OPEN-0800", @obs.reload.field_slip.code)
   end
 
+  # An image on several observations makes "whose slip is this?"
+  # ambiguous, and a background guess would consume the slip for the
+  # right one -- only the review's human decides those.
+  def test_an_ambiguous_image_attaches_nothing
+    @obs.update!(occurrence: nil)
+
+    assert_operator(@image.observations.count, :>, 1,
+                    "premise: the fixture image is shared")
+
+    FieldSlip::Extractor.stub(:default,
+                              fake_extractor(result_with_code("OPEN-0219"))) do
+      ExtractFieldSlipJob.perform_now(@image.id, users(:rolf).id)
+    end
+
+    assert_nil(@obs.reload.occurrence)
+  end
+
   def test_a_read_without_a_code_attaches_nothing
+    isolate_image_to_obs
     @obs.update!(occurrence: nil)
 
     FieldSlip::Extractor.stub(:default, fake_extractor(result)) do

--- a/test/jobs/extract_field_slip_job_test.rb
+++ b/test/jobs/extract_field_slip_job_test.rb
@@ -93,4 +93,53 @@ class ExtractFieldSlipJobTest < ActiveJob::TestCase
 
     assert_nil(FieldSlipExtract.find_by(image_id: @image.id))
   end
+
+  # ---------- attaching the read code ----------
+
+  def result_with_code(code)
+    FieldSlip::Extractor::Result.new(
+      provider: "gemini", model: "m", raw: {},
+      fields: { "Field Slip Code" => code }, confidence: {}, template: "mo"
+    )
+  end
+
+  # zbar missed ~27% of the CMS fair's slip photos; the extraction read
+  # the printed code off nearly all of them. A successful read now
+  # attaches the slip when the observation has none.
+  def test_a_read_code_attaches_the_slip_to_a_slipless_observation
+    @obs.update!(occurrence: nil)
+
+    FieldSlip::Extractor.stub(:default,
+                              fake_extractor(result_with_code("OPEN-0219"))) do
+      ExtractFieldSlipJob.perform_now(@image.id, users(:rolf).id)
+    end
+
+    assert_equal("OPEN-0219", @obs.reload.field_slip.code)
+    assert_includes(projects(:open_membership_project).observations.reload,
+                    @obs)
+  end
+
+  def test_a_read_code_never_touches_a_linked_observation
+    @obs.update!(occurrence: nil)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0800", @obs.user)
+    @obs.field_slip = slip
+    @obs.save!
+
+    FieldSlip::Extractor.stub(:default,
+                              fake_extractor(result_with_code("OPEN-0219"))) do
+      ExtractFieldSlipJob.perform_now(@image.id, users(:rolf).id)
+    end
+
+    assert_equal("OPEN-0800", @obs.reload.field_slip.code)
+  end
+
+  def test_a_read_without_a_code_attaches_nothing
+    @obs.update!(occurrence: nil)
+
+    FieldSlip::Extractor.stub(:default, fake_extractor(result)) do
+      ExtractFieldSlipJob.perform_now(@image.id, users(:rolf).id)
+    end
+
+    assert_nil(@obs.reload.occurrence)
+  end
 end

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -234,6 +234,23 @@ class FieldSlipExtractTest < UnitTestCase
     assert_nil(record(fields: {}).unknown_location_alias)
   end
 
+  # The applier resolves aliases across every project the observation
+  # is in, so an alias defined in a sibling project (not the slip's
+  # own) must not warn either -- the warning may never contradict what
+  # applying would do.
+  def test_unknown_location_alias_consults_all_the_obs_projects
+    sibling = projects(:eol_project)
+    sibling.observations << @obs unless sibling.observations.include?(@obs)
+    @obs.field_slip.update_columns(
+      project_id: projects(:open_membership_project).id
+    )
+    ProjectAlias.create!(project: sibling, name: "EB2",
+                         target: locations(:albion))
+
+    assert_nil(record(fields: { "Location" => "EB2" }).
+               reload.unknown_location_alias)
+  end
+
   # The reported bug: an observation in two projects warned "no
   # abbreviation defined for EB2" although the slip's own project
   # defined it -- the check consulted `projects.first` instead of the

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -234,6 +234,23 @@ class FieldSlipExtractTest < UnitTestCase
     assert_nil(record(fields: {}).unknown_location_alias)
   end
 
+  # The reported bug: an observation in two projects warned "no
+  # abbreviation defined for EB2" although the slip's own project
+  # defined it -- the check consulted `projects.first` instead of the
+  # attached slip's project.
+  def test_unknown_location_alias_consults_the_slips_project
+    project = projects(:eol_project)
+    project.observations << @obs unless project.observations.include?(@obs)
+    slip_project = projects(:open_membership_project)
+    @obs.field_slip.update_columns(project_id: slip_project.id)
+    ProjectAlias.create!(project: slip_project, name: "EB2",
+                         target: locations(:albion))
+
+    extract = record(fields: { "Location" => "EB2" })
+
+    assert_nil(extract.reload.unknown_location_alias)
+  end
+
   # A full MO location name is not an unknown abbreviation, alias or no
   # alias -- warning about one would tell the reviewer that something MO
   # already knows is unrecognized, and offer to define an alias for it.

--- a/test/models/image/dhash_test.rb
+++ b/test/models/image/dhash_test.rb
@@ -11,6 +11,16 @@ class Image::DhashTest < UnitTestCase
     skip("ImageMagick `convert` not available")
   end
 
+  # An IMv6-only host (the production servers) has no `magick`.
+  def test_magick_binary_falls_back_to_convert_without_imv7
+    Image::Dhash.instance_variable_set(:@magick_binary, nil)
+    Image::Dhash.stub(:system, false) do
+      assert_equal("convert", Image::Dhash.send(:magick_binary))
+    end
+  ensure
+    Image::Dhash.instance_variable_set(:@magick_binary, nil)
+  end
+
   def test_from_file_is_stable
     hash = Image::Dhash.from_file(FIXTURE)
 

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -300,6 +300,9 @@ module Views::Controllers::Images::FieldSlipExtracts
 
       assert_html(html,
                   "input[name='value[Location]'][value='#{target.name}']")
+      # The guess message renders its .t markup (the em dash) rather
+      # than a double-escaped "&#8212;" entity.
+      assert_html(html, ".alert-warning", text: "below — check")
     end
 
     def test_locality_keeps_what_was_written_when_nothing_matches

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -260,8 +260,7 @@ module Views::Controllers::Images::FieldSlipExtracts
       html = render_page(slip_present: true, template_matched: false)
 
       assert_html(html, ".alert-danger",
-                  text: :field_slip_extract_template_mismatch.t.
-                        as_displayed[0, 40])
+                  text: :field_slip_extract_template_mismatch.l[0, 40])
     end
 
     def test_no_mismatch_flag_for_a_matching_read

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -148,12 +148,18 @@ module Views::Controllers::Images::FieldSlipExtracts
 
       assert_includes(html, "NEMF-99999")
       assert_includes(html, @obs.field_slip.code)
+      # The row itself states the check's outcome, not the generic
+      # "cross-check only" that read as "nothing was read".
+      assert_html(html, "td small",
+                  text: :field_slip_extract_code_differs.l)
     end
 
     def test_no_code_flag_when_they_agree
       html = render_page(fields: { "Field Slip Code" => @obs.field_slip.code })
 
       assert_no_html(html, ".alert-danger")
+      assert_html(html, "td small",
+                  text: :field_slip_extract_code_matches.l)
     end
 
     # Naming the undefined abbreviation is what lets an admin add it,

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -141,6 +141,17 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_html(html, "input[name='use[Collector]'][checked]")
     end
 
+    # A field with no observation target and no attach action (dbg's
+    # "State" box) gets the plain check-only cell, not a save checkbox.
+    def test_a_targetless_field_renders_check_only
+      html = render_page(template: "dbg",
+                         fields: { "State" => "Colorado" })
+
+      assert_no_html(html, "input[name='use[State]']")
+      assert_html(html, "td small",
+                  text: :field_slip_extract_check_only.l)
+    end
+
     # ---------- flags ----------
 
     def test_flags_a_code_that_disagrees_with_the_attached_slip

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -4,6 +4,12 @@ require("test_helper")
 
 module Views::Controllers::Images::FieldSlipExtracts
   class EditTest < ComponentTestCase
+    # A proxy, not an include: including url_helpers makes MiniTest
+    # pick up route helpers named test_* as test methods.
+    def routes
+      Rails.application.routes.url_helpers
+    end
+
     def setup
       super
       @user = users(:rolf)
@@ -159,6 +165,23 @@ module Views::Controllers::Images::FieldSlipExtracts
 
       assert_includes(html, "EB2")
       assert_html(html, "a[href*='aliases/new']")
+    end
+
+    # The reported bug's other half: the Add-abbreviation link went to
+    # whichever other project the observation was in, not the slip's.
+    def test_alias_link_targets_the_slips_project
+      @project.observations << @obs unless @project.observations.include?(@obs)
+      slip_project = projects(:open_membership_project)
+      @obs.field_slip.update_columns(project_id: slip_project.id)
+
+      html = render_page(fields: { "Location" => "EB2" })
+
+      assert_html(
+        html,
+        "a[href='#{routes.new_project_alias_path(
+          project_id: slip_project.id
+        )}']"
+      )
     end
 
     def test_no_alias_flag_for_a_known_abbreviation

--- a/test/views/controllers/images/field_slip_extracts/status_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/status_test.rb
@@ -40,35 +40,10 @@ module Views::Controllers::Images::FieldSlipExtracts
       )
     end
 
-    # No extract: the not-scanned-yet state offers a scan button per
-    # photo -- zbar found no code anywhere, so only the person can say
-    # which photo shows the slip -- and does NOT poll; nothing is
-    # running until a button is pressed. This is where the
-    # no-slip-detected flash lands, and how a zbar-missed slip photo
-    # gets read at all.
-    def test_unscanned_state_offers_a_scan_button_per_photo
-      other = images(:turned_over_image)
-      obs = @image.observations.first
-      obs.images << other unless obs.images.include?(other)
-
-      html = render_status
-
-      assert_html(html, "#field_slip_extract_none",
-                  text: :field_slip_extract_choose_photo.t.as_displayed[0, 40])
-      obs.images.each do |image|
-        assert_html(
-          html,
-          "form[action='#{routes.image_field_slip_extract_path(image.id)}'] " \
-          "button[type='submit']"
-        )
-      end
-      assert_no_html(html, "[data-controller='reload-poll']")
-    end
-
-    def test_unscanned_state_with_one_photo_keeps_the_simple_prompt
-      obs = @image.observations.first
-      (obs.images - [@image]).each { |img| obs.images.delete(img) }
-
+    # No extract: the not-scanned-yet state scans THIS photo and does
+    # NOT poll; picking among the observation's photos belongs to the
+    # observation-scoped scan page, linked below the button.
+    def test_unscanned_state_offers_the_scan_and_the_chooser_link
       html = render_status
 
       assert_html(html, "#field_slip_extract_none",
@@ -78,6 +53,13 @@ module Views::Controllers::Images::FieldSlipExtracts
         "form[action='#{routes.image_field_slip_extract_path(@image.id)}'] " \
         "button[type='submit']"
       )
+      linked = @image.reload.observations.first
+
+      assert_html(
+        html,
+        "a[href='#{routes.field_slip_scan_observation_path(linked.id)}']"
+      )
+      assert_no_html(html, "[data-controller='reload-poll']")
     end
 
     def test_failed_read_shows_the_error_and_a_retry_button

--- a/test/views/controllers/images/field_slip_extracts/status_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/status_test.rb
@@ -40,12 +40,21 @@ module Views::Controllers::Images::FieldSlipExtracts
       )
     end
 
-    # No extract yet -- the QR jobs are still attaching -- looks the
-    # same as pending: something is happening, keep refreshing.
-    def test_awaiting_detection_self_refreshes_too
+    # No extract: the not-scanned-yet state offers the scan button and
+    # does NOT poll -- nothing is running until it is pressed. This is
+    # where the no-slip-detected flash lands, and how a zbar-missed
+    # slip photo gets read at all.
+    def test_unscanned_state_offers_the_scan_button
       html = render_status
 
-      assert_html(html, "[data-controller='reload-poll']")
+      assert_html(html, "#field_slip_extract_none",
+                  text: :field_slip_extract_none_yet.t.as_displayed[0, 40])
+      assert_html(
+        html,
+        "form[action='#{routes.image_field_slip_extract_path(@image.id)}'] " \
+        "button[type='submit']"
+      )
+      assert_no_html(html, "[data-controller='reload-poll']")
     end
 
     def test_failed_read_shows_the_error_and_a_retry_button

--- a/test/views/controllers/images/field_slip_extracts/status_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/status_test.rb
@@ -40,11 +40,35 @@ module Views::Controllers::Images::FieldSlipExtracts
       )
     end
 
-    # No extract: the not-scanned-yet state offers the scan button and
-    # does NOT poll -- nothing is running until it is pressed. This is
-    # where the no-slip-detected flash lands, and how a zbar-missed
-    # slip photo gets read at all.
-    def test_unscanned_state_offers_the_scan_button
+    # No extract: the not-scanned-yet state offers a scan button per
+    # photo -- zbar found no code anywhere, so only the person can say
+    # which photo shows the slip -- and does NOT poll; nothing is
+    # running until a button is pressed. This is where the
+    # no-slip-detected flash lands, and how a zbar-missed slip photo
+    # gets read at all.
+    def test_unscanned_state_offers_a_scan_button_per_photo
+      other = images(:turned_over_image)
+      obs = @image.observations.first
+      obs.images << other unless obs.images.include?(other)
+
+      html = render_status
+
+      assert_html(html, "#field_slip_extract_none",
+                  text: :field_slip_extract_choose_photo.t.as_displayed[0, 40])
+      obs.images.each do |image|
+        assert_html(
+          html,
+          "form[action='#{routes.image_field_slip_extract_path(image.id)}'] " \
+          "button[type='submit']"
+        )
+      end
+      assert_no_html(html, "[data-controller='reload-poll']")
+    end
+
+    def test_unscanned_state_with_one_photo_keeps_the_simple_prompt
+      obs = @image.observations.first
+      (obs.images - [@image]).each { |img| obs.images.delete(img) }
+
       html = render_status
 
       assert_html(html, "#field_slip_extract_none",
@@ -54,7 +78,6 @@ module Views::Controllers::Images::FieldSlipExtracts
         "form[action='#{routes.image_field_slip_extract_path(@image.id)}'] " \
         "button[type='submit']"
       )
-      assert_no_html(html, "[data-controller='reload-poll']")
     end
 
     def test_failed_read_shows_the_error_and_a_retry_button

--- a/test/views/controllers/images/field_slip_extracts/status_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/status_test.rb
@@ -29,7 +29,7 @@ module Views::Controllers::Images::FieldSlipExtracts
 
       assert_html(html, "[data-controller='reload-poll']")
       assert_html(html, "#field_slip_extract_pending",
-                  text: :field_slip_extract_pending.t.as_displayed[0, 40])
+                  text: :field_slip_extract_pending.l[0, 40])
       # The view links image.observations.first -- the fixture image
       # hangs off several observations, so pin whichever IS first
       # rather than assuming an association order.
@@ -47,7 +47,7 @@ module Views::Controllers::Images::FieldSlipExtracts
       html = render_status
 
       assert_html(html, "#field_slip_extract_none",
-                  text: :field_slip_extract_none_yet.t.as_displayed[0, 40])
+                  text: :field_slip_extract_none_yet.l[0, 40])
       assert_html(
         html,
         "form[action='#{routes.image_field_slip_extract_path(@image.id)}'] " \


### PR DESCRIPTION
## The two code readers, and what this PR changes

A slip's code is readable two ways, by two independent readers:

- **zbar reads the QR** — fast, free, runs automatically (at create and on image attach). When it succeeds, the slip attaches immediately. It missed ~27% of the fair's slip photos (glare/angle), and its decode rate is untouched here (a miss is indistinguishable from "photo with no slip", so it can't auto-escalate to the paid scan — see #5041's scanner-economics section).
- **Gemini reads the printed code text** — as one of the slip's fields, during the extraction, with no dependence on the QR at all. It read the printed code correctly on 26 of the 27 observations zbar had missed.

**Before this PR, Gemini's reading of the code was used for nothing but display** — a cross-check row on the review form. The correct code sat unused in the extract while the observation stayed slip-less. This PR makes that reading actionable:

- **`ExtractFieldSlipJob#attach_read_code`**: a successful extraction attaches the slip from the read code when the observation has none — same conservative `Attacher` guards as the QR path (never an observation with a slip, never a slip in use, never a closed project's existing slip).
- **The review form's code row becomes an attach control** on a slip-less observation: editable (a misread code gets corrected in the box), ticked by default, attaching before the field writes so the project's aliases apply to them. On a slip-linked observation the row now states the check's outcome ("matches the attached field slip" / "differs…!") instead of the opaque "cross-check only".
- **`script/attach_slips_from_extracts.rb`** (dry-run default, `--apply`) repairs the backlog: 29 attachable, 3 flagged for human judgment against the 2026-08-10 dump.

## The zbar-miss UX

- **Warning flash at create**: when the scan ran and found no code on an observation in a slip-prefix project, the flash says so and links to the scan page. Gated identically to the scan itself; ordinary observations never see it.
- **Observation-scoped scan page**: `GET /observations/:id/field_slip_scan` (`Observations::FieldSlipScans#show`) renders every photo with its scan state — a **Read Field Slip** button when unscanned, a link to the photo's review/status page once a scan exists. Choosing which photo shows the slip is a decision about the observation, so it lives at an observation route; this is also the way back to scan results later, and the stable target for #5041's field-slip-show-page link. The per-image page keeps a single-photo not-scanned state (scan *this* photo) with a link up to the chooser.

## Also in this PR

- **The slip's project is authoritative** everywhere the pipeline needs "the project" (prompt aliases/template/dates, unknown-alias + suggestion checks, the Add-abbreviation link) — `projects.first` picked the wrong project for multi-project observations.
- **The alias warning matches the applier**: the unknown-abbreviation check unions the slip's project with all the observation's projects, the same resolution `Applier#project_alias` uses, so it can never warn about an alias that applying would resolve.
- **Review-save re-evaluates the slip's project**: the join decision at attach time runs against pre-review data (form-default date/locality); after the review applies the slip's real values, an observation now satisfying the constraints joins the project (notice), one still violating gets a warning.
- **Rendering fix**: review alerts wrapped `.t` output in `plain()`, double-escaping the HTML-safe markup (the literal `&#8212;`); translated alert text now renders via `trusted_html`.
- `FieldSlip::QRDecoder` scans the 1280px copy before the full-resolution original (faster; full size remains the fallback). A size no longer on local disk is fetched from the image server (transfer can outrun the scan), but any fetch failure is a plain miss — an archived original is never pulled out of the archive for a scan; the no-slip-detected flash points at the manual scan page.

Built directly on main; #5036 was closed in favor of keeping the background pipeline.

## Test plan

- [x] Full extract suite (jobs, review form object, controllers, views, templates) + RuboCop
- Photograph a slip with the QR covered → create → warning flash links to the scan page → pick the photo, press **Read Field Slip** → the read completes and the slip attaches automatically; the review shows no mismatch.
- On a slip-less observation with an extract, the review form shows the "attach this field slip" tick; correcting a misread code attaches the corrected one.
- Review a slip whose observation carried form defaults at attach time → saving the slip's real date/locality joins the slip's project with a notice.
- Run `bin/rails runner script/attach_slips_from_extracts.rb` (dry run), then `--apply`; hand-resolve the 3 flagged cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

