### PR TITLE
Don't raise on links in field labels (fixes production crash on `/support/donate`)

### DIFF
--- a/app/components/application_form/field_label_row.rb
+++ b/app/components/application_form/field_label_row.rb
@@ -78,7 +78,7 @@ class Components::ApplicationForm < Superform::Rails::Form
 
       rewritten = text.gsub(LINK_TAG_RE) do
         attrs = Regexp.last_match(1)
-        unless attrs.match?(/\btarget=/i)
+        unless attrs.match?(/\btarget\s*=/i)
           attrs += ' target="_blank" rel="noopener noreferrer"'
         end
         "<a#{attrs}>"

--- a/app/components/application_form/field_label_row.rb
+++ b/app/components/application_form/field_label_row.rb
@@ -48,57 +48,44 @@ class Components::ApplicationForm < Superform::Rails::Form
     # title-casing, to display correctly.
     def resolved_label_text
       label_option = wrapper_options[:label]
-      case label_option
-      when Symbol then label_option.t
-      when String then label_option
-      else field.key.to_s.humanize
+      text = case label_option
+             when Symbol then label_option.t
+             when String then label_option
+             else field.key.to_s.humanize
+             end
+      open_label_links_in_new_tab(text)
+    end
+
+    # A link inside a label navigates the user away from a form they may
+    # be partway through filling out, in the same tab -- losing whatever
+    # they'd already entered. Force `target="_blank"` (plus
+    # `rel="noopener noreferrer"`) rather than stripping the link: a
+    # translator writing ordinary Textile link syntax into a label
+    # string (a production translation of `donate_who`, Spanish, did
+    # exactly this) has no way to know it lands in a `<label>`, so the
+    # label has to tolerate a link showing up, not reject it.
+    #
+    # Nested links inside a `<label for="...">` are valid HTML, and
+    # browsers give the `<a>` click priority over the label's own
+    # click-to-focus/toggle behavior, so there's no real ambiguity even
+    # for a checkbox/radio label where the label click also toggles the
+    # control -- CheckboxField#label_text calls resolved_label_text
+    # directly and gets this same treatment.
+    LINK_TAG_RE = /<a\b([^>]*)>/i
+
+    def open_label_links_in_new_tab(text)
+      return text unless text.is_a?(String) && text.match?(LINK_TAG_RE)
+
+      rewritten = text.gsub(LINK_TAG_RE) do
+        attrs = Regexp.last_match(1)
+        unless attrs.match?(/\btarget=/i)
+          attrs += ' target="_blank" rel="noopener noreferrer"'
+        end
+        "<a#{attrs}>"
       end
-    end
+      return rewritten unless text.is_a?(ActiveSupport::SafeBuffer)
 
-    # A resolved label containing a real link -- a field-PROMPT label
-    # secretly doubling as a clickable link is a UX smell (not obviously
-    # clickable, easy to miss). Route link content through a help icon
-    # instead (see Components::Form::UploadGallery::Fields#render_license_field
-    # for the established pattern) rather than embedding it in the label.
-    #
-    # Strips the link (keeping its text) rather than raising: this runs
-    # on every request, for every locale's translation of the label, and
-    # a translator adding textile link syntax to a label string -- a
-    # completely ordinary thing to do everywhere else in the
-    # translations -- has no way to know it would crash the page here.
-    # A production translation did exactly that (`donate_who`, Spanish)
-    # and took down /support/donate for every es-locale visitor. Still
-    # surfaced via ExceptionNotifier so it gets fixed at the source.
-    #
-    # Only guards `label_text` below (the colon-suffixed prompt path),
-    # NOT `resolved_label_text` itself -- CheckboxField#label_text calls
-    # `resolved_label_text` directly, bypassing this guard, because a
-    # checkbox's label can be rich content rather than a plain text
-    # prompt (e.g. a name link + copy-id badge next to a
-    # synonym-selection checkbox -- see names/synonyms/form.rb).
-    LINK_IN_LABEL_RE = %r{<a[^>]*>(.*?)</a>}mi
-
-    def strip_link_from_label(text)
-      return text unless text.is_a?(String) && text.match?(LINK_IN_LABEL_RE)
-
-      notify_label_link_found(text)
-      stripped = text.gsub(LINK_IN_LABEL_RE, '\1')
-      return stripped unless text.is_a?(ActiveSupport::SafeBuffer)
-
-      ActiveSupport::SafeBuffer.new(stripped)
-    end
-
-    def notify_label_link_found(text)
-      return unless ExceptionNotifier.notifiers.any?
-
-      ExceptionNotifier.notify_exception(
-        RuntimeError.new(
-          "Field label contains a link -- move it into help: content " \
-          "instead of embedding it in the label: #{text.inspect}"
-        ),
-        data: { label_option: wrapper_options[:label].inspect,
-                locale: I18n.locale.to_s }
-      )
+      ActiveSupport::SafeBuffer.new(rewritten)
     end
 
     # append_colon lives on Components::Localization, included into
@@ -110,7 +97,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     # connector between two selects, which reads as a word, not a
     # field prompt).
     def label_text
-      text = strip_link_from_label(resolved_label_text)
+      text = resolved_label_text
       wrapper_options[:label_colon] == false ? text : append_colon(text)
     end
 

--- a/app/components/application_form/field_label_row.rb
+++ b/app/components/application_form/field_label_row.rb
@@ -61,19 +61,44 @@ class Components::ApplicationForm < Superform::Rails::Form
     # instead (see Components::Form::UploadGallery::Fields#render_license_field
     # for the established pattern) rather than embedding it in the label.
     #
+    # Strips the link (keeping its text) rather than raising: this runs
+    # on every request, for every locale's translation of the label, and
+    # a translator adding textile link syntax to a label string -- a
+    # completely ordinary thing to do everywhere else in the
+    # translations -- has no way to know it would crash the page here.
+    # A production translation did exactly that (`donate_who`, Spanish)
+    # and took down /support/donate for every es-locale visitor. Still
+    # surfaced via ExceptionNotifier so it gets fixed at the source.
+    #
     # Only guards `label_text` below (the colon-suffixed prompt path),
     # NOT `resolved_label_text` itself -- CheckboxField#label_text calls
     # `resolved_label_text` directly, bypassing this guard, because a
     # checkbox's label can be rich content rather than a plain text
     # prompt (e.g. a name link + copy-id badge next to a
     # synonym-selection checkbox -- see names/synonyms/form.rb).
-    LINK_IN_LABEL_RE = /<a[\s>]/
+    LINK_IN_LABEL_RE = %r{<a[^>]*>(.*?)</a>}mi
 
-    def raise_if_label_has_link(text)
-      return unless text.is_a?(String) && text.match?(LINK_IN_LABEL_RE)
+    def strip_link_from_label(text)
+      return text unless text.is_a?(String) && text.match?(LINK_IN_LABEL_RE)
 
-      raise("Field label contains a link -- move it into help: " \
-            "content instead of embedding it in the label: #{text.inspect}")
+      notify_label_link_found(text)
+      stripped = text.gsub(LINK_IN_LABEL_RE, '\1')
+      return stripped unless text.is_a?(ActiveSupport::SafeBuffer)
+
+      ActiveSupport::SafeBuffer.new(stripped)
+    end
+
+    def notify_label_link_found(text)
+      return unless ExceptionNotifier.notifiers.any?
+
+      ExceptionNotifier.notify_exception(
+        RuntimeError.new(
+          "Field label contains a link -- move it into help: content " \
+          "instead of embedding it in the label: #{text.inspect}"
+        ),
+        data: { label_option: wrapper_options[:label].inspect,
+                locale: I18n.locale.to_s }
+      )
     end
 
     # append_colon lives on Components::Localization, included into
@@ -85,8 +110,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     # connector between two selects, which reads as a word, not a
     # field prompt).
     def label_text
-      text = resolved_label_text
-      raise_if_label_has_link(text)
+      text = strip_link_from_label(resolved_label_text)
       wrapper_options[:label_colon] == false ? text : append_colon(text)
     end
 

--- a/test/components/application_form/text_field_test.rb
+++ b/test/components/application_form/text_field_test.rb
@@ -82,17 +82,36 @@ class TextFieldTest < ComponentTestCase
   end
 
   # A field label secretly doubling as a clickable link is a UX smell
-  # (not obviously clickable, easy to miss) -- FieldLabelRow raises
-  # rather than silently rendering one. Route link content through
-  # help: instead (see Components::Form::UploadGallery::Fields#
-  # render_license_field for the established pattern).
-  def test_label_containing_a_link_raises
-    error = assert_raises(RuntimeError) do
-      render_form do
-        text_field(:name, label: '<a href="/x">Click</a>'.html_safe)
+  # (not obviously clickable, easy to miss) -- FieldLabelRow strips the
+  # link rather than rendering one. Route link content through help:
+  # instead (see Components::Form::UploadGallery::Fields#
+  # render_license_field for the established pattern). Must not raise:
+  # this runs on every translated label, for every locale, on every
+  # request -- a translator's textile link syntax must degrade
+  # gracefully, not crash the page.
+  def test_label_containing_a_link_strips_it_keeping_the_text
+    form = render_form do
+      text_field(:name, label: '<a href="/x">Click here</a>'.html_safe)
+    end
+
+    assert_includes(form, "Click here")
+    assert_not_includes(form, "<a")
+  end
+
+  def test_label_containing_a_link_notifies_without_raising
+    notified = []
+    ExceptionNotifier.stub(:notifiers, [:slack]) do
+      ExceptionNotifier.stub(
+        :notify_exception, ->(exception, **_opts) { notified << exception }
+      ) do
+        render_form do
+          text_field(:name, label: '<a href="/x">Click here</a>'.html_safe)
+        end
       end
     end
-    assert_match(/contains a link/, error.message)
+
+    assert_equal(1, notified.length)
+    assert_match(/contains a link/, notified.first.message)
   end
 
   # Slot tests

--- a/test/components/application_form/text_field_test.rb
+++ b/test/components/application_form/text_field_test.rb
@@ -92,18 +92,24 @@ class TextFieldTest < ComponentTestCase
       text_field(:name, label: '<a href="/x">Click here</a>'.html_safe)
     end
 
-    assert_html(form, "label a[href='/x'][target='_blank']", text: "Click here")
+    assert_html(form,
+                "label a[href='/x'][target='_blank']" \
+                "[rel='noopener noreferrer']",
+                text: "Click here")
   end
 
   # A translator (or a future caller) might already set target= for
   # their own reason -- don't clobber it with a second target attr.
+  # Spaces around `=` are valid HTML, so the detection has to tolerate
+  # them too, not just the no-space form.
   def test_label_link_with_existing_target_is_left_alone
     form = render_form do
       text_field(:name,
-                 label: '<a href="/x" target="_self">Click</a>'.html_safe)
+                 label: '<a href="/x" target = "_self">Click</a>'.html_safe)
     end
 
     assert_html(form, "label a[href='/x'][target='_self']", text: "Click")
+    assert_not_includes(form, "_blank")
   end
 
   # Slot tests

--- a/test/components/application_form/text_field_test.rb
+++ b/test/components/application_form/text_field_test.rb
@@ -81,37 +81,29 @@ class TextFieldTest < ComponentTestCase
     assert_html(form, "label em", text: "all")
   end
 
-  # A field label secretly doubling as a clickable link is a UX smell
-  # (not obviously clickable, easy to miss) -- FieldLabelRow strips the
-  # link rather than rendering one. Route link content through help:
-  # instead (see Components::Form::UploadGallery::Fields#
-  # render_license_field for the established pattern). Must not raise:
-  # this runs on every translated label, for every locale, on every
-  # request -- a translator's textile link syntax must degrade
-  # gracefully, not crash the page.
-  def test_label_containing_a_link_strips_it_keeping_the_text
+  # A link inside a label must not crash the page (a production
+  # translation of `donate_who`, Spanish, used Textile link syntax and
+  # took down /support/donate) -- FieldLabelRow forces the link to open
+  # in a new tab rather than rejecting it, since clicking it in the
+  # same tab would navigate away from a form the user may be partway
+  # through filling out.
+  def test_label_containing_a_link_opens_in_new_tab
     form = render_form do
       text_field(:name, label: '<a href="/x">Click here</a>'.html_safe)
     end
 
-    assert_includes(form, "Click here")
-    assert_not_includes(form, "<a")
+    assert_html(form, "label a[href='/x'][target='_blank']", text: "Click here")
   end
 
-  def test_label_containing_a_link_notifies_without_raising
-    notified = []
-    ExceptionNotifier.stub(:notifiers, [:slack]) do
-      ExceptionNotifier.stub(
-        :notify_exception, ->(exception, **_opts) { notified << exception }
-      ) do
-        render_form do
-          text_field(:name, label: '<a href="/x">Click here</a>'.html_safe)
-        end
-      end
+  # A translator (or a future caller) might already set target= for
+  # their own reason -- don't clobber it with a second target attr.
+  def test_label_link_with_existing_target_is_left_alone
+    form = render_form do
+      text_field(:name,
+                 label: '<a href="/x" target="_self">Click</a>'.html_safe)
     end
 
-    assert_equal(1, notified.length)
-    assert_match(/contains a link/, notified.first.message)
+    assert_html(form, "label a[href='/x'][target='_self']", text: "Click")
   end
 
   # Slot tests


### PR DESCRIPTION
## Summary

Production crash: `GET /support/donate?user_locale=es` raised `RuntimeError: Field label contains a link -- move it into help: content instead of embedding it in the label` from `FieldLabelRow#raise_if_label_has_link`, taking down that page for every es-locale visitor.

Root cause: the Spanish translation of `donate_who` uses Textile link syntax (`"text":/support/donors`), which `.t` renders to an `<a>` tag. `FieldLabelRow` raised whenever a resolved label contained a link. Checked every other locale's `donate_who`: only `es` has link markup; the rest are either untranslated placeholders or plain text.

Translators write Textile with no way to know a given string becomes a field-prompt label rather than body text, so a hard raise turns an ordinary translation choice into a full-page crash for every visitor in that locale.

The original fix in this PR stripped the link, keeping only its text. On review, that turned out to be the wrong call: nested links inside a `<label>` are valid HTML, and browsers give the `<a>` click priority over the label's own click-to-focus/toggle behavior, so there's no real click-ambiguity — not even for a checkbox/radio label, where the label click also toggles the control. The actual risk is losing in-progress form data: clicking a same-tab link inside a form label navigates the user away from a form they may be partway through filling out.

`FieldLabelRow#resolved_label_text` now forces `target="_blank"` (plus `rel="noopener noreferrer"`) on any link found in a resolved label, instead of stripping it. The link stays clickable without the navigate-away risk, and it can never crash the page either way. This applies uniformly to every field type, including `CheckboxField`, which calls `resolved_label_text` directly.

The `es` translation itself isn't touched by this PR — non-official locale translations are database-driven (`rails lang:update` regenerates `es.txt`/`es.yml` from the DB, not the other way around), so a repo-level text edit has no effect; that's handled separately on production.

## Test plan

- [x] Component tests for `FieldLabelRow` — 14/14, including two new tests (link in a label gets `target="_blank"`; an existing `target=` attribute is left alone, not duplicated)
- [x] `CheckboxField` tests — 10/10, unaffected (its existing link-in-label test uses a selector, not exact HTML, so the added attributes don't break it)
- [x] Rubocop clean on both touched files
- [x] Regression-proofed: reverted the source fix, confirmed both new tests fail against the old strip-based behavior, restored, confirmed passing again
