### PR TITLE
Remove the last #5038 locality-trap leftovers from the event docs

### DIFF
--- a/README_FIELD_SLIP_EVENTS.md
+++ b/README_FIELD_SLIP_EVENTS.md
@@ -48,9 +48,9 @@ Both are documented in their own headers; short form:
   non-member's slip on a closed project comes out as a project-less
   spare.
 - **"The form prefilled a locality from the wrong region."** A form
-  opened with a field slip code defaults the locality from the slip
-  project's location (`apply_field_slip_location`), overriding the
-  usual previous-observation default. Without a code the old default
+  opened with a field slip code defaults the locality from the slip's
+  default location (`apply_field_slip_location` / `FieldSlip#calc_location`),
+  overriding the usual previous-observation default. Without a code the old default
   applies, but a resulting constraint problem surfaces in the pre-save
   project alert rather than silently keeping the observation out.
 - **Slip reading/review is admin-gated** (project admins + site

--- a/README_FIELD_SLIP_EVENTS.md
+++ b/README_FIELD_SLIP_EVENTS.md
@@ -47,11 +47,12 @@ Both are documented in their own headers; short form:
   using a slip only auto-enrolls for `open_membership` projects. A
   non-member's slip on a closed project comes out as a project-less
   spare.
-- **"The slip workflow broke for an admin who just arrived."** The
-  observation form defaults locality from the user's *previous*
-  observation, so an admin from another region violates the location
-  constraint on their first event observation (#5038 tracks the fix;
-  the admin guide carries the workaround).
+- **"The form prefilled a locality from the wrong region."** A form
+  opened with a field slip code defaults the locality from the slip
+  project's location (`apply_field_slip_location`), overriding the
+  usual previous-observation default. Without a code the old default
+  applies, but a resulting constraint problem surfaces in the pre-save
+  project alert rather than silently keeping the observation out.
 - **Slip reading/review is admin-gated** (project admins + site
   admins): each read is a paid API call and writes to observations the
   reviewer may not own. Recorders who should review need admin, not

--- a/doc/field_slip_event_admin_article.md
+++ b/doc/field_slip_event_admin_article.md
@@ -103,5 +103,3 @@ your admins.
   observations
 - Aliases entered (sites, walks, collector initials)
 - Every reviewer is a project admin
-- Every reviewer has made one observation with the event's locality
-  set by hand, so the form default doesn't fight them


### PR DESCRIPTION
Follow-up to closing #5038: the dev README's "admin who just arrived" bullet described the old previous-observation default as current and cited #5038 as open; it now states the fixed behavior (`apply_field_slip_location` + the pre-save alert). The admin article's checklist drops the set-locality-by-hand first-observation ritual, whose rationale section was already removed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)