### PR TITLE
Normalize separator-grouped iNaturalist ids in every template's iNat slot (`Template::Base`)

### DIFF
--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -62,14 +62,20 @@ class FieldSlip
       # The box may hold more than the id ("10:29 388879492" -- a
       # timestamp doubling as a checksum against the iNat record). The
       # id becomes the link; the rest is kept beside it rather than
-      # dropped.
+      # dropped. Removing the id uses the span as written, which can
+      # differ from the id itself ("388 596 423").
       def inat_link_for(text)
         code = @template.inat_code_in(text)
         return text unless code
 
         link = FieldSlipNotesBuilder.inat_link(code)
-        rest = text.sub(code, "").squish
+        rest = leftover_around_code(text, @template.inat_code_raw(text))
         rest.present? ? "#{link} (#{rest})" : link
+      end
+
+      def leftover_around_code(text, raw_span)
+        text.sub(raw_span.to_s, " ").squish.
+          sub(/\A[#:\-\s]+/, "").sub(/[#:\-\s]+\z/, "")
       end
 
       def assign_columns

--- a/app/classes/field_slip/template/base.rb
+++ b/app/classes/field_slip/template/base.rb
@@ -46,7 +46,11 @@ class FieldSlip
       # timestamp ("fungus_junkie iNat: 388891116", "10:29 388879492";
       # all real entries from the 2026 CMS fair). Digits joined across
       # single spaces/dashes make the id; seven digits minimum keeps
-      # clock times, dates, and short accession numbers out.
+      # clock times, dates, and short accession numbers out. Ten digits
+      # maximum is equally deliberate: 16 years in, iNat ids are 9
+      # digits (~400M observations), so a longer run in a handwritten
+      # box is a misread or a stray digit, not an id -- 11+ digits
+      # would mean iNat grew 25-fold.
       RAW_ID = /(?<!\d)\d(?:[\s\-–]?\d){6,9}(?!\d)/
 
       # The iNaturalist observation id in a value read from

--- a/app/classes/field_slip/template/base.rb
+++ b/app/classes/field_slip/template/base.rb
@@ -45,6 +45,11 @@ class FieldSlip
       # `inat_codes_field`, or nil when the value doesn't hold one.
       def inat_code_in(_value) = nil
 
+      # The span of the value the id was read from, as written --
+      # identical to the id unless a template normalizes separators
+      # out of it.
+      def inat_code_raw(value) = inat_code_in(value)
+
       def inat_code?(value) = inat_code_in(value).present?
     end
   end

--- a/app/classes/field_slip/template/base.rb
+++ b/app/classes/field_slip/template/base.rb
@@ -41,14 +41,25 @@ class FieldSlip
       # Extractor::Prompt.
       def field_rules = raise(NotImplementedError)
 
+      # Collectors write iNat observation ids with separators
+      # ("388 596 423", "388-401-241") or beside a username or
+      # timestamp ("fungus_junkie iNat: 388891116", "10:29 388879492";
+      # all real entries from the 2026 CMS fair). Digits joined across
+      # single spaces/dashes make the id; seven digits minimum keeps
+      # clock times, dates, and short accession numbers out.
+      RAW_ID = /(?<!\d)\d(?:[\s\-–]?\d){6,9}(?!\d)/
+
       # The iNaturalist observation id in a value read from
       # `inat_codes_field`, or nil when the value doesn't hold one.
-      def inat_code_in(_value) = nil
+      def inat_code_in(value)
+        inat_code_raw(value)&.gsub(/\D/, "")
+      end
 
-      # The span of the value the id was read from, as written --
-      # identical to the id unless a template normalizes separators
-      # out of it.
-      def inat_code_raw(value) = inat_code_in(value)
+      # The span of the value the id was read from, as written, for
+      # callers separating it from the rest of the entry.
+      def inat_code_raw(value)
+        value.to_s[RAW_ID]
+      end
 
       def inat_code?(value) = inat_code_in(value).present?
     end

--- a/app/classes/field_slip/template/dbg.rb
+++ b/app/classes/field_slip/template/dbg.rb
@@ -76,12 +76,23 @@ class FieldSlip
         RULES
       end
 
-      # The box is dedicated to iNaturalist, so any long digit run in
-      # it is the observation id -- even mixed with a username or
-      # timestamp ("10:29 388879492"). Five digits keeps clock times
-      # and dates from qualifying.
+      # The box is dedicated to iNaturalist, so the digits in it are
+      # the observation id -- and collectors write them with separators
+      # ("388 596 423", "388-401-241") or beside a username or
+      # timestamp ("fungus_junkie iNat: 388891116", "10:29 388879492";
+      # all real entries from the 2026 CMS fair). Digits joined across
+      # single spaces/dashes make the id; seven digits minimum keeps
+      # clock times and dates out.
+      RAW_ID = /(?<!\d)\d(?:[\s\-–]?\d){6,9}(?!\d)/
+
       def inat_code_in(value)
-        value.to_s[/\d{5,}/]
+        inat_code_raw(value)&.gsub(/\D/, "")
+      end
+
+      # The id as actually written, for callers separating it from the
+      # rest of the entry.
+      def inat_code_raw(value)
+        value.to_s[RAW_ID]
       end
     end
   end

--- a/app/classes/field_slip/template/dbg.rb
+++ b/app/classes/field_slip/template/dbg.rb
@@ -75,25 +75,6 @@ class FieldSlip
             field slip code. Give it exactly as written.
         RULES
       end
-
-      # The box is dedicated to iNaturalist, so the digits in it are
-      # the observation id -- and collectors write them with separators
-      # ("388 596 423", "388-401-241") or beside a username or
-      # timestamp ("fungus_junkie iNat: 388891116", "10:29 388879492";
-      # all real entries from the 2026 CMS fair). Digits joined across
-      # single spaces/dashes make the id; seven digits minimum keeps
-      # clock times and dates out.
-      RAW_ID = /(?<!\d)\d(?:[\s\-–]?\d){6,9}(?!\d)/
-
-      def inat_code_in(value)
-        inat_code_raw(value)&.gsub(/\D/, "")
-      end
-
-      # The id as actually written, for callers separating it from the
-      # rest of the entry.
-      def inat_code_raw(value)
-        value.to_s[RAW_ID]
-      end
     end
   end
 end

--- a/app/classes/field_slip/template/mo.rb
+++ b/app/classes/field_slip/template/mo.rb
@@ -55,14 +55,6 @@ class FieldSlip
             Codes box.
         RULES
       end
-
-      # "Other Codes" is free text, but in practice a purely numeric
-      # one is an iNaturalist observation id -- that is what collectors
-      # write in that box.
-      def inat_code_in(value)
-        text = value.to_s.strip
-        text if text.match?(/\A\d+\z/)
-      end
     end
   end
 end

--- a/test/classes/field_slip/extractor/applier_test.rb
+++ b/test/classes/field_slip/extractor/applier_test.rb
@@ -290,6 +290,26 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
                  @obs.notes[:iNaturalist])
   end
 
+  # Grouped digits (a real CMS fair entry) normalize into one id, and
+  # removing the id from the entry uses the span as written, so no
+  # digit fragments leak into the leftover.
+  def test_dbg_grouped_inat_digits_link_as_one_id
+    apply_fields({ "iNaturalist" => "388 596 423" },
+                 template: :dbg, inat_code: true)
+
+    assert_equal(FieldSlipNotesBuilder.inat_link("388596423"),
+                 @obs.notes[:iNaturalist])
+  end
+
+  def test_dbg_username_beside_the_id_is_kept
+    apply_fields({ "iNaturalist" => "fungus_junkie iNat: 388891116" },
+                 template: :dbg, inat_code: true)
+
+    link = FieldSlipNotesBuilder.inat_link("388891116")
+
+    assert_equal("#{link} (fungus_junkie iNat)", @obs.notes[:iNaturalist])
+  end
+
   # Flagged but holding no id -- a username and clock time only -- the
   # entry stays as written rather than becoming a broken link.
   def test_dbg_inat_box_without_an_id_left_bare

--- a/test/classes/field_slip/template_test.rb
+++ b/test/classes/field_slip/template_test.rb
@@ -80,4 +80,22 @@ class FieldSlip::TemplateTest < UnitTestCase
     assert_nil(template.inat_code_in("10:29 am"))
     assert_nil(template.inat_code_in("someuser 8/6"))
   end
+
+  # Every shape below is a real entry from the 2026 CMS fair scans:
+  # collectors group the digits with spaces or dashes, prefix them, or
+  # write them beside usernames and times.
+  def test_dbg_inat_code_normalizes_separators
+    template = FieldSlip::Template.for(:dbg)
+
+    assert_equal("388596423", template.inat_code_in("388 596 423"))
+    assert_equal("388401241", template.inat_code_in("388-401241"))
+    assert_equal("389207996", template.inat_code_in("389-207-996"))
+    assert_equal("389176438", template.inat_code_in("#389176438"))
+    assert_equal("388891116",
+                 template.inat_code_in("fungus_junkie iNat: 388891116"))
+    assert_equal("389198780",
+                 template.inat_code_in("1:59 pm 389-198-780 (iNat#) see Alex"))
+    assert_nil(template.inat_code_in("gSanchez"))
+    assert_nil(template.inat_code_in("1:58 PM"))
+  end
 end

--- a/test/classes/field_slip/template_test.rb
+++ b/test/classes/field_slip/template_test.rb
@@ -58,14 +58,15 @@ class FieldSlip::TemplateTest < UnitTestCase
 
   # ---------- iNat code detection ----------
 
-  # MO's Other Codes box is free text, so only a purely numeric value
-  # is treated as an iNat id.
-  def test_mo_inat_code_requires_purely_numeric
+  # Every template's iNat slot reads ids the same way (see
+  # Template::Base::RAW_ID) -- MO's free-text Other Codes box included.
+  def test_mo_inat_code_normalizes_like_any_other_template
     template = FieldSlip::Template.for(:mo)
 
     assert_equal("12345678", template.inat_code_in(" 12345678 "))
+    assert_equal("388596423", template.inat_code_in("388 596 423"))
+    assert_equal("388879492", template.inat_code_in("10:29 388879492"))
     assert_nil(template.inat_code_in("DBG-12345"))
-    assert_nil(template.inat_code_in("10:29 388879492"))
     assert_not(template.inat_code?(nil))
   end
 


### PR DESCRIPTION
Part of the #5042 umbrella (post-CMS-fair fixes). At the 2026 CMS fair, collectors wrote iNaturalist observation ids on DBG slips in every shape but a plain digit run: grouped with spaces or dashes ("388 596 423", "388-401-241", "388-401241"), prefixed ("#389176438"), or beside usernames and clock times ("fungus_junkie iNat: 388891116", "1:59 pm 389-198-780 (iNat#) see Alex"). The old extraction only matched an unbroken digit run, so grouped ids failed to resolve and 2 of the fair's entries needed hand-fixing.

## Changes

- **The normalization is shared by every template with an iNat slot** — it lives in `FieldSlip::Template::Base` (`RAW_ID = /(?<!\d)\d(?:[\s\-–]?\d){6,9}(?!\d)/`): digits joined across single spaces/dashes make the id, separators are stripped from the returned value, and seven digits minimum keeps clock times, dates, and short accession numbers from qualifying. The dbg template's "iNaturalist" box and MO's free-text "Other Codes" box both read ids the same way; MO's previous whole-value-digits-only rule is gone, so "388 596 423" written on an MO slip resolves too.
- New `Template::Base#inat_code_raw` returns the span as actually written, so `Applier#inat_link_for` can remove the id from the entry without leaving digit fragments behind when the written form differs from the normalized id — the leftover ("fungus_junkie iNat") is kept beside the link, stray `#`/`:`/dash punctuation trimmed.
- Entries flagged as iNat but holding no id (a bare username, a clock time) still stay as written rather than becoming a broken link.

Every test case is a real entry from the fair's scans. This is the prerequisite for #5039 (iNat in-situ GPS backfill needs the ids resolving first).

## Test plan

- In the review form for a dbg-template extract, enter `388 596 423` in the iNaturalist box, tick it, and save: the observation's iNaturalist note becomes a single link to iNat observation 388596423.
- Enter `fungus_junkie iNat: 388891116`: the note links the id with "(fungus_junkie iNat)" kept beside it.
- Same for an MO slip's Other Codes box: `388 596 423` there resolves to one link as well.
- Enter a bare username or `1:58 PM`: the entry is stored as written, no link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
