### PR TITLE
Address Copilot findings on `Account::PasswordResetsController` from #5070

### DIFF
--- a/app/controllers/account/password_resets_controller.rb
+++ b/app/controllers/account/password_resets_controller.rb
@@ -24,6 +24,8 @@ module Account
     private
 
     def find_user_by_login_name_or_email(login)
+      return nil if login.blank?
+
       User.find_by(
         User[:login].eq(login).
         or(User[:name].eq(login)).

--- a/app/controllers/account/password_resets_controller.rb
+++ b/app/controllers/account/password_resets_controller.rb
@@ -12,8 +12,7 @@ module Account
 
     def create
       @login = params[:new_user] && params[:new_user][:login]
-      @new_user = User.where("login = ? OR name = ? OR email = ?",
-                             @login, @login, @login).first
+      @new_user = find_user_by_login_name_or_email(@login)
       if @new_user.nil?
         flash_error(:runtime_email_new_password_failed.t(user: @login))
         return render_new_view_invalid
@@ -24,6 +23,14 @@ module Account
 
     private
 
+    def find_user_by_login_name_or_email(login)
+      User.find_by(
+        User[:login].eq(login).
+        or(User[:name].eq(login)).
+        or(User[:email].eq(login))
+      )
+    end
+
     def render_new_view(status: :ok, **render_opts)
       render(Views::Controllers::Account::PasswordResets::New.new(
                new_user: @new_user
@@ -32,8 +39,14 @@ module Account
 
     def set_random_password_for_new_user_and_email_them
       password = String.random(10)
-      @new_user.change_password(password)
-      if @new_user.save
+      # `change_password` persists immediately via `update_attribute`
+      # (bypassing validations) and returns that save's result -- a
+      # separate `@new_user.save` afterward would be redundant, and
+      # worse, misleading: it can't undo a password change that
+      # already landed, so checking it as the success signal risks
+      # flashing an error (no redirect, no email) after the password
+      # was already silently changed underneath the user.
+      if @new_user.change_password(password)
         flash_notice(:runtime_email_new_password_success.tp +
                      :email_spam_notice.tp)
         # Migrated from QueuedEmail::Password to ActionMailer + ActiveJob.

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -10,25 +10,9 @@
 #   P = prefetching allowed
 #
 #  ==== Sign-up
-#  signup::             <tt>(. V P)</tt> Create new account.
-#  verify::             <tt>(. V .)</tt> Verify new account.
-#  reverify::           <tt>(. V .)</tt> If verify fails(?)
-#  send_verify::        <tt>(. . .)</tt> Callback used by reverify.
+#  new::                <tt>(. V P)</tt> New-account form.
+#  create::             <tt>(. V P)</tt> Create new account.
 #  welcome::            <tt>(. V .)</tt> Welcome page after signup and verify.
-#
-#  ==== Login
-#  login::              <tt>(. V P)</tt>
-#  logout_user::        <tt>(. V .)</tt>
-#
-#  ==== Preferences
-#  prefs::              <tt>(L V P)</tt>
-#  profile::            <tt>(L V P)</tt>
-#  remove_image::       <tt>(L . .)</tt>
-#  no_email::           <tt>(L V .)</tt>
-#  api_keys::           <tt>(L V .)</tt>
-#
-#  ==== Testing
-#  test_autologin::     <tt>(L V .)</tt>
 #
 ################################################################################
 class AccountController < ApplicationController

--- a/test/controllers/account/password_resets_controller_test.rb
+++ b/test/controllers/account/password_resets_controller_test.rb
@@ -50,7 +50,7 @@ module Account
                        "New password should be different from old")
     end
 
-    # `@new_user.save` failing used to fall through with no render or
+    # A failing password change used to fall through with no render or
     # redirect at all -- a real request would raise, since there's no
     # ERB fallback template in this Phlex-only app (found via Copilot
     # review on #5058). Force the failure by stubbing `save` on the
@@ -59,13 +59,12 @@ module Account
     # fix.
     def test_create_save_failure
       user = users(:roy)
-      # `update_attribute` (called internally by `change_password`)
-      # calls `save(validate: false)` -- accept and ignore args so
-      # both that call and the controller's own `@new_user.save`
-      # hit this stub.
+      # `change_password` calls `update_attribute`, which calls
+      # `save(validate: false)` -- accept and ignore args so that
+      # call hits this stub.
       user.define_singleton_method(:save) { |*_args| false }
 
-      User.stub(:where, ->(*_args) { [user] }) do
+      User.stub(:find_by, ->(*_args) { user }) do
         assert_no_enqueued_jobs do
           post(:create, params: { new_user: { login: user.login } })
         end

--- a/test/controllers/account/password_resets_controller_test.rb
+++ b/test/controllers/account/password_resets_controller_test.rb
@@ -28,6 +28,29 @@ module Account
       assert_select("form#account_password_reset_form")
     end
 
+    # A missing/blank `login` param used to build `User[:name].eq(nil)`
+    # -> `name IS NULL` in the query, which could match an arbitrary
+    # user who never set a display name (`users.name` has no NOT NULL
+    # constraint), silently resetting a stranger's password (Copilot
+    # review on #5072). Create a user with a nil name so this test
+    # would have matched them before the `login.blank?` guard.
+    def test_create_blank_login_does_not_match_nil_name_user
+      nameless_user = User.create!(login: "nameless_login_user",
+                                   email: "nameless_login_user@example.com")
+      assert_nil(nameless_user.name)
+      old_password = nameless_user.password
+
+      assert_no_enqueued_jobs do
+        post(:create, params: { new_user: { login: "" } })
+      end
+
+      assert_unprocessable
+      assert_flash_error
+      nameless_user.reload
+      assert_equal(old_password, nameless_user.password,
+                   "Blank login should not match the nameless user")
+    end
+
     def test_create_success
       user = users(:roy)
       old_password = user.password


### PR DESCRIPTION
## Summary

Follow-up to #5070, addressing four Copilot review findings that landed after merge:

- `Account::PasswordResetsController#create` used a raw SQL string (`User.where("login = ? OR name = ? OR email = ?", ...)`), violating `.claude/rules/no_raw_sql.md`. Replaced with the same Arel pattern `User.authenticate` already uses.
- `set_random_password_for_new_user_and_email_them` called `@new_user.change_password(password)` then separately checked `@new_user.save`. `change_password` already persists via `update_attribute` (skipping validations) and returns that save's result, so the second `save` was redundant — and its failure couldn't undo an already-persisted password change, so a user could get a silently-changed password alongside a flashed error and no email. Now checks `change_password`'s own return value directly.
- `AccountController`'s header doc comment still listed `Login`/`Preferences`/`Testing` actions (`login`, `logout_user`, `prefs`, `profile`, `remove_image`, `no_email`, `api_keys`, `test_autologin`) that moved into their own `Account::*` controllers in earlier refactors — none of them are defined in this file anymore. Trimmed to the actions that are actually here (`new`/`create`/`welcome`) rather than appending the new `password_reset` route to an already-stale list.
- A second Copilot pass flagged that a missing/blank `new_user[login]` param built `User[:name].eq(nil)` -> `name IS NULL` in the lookup query. `users.name` has no `NOT NULL` constraint (unlike `login`/`email`, which default to `""`), so this could match an arbitrary user who never set a display name and reset their password from a malformed request with no real identifying info. Added a `login.blank?` guard before the query is built, plus a regression test — verified by temporarily removing the guard and confirming the test fails (a password-reset email gets enqueued for the nameless user).

## Test plan

- [x] `bin/rails test test/controllers/account/password_resets_controller_test.rb`
- [x] `bin/rails test test/controllers/account_controller_test.rb`
- [x] `bundle exec rubocop` on all touched files, clean
