### PR TITLE
Review-save joins an in-use slip's occurrence (`Attacher` `join_in_use:`); explain the create-time pause

### DIFF
--- a/app/classes/field_slip/attacher.rb
+++ b/app/classes/field_slip/attacher.rb
@@ -12,15 +12,23 @@ class FieldSlip
   # the code's slip is unused, so it can never move an observation,
   # join one to somebody else's collection, or override a choice a
   # person made on a form.
+  #
+  # `join_in_use: true` widens that for a human-confirmed call site
+  # (the review form's ticked code): an in-use slip's occurrence is
+  # joined instead of refused, the same act as editing the code onto
+  # the observation, and the newly reviewed observation becomes the
+  # occurrence's primary.
   class Attacher
-    def self.attach(observation:, code:, user:)
-      new(observation: observation, code: code, user: user).attach
+    def self.attach(observation:, code:, user:, join_in_use: false)
+      new(observation: observation, code: code, user: user,
+          join_in_use: join_in_use).attach
     end
 
-    def initialize(observation:, code:, user:)
+    def initialize(observation:, code:, user:, join_in_use: false)
       @observation = observation
       @code = code.to_s.strip.upcase
       @user = user
+      @join_in_use = join_in_use
     end
 
     # Returns what happened, for the caller's log line.
@@ -28,7 +36,7 @@ class FieldSlip
       return :already_linked if @observation.occurrence_id
 
       existing = FieldSlip.find_by(code: @code)
-      return :in_use if existing&.occurrence
+      return join_or_refuse(existing) if existing&.occurrence
       return :closed_project if barred?(existing)
 
       slip = existing || FieldSlip.find_or_create_by_code(@code, @user)
@@ -48,6 +56,23 @@ class FieldSlip
     def barred?(slip)
       project = slip&.project
       project && !project.member?(@user) && !project.can_join?(@user)
+    end
+
+    def join_or_refuse(slip)
+      return :in_use unless @join_in_use
+      return :occurrence_full if occurrence_full?(slip)
+      return :closed_project if barred?(slip)
+
+      link(slip)
+      # The reviewed observation carries the slip's freshly applied
+      # data, so it becomes the record the slip's /qr/ page shows.
+      slip.occurrence.update!(primary_observation_id: @observation.id)
+      Occurrence.log_field_slip_added([@observation], @user)
+      :joined
+    end
+
+    def occurrence_full?(slip)
+      slip.occurrence.observations.count >= Occurrence::MAX_OBSERVATIONS
     end
 
     def link(slip)

--- a/app/classes/language/unused_tag_finder.rb
+++ b/app/classes/language/unused_tag_finder.rb
@@ -77,6 +77,7 @@ class Language::UnusedTagFinder
     rss_one_ visual_group_count_ show_location_ search_value_
     search_term_ pattern_ email_subject_occurrence_
     email_object_change_reason_ api_ source_credit_ log_
+    field_slip_attach_reason_
   ].freeze
   KNOWN_DYNAMIC_SUFFIXES = %w[_help _with_text _success _note].freeze
   KNOWN_DYNAMIC_SUBSTRINGS = %w[_term_ _title_].freeze

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -208,10 +208,12 @@ module Images
       return unless params.dig(:use, code_field) == "1"
       return unless @observation.occurrence_id.nil?
 
-      code = params.dig(:value, code_field).to_s.strip
+      # Normalized once, so lookups, the attach, and the flash all
+      # speak the same canonical code.
+      code = params.dig(:value, code_field).to_s.strip.upcase
       return if code.blank?
 
-      existed = FieldSlip.exists?(code: code.upcase)
+      existed = FieldSlip.exists?(code: code)
       result = FieldSlip::Attacher.attach(observation: @observation,
                                           code: code, user: @user,
                                           join_in_use: true)

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -213,20 +213,27 @@ module Images
 
       existed = FieldSlip.exists?(code: code.upcase)
       result = FieldSlip::Attacher.attach(observation: @observation,
-                                          code: code, user: @user)
+                                          code: code, user: @user,
+                                          join_in_use: true)
       flash_attach_result(code, result, existed)
     end
 
-    # "Created" or "attached", honestly: the code may have named a
-    # pre-existing spare slip.
+    # "Created", "attached", or "joined", honestly: the code may have
+    # named a pre-existing spare slip, or one already in use -- joining
+    # its occurrence is this form's resolution of that case.
     def flash_attach_result(code, result, existed)
-      if result == :attached
+      case result
+      when :attached
         key = existed ? :field_slip_attached : :field_slip_created
         flash_notice(key.t(code: code))
         @observation.reload
+      when :joined
+        flash_notice(:field_slip_extract_joined.t(code: code))
+        @observation.reload
       else
         flash_warning(:field_slip_extract_attach_failed.t(
-                        code: code, reason: result.to_s.tr("_", " ")
+                        code: code,
+                        reason: :"field_slip_attach_reason_#{result}".l
                       ))
       end
     end

--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -41,9 +41,26 @@ module ObservationsController::FieldSlips
       next unless code && reviewable_slip_code?(code)
 
       start_extraction_for_linked_slip(image, code)
+      explain_in_use_slip(code)
       return image
     end
     nil
+  end
+
+  # The QR jobs refuse an in-use slip, so nothing starts the read and
+  # the review page would just sit on its scan button -- say why, and
+  # that saving the review is what links this observation to the slip.
+  def explain_in_use_slip(code)
+    return if @observation.field_slip&.code == code
+
+    slip = FieldSlip.find_by(code: code)
+    primary_id = slip&.occurrence&.primary_observation_id
+    return unless primary_id
+
+    flash_warning(:observation_field_slip_in_use.t(
+                    code: code,
+                    url: permanent_observation_path(primary_id)
+                  ))
   end
 
   # A slip already linked to the observation only counts when the

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2612,7 +2612,13 @@
   field_slip_scan_all_photos: Choose among all of this observation's photos
   observation_no_field_slip_detected: 'No field slip code was automatically detected in the photos. If one of them shows a field slip, you can "scan it":[url].'
   field_slip_extract_code_differs: differs from the attached field slip!
-  field_slip_extract_attach_failed: "Could not attach field slip [code]: [reason]."
+  field_slip_extract_attach_failed: "This observation could not be associated with field slip [code] ([reason]). The other values were still saved."
+  field_slip_attach_reason_closed_project: its project is not open to you
+  field_slip_attach_reason_occurrence_full: it already has the maximum number of linked observations
+  field_slip_attach_reason_invalid: the code is not valid
+  field_slip_attach_reason_already_linked: this observation already has a field slip
+  field_slip_extract_joined: Field slip [code] was already in use, so this observation was linked to it as another observation of the same collection.
+  observation_field_slip_in_use: 'Field slip [code] was detected in a photo, but it is already attached to "another observation":[url], so it was not attached automatically. Use Read Field Slip to review the photo — saving the review will link this observation to the same field slip.'
   field_slip_extract_project_joined: Added the observation to [title], whose constraints it now satisfies.
   field_slip_extract_project_blocked: The observation is still not in [title] because it does not satisfy that project's constraints (location, dates, or species).
   field_slip_extract_add_alias: Add this abbreviation

--- a/test/classes/field_slip/attacher_test.rb
+++ b/test/classes/field_slip/attacher_test.rb
@@ -61,6 +61,52 @@ class FieldSlip::AttacherTest < UnitTestCase
     assert_nil(@obs.reload.occurrence)
   end
 
+  # `join_in_use:` is the review form's human-confirmed resolution of
+  # the in-use case: the observation joins the slip's occurrence and,
+  # carrying the freshly reviewed data, becomes its primary.
+  def test_join_in_use_joins_the_occurrence_and_takes_primary
+    other = observations(:coprinus_comatus_obs)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0510", other.user)
+    other.update!(occurrence: nil)
+    other.field_slip = slip
+    other.save!
+
+    result = FieldSlip::Attacher.attach(observation: @obs, code: "OPEN-0510",
+                                        user: @obs.user, join_in_use: true)
+
+    assert_equal(:joined, result)
+    @obs.reload
+
+    assert_equal(slip.reload.occurrence, @obs.occurrence)
+    assert_equal(@obs.id, @obs.occurrence.primary_observation_id)
+    assert_includes(@obs.occurrence.observations, other.reload)
+  end
+
+  def test_join_in_use_refuses_a_full_occurrence
+    other = observations(:coprinus_comatus_obs)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0511", other.user)
+    other.update!(occurrence: nil)
+    other.field_slip = slip
+    other.save!
+
+    # Filling a real occurrence to MAX_OBSERVATIONS is heavy; lower the
+    # cap to the one member it already has instead.
+    original = Occurrence::MAX_OBSERVATIONS
+    Occurrence.send(:remove_const, :MAX_OBSERVATIONS)
+    Occurrence.const_set(:MAX_OBSERVATIONS, 1)
+
+    result = FieldSlip::Attacher.attach(
+      observation: @obs, code: "OPEN-0511",
+      user: @obs.user, join_in_use: true
+    )
+
+    assert_equal(:occurrence_full, result)
+    assert_nil(@obs.reload.occurrence)
+  ensure
+    Occurrence.send(:remove_const, :MAX_OBSERVATIONS)
+    Occurrence.const_set(:MAX_OBSERVATIONS, original)
+  end
+
   # An existing slip in a project the user can neither join nor is a
   # member of: attaching would put the observation there against
   # invariant 4 (#4932).

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -457,7 +457,11 @@ module Images
       assert_equal("OPEN-0220", @obs.reload.field_slip.code)
     end
 
-    def test_update_warns_when_the_ticked_code_cannot_attach
+    # An in-use code is the "second observation of the same collection"
+    # case (a recorder re-photographing an already-used slip): saving
+    # the review joins the slip's occurrence, and the newly reviewed
+    # observation becomes its primary.
+    def test_update_with_an_in_use_code_joins_the_occurrence
       @obs.update!(occurrence: nil)
       other = observations(:coprinus_comatus_obs)
       other.update!(occurrence: nil)
@@ -471,8 +475,40 @@ module Images
                              use: { "Field Slip Code" => "1" },
                              value: { "Field Slip Code" => "OPEN-0500" } })
 
+      @obs.reload
+
+      assert_equal(slip.reload.occurrence, @obs.occurrence)
+      assert_equal(@obs.id, @obs.occurrence.primary_observation_id)
+    end
+
+    def test_update_warns_when_the_ticked_code_cannot_attach
+      @obs.update!(occurrence: nil)
+      other = observations(:coprinus_comatus_obs)
+      other.update!(occurrence: nil)
+      slip = FieldSlip.find_or_create_by_code("OPEN-0501", other.user)
+      other.field_slip = slip
+      other.save!
+      record_extract(fields: { "Field Slip Code" => "OPEN-0501",
+                               "Collector" => "A. Recorder" })
+      login_as_site_admin
+
+      original = Occurrence::MAX_OBSERVATIONS
+      Occurrence.send(:remove_const, :MAX_OBSERVATIONS)
+      Occurrence.const_set(:MAX_OBSERVATIONS, 1)
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Field Slip Code" => "1",
+                                    "Collector" => "1" },
+                             value: { "Field Slip Code" => "OPEN-0501",
+                                      "Collector" => "A. Recorder" } })
+
       assert_nil(@obs.reload.occurrence)
       assert_flash_warning
+      # The failed link never blocks the rest of the save.
+      assert_equal("A. Recorder", @obs.collector)
+    ensure
+      Occurrence.send(:remove_const, :MAX_OBSERVATIONS)
+      Occurrence.const_set(:MAX_OBSERVATIONS, original)
     end
 
     # The reported bug: the join decision at slip-attach time ran

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -428,6 +428,8 @@ module Images
     end
 
     # A pre-existing spare slip gets "attached", not "created".
+    # Submitted lowercase to pin the canonicalization: the lookup, the
+    # attach, and the flash all speak the upcased code.
     def test_update_attaching_an_existing_spare_slip_says_attached
       @obs.update!(occurrence: nil)
       FieldSlip.find_or_create_by_code("OPEN-0219", @obs.user)
@@ -436,7 +438,7 @@ module Images
 
       put(:update, params: { image_id: @image.id,
                              use: { "Field Slip Code" => "1" },
-                             value: { "Field Slip Code" => "OPEN-0219" } })
+                             value: { "Field Slip Code" => "open-0219" } })
 
       assert_equal("OPEN-0219", @obs.reload.field_slip.code)
       assert_flash([[:field_slip_attached, { code: "OPEN-0219" }],

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -1961,7 +1961,14 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert_redirected_to(
       edit_image_field_slip_extract_path(image.id, await: 1)
     )
-    assert_flash_warning
+    # The warning names the in-use code and links the observation that
+    # holds the slip -- that explanation IS the behavior under test.
+    assert_flash(
+      [[:runtime_observation_success, { id: assigns(:observation).id }],
+       [:observation_field_slip_in_use,
+        { code: "OPEN-0880",
+          url: permanent_observation_path(other.id) }]]
+    )
   end
 
   # A photographed code for some OTHER slip than the attached one is

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -1941,6 +1941,29 @@ class ObservationsControllerCreateTest < FunctionalTestCase
            "the read starts here; the QR jobs skip linked observations")
   end
 
+  # The QR jobs refuse an in-use slip, so the review page would sit on
+  # its scan button with nothing running -- the redirect explains why,
+  # naming the observation that has the slip.
+  def test_create_explains_a_detected_code_already_in_use
+    image = images(:in_situ_image)
+    other = observations(:coprinus_comatus_obs)
+    other.update!(occurrence: nil)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0880", other.user)
+    other.field_slip = slip
+    other.save!
+    make_slip_project_admin(rolf)
+    login("rolf")
+
+    with_decoded_slip_code("OPEN-0880") do
+      post(:create, params: slip_photo_params(image))
+    end
+
+    assert_redirected_to(
+      edit_image_field_slip_extract_path(image.id, await: 1)
+    )
+    assert_flash_warning
+  end
+
   # A photographed code for some OTHER slip than the attached one is
   # never auto-reviewed into this observation.
   def test_create_ignores_a_code_that_mismatches_the_attached_slip

--- a/test/models/image/dhash_test.rb
+++ b/test/models/image/dhash_test.rb
@@ -6,9 +6,10 @@ class Image::DhashTest < UnitTestCase
   FIXTURE = Rails.root.join("test/images/Coprinus_comatus.jpg").to_s
 
   def setup
-    return if system("command -v convert >/dev/null 2>&1")
+    return if system("command -v magick >/dev/null 2>&1") ||
+              system("command -v convert >/dev/null 2>&1")
 
-    skip("ImageMagick `convert` not available")
+    skip("ImageMagick not available")
   end
 
   # An IMv6-only host (the production servers) has no `magick`.
@@ -33,7 +34,8 @@ class Image::DhashTest < UnitTestCase
     hash = Image::Dhash.from_file(FIXTURE)
 
     Tempfile.create(["small", ".jpg"]) do |file|
-      system("convert", FIXTURE, "-resize", "240x240", file.path)
+      system(Image::Dhash.send(:magick_binary),
+             FIXTURE, "-resize", "240x240", file.path)
       resized = Image::Dhash.from_file(file.path)
 
       assert_operator(Image::Dhash.distance(hash, resized), :<=, 2)


### PR DESCRIPTION
Part of the #5042 umbrella. Testing the SMHF scenario surfaced two problems when a photographed slip's code is already in use by another observation (the re-photographed-slip case: a partially obscured slip attaches to observation A, then a clean photo of the same slip creates observation B):

1. **The create redirect paused on the review page with no explanation.** The redirect fires for any reviewable code, but the QR jobs refuse an in-use slip and nothing chains the read — so the page sat on its scan button, unlike the fresh-code case where the scan is already running on arrival.
2. **Saving the review flashed "Could not attach field slip 2026-SMHF-1151: in use"** — the Attacher's internal symbol, meaningless to users, and a dead end besides.

## Changes

- **Review-save now joins the occurrence.** `FieldSlip::Attacher` gains an explicit `join_in_use:` mode, used only by the review form's ticked code (background attach paths keep their conservative in-use refusal). Joining is the same act as editing the code onto the observation (`assign_field_slip`): capacity check, `Observation#field_slip=` into the existing occurrence, occurrence sync + activity log, project application per the #4932 invariants — plus the newly reviewed observation becomes the occurrence's **primary**, since it carries the slip's freshly applied data and is what the slip's `/qr/` page should show. Notice: "Field slip [code] was already in use, so this observation was linked to it as another observation of the same collection."
- **Refusals get plain language and never block the save.** A join the invariants refuse (occurrence at capacity, slip's project closed to the user) flashes "This observation could not be associated with field slip [code] ([reason]). The other values were still saved." — and the field writes and naming proceed regardless.
- **The create redirect explains the pause.** When the detected code names an in-use slip, the redirect flashes why nothing is scanning: the slip is attached to "another observation" (linked), and saving the review is what will link this observation to the same slip.

## Test plan

Reproduce the SMHF scenario: create an observation with a slip photo and let it attach (or attach via review), then create a second observation with a clean photo of the same slip.

- The second create lands on the review page with a warning naming the observation that holds the slip, instead of pausing unexplained.
- Run the scan, tick the code, save: the second observation joins the slip's occurrence, becomes its primary (the `/qr/<code>` URL now shows it), and the notice says it was linked as another observation of the same collection.
- With the occurrence full (or a closed project's slip), the save still applies the reviewed values and the warning explains the link refusal in plain language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
