### PR TITLE
A spare slip still resolves its event's aliases via the printed prefix (`FieldSlip#event_project`)

### DIFF
--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -188,8 +188,12 @@ class FieldSlip
         project_alias(value, "User")&.target
       end
 
+      # The slip's event project resolves aliases too -- the collector
+      # wrote its abbreviations -- even when the observation isn't in
+      # it (a spare slip, a constraint violation keeping both out).
       def project_alias(value, target_type)
-        ids = @observation.project_ids
+        ids = ([@observation.field_slip&.event_project&.id] +
+               @observation.project_ids).compact.uniq
         return nil if ids.empty?
 
         ProjectAlias.where(project_id: ids, name: value.to_s.strip,

--- a/app/classes/field_slip/extractor/applier.rb
+++ b/app/classes/field_slip/extractor/applier.rb
@@ -188,15 +188,23 @@ class FieldSlip
         project_alias(value, "User")&.target
       end
 
-      # The slip's event project resolves aliases too -- the collector
-      # wrote its abbreviations -- even when the observation isn't in
-      # it (a spare slip, a constraint violation keeping both out).
+      # The slip's event project resolves aliases FIRST -- the
+      # collector wrote that event's abbreviations -- even when the
+      # observation isn't in it (a spare slip, a constraint violation
+      # keeping both out). Other memberships are only a fallback, so a
+      # same-named alias in an unrelated project can't outrank the
+      # event's.
       def project_alias(value, target_type)
-        ids = ([@observation.field_slip&.event_project&.id] +
-               @observation.project_ids).compact.uniq
-        return nil if ids.empty?
+        event_id = @observation.field_slip&.event_project&.id
+        find_alias(value, target_type, [event_id].compact) ||
+          find_alias(value, target_type, @observation.project_ids)
+      end
 
-        ProjectAlias.where(project_id: ids, name: value.to_s.strip,
+      def find_alias(value, target_type, project_ids)
+        return nil if project_ids.empty?
+
+        ProjectAlias.where(project_id: project_ids,
+                           name: value.to_s.strip,
                            target_type: target_type).
           includes(:target).order(updated_at: :desc).first
       end

--- a/app/classes/field_slip/extractor/context.rb
+++ b/app/classes/field_slip/extractor/context.rb
@@ -22,13 +22,14 @@ class FieldSlip
         @observation = observation
       end
 
-      # The attached slip's project is authoritative: an observation
+      # The attached slip's event is authoritative: an observation
       # can sit in several projects (the obs form pre-checks the last
       # one used), and picking `projects.first` read the wrong event's
-      # aliases and template for a slip that says exactly which project
-      # it belongs to.
+      # aliases and template for a slip that says exactly which event
+      # it belongs to -- including a spare slip, whose printed prefix
+      # still names it (see FieldSlip#event_project).
       def project
-        @project ||= observation&.field_slip&.project ||
+        @project ||= observation&.field_slip&.event_project ||
                      observation&.projects&.first
       end
 

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -159,7 +159,7 @@ module Images
     def reconcile_slip_project
       @observation.reload
       slip = @observation.field_slip
-      project = slip && slip_event_project(slip)
+      project = slip&.event_project
       return unless project
 
       if project.violates_constraints?(@observation)
@@ -167,14 +167,6 @@ module Images
       else
         rejoin_slip_project(slip, project)
       end
-    end
-
-    # The slip row's own project is nil once the slip has gone spare,
-    # but the printed prefix still names the event.
-    def slip_event_project(slip)
-      slip.project ||
-        Project.find_by(field_slip_prefix:
-                          FieldSlip.prefix_for_code(slip.code))
     end
 
     def rejoin_slip_project(slip, project)

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -168,6 +168,18 @@ class FieldSlip < AbstractModel
     update(user: obs.user)
   end
 
+  # The event this slip was printed for: its own project, or -- once a
+  # spare-slip release has cleared that -- the project its printed
+  # prefix names. Alias resolution and prompt building key off the
+  # event, which is a fact of the printed slip, not of current project
+  # membership.
+  def event_project
+    return project if project
+
+    prefix = FieldSlip.prefix_for_code(code)
+    prefix && Project.find_by(field_slip_prefix: prefix)
+  end
+
   def update_project
     prefix = self.class.prefix_for_code(code)
     return unless prefix

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -212,13 +212,14 @@ class FieldSlipExtract < AbstractModel
   end
 
   def relevant_project_ids
-    ([observation&.field_slip&.project_id] +
-     Array(observation&.project_ids)).compact.uniq
+    event_project = observation&.field_slip&.event_project
+    ([event_project&.id] + Array(observation&.project_ids)).compact.uniq
   end
 
-  # The attached slip's project wins over `projects.first` -- see
-  # FieldSlip::Extractor::Context#project.
+  # The attached slip's event wins over `projects.first` -- see
+  # FieldSlip::Extractor::Context#project. A spare slip still names
+  # its event via the printed prefix (FieldSlip#event_project).
   def slip_project
-    observation&.field_slip&.project || observation&.projects&.first
+    observation&.field_slip&.event_project || observation&.projects&.first
   end
 end

--- a/test/classes/field_slip/extractor/applier_test.rb
+++ b/test/classes/field_slip/extractor/applier_test.rb
@@ -123,6 +123,24 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
     assert_equal(locations(:albion).name, @obs.where)
   end
 
+  # The event's alias wins over a same-named alias in another project
+  # the observation belongs to, however recently that one was touched
+  # -- the collector wrote the EVENT's abbreviations.
+  def test_event_alias_outranks_another_projects_newer_alias
+    other = projects(:open_membership_project)
+    other.observations << @obs
+    ProjectAlias.create!(project: @project, name: "EB2",
+                         target: locations(:albion)).
+      update_columns(updated_at: 2.days.ago)
+    ProjectAlias.create!(project: other, name: "EB2",
+                         target: locations(:burbank))
+
+    apply_fields({ "Location" => "EB2" })
+
+    assert_equal(locations(:albion), @obs.location,
+                 "the slip's event project defined the vocabulary")
+  end
+
   # A spare slip's event still resolves its aliases (reported: "EB2"
   # applied verbatim after a constraint violation released the slip's
   # project) -- the printed prefix names the event, membership or not.

--- a/test/classes/field_slip/extractor/applier_test.rb
+++ b/test/classes/field_slip/extractor/applier_test.rb
@@ -123,6 +123,20 @@ class FieldSlip::Extractor::ApplierTest < UnitTestCase
     assert_equal(locations(:albion).name, @obs.where)
   end
 
+  # A spare slip's event still resolves its aliases (reported: "EB2"
+  # applied verbatim after a constraint violation released the slip's
+  # project) -- the printed prefix names the event, membership or not.
+  def test_location_resolves_a_spare_slips_event_alias
+    @project.observations.delete(@obs)
+    @obs.field_slip.update_columns(project_id: nil)
+    ProjectAlias.create!(project: @project, name: "EB2",
+                         target: locations(:albion))
+
+    apply_fields({ "Location" => "EB2" })
+
+    assert_equal(locations(:albion), @obs.reload.location)
+  end
+
   def test_location_resolves_a_real_location_name
     apply_fields({ "Location" => locations(:burbank).name })
 

--- a/test/classes/field_slip/extractor/context_test.rb
+++ b/test/classes/field_slip/extractor/context_test.rb
@@ -102,7 +102,9 @@ class FieldSlip::Extractor::ContextTest < UnitTestCase
     # "No project" now means no slip project AND no prefix-named event
     # (see FieldSlip#event_project), so the code moves to an unknown
     # prefix too.
-    @obs.field_slip.update_columns(project_id: nil, code: "NEMF-12781")
+    assert_nil(Project.find_by(field_slip_prefix: "ZZZX"),
+               "premise: no fixture project claims this prefix")
+    @obs.field_slip.update_columns(project_id: nil, code: "ZZZX-12781")
 
     assert_empty(context_for(@obs.reload).aliases("Location"))
   end

--- a/test/classes/field_slip/extractor/context_test.rb
+++ b/test/classes/field_slip/extractor/context_test.rb
@@ -49,6 +49,17 @@ class FieldSlip::Extractor::ContextTest < UnitTestCase
     assert_equal(@project, context_for(@obs.reload).project)
   end
 
+  # A spare slip's printed prefix still names the event, so the prompt
+  # is built from that project's aliases even when the observation
+  # belongs to no project at all.
+  def test_project_resolves_a_spare_slip_via_the_printed_prefix
+    @obs.field_slip.update_columns(project_id: nil)
+
+    assert_empty(@obs.projects, "premise: no membership to fall back on")
+    assert_equal(projects(:eol_project), context_for(@obs.reload).project,
+                 "the EOL prefix names the event")
+  end
+
   # The abbreviation table is the project's own aliases rather than
   # anything written into the prompt -- that is what lets an alias added
   # during review improve the next slip.
@@ -88,9 +99,10 @@ class FieldSlip::Extractor::ContextTest < UnitTestCase
   end
 
   def test_aliases_empty_without_a_project
-    # The fixture slip carries a project; "no project" now means the
-    # slip's is gone too.
-    @obs.field_slip.update_columns(project_id: nil)
+    # "No project" now means no slip project AND no prefix-named event
+    # (see FieldSlip#event_project), so the code moves to an unknown
+    # prefix too.
+    @obs.field_slip.update_columns(project_id: nil, code: "NEMF-12781")
 
     assert_empty(context_for(@obs.reload).aliases("Location"))
   end

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -224,6 +224,24 @@ class FieldSlipExtractTest < UnitTestCase
     assert_nil(extract.reload.unknown_location_alias)
   end
 
+  # The reported bug (obs 664208): a spare slip -- its project released
+  # after a constraint violation -- stopped resolving its event's
+  # aliases, so "EB2" warned as undefined while the event's project
+  # defined it. The printed prefix still names the event.
+  def test_unknown_location_alias_uses_a_spare_slips_event_project
+    project = projects(:eol_project)
+
+    assert_not_includes(project.observations, @obs,
+                        "premise: membership is not what resolves it")
+
+    ProjectAlias.create!(project: project, name: "EB2",
+                         target: locations(:albion))
+    @obs.field_slip.update_columns(project_id: nil)
+    extract = record(fields: { "Location" => "EB2" })
+
+    assert_nil(extract.reload.unknown_location_alias)
+  end
+
   def test_unknown_location_alias_nil_when_it_matches_the_location
     extract = record(fields: { "Location" => @obs.location.name })
 

--- a/test/models/field_slip_test.rb
+++ b/test/models/field_slip_test.rb
@@ -157,4 +157,26 @@ class FieldSlipTest < UnitTestCase
 
     assert_equal(locations(:albion), slip.location)
   end
+
+  # The event a slip was printed for survives a spare-slip release:
+  # its project association may be gone, but the printed prefix still
+  # names the project, and alias resolution keys off the event.
+  def test_event_project_falls_back_to_the_printed_prefix
+    slip = field_slips(:field_slip_one)
+
+    assert_not_nil(slip.project, "premise: slip starts with a project")
+    assert_equal(slip.project, slip.event_project)
+
+    slip.update_columns(project_id: nil)
+
+    assert_equal(projects(:eol_project), slip.reload.event_project,
+                 "the EOL prefix still names the event")
+  end
+
+  def test_event_project_nil_for_an_unknown_prefix
+    slip = field_slips(:field_slip_one)
+    slip.update_columns(code: "NEMF-12781", project_id: nil)
+
+    assert_nil(slip.reload.event_project)
+  end
 end

--- a/test/models/field_slip_test.rb
+++ b/test/models/field_slip_test.rb
@@ -174,8 +174,11 @@ class FieldSlipTest < UnitTestCase
   end
 
   def test_event_project_nil_for_an_unknown_prefix
+    assert_nil(Project.find_by(field_slip_prefix: "ZZZX"),
+               "premise: no fixture project claims this prefix")
+
     slip = field_slips(:field_slip_one)
-    slip.update_columns(code: "NEMF-12781", project_id: nil)
+    slip.update_columns(code: "ZZZX-12781", project_id: nil)
 
     assert_nil(slip.reload.event_project)
   end


### PR DESCRIPTION
Part of the #5042 umbrella. Manual testing on main (obs 664208, a NEMF slip on a Colorado observation) hit "No project abbreviation is defined for EB2" — while the NEMF project defines EB2.

## Root cause

A knock-on effect of #5046's spare-slip semantics. The attach released the slip's project (the observation violates NEMF's constraints, so slip and observation stay out together — working as designed), but every alias-resolution path found the event by walking `slip.project` or the observation's memberships. With `slip.project_id` nil and the observation only in SMHF, the NEMF alias table became unreachable: the review warned about a defined abbreviation, the scan prompt was built from the wrong project's aliases, and applying the reviewed value would have left "EB2" verbatim instead of expanding it.

## Fix

New `FieldSlip#event_project`: the slip's own project, or — once a spare release has cleared that — the project its printed prefix names. Which event a slip was printed for (and therefore whose aliases decode the collector's scribbles) is a fact of the physical slip, not of current project membership. All four consumers now use it:

- `FieldSlipExtract#relevant_project_ids` / `#slip_project` — the unknown-abbreviation warning and location suggestions;
- `FieldSlip::Extractor::Context#project` — the scan prompt's alias table and template selection;
- `Extractor::Applier#project_alias` — applying reviewed values (this one previously consulted only the observation's memberships, not the slip's project at all);
- the review-save reconcile, which already derived the prefix project locally — its private helper is replaced by the shared method.

## Test plan

- Attach an event slip to an observation that violates the event project's constraints (the slip goes spare), then scan and review: an abbreviation the event project defines is not warned about, the location suggestion works, and saving the review expands the abbreviation to the real location.
- A spare slip whose prefix names no project (a retired event) still behaves as before: no aliases, no suggestions, plain-text location kept as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
