### PR TITLE
Manual geocoding entry - Fix `#5017` viewport jump / paste-split and `#5014` zero-coordinate falsy bug

### DIFF
--- a/app/javascript/controllers/autocompleter/base_controller.js
+++ b/app/javascript/controllers/autocompleter/base_controller.js
@@ -46,6 +46,14 @@ const INTERNAL_OPTS = {
   ROW_HEIGHT: null,
   SCROLLBAR_WIDTH: null,
   focused: false,
+  // Set by constrainedSelectionUI() right before a redraw it triggers
+  // programmatically (e.g. the map controller refreshing the locality
+  // dropdown while the user is typing coordinates elsewhere), so that
+  // redraw doesn't also steal keyboard focus. Cleared by the next real
+  // interaction with this field (ourFocus/ourChange), so a genuine
+  // redraw triggered by the user actually typing here still reclaims
+  // focus as before.
+  silentRedraw: false,
   menu_up: false,
   old_value: null,
   stored_id: 0,
@@ -213,8 +221,11 @@ export default class BaseAutocompleterController extends Controller {
     }
     if (type == undefined) { return; }
 
-    // If same type but different lat/lng params, still update the location
-    const hasNewParams = detail?.request_params?.lat && detail?.request_params?.lng;
+    // If same type but different lat/lng params, still update the location.
+    // 0 is a valid coordinate (equator/prime meridian) -- Number.isFinite,
+    // not truthiness.
+    const hasNewParams = Number.isFinite(detail?.request_params?.lat) &&
+      Number.isFinite(detail?.request_params?.lng);
     const paramsChanged = hasNewParams &&
       (detail.request_params.lat !== this.request_params?.lat ||
        detail.request_params.lng !== this.request_params?.lng);
@@ -425,6 +436,7 @@ export default class BaseAutocompleterController extends Controller {
   }
 
   ourChange(do_refresh) {
+    this.silentRedraw = false;
     const old_value = this.old_value;
     const new_value = this.inputTarget.value;
     if (new_value.length == 0) {
@@ -466,6 +478,7 @@ export default class BaseAutocompleterController extends Controller {
     if (!this.ROW_HEIGHT)
       this.getRowHeight();
     this.focused = true;
+    this.silentRedraw = false;
   }
 
   ourBlur(event) {
@@ -710,7 +723,14 @@ export default class BaseAutocompleterController extends Controller {
       this.highlightNewRow(rows);
       this.makePulldownVisible();
     }
-    this.inputTarget.focus();
+    // Skip when this redraw was triggered programmatically (see
+    // constrainedSelectionUI()) rather than by the user actually typing
+    // in this field -- otherwise it steals keyboard focus (and the
+    // browser's scroll-into-view) from whatever field the user is
+    // really in.
+    if (!this.silentRedraw) {
+      this.inputTarget.focus();
+    }
   }
 
   updateRows(rows) {
@@ -975,7 +995,10 @@ export default class BaseAutocompleterController extends Controller {
         if (this.hasKeepBtnTarget) {
           this.keepBtnTarget.classList.remove('active');
         }
-        this.inputTarget.focus();
+        // See the comment in drawPulldown().
+        if (!this.silentRedraw) {
+          this.inputTarget.focus();
+        }
         if (this.hasMapOutlet) {
           let map;
           try {
@@ -1366,7 +1389,8 @@ export default class BaseAutocompleterController extends Controller {
       }
     }
 
-    if ((this.primer.length > 1) && this.ACT_LIKE_SELECT) {
+    if ((this.primer.length > 1) && this.ACT_LIKE_SELECT &&
+        !this.silentRedraw) {
       this.inputTarget.focus();
     }
   }

--- a/app/javascript/controllers/autocompleter/base_controller.js
+++ b/app/javascript/controllers/autocompleter/base_controller.js
@@ -1271,7 +1271,17 @@ export default class BaseAutocompleterController extends Controller {
       return;
     }
 
+    // ACT_LIKE_SELECT types (location_containing, location_google) key
+    // their results off request_params (lat/lng), not the search
+    // string -- the server ignores the string entirely for these. This
+    // "is my new string just a longer version of the last one" check
+    // is meaningless for them and, worse, actively wrong: leftover
+    // text from a previous selection can look like a valid refinement
+    // of itself even though request_params changed underneath it,
+    // silently skipping the fetch for the new point. The request_params
+    // comparison below is the correct dedup check for these types.
     const new_val_refines_last_request =
+      !this.ACT_LIKE_SELECT &&
       !this.WHOLE_WORDS_ONLY &&
       (last_request?.length < token.length) &&
       (last_request == token.substr(0, last_request?.length));

--- a/app/javascript/controllers/autocompleter/map_integration_mixin.js
+++ b/app/javascript/controllers/autocompleter/map_integration_mixin.js
@@ -166,6 +166,10 @@ export const MapIntegrationMixin = {
       this.deactivateMapOutlet();
       // primer is not based on input, so go ahead and request from server.
       this.focused = true; // so it will draw the pulldown immediately
+      // This redraw is programmatic, not the user typing here -- don't
+      // let it steal keyboard focus. Cleared by the next real
+      // interaction with this field (ourFocus/ourChange).
+      this.silentRedraw = true;
       this.refreshPrimer(); // directly refresh the primer w/request_params
       this.element.classList.add('constrained');
       this.element.classList.remove('create');

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -254,7 +254,7 @@ export default class extends Controller {
     // Update lat/lng inputs directly
     if (["observation", "hybrid"].includes(this.map_type) &&
         this.hasLatInputTarget && !viewport && !extents) {
-      if (center != undefined && center?.lat) {
+      if (center != undefined && Number.isFinite(center?.lat)) {
         this.updateLatLngInputs(center)
         points = [center]
       }
@@ -269,7 +269,7 @@ export default class extends Controller {
       type = "rectangle"
     } else if (this.hasLatInputTarget) {
       // Fallback for non-map geocode with lat/lng
-      if (center != undefined && center?.lat) {
+      if (center != undefined && Number.isFinite(center?.lat)) {
         this.updateLatLngInputs(center)
         points = [center]
       }
@@ -401,7 +401,7 @@ export default class extends Controller {
         lng = parseFloat(origLng)
       }
     }
-    if (!lat || !lng)
+    if (!Number.isFinite(lat) || !Number.isFinite(lng))
       return false
     if (lat > 90 || lat < -90 || lng > 180 || lng < -180)
       return false
@@ -409,6 +409,32 @@ export default class extends Controller {
 
     if (update) this.updateLatLngInputs(location)
     return location
+  }
+
+  // Handles pasting a full "lat, lng" pair (e.g. iNat's copy format,
+  // "40.0028333333, -77.3633033333") into either coordinate field.
+  // Only intercepts the paste when the clipboard text parses as a
+  // complete pair on its own -- an ordinary single-value paste (just a
+  // latitude, say) fails to convert and falls through to the browser's
+  // default paste.
+  splitPastedCoordinates(event) {
+    if (!this.hasLatInputTarget || !this.hasLngInputTarget) return
+
+    const pasted = (event.clipboardData || window.clipboardData)?.
+      getData("text")
+    if (!pasted) return
+
+    let coords
+    try {
+      coords = convert(pasted)
+    } catch {
+      return
+    }
+
+    event.preventDefault()
+    this.latInputTarget.value = coords.decimalLatitude
+    this.lngInputTarget.value = coords.decimalLongitude
+    this.latInputTarget.dispatchEvent(new Event("input", { bubbles: true }))
   }
 
   // For reference:
@@ -432,7 +458,7 @@ export default class extends Controller {
   sendPointChanged({ lat, lng }) {
     this.clearAutocompleterSwapBuffer()
 
-    if (lat && lng) {
+    if (Number.isFinite(lat) && Number.isFinite(lng)) {
       this.autocomplete_buffer = setTimeout(() => {
         if (this.hasAutocompleterLocationOutlet) {
           this.autocompleterLocationOutlet.swap({

--- a/app/javascript/controllers/geocode_controller.js
+++ b/app/javascript/controllers/geocode_controller.js
@@ -432,8 +432,8 @@ export default class extends Controller {
     }
 
     event.preventDefault()
-    this.latInputTarget.value = coords.decimalLatitude
-    this.lngInputTarget.value = coords.decimalLongitude
+    this.latInputTarget.value = this.roundOff(coords.decimalLatitude)
+    this.lngInputTarget.value = this.roundOff(coords.decimalLongitude)
     this.latInputTarget.dispatchEvent(new Event("input", { bubbles: true }))
   }
 

--- a/app/views/controllers/observations/form/details.rb
+++ b/app/views/controllers/observations/form/details.rb
@@ -203,10 +203,18 @@ class Views::Controllers::Observations::Form::Details < Views::Base
         addon: addon,
         data: {
           map_target: "#{field}Input",
-          action: "map#bufferInputs"
+          action: coordinate_field_action(field)
         }
       )
     end
+  end
+
+  # Lat/lng also split a pasted "lat, lng" pair (e.g. from iNat) across
+  # both fields -- see GeocodeController#splitPastedCoordinates.
+  def coordinate_field_action(field)
+    return "map#bufferInputs" unless [:lat, :lng].include?(field)
+
+    "map#bufferInputs paste->map#splitPastedCoordinates"
   end
 
   # Label with responsive show/hide variants

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1018,6 +1018,127 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     university_park.destroy
   end
 
+  # Bug fix: a latitude or longitude of exactly 0 (equator or
+  # prime meridian) used to be treated as "no coordinate" by a falsy
+  # check and silently rejected. Under the old bug, a latitude of 0
+  # would keep the autocompleter in plain "location" mode; the fixed
+  # code swaps it into "location_containing" like any other valid
+  # point, and carries the exact (0-valued) params along.
+  def test_zero_latitude_triggers_locality_lookup
+    login!(katrina)
+    visit(new_observation_path)
+    assert_selector("body.observations__new")
+    wait_for_map_outlet_ready
+
+    execute_script(<<~JS)
+      const latField = document.getElementById('observation_lat');
+      const lngField = document.getElementById('observation_lng');
+      latField.value = '0';
+      lngField.value = '0.5';
+      latField.dispatchEvent(new Event('input', { bubbles: true }));
+      lngField.dispatchEvent(new Event('input', { bubbles: true }));
+    JS
+
+    assert_selector("[data-type='location_containing']", wait: 10)
+
+    request_params = evaluate_script(<<~JS)
+      (() => {
+        const el = document.getElementById('observation_location_autocompleter');
+        const controller = window.Stimulus.getControllerForElementAndIdentifier(
+          el, 'autocompleter--location'
+        );
+        return controller?.request_params;
+      })()
+    JS
+    assert_equal(0, request_params["lat"])
+    assert_in_delta(0.5, request_params["lng"])
+  end
+
+  # Bug fix: iNat exports coordinates as a single
+  # "lat, lng" string. Pasting that into the latitude field should
+  # split it across both fields instead of dumping the whole string
+  # into latitude alone.
+  def test_pasting_coordinate_pair_splits_lat_lng_fields
+    login!(katrina)
+    visit(new_observation_path)
+    assert_selector("body.observations__new")
+    # Wait for the map controller to connect before dispatching a
+    # synthetic paste event at it -- otherwise it can fire before the
+    # controller's action listeners are attached.
+    assert_selector("[data-map='connected']", wait: 10)
+
+    execute_script(<<~JS)
+      const latField = document.getElementById('observation_lat');
+      const dt = new DataTransfer();
+      dt.setData('text', '40.0028333333, -77.3633033333');
+      const pasteEvent = new ClipboardEvent('paste', {
+        clipboardData: dt, bubbles: true, cancelable: true
+      });
+      latField.dispatchEvent(pasteEvent);
+    JS
+
+    assert_field("observation_lat", with: "40.00283", visible: :all, wait: 5)
+    assert_field("observation_lng", with: "-77.3633", visible: :all, wait: 5)
+
+    # An ordinary single-value paste (no pair) must NOT be intercepted --
+    # it should fall through to the browser's normal paste behavior.
+    execute_script(<<~JS)
+      const lngField = document.getElementById('observation_lng');
+      lngField.value = '';
+      const dt = new DataTransfer();
+      dt.setData('text', '40.7128');
+      const pasteEvent = new ClipboardEvent('paste', {
+        clipboardData: dt, bubbles: true, cancelable: true
+      });
+      window.__pasteDefaultPrevented =
+        !lngField.dispatchEvent(pasteEvent);
+    JS
+    assert_not(evaluate_script("window.__pasteDefaultPrevented"),
+               "A single-value paste should not be intercepted")
+  end
+
+  # Bug fix: each keystroke in the coordinate fields
+  # used to force-focus the locality autocompleter's input as a side
+  # effect of redrawing its dropdown, yanking keyboard focus (and the
+  # viewport) away from the field the user was actually typing in.
+  def test_typing_coordinates_does_not_steal_focus
+    setup_image_dirs
+    login!(katrina)
+    university_park = Location.create!(**UNIVERSITY_PARK, user: katrina)
+    pasadena = Location.create!(
+      name: "Pasadena, Los Angeles Co., California, USA",
+      north: 34.25, south: 34.12, east: -118.07, west: -118.20,
+      user: katrina
+    )
+
+    visit(new_observation_path)
+    assert_selector("body.observations__new")
+
+    click_attach_file("geotagged.jpg")
+    assert_field("observation_lat", with: GEOTAGGED_EXIF[:lat].to_s, wait: 10)
+    assert_selector("[data-type='location_containing']", wait: 10)
+    sleep(2)
+
+    lat_field = find_by_id("observation_lat")
+    lng_field = find_by_id("observation_lng")
+    lat_field.click
+    lat_field.set("34.15")
+    lng_field.click
+    lng_field.set("-118.14")
+
+    # Give the 1s debounce + async autocompleter fetch time to run.
+    sleep(2)
+
+    assert_equal("observation_lng",
+                 evaluate_script("document.activeElement.id"),
+                 "Typing a coordinate should not move focus off the field")
+    place_field = find_by_id("observation_place_name")
+    assert_match(/Pasadena/, place_field.value, wait: 5)
+
+    university_park.destroy
+    pasadena.destroy
+  end
+
   # Editing the primary of a multi-member occurrence, adopting a
   # sibling's note value via its button enables + fills the (initially
   # disabled) textarea so it will submit.
@@ -1239,6 +1360,32 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     assert_field("observation_alt", with: "", visible: :all)
   end
   private :assert_geolocation_is_empty
+
+  # Waits for the map controller AND its autocompleter--location outlet
+  # to both be ready. `data-map="connected"` alone isn't enough --
+  # Stimulus outlets can connect on a later tick, so a synthetic event
+  # dispatched right after "connected" can still fire into a map
+  # controller whose `sendPointChanged` finds `hasAutocompleterLocationOutlet`
+  # false and silently drops the swap.
+  def wait_for_map_outlet_ready
+    Timeout.timeout(10) do
+      loop do
+        ready = evaluate_script(<<~JS)
+          (() => {
+            const f = document.getElementById('observation_form');
+            const c = window.Stimulus.getControllerForElementAndIdentifier(
+              f, 'map'
+            );
+            return !!(c && c.hasAutocompleterLocationOutlet);
+          })()
+        JS
+        break if ready
+
+        sleep(0.1)
+      end
+    end
+  end
+  private :wait_for_map_outlet_ready
 
   def assert_image_exif_available(image_data)
     assert_selector('[id$="when_1i"]', visible: :all)

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1139,6 +1139,47 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     pasadena.destroy
   end
 
+  # Bug fix: when typed coordinates match no existing MO location, the
+  # locality autocompleter falls back from location_containing to
+  # location_google and runs a real Google geocode lookup.
+  # refreshGooglePrimer force-sets `focused = true` "even if input lost
+  # focus" so that fallback's result still gets processed -- without
+  # the fix, that flag doesn't distinguish real vs. programmatic focus,
+  # so the geocode result would also steal focus once it arrives.
+  def test_typing_coordinates_with_no_matching_location_does_not_steal_focus
+    login!(katrina)
+    visit(new_observation_path)
+    assert_selector("body.observations__new")
+    wait_for_map_outlet_ready
+    wait_for_map_geocoder_ready
+
+    # Alert, Nunavut -- the northernmost permanently inhabited place on
+    # Earth. No MO location record contains this point (forcing the
+    # location_containing -> location_google fallback), but it's a
+    # real locality Google geocodes to non-filtered results (unlike a
+    # mid-ocean point, which geocodes only to filtered-out types like
+    # plus_code and comes back empty).
+    execute_script(<<~JS)
+      const latField = document.getElementById('observation_lat');
+      const lngField = document.getElementById('observation_lng');
+      latField.value = '82.5';
+      lngField.value = '-62.3';
+      latField.dispatchEvent(new Event('input', { bubbles: true }));
+      lngField.dispatchEvent(new Event('input', { bubbles: true }));
+    JS
+
+    assert_selector("[data-type='location_google']", wait: 10)
+    # Confirms the Google geocode round-trip actually completed and
+    # populated the dropdown, rather than the fetch simply not having
+    # resolved yet (which would make the focus assertion a false pass).
+    wait_for_autocompleter_match
+
+    assert_not_equal("observation_place_name",
+                     evaluate_script("document.activeElement.id"),
+                     "A background Google geocode result should not " \
+                     "steal focus from the coordinate field")
+  end
+
   # Editing the primary of a multi-member occurrence, adopting a
   # sibling's note value via its button enables + fills the (initially
   # disabled) textarea so it will submit.
@@ -1386,6 +1427,53 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     end
   end
   private :wait_for_map_outlet_ready
+
+  # Waits for the map controller's Google Maps loader promise to
+  # resolve (sets up `this.geocoder`), independently of whether the
+  # map itself has been drawn.
+  def wait_for_map_geocoder_ready
+    Timeout.timeout(10) do
+      loop do
+        ready = evaluate_script(<<~JS)
+          (() => {
+            const f = document.getElementById('observation_form');
+            const c = window.Stimulus.getControllerForElementAndIdentifier(
+              f, 'map'
+            );
+            return !!(c && c.geocoder);
+          })()
+        JS
+        break if ready
+
+        sleep(0.1)
+      end
+    end
+  end
+  private :wait_for_map_geocoder_ready
+
+  # Waits for the locality autocompleter to have populated at least
+  # one match.
+  def wait_for_autocompleter_match
+    Timeout.timeout(10) do
+      loop do
+        count = evaluate_script(<<~JS)
+          (() => {
+            const el = document.getElementById(
+              'observation_location_autocompleter'
+            );
+            const c = window.Stimulus.getControllerForElementAndIdentifier(
+              el, 'autocompleter--location'
+            );
+            return (c?.matches || []).length;
+          })()
+        JS
+        break if count.positive?
+
+        sleep(0.2)
+      end
+    end
+  end
+  private :wait_for_autocompleter_match
 
   def assert_image_exif_available(image_data)
     assert_selector('[id$="when_1i"]', visible: :all)

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1077,7 +1077,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
       latField.dispatchEvent(pasteEvent);
     JS
 
-    assert_field("observation_lat", with: "40.00283", visible: :all, wait: 5)
+    assert_field("observation_lat", with: "40.0028", visible: :all, wait: 5)
     assert_field("observation_lng", with: "-77.3633", visible: :all, wait: 5)
 
     # An ordinary single-value paste (no pair) must NOT be intercepted --

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1180,6 +1180,74 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
                      "steal focus from the coordinate field")
   end
 
+  # Bug fix: after coordinates matched a location and its name got
+  # auto-filled into the locality field, correcting to a second,
+  # unrelated point silently failed to re-search at all -- the
+  # leftover locality text from the first match looked to
+  # refreshPrimer() like a valid "refinement" of itself, even though
+  # request_params (the actual lat/lng driving the search) had
+  # changed underneath it. Found via user testing during review.
+  def test_correcting_coordinates_after_a_prior_match_still_searches
+    login!(katrina)
+    # MAX_STRING_LENGTH (50 chars) truncates the search token -- the
+    # name has to be longer than that so the leftover text, once
+    # truncated by the intermediate text-based search the "location"
+    # type fallback runs, becomes a proper (shorter) prefix of itself.
+    # That's what makes refreshPrimer() misidentify it as "the same
+    # search, just refined" instead of noticing request_params changed.
+    alpha = Location.create!(
+      name: "Test Location Alpha Extended Forest Preserve Area, " \
+            "Testland Co., Testania, USA",
+      north: 40.05, south: 39.95, east: -77.30, west: -77.40,
+      user: katrina
+    )
+    beta = Location.create!(
+      name: "Test Location Beta, Testland",
+      north: 10.05, south: 9.95, east: 10.40, west: 10.30,
+      user: katrina
+    )
+
+    visit(new_observation_path)
+    assert_selector("body.observations__new")
+    wait_for_map_outlet_ready
+
+    execute_script(<<~JS)
+      const latField = document.getElementById('observation_lat');
+      const lngField = document.getElementById('observation_lng');
+      latField.value = '40.0028';
+      lngField.value = '-77.35';
+      latField.dispatchEvent(new Event('input', { bubbles: true }));
+      lngField.dispatchEvent(new Event('input', { bubbles: true }));
+    JS
+    assert_field("observation_place_name", with: alpha.name, wait: 10)
+
+    # Clear, then enter coordinates for a second, unrelated point.
+    # With the bug, the leftover "Alpha" text would make
+    # refreshPrimer() bail before ever fetching for the new point.
+    execute_script(<<~JS)
+      const latField = document.getElementById('observation_lat');
+      const lngField = document.getElementById('observation_lng');
+      latField.value = '';
+      lngField.value = '';
+      latField.dispatchEvent(new Event('input', { bubbles: true }));
+      lngField.dispatchEvent(new Event('input', { bubbles: true }));
+    JS
+    sleep(1)
+
+    execute_script(<<~JS)
+      const latField = document.getElementById('observation_lat');
+      const lngField = document.getElementById('observation_lng');
+      latField.value = '10.0028';
+      lngField.value = '10.35';
+      latField.dispatchEvent(new Event('input', { bubbles: true }));
+      lngField.dispatchEvent(new Event('input', { bubbles: true }));
+    JS
+    assert_field("observation_place_name", with: beta.name, wait: 10)
+
+    alpha.destroy
+    beta.destroy
+  end
+
   # Editing the primary of a multi-member occurrence, adopting a
   # sibling's note value via its button enables + fills the (initially
   # disabled) textarea so it will submit.


### PR DESCRIPTION
## Summary

Fixes four bugs in the observation form's coordinate-entry UX, all obstructing the same correction workflow described in issue #5017 (which also references #5014).

- **Viewport jumps to the locality dropdown while typing coordinates** (#5017 item 1). Root cause: `constrainedSelectionUI()` force-sets `this.focused = true` on the locality autocompleter to redraw its "localities containing this point" dropdown as coordinates change, and the redraw path (`drawPulldown()` and two related spots) unconditionally called `.focus()` on that field afterward, stealing keyboard focus and scrolling the page to it. Fixed by adding a `silentRedraw` flag: `constrainedSelectionUI()` sets it before a programmatic redraw, the three `.focus()` call sites skip stealing focus while it's set, and it's cleared by the next real interaction with that field (so a redraw triggered by the user actually typing there still reclaims focus as before). This also covers the `location_containing` → `location_google` Google-geocode fallback (`refreshGooglePrimer`, which force-sets focus "even if input lost focus" for its own reasons) since the flag persists through that whole cascade.
- **Pasting a `lat, lng` pair doesn't split across fields** (#5017 item 2). iNat exports coordinates as a single string (e.g. `40.0028333333, -77.3633033333`). `GeocodeController#validateLatLngInputs` already parses combined pairs via `geo-coordinates-parser`, but its guard clause bailed whenever either field was empty, before that parsing ever ran. Added `GeocodeController#splitPastedCoordinates`, wired to a `paste` action on both lat/lng fields, which parses the pasted text directly and splits it across both fields when it's a full pair; an ordinary single-value paste isn't intercepted.
- **A latitude or longitude of exactly 0 is treated as absent** (#5014). Several falsy checks (`!lat || !lng`, `lat && lng`, `center?.lat`) rejected the equator/prime meridian as if no coordinate were given. Replaced with `Number.isFinite` checks in `GeocodeController` and in the autocompleter's own `swap()` (`hasNewParams`), which had the identical bug for a different call path.
- **Re-entering coordinates after a prior match silently does nothing** (found via manual testing during review). Once a search auto-fills the locality field with a match, correcting to a second point left the field stuck on the old name. `refreshPrimer()`'s "is my new search string just a longer version of the last one" caching heuristic is a text-search optimization that doesn't apply to `location_containing`/`location_google` (their results are keyed off `request_params`, i.e. lat/lng, not the search string — the server ignores the string entirely for these). It ran anyway, and the leftover locality text from the prior match looked like a valid "refinement" of itself once truncated by an intermediate search, so the fetch for the new point was silently skipped. Now skipped for `ACT_LIKE_SELECT` types, which already have a correct `request_params`-based dedup check.

## Test plan

- [x] `bin/rails test test/system/observation_form_system_test.rb` -- full file, including 5 new system tests covering all four fixes, plus regression-checked each fix by reverting/re-confirming failure before restoring
- [x] `bundle exec rubocop` clean on all touched Ruby files
- [x] Verified all fixes directly in a running dev server (Chrome), including the pre-fix broken behavior for comparison
