### PR TITLE
Update gets Create's slip-review handoff for newly added photos

### DIFF
--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -122,6 +122,9 @@ module ObservationsController::EditAndUpdate
   def init_update
     init_license_var
     init_new_image_var(@observation.when)
+    # Snapshotted so the post-save redirect can tell which photos THIS
+    # update added -- only those get the slip-review detour.
+    @image_ids_before_update = @observation.image_ids
     @any_errors = false
   end
 
@@ -311,7 +314,24 @@ module ObservationsController::EditAndUpdate
       redirect_to(new_location_path(where: @observation.place_name(@user),
                                     set_observation: @observation.id))
     else
+      return if redirected_to_new_photo_slip_review?
+
       redirect_to(permanent_observation_path(@observation.id))
     end
+  end
+
+  # A slip photographed into an existing observation gets the same
+  # review handoff Create gives (reported: a photo added on edit read
+  # the slip invisibly -- no redirect, no link -- so the observation
+  # sat unnamed and the collector rescanned by hand). Only photos this
+  # update added are candidates, so routine edits of a slip
+  # observation never detour.
+  def redirected_to_new_photo_slip_review?
+    new_images = @observation.images.reject do |image|
+      @image_ids_before_update.include?(image.id)
+    end
+    return false if new_images.empty?
+
+    redirected_to_field_slip_review?(new_images)
   end
 end

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -327,11 +327,12 @@ module ObservationsController::EditAndUpdate
   # update added are candidates, so routine edits of a slip
   # observation never detour.
   def redirected_to_new_photo_slip_review?
-    new_images = @observation.images.reject do |image|
-      @image_ids_before_update.include?(image.id)
-    end
-    return false if new_images.empty?
+    new_ids = @observation.image_ids - @image_ids_before_update
+    return false if new_ids.empty?
 
+    new_images = @observation.images.select do |image|
+      new_ids.include?(image.id)
+    end
     redirected_to_field_slip_review?(new_images)
   end
 end

--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -12,14 +12,15 @@
 module ObservationsController::FieldSlips
   private
 
-  # After Create, a slip reviewer lands straight on the review of the
-  # photographed slip: the extraction is usually already running by
-  # then (the QR jobs chain it on attach -- see DetectFieldSlipQRJob),
-  # and the review page shows its progress until the read is done.
-  # Decode-only here -- attaching the slip is the QR jobs' business --
-  # so this adds no writes to the request.
-  def redirected_to_field_slip_review?
-    image = field_slip_review_image
+  # After Create -- and after an update that photographed a slip into
+  # an existing observation -- a slip reviewer lands straight on the
+  # review of the photographed slip: the extraction is usually already
+  # running by then (the QR jobs chain it on attach -- see
+  # DetectFieldSlipQRJob), and the review page shows its progress
+  # until the read is done. Decode-only here -- attaching the slip is
+  # the QR jobs' business -- so this adds no writes to the request.
+  def redirected_to_field_slip_review?(images = @observation.images)
+    image = field_slip_review_image(images)
     return false unless image
 
     redirect_to(edit_image_field_slip_extract_path(image.id, await: 1))
@@ -32,11 +33,11 @@ module ObservationsController::FieldSlips
   # observation already HAS the matching slip -- created by scanning
   # or typing the code, which makes the QR jobs skip it -- the read is
   # started from here instead.
-  def field_slip_review_image
+  def field_slip_review_image(images)
     return nil unless FieldSlip::QRDecoder.available?
     return nil unless reviews_field_slips?
 
-    @observation.images.each do |image|
+    images.each do |image|
       code = FieldSlip::QRDecoder.slip_code_in(image)
       next unless code && reviewable_slip_code?(code)
 

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -1152,6 +1152,34 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     )
   end
 
+  # Location creation still wins over the slip-review detour: an
+  # unresolved locality has to become a Location before anything else.
+  def test_update_location_creation_outranks_the_slip_review_detour
+    obs = observations(:coprinus_comatus_obs)
+    obs.update!(occurrence: nil)
+    image = images(:in_situ_image)
+    project = projects(:open_membership_project)
+    project.admin_group.users << rolf unless project.is_admin?(rolf)
+
+    assert_nil(obs.location_id, "premise: locality unresolved")
+
+    login("rolf")
+    params = { id: obs.id,
+               observation: obs_params(obs).merge(
+                 good_image_ids: (obs.image_ids + [image.id]).join(" ")
+               ) }
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:slip_code_in, "OPEN-0923") do
+        put(:update, params: params)
+      end
+    end
+
+    assert_redirected_to(
+      new_location_path(where: obs.reload.place_name(rolf),
+                        set_observation: obs.id)
+    )
+  end
+
   # Routine edits of a slip observation never detour: only photos THIS
   # update added are candidates.
   def test_update_without_new_photos_does_not_detour

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -1117,6 +1117,92 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     assert_equal(rolf.textile_name, obs.reload.notes[:Field_Slip_ID_By])
   end
 
+  # ----------------------------------------------------------------
+  #  Slip-review handoff for photos added on edit (#5024 pipeline)
+  # ----------------------------------------------------------------
+
+  # A slip photographed into an existing observation gets the same
+  # review detour Create gives. Reported: a phone upload failed during
+  # create, the photo was added on edit instead, and the completed
+  # read sat invisible -- no redirect, no link -- so the observation
+  # stayed unnamed and got rescanned by hand (obs 664471).
+  def test_update_adding_a_slip_photo_detours_to_the_review
+    obs = observations(:coprinus_comatus_obs)
+    obs.update!(occurrence: nil, location: locations(:burbank),
+                where: locations(:burbank).name)
+    image = images(:in_situ_image)
+    project = projects(:open_membership_project)
+    project.admin_group.users << rolf unless project.is_admin?(rolf)
+
+    assert_not_includes(obs.images, image, "premise: the photo is new")
+
+    login("rolf")
+    params = { id: obs.id,
+               observation: obs_params(obs).merge(
+                 good_image_ids: (obs.image_ids + [image.id]).join(" ")
+               ) }
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:slip_code_in, "OPEN-0920") do
+        put(:update, params: params)
+      end
+    end
+
+    assert_redirected_to(
+      edit_image_field_slip_extract_path(image.id, await: 1)
+    )
+  end
+
+  # Routine edits of a slip observation never detour: only photos THIS
+  # update added are candidates.
+  def test_update_without_new_photos_does_not_detour
+    obs = observations(:coprinus_comatus_obs)
+    obs.update!(occurrence: nil, location: locations(:burbank),
+                where: locations(:burbank).name)
+    project = projects(:open_membership_project)
+    project.admin_group.users << rolf unless project.is_admin?(rolf)
+
+    assert_not_empty(obs.images, "premise: existing photos to re-decode")
+
+    login("rolf")
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:slip_code_in, "OPEN-0921") do
+        put(:update, params: { id: obs.id, observation: obs_params(obs) })
+      end
+    end
+
+    assert_redirected_to(permanent_observation_path(obs.id))
+  end
+
+  def test_update_adding_a_photo_does_not_detour_a_non_reviewer
+    obs = observations(:coprinus_comatus_obs)
+    obs.update!(occurrence: nil, location: locations(:burbank),
+                where: locations(:burbank).name)
+    image = images(:in_situ_image)
+
+    Project.where.not(field_slip_prefix: nil).find_each do |proj|
+      proj.admin_group.users.delete(rolf)
+    end
+
+    assert_not(
+      Project.where.not(field_slip_prefix: nil).
+        exists?(admin_group_id: rolf.reload.user_group_ids),
+      "premise: rolf reviews no slip projects"
+    )
+
+    login("rolf")
+    params = { id: obs.id,
+               observation: obs_params(obs).merge(
+                 good_image_ids: (obs.image_ids + [image.id]).join(" ")
+               ) }
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      FieldSlip::QRDecoder.stub(:slip_code_in, "OPEN-0922") do
+        put(:update, params: params)
+      end
+    end
+
+    assert_redirected_to(permanent_observation_path(obs.id))
+  end
+
   private
 
   def assert_field_slip_race_reported(status)


### PR DESCRIPTION
Part of the #5042 umbrella. Live-event finding (obs 664471): a phone's create-time photo upload failed, so the observation was created without images and the slip photo was added on **edit**. The QR job attached the slip and the chained extraction completed within seconds — but the update flow redirected straight to the show page with no pointer to the review, so the completed read sat invisible, the observation stayed unnamed, and the collector rescanned by hand from another browser (a second paid read of the same slip).

## Root cause

The review handoff (`redirected_to_field_slip_review?` → the `await=1` redirect) was wired into **create only**. Update always went to the show page (or location creation), and the observation show page has no scan-state indicator yet (#5041). Renaming is by design a review-save act, so with no path to the review, nothing visible happened.

## Fix

Update now detours to the review await page exactly as Create does, with two scoping guards:

- **Only photos this update added are candidates** — `init_update` snapshots the observation's image ids, and only images not in the snapshot are decoded. Routine edits of a slip observation never detour.
- **Location creation still wins** (an observation with an unresolved locality goes to the location form first), and the existing `reviews_field_slips?` gate keeps ordinary editors undetoured — same economics as create: only slip-project admins pay for scans or get detoured.

The shared helper now takes the image collection as a parameter; create passes its default (all images, which at create time are all new).

## Test plan

- Create an observation without photos, then add a slip photo on edit (as a slip-project admin): the save lands on the review await page, the read completes there, and saving the review applies the slip's fields and proposes the name — one scan, no manual rescan.
- Edit the same observation again without adding photos: normal redirect to the show page.
- A non-reviewer adding a photo: normal redirect, no scan cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
