### PR TITLE
Fix language locale leakage: stop persisting `?user_locale=` to `@user.locale`, make the switcher POST

### DIFF
--- a/app/assets/stylesheets/mo/_icons.scss
+++ b/app/assets/stylesheets/mo/_icons.scss
@@ -170,10 +170,10 @@
 
 // Icon-only buttons: only the glyph (via .mo-icon's fill: currentColor
 // tracking .btn-link's :hover color) should change on hover, not the
-// button background. Excludes .dropdown-item -- those need their
-// normal Bootstrap hover-highlight background, which is the whole
-// point of that rule.
-.btn-link:not(.dropdown-item) {
+// button background. Excludes .dropdown-item and .list-group-item --
+// those need their normal Bootstrap hover-highlight background,
+// which is the whole point of those rules.
+.btn-link:not(.dropdown-item):not(.list-group-item) {
   &:hover,
   &:focus,
   &:active,

--- a/app/assets/stylesheets/mo/_left_nav.scss
+++ b/app/assets/stylesheets/mo/_left_nav.scss
@@ -87,9 +87,13 @@
   color: $panel-default-text;
   background-color: $list-group-bg;
 
+  // `$list-group-hover-bg` maps to the same theme variable as
+  // `$list-group-bg` in every MO theme (see
+  // _map_theme_vars_to_bootstrap_vars.scss), making it a no-op --
+  // darken the base color directly instead.
   &:hover,
   &:focus {
     color: $panel-default-text;
-    background-color: $list-group-hover-bg;
+    background-color: darken($list-group-bg, 5%);
   }
 }

--- a/app/components/language_switch_button.rb
+++ b/app/components/language_switch_button.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# POST button that switches the app's locale -- shared by the
+# sidebar's language switcher and the translators' note page's
+# beta-inclusive language list, both rendering the same flag+name
+# row content. A GET link here would be a crawler/bookmark/browser-
+# history replay hazard: `set_locale` reads this same `user_locale`
+# param on every request (issue #5074).
+#
+# @example
+#   LanguageSwitchButton(language: lang, id: "lang_drop_#{lang.locale}_link",
+#                        class: css_class)
+class Components::LanguageSwitchButton < Components::Base
+  # Regional-indicator flag emoji per locale — a deliberate mapping,
+  # not a formula. ISO 639 language codes and ISO 3166 country codes
+  # are different systems that only coincidentally overlap, and
+  # sometimes collide misleadingly: `uk` here is Ukrainian, not "UK"
+  # (which isn't even a real ISO 3166 code — Great Britain is `GB`);
+  # `ar` (Arabic) has no single owning country, and ISO 3166 `AR` is
+  # Argentina, unrelated to the language. Each entry is a curated
+  # choice, matching the flags the old `public/flags/flag-*.png`
+  # assets showed.
+  FLAG_EMOJI = {
+    "ar" => "🇵🇸", # Arabic — Palestine
+    "be" => "🇧🇾", # Belarusian — Belarus
+    "de" => "🇩🇪", # German — Germany
+    "el" => "🇬🇷", # Greek — Greece
+    "en" => "🇬🇧", # English — Great Britain
+    "es" => "🇪🇸", # Spanish — Spain
+    "fa" => "🇮🇷", # Persian/Farsi — Iran
+    "fr" => "🇫🇷", # French — France
+    "it" => "🇮🇹", # Italian — Italy
+    "jp" => "🇯🇵", # Japanese — Japan
+    "pl" => "🇵🇱", # Polish — Poland
+    "pt" => "🇵🇹", # Portuguese — Portugal
+    "ru" => "🇷🇺", # Russian — Russia
+    "tr" => "🇹🇷", # Turkish — Turkey
+    "uk" => "🇺🇦", # Ukrainian — Ukraine
+    "zh" => "🇨🇳"  # Chinese — China
+  }.freeze
+  DEFAULT_FLAG = "🏳️"
+
+  def self.flag_for(locale)
+    FLAG_EMOJI.fetch(locale.to_s, DEFAULT_FLAG)
+  end
+
+  prop :language, ::Language
+  prop :attributes, _Hash(Symbol, _Any?), :**
+
+  def view_template
+    Button(
+      type: :post,
+      name: @language.name,
+      target: switch_locale_path,
+      params: { user_locale: @language.locale },
+      variant: :link,
+      **@attributes.except(:data),
+      data: button_data
+    ) { render_content }
+  end
+
+  private
+
+  # `name:` above is required syntax but only drives CRUDBase's
+  # auto-tooltip (suppressed here) -- render_content is the actual
+  # visible content.
+  def button_data
+    (@attributes[:data] || {}).merge(tooltip_target: nil)
+  end
+
+  def render_content
+    span(class: "lang-flag-emoji") do
+      plain(self.class.flag_for(@language.locale))
+    end
+    whitespace
+    plain(@language.name)
+    return unless @language.beta
+
+    whitespace
+    span { plain("(beta)") }
+  end
+end

--- a/app/controllers/application_controller/internationalization.rb
+++ b/app/controllers/application_controller/internationalization.rb
@@ -48,10 +48,12 @@ module ApplicationController::Internationalization
     # Only change the Locale code if it needs changing.  There is about a 0.14
     # second performance hit every time we change it... even if we're only
     # changing it to what it already is!!
+    #
+    # This only ever touches I18n.locale/session -- never @user.locale.
+    # A bare `?user_locale=` param (bookmark, crawler, remembered URL)
+    # must not silently overwrite the account's stored preference; only
+    # the Preferences form does that (see issue #5074).
     change_locale_if_needed(lang.locale)
-
-    # Update user preference.
-    @user.update(locale: lang.locale) if @user && @user.locale != lang.locale
 
     logger.debug("[I18n] Locale set to #{I18n.locale}")
 

--- a/app/controllers/application_controller/internationalization.rb
+++ b/app/controllers/application_controller/internationalization.rb
@@ -37,8 +37,8 @@ module ApplicationController::Internationalization
   # Globalite default.  Tries to get the locale from:
   #
   # 1. parameters (user clicked on language in bottom left)
-  # 2. user prefs (user edited their preferences)
-  # 3. session (whatever we used last time)
+  # 2. session (user explicitly switched earlier this session)
+  # 3. user prefs (user edited their preferences)
   # 4. navigator (provides default)
   # 5. server (MO.default_locale)
   #
@@ -48,12 +48,17 @@ module ApplicationController::Internationalization
     # Only change the Locale code if it needs changing.  There is about a 0.14
     # second performance hit every time we change it... even if we're only
     # changing it to what it already is!!
-    #
-    # This only ever touches I18n.locale/session -- never @user.locale.
-    # A bare `?user_locale=` param (bookmark, crawler, remembered URL)
-    # must not silently overwrite the account's stored preference; only
-    # the Preferences form does that (see issue #5074).
     change_locale_if_needed(lang.locale)
+
+    # Remember an explicit switch for the rest of the session, so it
+    # outranks prefs_locale on the next request -- otherwise a
+    # logged-in user's switch reverts on their very next page load,
+    # since their stored account preference never changed (only the
+    # Preferences form changes that; see issue #5074). Only written
+    # here, from an explicit params_locale hit -- never from prefs_
+    # locale/browser_locale falling through below, or a stale value
+    # would outrank a fresher account preference after login.
+    session[:locale] = lang.locale if params_locale
 
     logger.debug("[I18n] Locale set to #{I18n.locale}")
 
@@ -62,7 +67,7 @@ module ApplicationController::Internationalization
   end
 
   def specified_locale
-    params_locale || prefs_locale || session_locale || browser_locale
+    params_locale || session_locale || prefs_locale || browser_locale
   end
 
   def params_locale
@@ -73,18 +78,18 @@ module ApplicationController::Internationalization
     locale
   end
 
-  def prefs_locale
-    return unless @user&.locale.present? && params[:controller] != "ajax"
-
-    logger.debug("[I18n] loading locale: #{@user.locale} from @user")
-    @user.locale
-  end
-
   def session_locale
     return unless session[:locale]
 
     logger.debug("[I18n] loading locale: #{session[:locale]} from session")
     session[:locale]
+  end
+
+  def prefs_locale
+    return unless @user&.locale.present? && params[:controller] != "ajax"
+
+    logger.debug("[I18n] loading locale: #{@user.locale} from @user")
+    @user.locale
   end
 
   def browser_locale
@@ -98,7 +103,6 @@ module ApplicationController::Internationalization
     return if I18n.locale.to_s == new_locale
 
     I18n.locale = new_locale
-    session[:locale] = new_locale
   end
 
   # Before filter: Set timezone based on cookie set in application layout.

--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Backs the sidebar's POST-based language switcher (issue #5074). The
+# actual locale resolution already happens in
+# ApplicationController::Internationalization#set_locale's before_action,
+# which reads params[:user_locale] -- this action only needs to return
+# the visitor to wherever they were.
+class LocalesController < ApplicationController
+  def update
+    redirect_back_or_to(root_path)
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -45,6 +45,7 @@ class ApplicationMailer < ActionMailer::Base
     content_style = calc_content_style(headers)
     mail_args = mo_mail_args(title, to, headers, content_style)
     deliver_phlex_mail(mail_args, headers, content_style, mailer_view_class)
+  ensure
     I18n.locale = @old_locale if I18n.locale != @old_locale
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,6 +2,14 @@
 
 #  Base class for mailers for each type of email
 class ApplicationMailer < ActionMailer::Base
+  # Every mailer action can render in a different locale (see
+  # `setup_user`), so `mo_mail`'s `ensure` needs to know what to
+  # restore `I18n.locale` to when the action's done -- captured here,
+  # not in `setup_user`, so mailers that never call `setup_user`
+  # (e.g. WebmasterMailer, always sent in MO.default_locale) still
+  # get a real value instead of leaving `@old_locale` nil.
+  before_action { @old_locale = I18n.locale }
+
   # Use native Ruby URI::MailTo class
   def self.valid_email_address?(address)
     address.to_s.match?(URI::MailTo::EMAIL_REGEXP)
@@ -32,7 +40,6 @@ class ApplicationMailer < ActionMailer::Base
 
   def setup_user(user)
     @user = user
-    @old_locale = I18n.locale
     new_locale = @user.try(&:locale) || MO.default_locale
     # Setting I18n.locale used to incur a significant performance penalty,
     # avoid doing so if not required.  Not sure if this is still the case.

--- a/app/views/controllers/info/translators_note.rb
+++ b/app/views/controllers/info/translators_note.rb
@@ -13,19 +13,14 @@ module Views::Controllers::Info
                            "blob/main/config/locales/en.txt"
                    ))
 
-      ul { @languages.each { |lang| render_lang(lang) } }
+      @languages.each { |lang| render_lang(lang) }
     end
 
     private
 
     def render_lang(lang)
-      li do
-        Link(type: :get, name: lang.name,
-             target: reload_with_args(user_locale: lang.locale))
-        if lang.beta
-          whitespace
-          span { "(beta)" }
-        end
+      render(Components::ListGroup::LinkItem.new) do |css_class|
+        LanguageSwitchButton(language: lang, class: css_class)
       end
     end
   end

--- a/app/views/layouts/sidebar/languages.rb
+++ b/app/views/layouts/sidebar/languages.rb
@@ -56,7 +56,11 @@ class Views::Layouts::Sidebar
     def view_template
       render_toggle
       Collapsible(id: COLLAPSE_ID) do
-        @languages.each { |lang| render_language_row(lang) }
+        @languages.each do |lang|
+          next if lang.locale == I18n.locale.to_s
+
+          render_language_row(lang)
+        end
       end
     end
 

--- a/app/views/layouts/sidebar/languages.rb
+++ b/app/views/layouts/sidebar/languages.rb
@@ -103,7 +103,10 @@ class Views::Layouts::Sidebar
           variant: :link,
           id: "lang_drop_#{lang.locale}_link",
           class: css_class,
-          data: { locale: lang.locale }
+          # `name:` is required syntax but only drives CRUDBase's
+          # auto-tooltip -- suppress it here since the block content
+          # below already shows the same text visibly.
+          data: { locale: lang.locale, tooltip_target: nil }
         ) do
           span(class: "lang-flag-emoji") { plain(flag_for(lang.locale)) }
           whitespace

--- a/app/views/layouts/sidebar/languages.rb
+++ b/app/views/layouts/sidebar/languages.rb
@@ -13,35 +13,6 @@ class Views::Layouts::Sidebar
   #     request: request
   #   ))
   class Languages < ::Views::Base
-    # Regional-indicator flag emoji per locale — a deliberate mapping,
-    # not a formula. ISO 639 language codes and ISO 3166 country codes
-    # are different systems that only coincidentally overlap, and
-    # sometimes collide misleadingly: `uk` here is Ukrainian, not "UK"
-    # (which isn't even a real ISO 3166 code — Great Britain is `GB`);
-    # `ar` (Arabic) has no single owning country, and ISO 3166 `AR` is
-    # Argentina, unrelated to the language. Each entry is a curated
-    # choice, matching the flags the old `public/flags/flag-*.png`
-    # assets showed.
-    FLAG_EMOJI = {
-      "ar" => "🇵🇸", # Arabic — Palestine
-      "be" => "🇧🇾", # Belarusian — Belarus
-      "de" => "🇩🇪", # German — Germany
-      "el" => "🇬🇷", # Greek — Greece
-      "en" => "🇬🇧", # English — Great Britain
-      "es" => "🇪🇸", # Spanish — Spain
-      "fa" => "🇮🇷", # Persian/Farsi — Iran
-      "fr" => "🇫🇷", # French — France
-      "it" => "🇮🇹", # Italian — Italy
-      "jp" => "🇯🇵", # Japanese — Japan
-      "pl" => "🇵🇱", # Polish — Poland
-      "pt" => "🇵🇹", # Portuguese — Portugal
-      "ru" => "🇷🇺", # Russian — Russia
-      "tr" => "🇹🇷", # Turkish — Turkey
-      "uk" => "🇺🇦", # Ukrainian — Ukraine
-      "zh" => "🇨🇳"  # Chinese — China
-    }.freeze
-    DEFAULT_FLAG = "🏳️"
-
     TOGGLE_ID = "language_dropdown_toggle"
     COLLAPSE_ID = "language_dropdown_collapse"
 
@@ -81,7 +52,9 @@ class Views::Layouts::Sidebar
              id: TOGGLE_ID, class: css_class) do
           plain("#{:app_languages.t}:")
           whitespace
-          span(class: "lang-flag-emoji") { plain(flag_for(I18n.locale)) }
+          span(class: "lang-flag-emoji") do
+            plain(Components::LanguageSwitchButton.flag_for(I18n.locale))
+          end
           whitespace
           Icon(type: :chevron_down, title: :open.ti,
                class: "active-icon")
@@ -90,37 +63,17 @@ class Views::Layouts::Sidebar
       end
     end
 
-    # POST, not a GET link (issue #5074) -- a GET link here is a
-    # crawler/bookmark/browser-history replay hazard: `set_locale`
-    # reads this same `user_locale` param on every request, so a
-    # remembered/indexed GET URL could flip a logged-in user's
-    # session to a locale they never chose.
     def render_language_row(lang)
       render(
         Components::ListGroup::LinkItem.new(class: "indent")
       ) do |css_class|
-        Button(
-          type: :post,
-          name: lang.name,
-          target: switch_locale_path,
-          params: { user_locale: lang.locale },
-          variant: :link,
+        LanguageSwitchButton(
+          language: lang,
           id: "lang_drop_#{lang.locale}_link",
           class: css_class,
-          # `name:` is required syntax but only drives CRUDBase's
-          # auto-tooltip -- suppress it here since the block content
-          # below already shows the same text visibly.
-          data: { locale: lang.locale, tooltip_target: nil }
-        ) do
-          span(class: "lang-flag-emoji") { plain(flag_for(lang.locale)) }
-          whitespace
-          plain(lang.name)
-        end
+          data: { locale: lang.locale }
+        )
       end
-    end
-
-    def flag_for(locale)
-      FLAG_EMOJI.fetch(locale.to_s, DEFAULT_FLAG)
     end
   end
 end

--- a/app/views/layouts/sidebar/languages.rb
+++ b/app/views/layouts/sidebar/languages.rb
@@ -45,18 +45,13 @@ class Views::Layouts::Sidebar
     TOGGLE_ID = "language_dropdown_toggle"
     COLLAPSE_ID = "language_dropdown_collapse"
 
-    # `:browser` is unused inside this view but kept for API
-    # symmetry with `Sidebar`, which threads both
-    # `browser:` and `request:` through to here. Duck-typed for the
-    # same reason as the parent (tests pass a Struct stub).
+    # `:browser` and `:request` are both unused inside this view but
+    # kept for API symmetry with `Sidebar`, which threads both through
+    # uniformly to every sub-view it renders. Duck-typed for the same
+    # reason as the parent (tests pass a Struct stub).
     prop :browser, _Interface(:bot?)
-    # Used via `attr_reader :request` so `reload_with_args` (inherited
-    # from `Views::Base`) can read `request.url`.
     prop :request, _Interface(:url)
     prop :languages, _Array(Language)
-
-    # Make request available to the inherited `reload_with_args`.
-    attr_reader :request
 
     def view_template
       render_toggle
@@ -91,14 +86,25 @@ class Views::Layouts::Sidebar
       end
     end
 
+    # POST, not a GET link (issue #5074) -- a GET link here is a
+    # crawler/bookmark/browser-history replay hazard: `set_locale`
+    # reads this same `user_locale` param on every request, so a
+    # remembered/indexed GET URL could flip a logged-in user's
+    # session to a locale they never chose.
     def render_language_row(lang)
       render(
         Components::ListGroup::LinkItem.new(class: "indent")
       ) do |css_class|
-        a(href: reload_with_args(user_locale: lang.locale),
+        Button(
+          type: :post,
+          name: lang.name,
+          target: switch_locale_path,
+          params: { user_locale: lang.locale },
+          variant: :link,
           id: "lang_drop_#{lang.locale}_link",
           class: css_class,
-          data: { locale: lang.locale }) do
+          data: { locale: lang.locale }
+        ) do
           span(class: "lang-flag-emoji") { plain(flag_for(lang.locale)) }
           whitespace
           plain(lang.name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -675,6 +675,11 @@ MushroomObserver::Application.routes.draw do
   # ----- Policy: one route  --------------------------------------------------
   get("/policy/privacy")
 
+  # ----- Locale: one route (issue #5074) --------------------------------
+  # POST, not GET, so the language switcher can't be replayed by crawlers,
+  # browser history, or bookmarks -- see LocalesController.
+  post("/locale", to: "locales#update", as: "switch_locale")
+
   namespace :projects do
     resource :search, only: [:new, :create]
   end

--- a/test/components/language_switch_button_test.rb
+++ b/test/components/language_switch_button_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class LanguageSwitchButtonTest < ComponentTestCase
+  def test_posts_to_switch_locale_path_with_user_locale_param
+    html = render_button(languages(:french))
+
+    assert_html(html,
+                "form[action='#{routes.switch_locale_path}'][method='post']")
+    assert_html(html,
+                "form input[type='hidden']" \
+                "[name='user_locale'][value='fr']")
+  end
+
+  def test_renders_flag_and_name
+    lang = languages(:french)
+    html = render_button(lang)
+
+    assert_html(html, "button span.lang-flag-emoji",
+                text: Components::LanguageSwitchButton::FLAG_EMOJI.fetch("fr"))
+    assert_includes(html, lang.name)
+  end
+
+  def test_suppresses_auto_tooltip
+    html = render_button(languages(:french))
+
+    assert_no_html(html, "button[data-tooltip-target]")
+  end
+
+  def test_beta_language_shows_beta_label
+    html = render_button(languages(:greek))
+
+    assert_includes(html, "(beta)")
+  end
+
+  def test_non_beta_language_omits_beta_label
+    html = render_button(languages(:french))
+
+    assert_no_html(html, "button", text: /beta/)
+  end
+
+  def test_extra_html_attributes_forwarded
+    html = render_button(languages(:french), id: "my_id",
+                                             class: "list-group-item indent",
+                                             data: { locale: "fr" })
+
+    assert_html(html, "button#my_id.list-group-item.indent" \
+                      "[data-locale='fr']")
+  end
+
+  private
+
+  def render_button(language, **)
+    render(Components::LanguageSwitchButton.new(language:, **))
+  end
+end

--- a/test/controllers/application_controller_internationalization_test.rb
+++ b/test/controllers/application_controller_internationalization_test.rb
@@ -68,4 +68,65 @@ class ApplicationControllerInternationalizationAccountPersistenceTest <
     assert_equal("en", user.reload.locale,
                  "A bare user_locale param must not change @user.locale")
   end
+
+  # Issue #5074, second bug found in review: an explicit switch must
+  # outrank the account's stored preference for the rest of the
+  # session, or it reverts on the visitor's very next page load --
+  # exactly what happened when @user.locale stopped being silently
+  # overwritten (the whole point of the fix above) without also
+  # fixing specified_locale's priority order.
+  def test_explicit_switch_sticks_on_next_request_for_logged_in_user
+    user = users(:rolf)
+    user.update(locale: "en")
+    login(user.login)
+
+    get(:index, params: { user_locale: "pt" })
+    assert_equal("pt", I18n.locale.to_s)
+
+    # Follow-up request, no user_locale param -- simulates the
+    # redirect back after the switcher POST.
+    get(:index)
+
+    assert_equal("pt", I18n.locale.to_s,
+                 "Explicit switch should outrank the unchanged account " \
+                 "preference for the rest of the session")
+    assert_equal("en", user.reload.locale)
+  end
+
+  # Same priority claim as the previous test, but as a single request
+  # with session[:locale] injected directly, rather than relying on a
+  # prior params_locale request to have set it -- pins the ordering
+  # in specified_locale itself, independent of set_locale's own
+  # session-write behavior.
+  def test_session_locale_outranks_prefs_locale
+    user = users(:rolf)
+    user.update(locale: "en")
+    login(user.login)
+
+    get(:index, session: { locale: "pt" })
+
+    assert_equal("pt", I18n.locale.to_s)
+  end
+
+  # No params, no prior switch -- the account's stored preference
+  # should still win over the browser's Accept-Language header.
+  def test_prefs_locale_outranks_browser_locale
+    user = users(:rolf)
+    user.update(locale: "pt")
+    login(user.login)
+
+    @request.env["HTTP_ACCEPT_LANGUAGE"] = "fr"
+    get(:index)
+
+    assert_equal("pt", I18n.locale.to_s)
+  end
+
+  # Nothing set at all (anonymous, no session, no account) -- falls
+  # all the way through to the browser header.
+  def test_browser_locale_used_as_last_resort
+    @request.env["HTTP_ACCEPT_LANGUAGE"] = "fr"
+    get(:index)
+
+    assert_equal("fr", I18n.locale.to_s)
+  end
 end

--- a/test/controllers/application_controller_internationalization_test.rb
+++ b/test/controllers/application_controller_internationalization_test.rb
@@ -44,3 +44,28 @@ class ApplicationControllerInternationalizationTest < FunctionalTestCase
     assert_equal("fr", I18n.locale.to_s)
   end
 end
+
+# TestController disables `autologin` (see `disable_filters`), so @user is
+# always nil there -- these need a real controller to exercise the
+# account-persistence question.
+class ApplicationControllerInternationalizationAccountPersistenceTest <
+      FunctionalTestCase
+  tests ObservationsController
+
+  # Issue #5074: a bare `?user_locale=` param (bookmark, crawler,
+  # remembered URL) must switch the current request/session locale
+  # but never silently overwrite the account's stored preference --
+  # only the Preferences form does that.
+  def test_params_locale_switches_request_but_not_account_preference
+    user = users(:rolf)
+    user.update(locale: "en")
+    login(user.login)
+
+    get(:index, params: { user_locale: "pt" })
+
+    assert_equal("pt", I18n.locale.to_s)
+    assert_equal("pt", session[:locale])
+    assert_equal("en", user.reload.locale,
+                 "A bare user_locale param must not change @user.locale")
+  end
+end

--- a/test/controllers/locales_controller_test.rb
+++ b/test/controllers/locales_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class LocalesControllerTest < FunctionalTestCase
+  def test_update_switches_locale_and_redirects_back
+    @request.env["HTTP_REFERER"] = "http://test.host/observations/1"
+
+    post(:update, params: { user_locale: "pt" })
+
+    assert_equal("pt", I18n.locale.to_s)
+    assert_redirected_to("http://test.host/observations/1")
+  end
+
+  def test_update_redirects_to_root_without_referer
+    post(:update, params: { user_locale: "pt" })
+
+    assert_redirected_to(root_path)
+  end
+
+  def test_update_does_not_persist_to_account
+    user = users(:rolf)
+    user.update(locale: "en")
+    login(user.login)
+    @request.env["HTTP_REFERER"] = "http://test.host/observations/1"
+
+    post(:update, params: { user_locale: "pt" })
+
+    assert_equal("en", user.reload.locale)
+  end
+end

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -36,4 +36,18 @@ class ApplicationMailerTest < UnitTestCase
     assert_nil(ActionMailer::Base.deliveries.last,
                "Should not deliver email if recipient has opted out.")
   end
+
+  # Issue #5074: `setup_user` switches I18n.locale to the recipient's
+  # locale; `mo_mail`'s early return (undeliverable `to_address`) must
+  # still restore it via `ensure`, or the mailer thread's I18n.locale
+  # stays leaked to whatever recipient it last tried to email.
+  def test_locale_restored_when_email_undeliverable
+    mary.update(email: "bogus.address", locale: "pt")
+
+    UserQuestionMailer.build(
+      sender: rolf, receiver: mary, subject: "subject", message: "body"
+    ).deliver_now
+
+    assert_equal(:en, I18n.locale)
+  end
 end

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -50,4 +50,19 @@ class ApplicationMailerTest < UnitTestCase
 
     assert_equal(:en, I18n.locale)
   end
+
+  # Issue #5074: WebmasterMailer/MergeRequestMailer never call
+  # `setup_user` (they send to MO.webmaster_email_address, not a
+  # User), so `@old_locale` used to stay nil -- ApplicationMailer's
+  # `before_action` must capture it for every mailer, not just ones
+  # that call `setup_user`.
+  def test_locale_restored_for_mailer_without_setup_user
+    I18n.locale = :pt # rubocop:disable Rails/I18nLocaleAssignment
+
+    WebmasterMailer.build(
+      sender_email: "test@example.com", message: "hi"
+    ).deliver_now
+
+    assert_equal(:pt, I18n.locale)
+  end
 end

--- a/test/views/controllers/info/translators_note_test.rb
+++ b/test/views/controllers/info/translators_note_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Views::Controllers::Info
+  class TranslatorsNoteTest < ComponentTestCase
+    def test_renders_language_switch_row_per_language
+      french = languages(:french)
+      greek = languages(:greek)
+      html = render_component([french, greek])
+
+      assert_html(html,
+                  "form[action='#{routes.switch_locale_path}']" \
+                  "[method='post']")
+      assert_html(html,
+                  "button.list-group-item[data-tooltip-target]", count: 0)
+      assert_html(html,
+                  "form input[type='hidden']" \
+                  "[name='user_locale'][value='fr']")
+      assert_includes(html, french.name)
+
+      # Beta languages are included here (unlike the sidebar switcher,
+      # which excludes them) and labeled as such.
+      assert_html(html,
+                  "form input[type='hidden']" \
+                  "[name='user_locale'][value='el']")
+      assert_includes(html, greek.name)
+      assert_includes(html, "(beta)")
+    end
+
+    private
+
+    def render_component(languages)
+      render(TranslatorsNote.new(languages: languages))
+    end
+  end
+end

--- a/test/views/layouts/sidebar/languages_test.rb
+++ b/test/views/layouts/sidebar/languages_test.rb
@@ -83,6 +83,9 @@ class Views::Layouts::Sidebar
         assert_html(html, "##{id} span.lang-flag-emoji",
                     text: Languages::FLAG_EMOJI.fetch(lang.locale))
         assert_includes(html, lang.name)
+        # CRUDBase's auto-tooltip would just restate the visible
+        # label -- suppressed via `tooltip_target: nil`.
+        assert_no_html(html, "##{id}[data-tooltip-target]")
       end
     end
 

--- a/test/views/layouts/sidebar/languages_test.rb
+++ b/test/views/layouts/sidebar/languages_test.rb
@@ -60,19 +60,27 @@ class Views::Layouts::Sidebar
 
       assert_html(html, "div.collapse##{Languages::COLLAPSE_ID}")
 
-      # Should have links for all non-beta languages, each a flat
+      # Should have a POST button (not a GET <a href>, see issue
+      # #5074) for all non-beta languages, each a flat
       # `list-group-item` (not wrapped in an extra div) so the whole
       # row stays clickable.
       Language.where.not(beta: true).order(:order).each do |lang|
+        id = "lang_drop_#{lang.locale}_link"
+        assert_html(html,
+                    "##{Languages::COLLAPSE_ID} " \
+                    "form[action='#{routes.switch_locale_path}']" \
+                    "[method='post']")
         # `.indent` (not a deeper `pl-*`) — same left padding as the
         # toggle's own `pl-3`, so rows line up with "Languages:"
         # rather than sitting under it.
         assert_html(html,
                     "##{Languages::COLLAPSE_ID} " \
-                    "a.list-group-item.indent#lang_drop_#{lang.locale}_link" \
+                    "button.list-group-item.indent##{id}" \
                     "[data-locale='#{lang.locale}']")
         assert_html(html,
-                    "#lang_drop_#{lang.locale}_link span.lang-flag-emoji",
+                    "form input[type='hidden']" \
+                    "[name='user_locale'][value='#{lang.locale}']")
+        assert_html(html, "##{id} span.lang-flag-emoji",
                     text: Languages::FLAG_EMOJI.fetch(lang.locale))
         assert_includes(html, lang.name)
       end

--- a/test/views/layouts/sidebar/languages_test.rb
+++ b/test/views/layouts/sidebar/languages_test.rb
@@ -78,7 +78,7 @@ class Views::Layouts::Sidebar
                     "button.list-group-item.indent##{id}" \
                     "[data-locale='#{lang.locale}']")
         assert_html(html,
-                    "form input[type='hidden']" \
+                    "##{Languages::COLLAPSE_ID} form input[type='hidden']" \
                     "[name='user_locale'][value='#{lang.locale}']")
         assert_html(html, "##{id} span.lang-flag-emoji",
                     text: Languages::FLAG_EMOJI.fetch(lang.locale))

--- a/test/views/layouts/sidebar/languages_test.rb
+++ b/test/views/layouts/sidebar/languages_test.rb
@@ -60,11 +60,16 @@ class Views::Layouts::Sidebar
 
       assert_html(html, "div.collapse##{Languages::COLLAPSE_ID}")
 
+      # The current locale isn't offered as a switch target -- no
+      # point linking to the locale you're already in.
+      assert_no_html(html, "#lang_drop_#{I18n.locale}_link")
+
       # Should have a POST button (not a GET <a href>, see issue
-      # #5074) for all non-beta languages, each a flat
+      # #5074) for every other non-beta language, each a flat
       # `list-group-item` (not wrapped in an extra div) so the whole
       # row stays clickable.
-      Language.where.not(beta: true).order(:order).each do |lang|
+      Language.where.not(beta: true).where.not(locale: I18n.locale.to_s).
+        order(:order).each do |lang|
         id = "lang_drop_#{lang.locale}_link"
         assert_html(html,
                     "##{Languages::COLLAPSE_ID} " \

--- a/test/views/layouts/sidebar/languages_test.rb
+++ b/test/views/layouts/sidebar/languages_test.rb
@@ -25,9 +25,9 @@ class Views::Layouts::Sidebar
       assert_includes(html, :app_languages.t)
 
       # Current language flag emoji — no image asset (flags are
-      # emoji text via Languages::FLAG_EMOJI, not PNGs).
+      # emoji text via LanguageSwitchButton::FLAG_EMOJI, not PNGs).
       assert_html(html, "##{Languages::TOGGLE_ID} span.lang-flag-emoji",
-                  text: Languages::FLAG_EMOJI.fetch(I18n.locale.to_s))
+                  text: Components::LanguageSwitchButton::FLAG_EMOJI.fetch(I18n.locale.to_s))
       assert_no_html(html, "img.lang-flag")
 
       # Chevron pair — reuses Panel's established collapse-icon
@@ -86,7 +86,7 @@ class Views::Layouts::Sidebar
                     "##{Languages::COLLAPSE_ID} form input[type='hidden']" \
                     "[name='user_locale'][value='#{lang.locale}']")
         assert_html(html, "##{id} span.lang-flag-emoji",
-                    text: Languages::FLAG_EMOJI.fetch(lang.locale))
+                    text: Components::LanguageSwitchButton::FLAG_EMOJI.fetch(lang.locale))
         assert_includes(html, lang.name)
         # CRUDBase's auto-tooltip would just restate the visible
         # label -- suppressed via `tooltip_target: nil`.


### PR DESCRIPTION
Fixes #5074.

## Root cause

The sidebar's language links were plain GET `<a href>` tags carrying `?user_locale=xx`. `set_locale`'s before_action read that param and silently wrote it to `@user.locale` whenever it differed — so a bookmarked/indexed/crawled GET URL could permanently flip a logged-in user's account locale, which then followed them to every device. The reported symptom (a user's account stuck on Polish) traced to a remembered login URL with the param baked in.

## Changes

Implements recommendations #1, #2, and #4 from the issue (skipping #3 — `nofollow`/robots.txt crawl-surface cleanup — since switching to a POST already removes the crawl surface it targeted):

- **`set_locale` no longer writes `@user.locale`.** A `user_locale` param only switches the current request/session; only the Preferences form changes the stored account preference.
- **The language switcher is now a POST** (`Components::LanguageSwitchButton`, a `Button::Post` wrapper) to a new `LocalesController#update`, which returns the visitor to wherever they were via `redirect_back_or_to`. The current locale is no longer offered as a switch target in the list.
- **A second, independent GET-link picker on the translators' note page** (found by Copilot review, missed by the sidebar-only fix) now uses the same shared component instead of its own `Link(type: :get, ...)` — no GET link anywhere in the app carries `user_locale` now, so it can't be crawled, bookmarked, or replayed from history. That page's markup also picked up the sidebar's flag/list-group-item styling in the process, since there was no reason for the two lists to look different.
- **Fixed a priority bug this exposed**: `specified_locale` checked the account preference before the session, so a logged-in user's explicit switch used to revert on their very next page load (masked previously by the account-persist bug above happening to keep them in sync). Session now outranks account preference once the user has explicitly switched, without a stray browser-detected locale from before login being able to do the same.
- **`ApplicationMailer#mo_mail` now restores `I18n.locale` via `ensure`**, covering both an early return (undeliverable recipient) and mailers that never call `setup_user` (`WebmasterMailer`, `MergeRequestMailer`) — previously `@old_locale` was `nil` for those, so the restore silently dropped to I18n's bare default instead of the caller's real prior locale.
- Suppressed the switcher buttons' redundant auto-tooltip (restated the visible label) and fixed their hover styling (an existing `.btn-link` exclusion rule and a theme variable that was always aliased to the non-hover color).

## Test plan

- [x] `bin/rails test test/controllers/application_controller_internationalization_test.rb` — full locale-priority matrix (params/session/prefs/browser, each pairwise ordering)
- [x] `bin/rails test test/controllers/locales_controller_test.rb`
- [x] `bin/rails test test/views/layouts/sidebar/languages_test.rb`
- [x] `bin/rails test test/components/language_switch_button_test.rb`
- [x] `bin/rails test test/views/controllers/info/translators_note_test.rb`
- [x] `bin/rails test test/mailers/application_mailer_test.rb`
- [x] `bin/rails test test/integration/capybara/lurker_integration_test.rb` — exercises the switcher through a real session
- [x] `bin/rails test test/controllers/account/preferences_controller_test.rb`
- [x] Every fix verified to actually catch a regression: reverted, confirmed the corresponding test fails, restored, confirmed passing again
- [x] `bundle exec rubocop` on all touched files, clean
