### PR TITLE
Don't warn "in use" about a slip the QR job just attached to this observation (`explain_in_use_slip` race)

### DIFF
--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -51,15 +51,22 @@ module ObservationsController::FieldSlips
   # the review page would just sit on its scan button -- say why, and
   # that saving the review is what links this observation to the slip.
   def explain_in_use_slip(code)
-    return if @observation.field_slip&.code == code
-
     slip = FieldSlip.find_by(code: code)
-    primary_id = slip&.occurrence&.primary_observation_id
-    return unless primary_id
+    occurrence = slip&.occurrence
+    return unless occurrence
+    # Checked against the slip's freshly loaded occurrence, not
+    # `@observation.field_slip` -- the QR job can attach the slip to
+    # THIS observation between the image upload and this check (it
+    # regularly wins that race in production), and the stale in-memory
+    # association would then warn about "another observation" that is
+    # this one (reported: obs 664468 warned about itself).
+    return if occurrence.observation_ids.include?(@observation.id)
 
     flash_warning(:observation_field_slip_in_use.t(
                     code: code,
-                    url: permanent_observation_path(primary_id)
+                    url: permanent_observation_path(
+                      occurrence.primary_observation_id
+                    )
                   ))
   end
 

--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -62,11 +62,12 @@ module ObservationsController::FieldSlips
     # this one (reported: obs 664468 warned about itself).
     return if occurrence.observation_ids.include?(@observation.id)
 
+    primary_id = occurrence.primary_observation_id
+    return unless primary_id
+
     flash_warning(:observation_field_slip_in_use.t(
                     code: code,
-                    url: permanent_observation_path(
-                      occurrence.primary_observation_id
-                    )
+                    url: permanent_observation_path(primary_id)
                   ))
   end
 

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -2131,6 +2131,44 @@ class ObservationsControllerCreateTest < FunctionalTestCase
   # The QR jobs refuse an in-use slip, so the review page would sit on
   # its scan button with nothing running -- the redirect explains why,
   # naming the observation that has the slip.
+  # Production race (obs 664468 warned about itself): the QR job can
+  # attach the slip to THIS observation between the image upload and
+  # the create request's own decode -- an in-memory association check
+  # then reads stale nil while the slip's occurrence is fresh. The
+  # decode stub performs the attach mid-request, exactly as the job
+  # does when it wins the race.
+  def test_create_no_in_use_warning_when_the_job_attached_to_this_obs
+    image = images(:in_situ_image)
+    make_slip_project_admin(rolf)
+    login("rolf")
+
+    attach_during_decode = lambda do |img|
+      obs = img.observations.order(:id).last
+      if obs&.occurrence_id.nil?
+        FieldSlip::Attacher.attach(observation: obs, code: "OPEN-0910",
+                                   user: rolf)
+      end
+      "OPEN-0910"
+    end
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:slip_code_in, attach_during_decode) do
+        post(:create, params: slip_photo_params(image))
+      end
+    end
+
+    assert_redirected_to(
+      edit_image_field_slip_extract_path(image.id, await: 1)
+    )
+    obs = assigns(:observation)
+
+    assert_equal("OPEN-0910", obs.reload.field_slip.code,
+                 "premise: the slip is attached to this observation")
+    assert_flash(
+      [[:runtime_observation_success, { id: obs.id }]],
+      on_fail: "a slip attached to this very observation is not in use"
+    )
+  end
+
   def test_create_explains_a_detected_code_already_in_use
     image = images(:in_situ_image)
     other = observations(:coprinus_comatus_obs)


### PR DESCRIPTION
Part of the #5042 umbrella. On production, creating an observation with a slip photo flashed "Field slip 2026-SMHF-1153 was detected in a photo, but it is already attached to another observation" — where the linked observation was the one just created (obs 664468).

## Root cause

A race the create request loses on production's job workers. Timeline: the request saves the observation and attaches the image, which enqueues `DetectFieldSlipQRJob`; the job decodes the QR and attaches the slip to the new observation — all before the request's own synchronous decode reaches `explain_in_use_slip`. That guard compared the code against `@observation.field_slip`, the request's **stale in-memory association** (loaded when `occurrence_id` was still nil), while `FieldSlip.find_by` read the slip **fresh** — now carrying the occurrence the job just created, whose primary observation is the observation itself. Dev never reproduces it because the job doesn't win the race there.

## Fix

The guard now asks the freshly loaded slip's occurrence whether it contains this observation, instead of trusting the stale association. A slip attached to the observation being created (by whoever got there first) is not "in use"; a slip on a genuinely different observation still warns with the link to its primary.

The regression test reproduces the race deterministically: the QR-decode stub performs the attach mid-request, exactly as the job does when it wins, and asserts the create completes with only the success notice.

## Test plan

- Create an observation with a readable slip photo on a fast-worker environment: no self-referential "in use" warning; the slip attaches and the review page loads normally.
- The genuine in-use case (a second observation photographing an already-attached slip) still warns, naming the other observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
