### PR TITLE
Turbo-submit `Observations::NamingsController` + fix two lightbox/clone bugs found along the way

### DIFF
--- a/app/components/application_form/checkbox_field.rb
+++ b/app/components/application_form/checkbox_field.rb
@@ -58,7 +58,9 @@ class Components::ApplicationForm < Superform::Rails::Form
         # form control).
         render_boolean_with_wrapper(label_for: nil) { yield(self) }
       else
-        render_boolean_with_wrapper { render_boolean_inputs }
+        render_boolean_with_wrapper(label_for: boolean_label_for) do
+          render_boolean_inputs
+        end
       end
     end
 
@@ -238,6 +240,19 @@ class Components::ApplicationForm < Superform::Rails::Form
     # Use custom ID if provided, otherwise use Superform's generated ID
     def checkbox_id
       @attributes[:id] || field.dom.id
+    end
+
+    # Defaults to an explicit `for="<checkbox_id>"` (unchanged
+    # behavior), but a caller can pass `label_for: nil` when the
+    # checkbox's id isn't guaranteed unique on the page (e.g. content
+    # that gets cloned elsewhere in the DOM, like lightGallery's
+    # caption snapshot) -- an explicit `for=` pointing at a duplicated
+    # id makes browsers' label-click activation ambiguous even though
+    # the checkbox is ALSO nested inside this same label, which is a
+    # sufficient (and unambiguous) association on its own per the
+    # HTML label-activation spec.
+    def boolean_label_for
+      wrapper_options.fetch(:label_for) { checkbox_id }
     end
 
     def label_position_before?

--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -17,7 +17,8 @@ class Components::ApplicationForm < Superform::Rails::Form
                        :button_variant, :button_size, :button_target,
                        :button_rel, :button_title, :button_icon, :addon,
                        :monospace, :label_class, :label_data, :label_aria,
-                       :label_position, :width, :label_sr_only].freeze
+                       :label_position, :width, :label_sr_only,
+                       :label_for].freeze
 
     # Text field with label and Bootstrap form-group wrapper
     # @param field_name [Symbol] the field name

--- a/app/components/observation_fragment/mark_as_reviewed_toggle.rb
+++ b/app/components/observation_fragment/mark_as_reviewed_toggle.rb
@@ -39,6 +39,13 @@ class Components::ObservationFragment::MarkAsReviewedToggle <
                      label_position: :before,
                      wrap_class: "d-inline",
                      id: "#{@selector}_#{model.observation_id}",
+                     # The "caption" variant's id gets duplicated on
+                     # the page once its content is cloned into
+                     # lightGallery's caption snapshot -- an explicit
+                     # `for=` pointing at a duplicated id leaves label
+                     # clicks ambiguous. The checkbox is already
+                     # nested inside this label, which is sufficient.
+                     label_for: nil,
                      class: "mx-3",
                      data: checkbox_data)
     end

--- a/app/controllers/observations/namings_controller.rb
+++ b/app/controllers/observations/namings_controller.rb
@@ -31,7 +31,7 @@ module Observations
 
       respond_to do |format|
         format.turbo_stream { render_modal_naming_form }
-        format.html { render_phlex_new }
+        format.html { render_new_view }
       end
     end
 
@@ -67,7 +67,7 @@ module Observations
 
       respond_to do |format|
         format.turbo_stream { render_modal_naming_form }
-        format.html { render_phlex_edit }
+        format.html { render_edit_view }
       end
     end
 
@@ -177,16 +177,18 @@ module Observations
       }
     end
 
-    def render_phlex_new
+    def render_new_view(status: :ok, **render_opts)
       render(Views::Controllers::Observations::Namings::New.new(
                **naming_phlex_props
-             ))
+             ),
+             status: status, **render_opts)
     end
 
-    def render_phlex_edit
+    def render_edit_view(status: :ok, **render_opts)
       render(Views::Controllers::Observations::Namings::Edit.new(
                **naming_phlex_props
-             ))
+             ),
+             status: status, **render_opts)
     end
 
     # Successful-create response when the form was opened from the
@@ -339,8 +341,8 @@ module Observations
       respond_to do |format|
         format.html do
           case action_name
-          when "create" then render_phlex_new
-          when "update" then render_phlex_edit
+          when "create" then render_new_view_invalid
+          when "update" then render_edit_view_invalid
           end and return
         end
         format.turbo_stream do

--- a/app/javascript/controllers/lightgallery_controller.js
+++ b/app/javascript/controllers/lightgallery_controller.js
@@ -72,7 +72,16 @@ export default class extends Controller {
   // after the real DOM mutation completes.
   maybeRefreshOnStream(event) {
     const target = event.target.target;
-    if (!target || !/^(lightbox_caption_|lightbox_image_vote_)/.test(target)) {
+    // observation_what_/observation_identify_ -- Observations::
+    // NamingsController#render_update_matrix_box_streams, the
+    // "propose a name from the lightbox" success response. Without
+    // these, an open lightbox's cloned caption keeps showing the
+    // stale "needs naming" strip after a naming is proposed from
+    // inside it, even though the real (hidden) caption DOM updated
+    // correctly.
+    const refreshTriggers =
+      /^(lightbox_caption_|lightbox_image_vote_|observation_what_|observation_identify_)/;
+    if (!target || !refreshTriggers.test(target)) {
       return;
     }
 

--- a/app/views/controllers/observations/namings/edit.rb
+++ b/app/views/controllers/observations/namings/edit.rb
@@ -59,7 +59,7 @@ module Views::Controllers::Observations::Namings
                reasons: @reasons,
                feedback: @feedback,
                show_reasons: true,
-               local: true
+               local: false
              ))
     end
 

--- a/app/views/controllers/observations/namings/new.rb
+++ b/app/views/controllers/observations/namings/new.rb
@@ -61,7 +61,7 @@ module Views::Controllers::Observations::Namings
                reasons: @reasons,
                feedback: @feedback,
                show_reasons: true,
-               local: true
+               local: false
              ))
     end
 

--- a/test/controllers/observations/namings_controller_test.rb
+++ b/test/controllers/observations/namings_controller_test.rb
@@ -302,7 +302,8 @@ module Observations
       }
       login("dick")
       post(:create, params: params)
-      assert_response(:success) # really means failed
+      assert_unprocessable # really means failed
+      assert_select("form[data-turbo='true']")
       what = @controller.instance_variable_get(:@given_name)
       assert_equal("Agaricus campestris L.", what)
     end
@@ -344,7 +345,7 @@ module Observations
       }
       login("dick")
       post(:create, params: params)
-      assert_response(:success) # really means failed
+      assert_unprocessable # really means failed
     end
 
     def test_propose_naming_automatic_author_bug
@@ -365,8 +366,8 @@ module Observations
       name.reload
       assert_equal(old_author, name.author)
       assert_flash_error
-      assert_response(:success, "Was expecting it to re-serve the form " \
-                                "because the name wasn't recognized.")
+      assert_unprocessable("Was expecting it to re-serve the form " \
+                           "because the name wasn't recognized.")
     end
 
     def test_propose_naming_automatic_case_correction


### PR DESCRIPTION
## Summary

Split off from the batch-3 Turbo-submit sweep (issue #5052) into its own PR — converting `Observations::NamingsController` and auditing `Observations::Namings::VotesController` turned up two unrelated pre-existing browser bugs in the lightbox/matrix-box "propose a name" and "mark as reviewed" flows, all discovered and fixed via real-browser (Cuprite) instrumentation. Bundling the conversion with the fixes it needed to actually verify, rather than splitting them across branches.

## `Observations::NamingsController`

`local: false` on `New`/`Edit`'s `Form.new(...)` calls. Renamed `render_phlex_new`/`render_phlex_edit` to `render_new_view`/`render_edit_view`, matching the rest of this sweep, so `respond_to_form_errors`'s html branch (shared by both `create`'s and `update`'s failure paths) calls the shared `render_new_view_invalid`/`render_edit_view_invalid` instead of hand-rolling a status change. The turbo_stream paths (modal open/reload, matrix-box success response) were already safe, established patterns. No CRUD buttons in this controller's own view tree target its mutating actions.

## `Observations::Namings::VotesController`

Audited, no code changes needed — `Votes::Form` already had `local: false`, and every response path either redirects (html) or uses already-established-safe turbo_stream patterns.

## Bug 1: lightGallery's cloned caption never refreshes after proposing a name from the lightbox

`lightGallery` clones `.lightbox-caption`'s innerHTML into `.lg-sub-html` on open — a snapshot, not a live DOM reference. `section-update_controller.js`'s `maybeRefreshOnStream()` re-copies that snapshot after a relevant Turbo Stream update, but only recognized targets prefixed `lightbox_caption_`/`lightbox_image_vote_`. `Observations::NamingsController#render_update_matrix_box_streams` (the "propose a name from the lightbox" success response) uses `observation_what_<id>`/`observation_identify_<id>` targets instead, so the "needs naming" strip stayed visibly stuck in an open lightbox even though the real (hidden) caption DOM updated correctly. Widened the trigger regex to include those prefixes.

## Bug 2: reviewed-toggle checkbox stops working once a lightbox is open

Same root cause (lightGallery's id-preserving clone) manifesting differently: once a lightbox is open, there are two elements with `id="caption_reviewed_<obs_id>"` on the page — the original hidden one and the visible clone. `CheckboxField`'s boolean-mode label always added an explicit `for="<checkbox_id>"` in addition to nesting the checkbox inside the label. With a duplicated id, that `for=` attribute makes the browser's label-click activation ambiguous. Confirmed via real-browser instrumentation: clicking the label inside the open lightbox toggled neither checkbox and fired zero `turbo:submit-start` events.

Added an opt-in `label_for:` wrapper option to `CheckboxField`'s boolean mode (block mode already had this exact escape hatch internally, just not exposed) so a caller can suppress the `for=` attribute and rely on nesting alone — HTML's label-activation spec treats that as sufficient even with a duplicate id elsewhere on the page. Wired `MarkAsReviewedToggle` to use it. Default behavior is unchanged for the other 42 `checkbox_field` call sites in the app.

## Testing

- `test/controllers/observations/namings_controller_test.rb` (40 tests) — 3 pre-existing `assert_response(:success) # really means failed` assertions fixed to `assert_unprocessable`.
- `test/controllers/observations/namings/votes_controller_test.rb` (15 tests) — unchanged, still green.
- `test/components/application_form/checkbox_field_test.rb`, `test/components/observation_fragment/mark_as_reviewed_toggle_test.rb`, `test/views/controllers/observations/namings/form_test.rb`, `test/views/controllers/observations/namings/votes/form_test.rb` — unchanged, still green.
- Real-browser verification (Cuprite) of both bug fixes: `test/system/help_identify_system_test.rb` (all 3 tests fail on `main` today, all pass with these fixes) and `test/system/observation_naming_system_test.rb` (exercises the obs-show/`namings_table` context separately from identify/`matrix_box`).

## Test plan

- [x] `bin/rails test test/controllers/observations/namings_controller_test.rb` — 40 tests, all pass
- [x] `bin/rails test test/controllers/observations/namings/votes_controller_test.rb` — 15 tests, all pass
- [x] `bin/rails test test/system/help_identify_system_test.rb` — 3 tests, all pass (all 3 fail on `main`)
- [x] `bin/rails test test/system/observation_naming_system_test.rb` — passes
- [x] Confirmed both JS/component bugs via real-browser instrumentation before and after each fix
