### PR TITLE
Fix `Components::Form::NameFeedback` losing its help text for unrecognized names

### DIFF
--- a/app/components/form/name_feedback.rb
+++ b/app/components/form/name_feedback.rb
@@ -21,7 +21,14 @@ class Components::Form::NameFeedback < Components::Base
   prop :parent_deprecated, _Nilable(Name), default: nil
 
   def view_template
-    if @valid_names
+    # `@valid_names` can be a non-nil but EMPTY array when no
+    # corrections/synonyms were found (e.g. Naming::NameResolver's
+    # Name.suggest_alternate_spellings comes up empty for a
+    # completely unrecognized name) -- `if @valid_names` alone is
+    # true for `[]`, wrongly routing there instead of the "not
+    # recognized" branch below (whose help text always renders,
+    # JoeCohen review on #5055).
+    if @valid_names&.any?
       render_warning_alert
     elsif @names && @names.empty?
       render_not_recognized_error

--- a/test/components/form/name_feedback_test.rb
+++ b/test/components/form/name_feedback_test.rb
@@ -26,6 +26,27 @@ class FormNameFeedbackTest < ComponentTestCase
     assert_html(html, ".alert-danger")
   end
 
+  # Naming::NameResolver sets `valid_names` to a non-nil but EMPTY
+  # array (Name.suggest_alternate_spellings finding nothing), not
+  # nil, when a name is totally unrecognized -- `if @valid_names`
+  # alone is true for `[]` too, so this used to wrongly render the
+  # warning branch (whose help text is itself gated on
+  # `valid_names.any?`, so nothing but the bare "not recognized"
+  # sentence ever appeared). JoeCohen review on #5055.
+  def test_renders_not_recognized_error_when_valid_names_is_empty_array
+    html = render_feedback(
+      given_name: "Xxxx yyy",
+      names: [],
+      valid_names: [],
+      suggest_corrections: true
+    )
+
+    assert_html(html, "#name_messages")
+    assert_html(html, ".alert-danger")
+    assert_no_html(html, ".alert-warning")
+    assert_includes(html, :form_naming_not_recognized_help.t(button: "Create"))
+  end
+
   def test_renders_deprecated_warning_with_valid_synonyms
     html = render_feedback(
       given_name: "Deprecated name",

--- a/test/integration/capybara/namings_integration_test.rb
+++ b/test/integration/capybara/namings_integration_test.rb
@@ -61,8 +61,12 @@ class NamingsIntegrationTest < CapybaraIntegrationTestCase
       form.first("button[type='submit']").click
     end
     namer_session.assert_selector("body.namings__new")
+    # .alert-danger, not .alert-warning: no alternate-spelling
+    # suggestions exist for this name, so NameFeedback renders the
+    # "not recognized" branch (which always includes help text),
+    # not the "here are some valid names to pick from" warning.
     assert_true(namer_session.has_selector?(
-                  ".alert-warning",
+                  ".alert-danger",
                   text: /MO does not recognize the name.*#{text_name}/
                 ))
 

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -112,6 +112,30 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
                "Naming should not have reason 2 (was unchecked before submit)")
   end
 
+  # JoeCohen's review on #5055: the "MO does not recognize the name"
+  # message used to appear alone, missing the "To proceed..." help
+  # text telling the user to fix the spelling or click Create.
+  # Root cause was in Components::Form::NameFeedback, not this form,
+  # but the observation form is exactly where a user hits it.
+  def test_name_not_recognized_message_includes_help_text
+    login!(users(:zero_user))
+    visit(new_observation_path)
+    assert_selector("body.observations__new")
+
+    fill_in("observation_place_name", with: locations.first.name)
+    naming = find_by_id("observation_naming_specimen")
+    scroll_to(naming, align: :top)
+    fill_in("observation_naming_name", with: "Elfin saddle")
+    page.driver.browser.keyboard.type(:tab)
+
+    within("#observation_form") { click_commit }
+
+    assert_selector("#name_messages.alert-danger", wait: 6)
+    assert_selector("#name_messages", text: "MO does not recognize the name")
+    assert_selector("#name_messages", text: "To proceed")
+    assert_selector("#name_messages", text: "Create")
+  end
+
   def test_trying_to_create_duplicate_location_just_uses_existing_location
     setup_image_dirs # in general_extensions
     login!(katrina)


### PR DESCRIPTION
## Summary

Fixes the bug JoeCohen flagged on #5055 (called out there as preexisting/out of scope for that PR, tracked separately here).

- `Naming::NameResolver` sets `@valid_names` to a non-nil but **empty** array (`Name.suggest_alternate_spellings` finding nothing), not `nil`, when a name is completely unrecognized.
- `Components::Form::NameFeedback#view_template` checked `if @valid_names` alone, which is true for `[]` too, so it took the "warning with synonym choices" branch instead of the "not recognized" branch.
- That warning branch's own help text (`render_warning_help`) is itself gated on `@valid_names&.any?`, so nothing but the bare "MO does not recognize the name '...'." sentence ever rendered — the "To proceed: edit the name... or click 'Create'" follow-up silently disappeared.
- Fix: check `@valid_names&.any?` instead of `@valid_names` in `view_template`, so an empty-but-present array correctly falls through to the "not recognized" branch, whose help text always renders.

## Verification

Confirmed with a real browser (Cuprite) that the isolated component render was correct but the actual observation-form flow was not, which narrowed this down to the controller/resolver setting different props than assumed. Added a component test reproducing the exact prop shape `Naming::NameResolver` produces (`valid_names: []`, `suggest_corrections: true`), and verified it actually catches the regression by temporarily reverting the fix and confirming the test fails.

## Test plan

- [x] `bin/rails test test/components/form/name_feedback_test.rb`
- [x] `bin/rails test test/system/observation_form_system_test.rb`
- [x] `bin/rails test test/controllers/observations_controller_create_test.rb`
- [x] `bundle exec rubocop` on all touched files, clean
