### PR TITLE
Fix observation destroy-redirect test assumption; hook up dead `areAllItemsExifPopulated()` gate

### DIFF
--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -278,11 +278,17 @@ export default class extends Controller {
     if (this.areAllItemsExifPopulated() ||
       attempt >= this.constructor.MAX_EXIF_WAIT_ATTEMPTS) {
       this.block_form_submission = false;
-      // form.submit() (not requestSubmit()) is fine here for now: the
-      // observation form isn't Turbo-enabled (no local: false), so
-      // there's no submit-event listener to bypass yet. Swap to
-      // requestSubmit() when Turbo is enabled on this form -- see the
-      // nimmo-5052-turbo-submit-prototype branch, which already does.
+      // form.submit(), not requestSubmit(): when there are no images to
+      // upload, this call happens synchronously inside the ORIGINAL
+      // submit event's own onsubmit handler (see set_bindings), before
+      // that handler has returned. requestSubmit() re-enters the
+      // browser's submission algorithm while it's still marked as
+      // "firing submission events" for the outer submit -- the spec's
+      // reentrancy guard silently no-ops it (no error, no event, no
+      // request), and then the outer handler's `return false` cancels
+      // the original submission too, so nothing submits at all
+      // (verified: no network request, no thrown error). submit()
+      // bypasses that guard entirely by skipping the event pipeline.
       this.form.submit();
     } else {
       setTimeout(() => this.submitWhenExifReady(attempt + 1), 100);

--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -278,6 +278,11 @@ export default class extends Controller {
     if (this.areAllItemsExifPopulated() ||
       attempt >= this.constructor.MAX_EXIF_WAIT_ATTEMPTS) {
       this.block_form_submission = false;
+      // form.submit() (not requestSubmit()) is fine here for now: the
+      // observation form isn't Turbo-enabled (no local: false), so
+      // there's no submit-event listener to bypass yet. Swap to
+      // requestSubmit() when Turbo is enabled on this form -- see the
+      // nimmo-5052-turbo-submit-prototype branch, which already does.
       this.form.submit();
     } else {
       setTimeout(() => this.submitWhenExifReady(attempt + 1), 100);

--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -49,6 +49,11 @@ export default class extends Controller {
   static targets = ["form", "carousel", "item", "thumbnail", "removeImg",
     "imageGpsMap", "goodImageIds"]
 
+  // How long submitWhenExifReady polls before giving up and submitting
+  // anyway (30 * 100ms = 3s). See submitWhenExifReady for why this is
+  // bounded rather than an unbounded wait.
+  static MAX_EXIF_WAIT_ATTEMPTS = 30
+
   initialize() {
   }
 
@@ -151,14 +156,22 @@ export default class extends Controller {
   // Callback for form-exif event "populated", fired from the carousel-item
   itemExifPopulated(event) {
     const _item = this.findFileStoreItem(event.target);
-    _item.exif_populated = true;
+    // The item may already be gone (user removed it, or EXIF finished
+    // after `fileStore.items` drained past it during upload) -- `index`
+    // is kept in sync with removals, so a miss here means "no longer
+    // relevant," not a bug.
+    if (_item) _item.exif_populated = true;
   }
 
+  // Checks `index`, not the upload-queue `items` array: `items` is
+  // drained via `.shift()` as each image uploads (see `uploadAll`/
+  // `onUploadedCallback`), so by the time every image has uploaded it's
+  // always empty -- `index` is the only place a full, still-accurate
+  // "every item added" list survives to this point.
   areAllItemsExifPopulated() {
-    this.fileStore.items.forEach((item) => {
-      if (!item.exif_populated) return false;
-    });
-    return true;
+    return Object.values(this.fileStore.index).every(
+      (item) => item.exif_populated
+    );
   }
 
   addFiles(files) {
@@ -170,6 +183,7 @@ export default class extends Controller {
       this.loadAndDisplayItem(_item, i);
 
       this.fileStore.items.push(_item)
+      this.fileStore.index[_item.uuid] = _item
     }
   }
 
@@ -180,6 +194,7 @@ export default class extends Controller {
       this.loadAndDisplayItem(_item, 0);
 
       this.fileStore.items.push(_item);
+      this.fileStore.index[_item.uuid] = _item
     }
   }
 
@@ -217,8 +232,7 @@ export default class extends Controller {
       this.uploadItem(_firstUpload);
     } else {
       // no images to upload, submit form
-      this.block_form_submission = false;
-      this.form.submit();
+      this.submitWhenExifReady();
     }
 
     return false;
@@ -240,11 +254,33 @@ export default class extends Controller {
       this.uploadItem(_nextInLine);
     // now the form will be submitted without hitting the uploads.
     else {
-      this.block_form_submission = false;
       this.submit_buttons.forEach((element) => {
         element.value = this.localized_text.creating_observation_text;
       });
+      this.submitWhenExifReady();
+    }
+  }
+
+  // EXIF extraction (form-exif_controller.js) runs asynchronously per
+  // image, in parallel with the upload queue -- nothing otherwise
+  // guarantees it's finished by the time every image has uploaded, so
+  // GPS/date transferred from a photo's EXIF data could lose the race
+  // and never make it into the submitted observation fields. Poll
+  // briefly rather than submitting mid-extraction.
+  //
+  // Bounded: an image with no EXIF data, or EXIF ExifReader can't
+  // parse, never dispatches "populated" (form-exif_controller.js
+  // swallows that error), so `exif_populated` would otherwise stay
+  // false forever and this would poll indefinitely, permanently
+  // blocking submission. MAX_EXIF_WAIT_ATTEMPTS caps the wait at 3s;
+  // past that it submits anyway, no worse than before this existed.
+  submitWhenExifReady(attempt = 0) {
+    if (this.areAllItemsExifPopulated() ||
+      attempt >= this.constructor.MAX_EXIF_WAIT_ATTEMPTS) {
+      this.block_form_submission = false;
       this.form.submit();
+    } else {
+      setTimeout(() => this.submitWhenExifReady(attempt + 1), 100);
     }
   }
 
@@ -452,9 +488,10 @@ export default class extends Controller {
     const _identifiable = element.closest(".carousel-item") ??
       element.closest(".carousel-indicator");
 
-    return this.fileStore.items.find(
-      (item) => item.uuid === _identifiable?.dataset?.imageUuid
-    );
+    // `index` (keyed by uuid), not `items` -- `items` is a draining
+    // upload queue and may no longer hold this item by the time this
+    // is called (e.g. EXIF extraction finishing after upload).
+    return this.fileStore.index[_identifiable?.dataset?.imageUuid];
   }
 
   // This gives the img src a base64 string, or the url.
@@ -596,6 +633,7 @@ export default class extends Controller {
     const idx = this.fileStore.items.indexOf(item);
     if (idx > -1)
       this.fileStore.items.splice(idx, 1);
+    delete this.fileStore.index[item.uuid];
 
     // Re-sort the carousel
     this.sortCarousel();

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -760,7 +760,15 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     assert_selector("body.observations__show")
     click_and_confirm(find(".destroy_observation_link_#{new_obs.id}"))
     assert_flash_for_destroy_observation(new_obs.id)
-    assert_selector("body.observations__index")
+    # Redirects to :index only when there's no active query to fall
+    # back to; the `visit(activity_logs_path)` check above leaves a
+    # session-persisted RssLog query that ObservationsController::
+    # Destroy#redirect_after_destroy correctly adapts into an
+    # Observation subquery with a valid next_id, so this lands on the
+    # next observation's show page instead -- both are correct
+    # outcomes of the same (intentional) "go to next in context, else
+    # index" redirect logic.
+    assert_selector("body.observations__show, body.observations__index")
 
     # Make sure observation is not in log index
     visit(activity_logs_path)


### PR DESCRIPTION
Two small, independent fixes found while auditing the observation form's JS for issue #5052's Turbo-conversion scoping.

## Destroy-redirect test assumption

`test_post_edit_and_destroy_with_details_and_location` asserted landing on `body.observations__index` after destroying an observation, but `ObservationsController::Destroy#redirect_after_destroy` correctly redirects to the next item in an active query when one exists. Confirmed via a temporary debug trace that the test's own `visit(activity_logs_path)` step (needed to verify the observation appears in the log) leaves a session-persisted RssLog query that `find_query(:Observation)` legitimately adapts into an Observation subquery with a valid `next_id`. Both outcomes are correct depending on ambient query state — the test just hard-assumed the wrong one. Loosened the assertion to accept either.

## EXIF-populated gate

`areAllItemsExifPopulated()` existed in `form-images_controller.js` but was never called anywhere in the submit flow — dead code, not an intentional no-op. Wiring it up surfaced two more bugs it was hiding:

- The `forEach`-based early-return doesn't actually short-circuit — it always returned `true` regardless of any item's state.
- The array it checked (`fileStore.items`) is a draining upload queue, emptied via `.shift()` as each image uploads, so by the time every image had uploaded it was always empty anyway.

Fixed by populating the already-present-but-unused `fileStore.index` (keyed by uuid, never drained except on explicit removal) alongside `items`, checking that instead, and using `.every()` instead of the broken `forEach`. Also switched `findFileStoreItem` to the same index lookup, since it had the identical "item already shifted off `items`" risk.

Gated both `form.submit()` call sites behind a new `submitWhenExifReady()` that polls briefly rather than submitting mid-extraction — bounded at 3s (30 × 100ms), since an image with no EXIF data, or EXIF `ExifReader` can't parse, never dispatches the `"populated"` event at all (`form-exif_controller.js` swallows that error silently), which would otherwise poll forever and permanently block submission.

## Test plan

- [x] `bin/rails test test/system/observation_form_system_test.rb` — 15 tests, 0 failures (exercises the EXIF-transfer flow directly)
- [x] `bin/rails test test/system/observation_form_carousel_system_test.rb` — 3 tests, 0 failures
- [x] `bundle exec rubocop` clean on the touched Ruby file
