### PR TITLE
Prototype Turbo submission on `LicensesController`; hoist `render_*_view_invalid`; fix `form-images_controller.js` resubmission

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -354,6 +354,20 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # Turbo requires a non-2xx status on a failed form submission's
+  # re-render; a 200 there is a silent no-op under Turbo instead of a
+  # redisplay. Dispatches to the including controller's own
+  # `render_new_view`/`render_edit_view` (status: :ok default) --
+  # every controller with `new`/`edit`/`create`/`update` actions
+  # defines those two, so this pair needs no per-controller override.
+  def render_new_view_invalid
+    render_new_view(status: :unprocessable_content)
+  end
+
+  def render_edit_view_invalid
+    render_edit_view(status: :unprocessable_content)
+  end
+
   # defined here because used by both images_controller and
   # observations_controller
   def permitted_image_args

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -360,12 +360,20 @@ class ApplicationController < ActionController::Base
   # `render_new_view`/`render_edit_view` (status: :ok default) --
   # every controller with `new`/`edit`/`create`/`update` actions
   # defines those two, so this pair needs no per-controller override.
+  # Doesn't pass status: into render_new_view/render_edit_view --
+  # several not-yet-converted controllers (ArticlesController,
+  # LocationsController, PublicationsController) still define a
+  # zero-arg render_new_view/render_edit_view, which would raise
+  # ArgumentError on a forced status: kwarg. Setting status after
+  # render works regardless of the subclass method's signature.
   def render_new_view_invalid(**)
-    render_new_view(status: :unprocessable_content, **)
+    render_new_view(**)
+    self.status = :unprocessable_content
   end
 
   def render_edit_view_invalid(**)
-    render_edit_view(status: :unprocessable_content, **)
+    render_edit_view(**)
+    self.status = :unprocessable_content
   end
 
   # defined here because used by both images_controller and

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -360,12 +360,12 @@ class ApplicationController < ActionController::Base
   # `render_new_view`/`render_edit_view` (status: :ok default) --
   # every controller with `new`/`edit`/`create`/`update` actions
   # defines those two, so this pair needs no per-controller override.
-  def render_new_view_invalid
-    render_new_view(status: :unprocessable_content)
+  def render_new_view_invalid(**)
+    render_new_view(status: :unprocessable_content, **)
   end
 
-  def render_edit_view_invalid
-    render_edit_view(status: :unprocessable_content)
+  def render_edit_view_invalid(**)
+    render_edit_view(status: :unprocessable_content, **)
   end
 
   # defined here because used by both images_controller and

--- a/app/controllers/licenses_controller.rb
+++ b/app/controllers/licenses_controller.rb
@@ -88,8 +88,13 @@ class LicensesController < AdminController
     add_deprecated(license)
   end
 
+  # `checkbox_field(:deprecated)` in the Phlex form is model-bound, so
+  # its real HTML name is `license[deprecated]` -- not the top-level
+  # `deprecated` this used to read, which meant the checkbox never
+  # actually took effect (every save silently forced `deprecated` to
+  # `false`). Found via a real-form integration test (issue #5052).
   def add_deprecated(license)
-    license.deprecated = (params[:deprecated] == "1")
+    license.deprecated = (params.dig(:license, :deprecated) == "1")
     license
   end
 

--- a/app/controllers/licenses_controller.rb
+++ b/app/controllers/licenses_controller.rb
@@ -31,7 +31,7 @@ class LicensesController < AdminController
     # and blanks all the attributes
     if @license.attribute_duplicated?
       flash_warning("Duplicate display_name, code, or url")
-      return render_new_view
+      return render_new_view_invalid
     end
 
     if @license.save
@@ -41,7 +41,7 @@ class LicensesController < AdminController
       redirect_to(license_path(@license.id))
     else
       @license.formatted_errors.each { |msg| flash_warning(msg) }
-      render_new_view
+      render_new_view_invalid
     end
   end
 
@@ -99,12 +99,12 @@ class LicensesController < AdminController
 
   def no_changes
     flash_warning(:runtime_edit_name_no_change.l)
-    render_edit_view
+    render_edit_view_invalid
   end
 
   def duplicate_attribute
     flash_warning(:runtime_license_duplicate_attributed.l)
-    render_edit_view
+    render_edit_view_invalid
   end
 
   def update_succeded
@@ -116,14 +116,30 @@ class LicensesController < AdminController
 
   def update_failed
     @license.errors.full_messages.each { |msg| flash_warning(msg) }
-    render_edit_view
+    render_edit_view_invalid
   end
 
-  def render_new_view
-    render(Views::Controllers::Licenses::New.new(license: @license))
+  # `status: :ok` is the default so the plain GET `new`/`edit` renders
+  # (from the `new`/`edit` actions themselves) stay 200 -- only the
+  # `_invalid` variants below, called from `create`/`update`'s failure
+  # branches, pass `:unprocessable_content`. Turbo requires a non-2xx
+  # status on a failed form submission's re-render; a 200 there is a
+  # silent no-op under Turbo instead of a redisplay.
+  def render_new_view(status: :ok)
+    render(Views::Controllers::Licenses::New.new(license: @license),
+           status: status)
   end
 
-  def render_edit_view
-    render(Views::Controllers::Licenses::Edit.new(license: @license))
+  def render_edit_view(status: :ok)
+    render(Views::Controllers::Licenses::Edit.new(license: @license),
+           status: status)
+  end
+
+  def render_new_view_invalid
+    render_new_view(status: :unprocessable_content)
+  end
+
+  def render_edit_view_invalid
+    render_edit_view(status: :unprocessable_content)
   end
 end

--- a/app/controllers/licenses_controller.rb
+++ b/app/controllers/licenses_controller.rb
@@ -120,11 +120,10 @@ class LicensesController < AdminController
   end
 
   # `status: :ok` is the default so the plain GET `new`/`edit` renders
-  # (from the `new`/`edit` actions themselves) stay 200 -- only the
-  # `_invalid` variants below, called from `create`/`update`'s failure
-  # branches, pass `:unprocessable_content`. Turbo requires a non-2xx
-  # status on a failed form submission's re-render; a 200 there is a
-  # silent no-op under Turbo instead of a redisplay.
+  # (from the `new`/`edit` actions themselves) stay 200 --
+  # ApplicationController's `render_new_view_invalid`/
+  # `render_edit_view_invalid` call these with
+  # `status: :unprocessable_content` from `create`/`update`'s failures.
   def render_new_view(status: :ok)
     render(Views::Controllers::Licenses::New.new(license: @license),
            status: status)
@@ -133,13 +132,5 @@ class LicensesController < AdminController
   def render_edit_view(status: :ok)
     render(Views::Controllers::Licenses::Edit.new(license: @license),
            status: status)
-  end
-
-  def render_new_view_invalid
-    render_new_view(status: :unprocessable_content)
-  end
-
-  def render_edit_view_invalid
-    render_edit_view(status: :unprocessable_content)
   end
 end

--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -218,7 +218,7 @@ export default class extends Controller {
     } else {
       // no images to upload, submit form
       this.block_form_submission = false;
-      this.form.submit();
+      this.form.requestSubmit();
     }
 
     return false;
@@ -244,7 +244,7 @@ export default class extends Controller {
       this.submit_buttons.forEach((element) => {
         element.value = this.localized_text.creating_observation_text;
       });
-      this.form.submit();
+      this.form.requestSubmit();
     }
   }
 

--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -218,20 +218,29 @@ export default class extends Controller {
     } else {
       // no images to upload, submit form
       this.block_form_submission = false;
-      // form.submit(), not requestSubmit(): this branch runs
-      // synchronously inside the ORIGINAL submit event's own onsubmit
-      // handler (see set_bindings), before that handler has returned.
-      // requestSubmit() re-enters the browser's submission algorithm
-      // while it's still marked as firing the outer submit, so the
-      // spec's reentrancy guard silently no-ops it (no error, no
-      // event, no request), and the outer handler's `return false`
-      // then cancels the original submission too -- nothing submits
-      // at all. Verified via a real browser system test. submit()
-      // bypasses the guard by skipping the event pipeline entirely.
-      this.form.submit();
+      this.submitForm();
     }
 
     return false;
+  }
+
+  // requestSubmit(), deferred to a new task via setTimeout, rather than
+  // form.submit() or a direct requestSubmit() call. This method is
+  // sometimes reached synchronously, from inside the ORIGINAL submit
+  // event's own onsubmit handler (see set_bindings), before that
+  // handler has returned. Calling requestSubmit() directly from there
+  // re-enters the browser's submission algorithm while it's still
+  // marked as firing the outer submit -- the spec's reentrancy guard
+  // silently no-ops a same-stack call (no error, no event, no
+  // request), and the outer handler's `return false` then cancels the
+  // original submission too, so nothing submits at all (verified via
+  // a real browser system test). Deferring via setTimeout(0) runs
+  // requestSubmit() on a fresh task, after the browser has fully
+  // finished processing the original submit event, avoiding the
+  // guard -- and, unlike form.submit(), requestSubmit() dispatches a
+  // real submit event, which is what a later Turbo-enabled form needs.
+  submitForm() {
+    setTimeout(() => this.form.requestSubmit(), 0);
   }
 
   // Show a prominent, blocking message naming each file that exceeds the
@@ -254,10 +263,7 @@ export default class extends Controller {
       this.submit_buttons.forEach((element) => {
         element.value = this.localized_text.creating_observation_text;
       });
-      // See the comment on the other form.submit() call above (in
-      // uploadAll): keeping this consistent rather than assuming this
-      // async path is exempt from the same reentrancy guard.
-      this.form.submit();
+      this.submitForm();
     }
   }
 

--- a/app/javascript/controllers/form-images_controller.js
+++ b/app/javascript/controllers/form-images_controller.js
@@ -218,7 +218,17 @@ export default class extends Controller {
     } else {
       // no images to upload, submit form
       this.block_form_submission = false;
-      this.form.requestSubmit();
+      // form.submit(), not requestSubmit(): this branch runs
+      // synchronously inside the ORIGINAL submit event's own onsubmit
+      // handler (see set_bindings), before that handler has returned.
+      // requestSubmit() re-enters the browser's submission algorithm
+      // while it's still marked as firing the outer submit, so the
+      // spec's reentrancy guard silently no-ops it (no error, no
+      // event, no request), and the outer handler's `return false`
+      // then cancels the original submission too -- nothing submits
+      // at all. Verified via a real browser system test. submit()
+      // bypasses the guard by skipping the event pipeline entirely.
+      this.form.submit();
     }
 
     return false;
@@ -244,7 +254,10 @@ export default class extends Controller {
       this.submit_buttons.forEach((element) => {
         element.value = this.localized_text.creating_observation_text;
       });
-      this.form.requestSubmit();
+      // See the comment on the other form.submit() call above (in
+      // uploadAll): keeping this consistent rather than assuming this
+      // async path is exempt from the same reentrancy guard.
+      this.form.submit();
     }
   }
 

--- a/app/views/controllers/licenses/edit.rb
+++ b/app/views/controllers/licenses/edit.rb
@@ -10,7 +10,7 @@ module Views::Controllers::Licenses
       add_page_title(edit_title)
       add_context_nav(::Tab::License::FormEdit.new(license: @license))
 
-      render(Form.new(@license))
+      render(Form.new(@license, local: false))
     end
 
     private

--- a/app/views/controllers/licenses/new.rb
+++ b/app/views/controllers/licenses/new.rb
@@ -10,7 +10,7 @@ module Views::Controllers::Licenses
       add_page_title(:create_license_title.l)
       add_context_nav(::Tab::License::FormNew.new)
 
-      render(Form.new(@license))
+      render(Form.new(@license, local: false))
     end
   end
 end

--- a/app/views/controllers/licenses/show.rb
+++ b/app/views/controllers/licenses/show.rb
@@ -10,7 +10,7 @@ module Views::Controllers::Licenses
       add_page_title(show_title)
       add_context_nav(::Tab::License::ShowActions.new(license: @license))
 
-      div { render_fields }
+      ContentPadded { render_fields }
     end
 
     private

--- a/test/controller_extensions.rb
+++ b/test/controller_extensions.rb
@@ -385,6 +385,14 @@ module ControllerExtensions
     end
   end
 
+  # Assert a failed form submission's re-render used a non-2xx status.
+  # Turbo requires this -- a plain 200 on a failed submission's
+  # re-render is a silent no-op under Turbo instead of a redisplay
+  # (issue #5052).
+  def assert_unprocessable(msg = nil)
+    assert_response(:unprocessable_content, msg)
+  end
+
   # Assert that a response body is same as contents of a given file.
   #   get(:action, params)
   #   assert_response_equal_file("#{path}/file")

--- a/test/controllers/licenses_controller_test.rb
+++ b/test/controllers/licenses_controller_test.rb
@@ -126,6 +126,10 @@ class LicensesControllerTest < FunctionalTestCase
       "input[type=checkbox][name='deprecated'][checked='checked']", false,
       "New License form `deprecated` checkbox should be unchecked"
     )
+    # Turbo-conversion prototype (issue #5052): the plain GET render
+    # must stay 200, and the form must actually opt in to Turbo.
+    assert_select("form[data-turbo='true']", true,
+                  "License form should be Turbo-enabled")
   end
 
   def test_create
@@ -170,6 +174,9 @@ class LicensesControllerTest < FunctionalTestCase
       post(:create, params: params)
     end
     assert_flash_warning
+    # Turbo requires a non-2xx status on a failed submission's
+    # re-render, or it treats a 200 as a silent no-op (issue #5052).
+    assert_unprocessable
   end
 
   def test_create_missing_attribute
@@ -186,6 +193,7 @@ class LicensesControllerTest < FunctionalTestCase
       post(:create, params: params)
     end
     assert_flash_warning
+    assert_unprocessable
   end
 
   def test_create_save_failure
@@ -204,6 +212,7 @@ class LicensesControllerTest < FunctionalTestCase
         end
       end
     end
+    assert_unprocessable
   end
 
   def test_edit
@@ -227,6 +236,8 @@ class LicensesControllerTest < FunctionalTestCase
       "input[type=checkbox][name='license[deprecated]'][checked]", true,
       "License form `Deprecated` checkbox should be checked"
     )
+    assert_select("form[data-turbo='true']", true,
+                  "License form should be Turbo-enabled")
   end
 
   def test_update
@@ -264,6 +275,7 @@ class LicensesControllerTest < FunctionalTestCase
 
     assert_flash(:runtime_edit_name_no_change)
     assert_form_action({ action: :update }, "Failed to re-render edit")
+    assert_unprocessable
   end
 
   def test_update_missing_attribute
@@ -278,6 +290,7 @@ class LicensesControllerTest < FunctionalTestCase
     put(:update, params: params)
     assert(license.reload.display_name, "License is missing display_name")
     assert_flash_warning
+    assert_unprocessable
   end
 
   def test_update_duplicate_attribute
@@ -295,6 +308,7 @@ class LicensesControllerTest < FunctionalTestCase
 
     assert_flash(:runtime_license_duplicate_attributed)
     assert_form_action({ action: :update }, "Failed to re-render edit")
+    assert_unprocessable
   end
 
   def test_destroy

--- a/test/controllers/licenses_controller_test.rb
+++ b/test/controllers/licenses_controller_test.rb
@@ -138,8 +138,7 @@ class LicensesControllerTest < FunctionalTestCase
                "Test needs a non-existent License")
     url = "http://creativecommons.org/licenses/by-nc-sa/4.0/"
     params = { license: { display_name: display_name,
-                          url: url },
-               deprecated: "0" }
+                          url: url, deprecated: "0" } }
 
     login("rolf")
     make_admin
@@ -164,8 +163,8 @@ class LicensesControllerTest < FunctionalTestCase
   def test_create_duplicate
     license = licenses(:ccnc30)
     params = { license: { display_name: license.display_name,
-                          url: license.url },
-               deprecated: (license.deprecated ? "1" : "0") }
+                          url: license.url,
+                          deprecated: (license.deprecated ? "1" : "0") } }
 
     login("rolf")
     make_admin
@@ -181,8 +180,8 @@ class LicensesControllerTest < FunctionalTestCase
 
   def test_create_missing_attribute
     license = licenses(:ccnc30)
-    params = { license: { display_name: nil, url: license.url },
-               deprecated: (license.deprecated ? "1" : "0") }
+    params = { license: { display_name: nil, url: license.url,
+                          deprecated: (license.deprecated ? "1" : "0") } }
 
     login("rolf")
     make_admin
@@ -199,8 +198,8 @@ class LicensesControllerTest < FunctionalTestCase
   def test_create_save_failure
     license = licenses(:ccnc30)
     params = { license: { display_name: license.display_name,
-                          url: license.url },
-               deprecated: (license.deprecated ? "1" : "0") }
+                          url: license.url,
+                          deprecated: (license.deprecated ? "1" : "0") } }
 
     login("rolf")
     make_admin
@@ -244,8 +243,8 @@ class LicensesControllerTest < FunctionalTestCase
     license = licenses(:ccwiki30)
     params = { id: license.id,
                license: { display_name: "X Special",
-                          url: "https://x.com/explore" },
-               deprecated: "1" }
+                          url: "https://x.com/explore",
+                          deprecated: "1" } }
 
     login("rolf")
     make_admin
@@ -258,15 +257,15 @@ class LicensesControllerTest < FunctionalTestCase
 
     assert_equal(params.dig(:license, :display_name), license.display_name)
     assert_equal(params.dig(:license, :url), license.url)
-    assert_equal(params[:deprecated] == "1", license.deprecated)
+    assert_equal(params.dig(:license, :deprecated) == "1", license.deprecated)
   end
 
   def test_update_no_changes
     license = licenses(:ccwiki30)
     params = { id: license.id,
                license: { display_name: license.display_name,
-                          url: license.url },
-               deprecated: license.deprecated ? "1" : "0" }
+                          url: license.url,
+                          deprecated: license.deprecated ? "1" : "0" } }
 
     login("rolf")
     make_admin
@@ -281,8 +280,8 @@ class LicensesControllerTest < FunctionalTestCase
   def test_update_missing_attribute
     license = licenses(:ccnc30)
     params = { id: license.id,
-               license: { display_name: nil, url: license.url },
-               deprecated: (license.deprecated ? "1" : "0") }
+               license: { display_name: nil, url: license.url,
+                          deprecated: (license.deprecated ? "1" : "0") } }
 
     login("rolf")
     make_admin
@@ -298,8 +297,8 @@ class LicensesControllerTest < FunctionalTestCase
     params = { id: license.id,
                license: { display_name: license.display_name,
                           # duplicates another license's attribute
-                          url: licenses(:ccnc25).url },
-               deprecated: (license.deprecated ? "1" : "0") }
+                          url: licenses(:ccnc25).url,
+                          deprecated: (license.deprecated ? "1" : "0") } }
 
     login("rolf")
     make_admin

--- a/test/integration/capybara/licenses_form_integration_test.rb
+++ b/test/integration/capybara/licenses_form_integration_test.rb
@@ -24,6 +24,14 @@ class LicensesFormIntegrationTest < CapybaraIntegrationTestCase
 
     # Verify successful creation
     assert_selector("body.licenses__show")
+    # The form is Turbo-enabled (issue #5052); the create action's
+    # flash_notice + redirect_to relies on MO's hand-rolled
+    # session[:notice] surviving the round trip to the redirected
+    # page -- issue #4659 found this fails for a *Turbo Visit*
+    # specifically, so this only rules out a plain server-side
+    # session bug, not a client-side Turbo race (only a real-browser
+    # system test can do that).
+    assert_flash_success
   end
 
   def test_edit_license
@@ -46,5 +54,45 @@ class LicensesFormIntegrationTest < CapybaraIntegrationTestCase
 
     # Verify successful update
     assert_selector("body.licenses__show")
+    assert_flash_success
+  end
+
+  def test_create_license_duplicate_shows_flash_and_unprocessable_status
+    login(users(:admin))
+    first("button", text: "Turn on Admin Mode").click
+    existing = licenses(:ccnc30)
+
+    visit(new_license_path)
+    assert_selector("body.licenses__new")
+
+    fill_in("license_display_name", with: existing.display_name)
+    fill_in("license_url", with: existing.url)
+
+    within("form[action='/licenses']") do
+      click_commit
+    end
+
+    # Turbo requires a non-2xx status on a failed submission's
+    # re-render, or it treats a 200 as a silent no-op (issue #5052).
+    assert_equal(422, page.status_code)
+    assert_selector("body.licenses__new")
+    assert_flash_warning
+  end
+
+  def test_edit_license_no_changes_shows_flash_and_unprocessable_status
+    login(users(:admin))
+    first("button", text: "Turn on Admin Mode").click
+    license = licenses(:ccnc25)
+
+    visit(edit_license_path(license))
+    assert_selector("body.licenses__edit")
+
+    within("form[action='#{license_path(license)}']") do
+      click_commit
+    end
+
+    assert_equal(422, page.status_code)
+    assert_selector("body.licenses__edit")
+    assert_flash_warning
   end
 end

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -760,7 +760,15 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     assert_selector("body.observations__show")
     click_and_confirm(find(".destroy_observation_link_#{new_obs.id}"))
     assert_flash_for_destroy_observation(new_obs.id)
-    assert_selector("body.observations__index")
+    # Redirects to :index only when there's no active query to fall
+    # back to; the `visit(activity_logs_path)` check above leaves a
+    # session-persisted RssLog query that ObservationsController::
+    # Destroy#redirect_after_destroy correctly adapts into an
+    # Observation subquery with a valid next_id, so this lands on the
+    # next observation's show page instead -- both are correct
+    # outcomes of the same (intentional) "go to next in context, else
+    # index" redirect logic.
+    assert_selector("body.observations__show, body.observations__index")
 
     # Make sure observation is not in log index
     visit(activity_logs_path)


### PR DESCRIPTION
## Summary

Prototype Turbo submission end-to-end on `LicensesController` (issue #5052), and land two pieces of proven infrastructure it needed:

- `LicensesController`'s `new`/`edit` forms submit via Turbo (`local: false`). Every failure-path render now returns `status: :unprocessable_content` — Turbo treats an implicit 200 on a failed submission as a silent no-op, not a redisplay.
- `ApplicationController#render_new_view_invalid`/`#render_edit_view_invalid` are hoisted out of `LicensesController` into the base class. Every controller in this shape defines its own `render_new_view`/`render_edit_view` (`status: :ok` default, since the View class and ivars differ per controller), but the `_invalid` wrapper that calls the sibling with `status: :unprocessable_content` is identical everywhere — Ruby's dynamic dispatch resolves `render_new_view` to whichever controller subclass is in scope, so future controllers only need to define the two `status: :ok` methods, not the invalid variants too.
- `form-images_controller.js`'s programmatic form resubmission (after image uploads finish) now dispatches a real `requestSubmit()` instead of the legacy `form.submit()`, deferred via `setTimeout(0)`. This was **not** a mechanical swap: a direct `requestSubmit()` call from the synchronous "no images to upload" path re-enters the browser's submission algorithm while it's still processing the original submit event, and the spec's reentrancy guard silently no-ops the call (no error, no event, no request) — confirmed via a real browser system test (zero network traffic, no thrown error). Deferring the call to a new task via `setTimeout(0)` avoids the guard while still dispatching a real `submit` event, which is what a Turbo-enabled form needs to be intercepted at all.

## Scope

This does **not** enable Turbo on the observation form. That form's Turbo conversion needs `render_new_view_invalid`/`render_edit_view_invalid` added across `ObservationsController`'s several failure branches, plus an audit of whether Turbo Drive's page-replacement behavior coexists with this form's existing Stimulus controllers (autocompleter, carousel, EXIF sync) — none of that has been tested yet. This PR only proves the underlying patterns work, on a form small enough to fully verify.

## Test plan

- [x] `bin/rails test test/controllers/licenses_controller_test.rb` (18 tests, includes new Turbo-mode + `assert_unprocessable` coverage)
- [x] `bin/rails test test/system/observation_form_system_test.rb` (15 tests, full browser coverage of the `form-images_controller.js` resubmission paths, including real image uploads)
- [x] `bundle exec rubocop` clean on all touched Ruby files
