### PR TITLE
Restore the spinners the SVG-sprite conversion emptied (`.spinner-right`)

### DIFF
--- a/app/assets/stylesheets/mo/_icons.scss
+++ b/app/assets/stylesheets/mo/_icons.scss
@@ -248,6 +248,19 @@ a:not(.btn):not(.inline-icon-link) > .mo-icon,
   animation: spin-r 1s infinite linear;
 }
 
+// The class only animates; the visible glyph is normally an Icon
+// inside. A JS-created spinner can't reach the SVG sprite (its URL is
+// a digested asset), so an EMPTY .spinner-right draws its own ring.
+.spinner-right:empty {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: text-bottom;
+  border: 0.15em solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+}
+
 @keyframes spin-r {
   0% {
     transform: rotate(0deg);

--- a/app/components/icon.rb
+++ b/app/components/icon.rb
@@ -34,7 +34,7 @@ class Components::Icon < Components::Base
     :find_on_map, :apply, :chevron_down, :chevron_up, :chevron_left,
     :chevron_right, :qrcode, :mobile, :project, :download,
     :new_window, :search, :prev, :next, :goto, :grid, :menu, :info,
-    :fullscreen, :matrix, :info_circle, :user
+    :fullscreen, :matrix, :info_circle, :user, :spinner, :reload
   ].freeze
 
   # vendor/assets/images/icons/mo-icons.svg only exists on disk when

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -60,7 +60,7 @@ module Views::Controllers::Images::FieldSlipExtracts
             # `.spinner-right` only animates; the visible glyph is the
             # icon (a bare span shows nothing since the SVG-sprite
             # conversion dropped the class's glyphicon).
-            Icon(type: :reuse, class: "spinner-right mx-2")
+            Icon(type: :spinner, class: "spinner-right mx-2")
             plain(:field_slip_extract_pending.l)
           end
         end

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -79,7 +79,7 @@ module Views::Controllers::Images::FieldSlipExtracts
       observation = @image.observations.first
       return unless observation
 
-      p do
+      p(class: "mt-3") do
         Link(type: :get, name: :field_slip_extract_observation_link.l,
              target: permanent_observation_path(observation.id))
       end

--- a/app/views/controllers/images/field_slip_extracts/status.rb
+++ b/app/views/controllers/images/field_slip_extracts/status.rb
@@ -57,7 +57,10 @@ module Views::Controllers::Images::FieldSlipExtracts
       div(data: { controller: "reload-poll" }) do
         Panel(panel_id: "field_slip_extract_pending") do |p|
           p.with_body do
-            span(class: "spinner-right mx-2")
+            # `.spinner-right` only animates; the visible glyph is the
+            # icon (a bare span shows nothing since the SVG-sprite
+            # conversion dropped the class's glyphicon).
+            Icon(type: :reuse, class: "spinner-right mx-2")
             plain(:field_slip_extract_pending.l)
           end
         end


### PR DESCRIPTION
The icon sweep (7158dd87d0) removed `.spinner-right`'s `@extend .glyphicon, .glyphicon-repeat`, making the class animation-only — the visible glyph must now come from inside the element. The sweep gave `Modal::ProgressSpinner` an `Icon(type: :reuse, ...)` but missed the other spinner call sites, which now render as an empty spinning gap. Two fixes:

- **The field-slip status page** (the reported case: no arrow beside "Reading the field slip…") gets the same Icon-inside pattern as `ProgressSpinner`.
- **JS-created spinners get a CSS-drawn ring**: an *empty* `.spinner-right` now draws a rotating ring via `currentColor` borders. JS can't reach the SVG sprite (its URL is a digested asset), so this covers `links_controller.js` and the just-merged form-feedback controller (#5035) with no markup changes; Icon-filled spinners are unaffected by the `:empty` guard.

## Test plan

- Press Read Field Slip: a spinning arrow renders beside "Reading the field slip…" again.
- Submit any non-Turbo form: the disabled button shows "Submitting" with a visible spinning ring (form-feedback's spinner, invisible since the icon sweep, works again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)