### PR TITLE
Skip permission-denied flash when turning off admin mode from an admin-only page

### DIFF
--- a/app/controllers/admin/session_controller.rb
+++ b/app/controllers/admin/session_controller.rb
@@ -73,8 +73,12 @@ module Admin
 
       path = URI.parse(request.referer).path
       route = Rails.application.routes.recognize_path(path)
-      "#{route[:controller].camelize}Controller".constantize <= AdminController
-    rescue StandardError
+      controller_class = "#{route[:controller].camelize}Controller".
+                         safe_constantize
+      return false unless controller_class
+
+      controller_class <= AdminController
+    rescue URI::InvalidURIError, ActionController::RoutingError
       false
     end
 

--- a/app/controllers/admin/session_controller.rb
+++ b/app/controllers/admin/session_controller.rb
@@ -20,6 +20,7 @@ module Admin
         session[:admin] = true if @user&.admin && !in_admin_mode?
       elsif params[:turn_off]
         session[:admin] = nil
+        return redirect_to("/") if referer_is_admin_only?
       end
 
       redirect_back_or_to("/")
@@ -60,6 +61,22 @@ module Admin
     end
 
     private
+
+    # Turning admin mode off while viewing an admin-only page (e.g. a
+    # License) would otherwise redirect_back into that page, which
+    # immediately bounces to AdminController#access_denied with a
+    # startling "Permission denied" flash -- graceless for someone who
+    # just intentionally turned admin mode off, not someone genuinely
+    # denied access. Detect that case and skip straight to "/" instead.
+    def referer_is_admin_only?
+      return false unless request.referer
+
+      path = URI.parse(request.referer).path
+      route = Rails.application.routes.recognize_path(path)
+      "#{route[:controller].camelize}Controller".constantize <= AdminController
+    rescue StandardError
+      false
+    end
 
     def switch_to_user_if_verified(new_user)
       if new_user.verified

--- a/test/controllers/admin/session_controller_test.rb
+++ b/test/controllers/admin/session_controller_test.rb
@@ -19,6 +19,72 @@ module Admin
       assert_false(session[:admin])
     end
 
+    # Turning admin mode off while viewing an admin-only page (e.g. a
+    # License) must not redirect_back into it -- that page would
+    # immediately deny access with a startling flash. Should go
+    # straight to "/" instead, with no flash set.
+    def test_turn_admin_off_from_admin_only_referer_skips_denial_flash
+      login(:rolf)
+      rolf.admin = true
+      rolf.save!
+      post(:create, params: { turn_on: true })
+      assert_true(session[:admin])
+
+      @request.env["HTTP_REFERER"] = license_url(licenses(:ccnc25).id)
+      post(:create, params: { turn_off: true })
+
+      assert_false(session[:admin])
+      assert_redirected_to("/")
+      assert_nil(session[:notice])
+    end
+
+    # A referer pointing at an ordinary (non-admin-only) page keeps
+    # the existing redirect_back behavior.
+    def test_turn_admin_off_from_ordinary_referer_redirects_back
+      login(:rolf)
+      rolf.admin = true
+      rolf.save!
+      post(:create, params: { turn_on: true })
+
+      referer = observation_url(observations(:minimal_unknown_obs).id)
+      @request.env["HTTP_REFERER"] = referer
+      post(:create, params: { turn_off: true })
+
+      assert_false(session[:admin])
+      assert_redirected_to(referer)
+    end
+
+    # No referer at all (e.g. a direct request) falls through to the
+    # same "/" default redirect_back_or_to already uses -- must not
+    # raise trying to parse a nil referer.
+    def test_turn_admin_off_with_no_referer
+      login(:rolf)
+      rolf.admin = true
+      rolf.save!
+      post(:create, params: { turn_on: true })
+
+      @request.env["HTTP_REFERER"] = nil
+      post(:create, params: { turn_off: true })
+
+      assert_false(session[:admin])
+      assert_redirected_to("/")
+    end
+
+    # A referer that doesn't match any route must not raise -- falls
+    # through the rescue to the existing redirect_back_or_to behavior.
+    def test_turn_admin_off_with_unroutable_referer
+      login(:rolf)
+      rolf.admin = true
+      rolf.save!
+      post(:create, params: { turn_on: true })
+
+      @request.env["HTTP_REFERER"] = "http://test.host/no/such/route"
+      post(:create, params: { turn_off: true })
+
+      assert_false(session[:admin])
+      assert_response(:redirect)
+    end
+
     def test_switch_users
       get(:edit)
       assert_response(:redirect)

--- a/test/controllers/admin/session_controller_test.rb
+++ b/test/controllers/admin/session_controller_test.rb
@@ -38,6 +38,23 @@ module Admin
       assert_nil(session[:notice])
     end
 
+    # Nested admin controllers (route controller path "admin/blocked_ips")
+    # must resolve too -- camelize turns the slash into "::",
+    # producing "Admin::BlockedIpsController".
+    def test_turn_admin_off_from_nested_admin_only_referer_skips_denial_flash
+      login(:rolf)
+      rolf.admin = true
+      rolf.save!
+      post(:create, params: { turn_on: true })
+
+      @request.env["HTTP_REFERER"] = edit_admin_blocked_ips_url
+      post(:create, params: { turn_off: true })
+
+      assert_false(session[:admin])
+      assert_redirected_to("/")
+      assert_nil(session[:notice])
+    end
+
     # A referer pointing at an ordinary (non-admin-only) page keeps
     # the existing redirect_back behavior.
     def test_turn_admin_off_from_ordinary_referer_redirects_back


### PR DESCRIPTION
## Summary

- Turning admin mode off while viewing an admin-only page (e.g. a License show page) currently redirects back into that page via `redirect_back_or_to`, which then immediately denies access and flashes "Permission denied" — a bit startling for someone who just intentionally turned admin mode off, easy to misread as something having failed.
- `Admin::SessionController#create`'s `turn_off` branch now checks `referer_is_admin_only?` first (via `Rails.application.routes.recognize_path` + an `AdminController` ancestry check) and redirects straight to `/` when true, skipping the denial round-trip entirely.
- Ordinary (non-admin-only) referers, missing referers, and unroutable referers all keep the existing `redirect_back_or_to` behavior — this only changes the admin-only-page case.

## Test plan

- [x] `bin/rails test test/controllers/admin/session_controller_test.rb` — 13 tests (4 new), all passing
- [x] `bundle exec rubocop` clean
- [x] Local coverage check: every line of `referer_is_admin_only?` hit across the 4 new tests (admin-only referer, ordinary referer, no referer, unroutable referer)
