### PR TITLE
Fix observation, species_list, project forms looping on a confirmed dubious location name (DRY)

### DIFF
--- a/app/controllers/concerns/locationable.rb
+++ b/app/controllers/concerns/locationable.rb
@@ -111,6 +111,25 @@ module Locationable
       @any_errors = true
     end
 
+    # Reasons `place_name` looks dubious (typo, wrong country, reversed
+    # name, bad terms, etc -- see Location.dubious_reasons_for), skipped
+    # once the caller has already confirmed it via an `approved_where`
+    # param. Reads the bare top-level `params[:approved_where]` (a
+    # form_action query param, or an unnamespaced hidden field) first,
+    # falling back to `params[param_key][:approved_where]` (a
+    # namespaced Superform hidden field) when `param_key` is given.
+    #
+    # Centralizes a pattern that lived duplicated (and, in two of its
+    # four copies, incompletely -- missing `approved:` entirely) across
+    # LocationsController, SpeciesListsController,
+    # SpeciesLists::WriteInController, and
+    # ObservationsController::Validators.
+    def dubious_where_reasons_for(place_name, param_key: nil)
+      approved = params[:approved_where] ||
+                 (param_key && params.dig(param_key, :approved_where))
+      Location.dubious_reasons_for(user: @user, place_name:, approved:)
+    end
+
     # Save location only (at this point rest of form is okay).
     def save_location(object)
       if save_with_log(@user, @location)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -405,6 +405,7 @@ class LocationsController < ApplicationController
              set_species_list: @set_species_list,
              set_user: @set_user,
              set_herbarium: @set_herbarium,
+             set_project: @set_project,
              dubious_where_reasons: @dubious_where_reasons
            ))
   end
@@ -451,11 +452,12 @@ class LocationsController < ApplicationController
 
     # Where to return after successfully creating location.
     set_params = params.permit(:set_observation, :set_species_list,
-                               :set_user, :set_herbarium)
+                               :set_user, :set_herbarium, :set_project)
     @set_observation  = set_params[:set_observation]
     @set_species_list = set_params[:set_species_list]
     @set_user         = set_params[:set_user]
     @set_herbarium    = set_params[:set_herbarium]
+    @set_project      = set_params[:set_project]
   end
 
   def create_location_ivar_and_save(done)
@@ -491,6 +493,8 @@ class LocationsController < ApplicationController
       attach_location_and_redirect(herbarium, herbarium_path(herbarium))
     elsif (user = User.safe_find(@set_user))
       attach_location_and_redirect(user, user_path(user))
+    elsif (project = Project.safe_find(@set_project))
+      attach_location_and_redirect(project, project_path(project))
     else
       redirect_to(location_path(@location.id))
     end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -18,6 +18,8 @@
 # Locations controller.
 # rubocop:disable Metrics/ClassLength
 class LocationsController < ApplicationController
+  include ::Locationable
+
   before_action :store_location, except: [:index, :destroy]
   before_action :login_required
 
@@ -440,10 +442,6 @@ class LocationsController < ApplicationController
     # Note: names are in user's preferred order unless explicitly otherwise.)
     @original_name = string_param(:where)
 
-    # Previous value of place name: ignore warnings if unchanged
-    # (i.e., resubmit same name).
-    @approved_name = params[:approved_where]
-
     # This is the latest value of place name.
     @display_name = begin
                       params[:location][:display_name].strip_squeeze
@@ -466,9 +464,7 @@ class LocationsController < ApplicationController
     @location.display_name = @display_name # (strip_squozen)
 
     # Validate name.
-    @dubious_where_reasons = Location.dubious_reasons_for(
-      user: @user, place_name: @display_name, approved: @approved_name
-    )
+    @dubious_where_reasons = dubious_where_reasons_for(@display_name)
 
     if @dubious_where_reasons.empty?
       if @location.save
@@ -550,10 +546,7 @@ class LocationsController < ApplicationController
     @location.high  = params[:location][:high]  if params[:location][:high]
     @location.low   = params[:location][:low]   if params[:location][:low]
     @location.display_name = @display_name
-    @dubious_where_reasons = Location.dubious_reasons_for(
-      user: @user, place_name: @display_name,
-      approved: params[:approved_where]
-    )
+    @dubious_where_reasons = dubious_where_reasons_for(@display_name)
   end
 
   def save_flash_and_redirect_or_render!

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -129,8 +129,7 @@ module ObservationsController::Validators
       return true
     end
 
-    @dubious_where_reasons =
-      dubious_where_reasons_for(@observation.place_name(@user))
+    @dubious_where_reasons = dubious_where_reasons_for(place_name)
     return true if @dubious_where_reasons.empty?
 
     @any_errors = true

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -130,7 +130,8 @@ module ObservationsController::Validators
     end
 
     @dubious_where_reasons = Location.dubious_reasons_for(
-      user: @user, place_name: @observation.place_name(@user)
+      user: @user, place_name: @observation.place_name(@user),
+      approved: params[:approved_where]
     )
     return true if @dubious_where_reasons.empty?
 

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -129,10 +129,8 @@ module ObservationsController::Validators
       return true
     end
 
-    @dubious_where_reasons = Location.dubious_reasons_for(
-      user: @user, place_name: @observation.place_name(@user),
-      approved: params[:approved_where]
-    )
+    @dubious_where_reasons =
+      dubious_where_reasons_for(@observation.place_name(@user))
     return true if @dubious_where_reasons.empty?
 
     @any_errors = true

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -144,6 +144,12 @@ class ProjectsController < ApplicationController
     end
     @project = Project.new(project_params)
     @project_dates_any = params[:project][:dates_any].downcase == "true"
+    # Echo the entered location back on reload, same as
+    # Creation#cleanup_failed_project_creation -- title/group-name
+    # failures land here too, and Project#place_name= has no
+    # free-text fallback for an unresolved name (see that method's
+    # comment for why raw_place_name exists at all).
+    @raw_place_name = params[:project][:place_name]
     image_ivars
     render_new_form
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectsController < ApplicationController
+  include ::Locationable
   include Validators
   include Creation
 
@@ -161,7 +162,7 @@ class ProjectsController < ApplicationController
         @project.save
         @project.log_update
         flash_notice(:runtime_edit_project_success.t(id: @project.id))
-        return redirect_to(project_path(@project.id))
+        return redirect_to(update_redirect_path)
       else
         flash_object_errors(@project)
       end
@@ -206,7 +207,9 @@ class ProjectsController < ApplicationController
   def render_new_form
     render(Views::Controllers::Projects::New.new(
              project: @project, dates_any: @project_dates_any,
-             upload_params: upload_params_hash
+             upload_params: upload_params_hash,
+             dubious_where_reasons: @dubious_where_reasons,
+             raw_place_name: @raw_place_name
            ))
   end
 
@@ -220,7 +223,9 @@ class ProjectsController < ApplicationController
     render(Views::Controllers::Projects::Admin::Show.new(
              project: @project, user: @user,
              dates_any: @project_dates_any,
-             upload_params: upload_params_hash
+             upload_params: upload_params_hash,
+             dubious_where_reasons: @dubious_where_reasons,
+             raw_place_name: @raw_place_name
            ))
   end
 
@@ -296,6 +301,18 @@ class ProjectsController < ApplicationController
   def find_project_and_where!
     find_project!
     @where = @project&.location&.display_name || ""
+  end
+
+  # Same offramp as create's finalize_saved_project: once the location
+  # has been resolved-or-confirmed-clean and still doesn't match an
+  # existing one, send the user to build it rather than leaving the
+  # project permanently location-less with no path to fix that.
+  def update_redirect_path
+    if @project.location.nil? && @raw_place_name.present?
+      new_location_path(where: @raw_place_name, set_project: @project.id)
+    else
+      project_path(@project.id)
+    end
   end
 
   def override_fixed_dates

--- a/app/controllers/projects_controller/creation.rb
+++ b/app/controllers/projects_controller/creation.rb
@@ -27,11 +27,19 @@ module ProjectsController::Creation
     nil
   end
 
+  # Exact/reverse-name match only -- Project has no bounding-box UI of
+  # its own, so (unlike Observation/SpeciesList) it can never build a
+  # brand new Location inline. A clean but unmatched name falls through
+  # to a post-save redirect to Locations::New instead (see
+  # finalize_saved_project); a dubious one blocks the save and asks the
+  # user to confirm via @dubious_where_reasons, same as everywhere else
+  # Locationable's dubious_where_reasons_for is used.
   def find_location(where)
     location = Location.find_by_name_or_reverse_name(where)
     return location if location || where == ""
 
-    flash_warning(:add_project_no_location.t(where: where))
+    @dubious_where_reasons = dubious_where_reasons_for(where,
+                                                       param_key: :project)
     nil
   end
 
@@ -40,19 +48,20 @@ module ProjectsController::Creation
     admin_group = create_admin_group(admin_name)
     location = find_location(where)
 
-    if project_groups_ok?(user_group, admin_group, location, where)
-      @project = build_new_project(user_group, admin_group, location)
-      upload_image_if_present
-      return finalize_saved_project if @project.save
-
-      flash_object_errors(@project)
+    if @dubious_where_reasons.blank? && user_group && admin_group
+      save_new_project(user_group, admin_group, location, where)
+    else
+      cleanup_failed_project_creation(user_group, admin_group, where)
     end
-
-    cleanup_failed_project_creation(user_group, admin_group)
   end
 
-  def project_groups_ok?(user_group, admin_group, location, where)
-    user_group && admin_group && (location || where == "")
+  def save_new_project(user_group, admin_group, location, where)
+    @project = build_new_project(user_group, admin_group, location)
+    upload_image_if_present
+    return finalize_saved_project(where) if @project.save
+
+    flash_object_errors(@project)
+    cleanup_failed_project_creation(user_group, admin_group, where)
   end
 
   def build_new_project(user_group, admin_group, location)
@@ -67,7 +76,7 @@ module ProjectsController::Creation
     project
   end
 
-  def finalize_saved_project
+  def finalize_saved_project(where)
     # Same trust the add-member and field-slip paths grant, and said out
     # loud for the same reason: someone setting a project up almost
     # always wants its admins able to work on the observations they put
@@ -78,14 +87,31 @@ module ProjectsController::Creation
     @project.log_create
     flash_notice(:add_project_success.t)
     flash_notice(:add_members_with_editing.l)
-    redirect_to(project_path(@project.id))
+    if @project.location.nil? && where.present?
+      redirect_to(new_location_path(where:, set_project: @project.id))
+    else
+      redirect_to(project_path(@project.id))
+    end
   end
 
-  def cleanup_failed_project_creation(user_group, admin_group)
+  # Rebuilds @project from what was actually submitted (project_params
+  # includes :place_name) rather than a blank Project.new, so a
+  # dubious-location reload shows the user's entered title/summary/etc
+  # back instead of an empty form (the literal #2248 complaint).
+  #
+  # Project#place_name= only ever resolves-or-clears +location+ (see
+  # app/models/project.rb) -- it has no free-text fallback the way
+  # Observation/SpeciesList's place_name does, so the just-submitted,
+  # still-unresolved text can't be read back off @project itself.
+  # @raw_place_name carries it explicitly for the visible autocompleter
+  # and the approved_where hidden field (see Views::Controllers::
+  # Projects::Form).
+  def cleanup_failed_project_creation(user_group, admin_group, where)
     admin_group&.destroy
     user_group&.destroy
-    @project = Project.new
+    @project = Project.new(project_params)
     @project_dates_any = true
+    @raw_place_name = where
     image_ivars
     render_new_form
   end

--- a/app/controllers/projects_controller/validators.rb
+++ b/app/controllers/projects_controller/validators.rb
@@ -17,10 +17,15 @@ module ProjectsController::Validators
     end
   end
 
+  # A clean-but-unmatched name is accepted here (location stays nil) --
+  # update_redirect_path sends the user to build it afterward, rather
+  # than the old behavior of hard-blocking the whole edit until they
+  # either fix the typo or give up on that name entirely.
   def valid_where
     where = params[:project][:place_name]
+    @raw_place_name = where
     location = find_location(where)
-    return false if !location && where != ""
+    return false if @dubious_where_reasons.present?
 
     @project.location = location
     @project.save

--- a/app/controllers/species_lists/write_in_controller.rb
+++ b/app/controllers/species_lists/write_in_controller.rb
@@ -2,6 +2,8 @@
 
 module SpeciesLists
   class WriteInController < ApplicationController
+    include ::Locationable
+
     before_action :login_required
 
     def new
@@ -97,7 +99,15 @@ module SpeciesLists
       return if redirected
 
       # Failed to create due to synonyms, unrecognized names, etc.
+      # init_name_vars_from_sorter (shared with uploads_controller,
+      # which has no separate resubmit-to-confirm mechanism) resets
+      # @place_name to the species_list's already-saved location --
+      # restore the just-submitted value so a dubious-location reload
+      # shows (and echoes back via approved_where) what the user
+      # actually typed, not what's already on the record.
+      submitted_place_name = @place_name
       init_name_vars_from_sorter(@species_list, sorter)
+      @place_name = submitted_place_name
       init_member_vars_for_reload
       init_project_vars_for_reload(@species_list)
       # Member notes parts are derived from the list, not from params;
@@ -202,10 +212,7 @@ module SpeciesLists
     def validate_place_name
       @place_name = params.permit(:place_name)[:place_name] ||
                     @species_list.place_name(@user)
-      @dubious_where_reasons = Location.dubious_reasons_for(
-        user: @user, place_name: @place_name,
-        approved: params[:approved_where]
-      )
+      @dubious_where_reasons = dubious_where_reasons_for(@place_name)
     end
 
     def init_member_vars_for_reload

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -8,6 +8,8 @@
 #  Observation's to spring into existence.
 #
 class SpeciesListsController < ApplicationController # rubocop:disable Metrics/ClassLength
+  include ::Locationable
+
   before_action :login_required
   before_action :require_successful_user, only: [:new, :create]
   before_action :store_location, only: [:show]
@@ -297,9 +299,8 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
     @dubious_where_reasons = []
     return if @species_list.location_id
 
-    @dubious_where_reasons = Location.dubious_reasons_for(
-      user: @user, place_name: @place_name,
-      approved: params.dig(:species_list, :approved_where)
+    @dubious_where_reasons = dubious_where_reasons_for(
+      @place_name, param_key: :species_list
     )
   end
 

--- a/app/views/controllers/locations/form.rb
+++ b/app/views/controllers/locations/form.rb
@@ -19,6 +19,7 @@ module Views::Controllers::Locations
     prop :set_species_list, _Nilable(Integer), default: nil
     prop :set_user, _Nilable(Integer), default: nil
     prop :set_herbarium, _Nilable(Integer), default: nil
+    prop :set_project, _Nilable(Integer), default: nil
     prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
          default: nil
 
@@ -204,6 +205,7 @@ module Views::Controllers::Locations
               set_observation: @set_observation,
               set_species_list: @set_species_list,
               set_user: @set_user, set_herbarium: @set_herbarium,
+              set_project: @set_project,
               only_path: true)
     end
 

--- a/app/views/controllers/locations/new.rb
+++ b/app/views/controllers/locations/new.rb
@@ -14,6 +14,7 @@ module Views::Controllers::Locations
     prop :set_species_list, _Nilable(Integer), default: nil, &TO_ID
     prop :set_user, _Nilable(Integer), default: nil, &TO_ID
     prop :set_herbarium, _Nilable(Integer), default: nil, &TO_ID
+    prop :set_project, _Nilable(Integer), default: nil, &TO_ID
     prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
          default: nil
     def view_template
@@ -29,6 +30,7 @@ module Views::Controllers::Locations
                set_species_list: @set_species_list,
                set_user: @set_user,
                set_herbarium: @set_herbarium,
+               set_project: @set_project,
                dubious_where_reasons: @dubious_where_reasons
              ))
     end

--- a/app/views/controllers/projects/admin/show.rb
+++ b/app/views/controllers/projects/admin/show.rb
@@ -11,6 +11,9 @@ module Views::Controllers::Projects::Admin
     prop :user, ::User
     prop :dates_any, _Boolean
     prop :upload_params, Hash
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
+         default: nil
+    prop :raw_place_name, _Nilable(String), default: nil
 
     def view_template
       add_project_banner(@project)
@@ -32,7 +35,9 @@ module Views::Controllers::Projects::Admin
                enctype: "multipart/form-data",
                dates_any: @dates_any,
                upload_params: @upload_params,
-               dirty_form: true
+               dirty_form: true,
+               dubious_where_reasons: @dubious_where_reasons,
+               raw_place_name: @raw_place_name
              ))
     end
 

--- a/app/views/controllers/projects/form.rb
+++ b/app/views/controllers/projects/form.rb
@@ -8,6 +8,14 @@ module Views::Controllers::Projects
     prop :dates_any, _Boolean
     prop :upload_params, _Nilable(Hash), default: nil
     prop :dirty_form, _Boolean, default: false
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
+         default: nil
+    # Project#place_name= only ever resolves-or-clears +location+ (no
+    # free-text fallback), so a just-submitted, still-unresolved name
+    # can't be read back off `model` -- the controller threads it
+    # through explicitly instead. See ProjectsController::Creation#
+    # cleanup_failed_project_creation.
+    prop :raw_place_name, _Nilable(String), default: nil
 
     # Adds the dirty-form Stimulus controller to the rendered <form>
     # tag when the caller opts in. Used on the Admin/Details tab to
@@ -33,6 +41,11 @@ module Views::Controllers::Projects
         render_summary
         render_field_slip_prefix
         render_location
+        render(Components::Form::LocationFeedback.new(
+                 dubious_where_reasons: @dubious_where_reasons,
+                 button: submit_text
+               ))
+        render_approved_where_hidden
         render_dates_section
         render_upload_fields if @upload_params
       end
@@ -71,7 +84,15 @@ module Views::Controllers::Projects
 
     def render_location
       autocompleter_field(:place_name, type: :location,
-                                       label: :where.ti)
+                                       label: :where.ti,
+                                       value: @raw_place_name ||
+                                              model.place_name(current_user))
+    end
+
+    def render_approved_where_hidden
+      return if @raw_place_name.blank?
+
+      hidden_field("approved_where", value: @raw_place_name)
     end
 
     def render_dates_section

--- a/app/views/controllers/projects/new.rb
+++ b/app/views/controllers/projects/new.rb
@@ -6,6 +6,9 @@ module Views::Controllers::Projects
     prop :project, ::Project
     prop :dates_any, _Boolean
     prop :upload_params, Hash
+    prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
+         default: nil
+    prop :raw_place_name, _Nilable(String), default: nil
 
     def view_template
       add_new_title(:create_object, :project)
@@ -15,7 +18,9 @@ module Views::Controllers::Projects
                @project,
                enctype: "multipart/form-data",
                dates_any: @dates_any,
-               upload_params: @upload_params
+               upload_params: @upload_params,
+               dubious_where_reasons: @dubious_where_reasons,
+               raw_place_name: @raw_place_name
              ))
     end
   end

--- a/app/views/controllers/species_lists/write_in/form.rb
+++ b/app/views/controllers/species_lists/write_in/form.rb
@@ -15,9 +15,9 @@ module Views::Controllers::SpeciesLists::WriteIn
   #   per-observation defaults applied to the obs constructed from
   #   the typed names
   # - `place_name`: top-level WHERE for the observations
-  # - `approved_names` / `approved_deprecated_names`: top-level
-  #   hidden re-submissions of name-confirmation state, only emitted
-  #   when those collections are non-empty
+  # - `approved_names` / `approved_deprecated_names` / `approved_where`:
+  #   top-level hidden re-submissions of name/location-confirmation
+  #   state, only emitted when there's something to confirm
   #
   # Field names go through the helpers in String form (`"member[lat]"`)
   # so the raw `name=` attribute lands as-is on the rendered input,
@@ -83,10 +83,13 @@ module Views::Controllers::SpeciesLists::WriteIn
         hidden_field("approved_names",
                      value: @new_names.join("\n"))
       end
-      return if @deprecated_names.blank?
+      if @deprecated_names.present?
+        hidden_field("approved_deprecated_names",
+                     value: @deprecated_names.map(&:id).join(" "))
+      end
+      return if @place_name.blank?
 
-      hidden_field("approved_deprecated_names",
-                   value: @deprecated_names.map(&:id).join(" "))
+      hidden_field("approved_where", value: @place_name)
     end
 
     def render_list_members_field

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3136,7 +3136,6 @@
   add_project_already_exists: A project named '[title]' already exists.
   add_project_ends_before_start: Project ends before it starts.
   add_project_group_exists: Unable to create project because a [:user_group] named '[group]' already exists.
-  add_project_no_location: No location matching '[where]' found.
   add_project_need_title: Projects must have a title.
   add_project_success: Project was successfully created.
 

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -809,6 +809,24 @@ class LocationsControllerTest < FunctionalTestCase
     assert_equal(loc, herbarium.location)
   end
 
+  # Part of #2248's fix: Project has no bounding-box UI, so a clean
+  # but unmatched name sends the user here (via set_project) to
+  # actually create the Location, same offramp as set_herbarium/
+  # set_user.
+  def test_create_location_with_set_project
+    project = projects(:eol_project)
+    login("rolf")
+    params = barton_flats_params
+    params[:set_project] = project.id.to_s
+
+    post(:create, params: params)
+
+    loc = assigns(:location)
+    assert_redirected_to(project_path(project))
+    project.reload
+    assert_equal(loc, project.location)
+  end
+
   # Regression test: a stale/tampered set_herbarium id used to make
   # return_to_caller issue no redirect at all (Herbarium.safe_find
   # returning nil skipped straight past the whole branch), raising a

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -1212,6 +1212,29 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     )
   end
 
+  # Regression: validate_place_name never passed `approved:` to
+  # Location.dubious_reasons_for, so resubmitting an unchanged dubious
+  # place_name -- the flow form_observations_dubious_help tells the user
+  # to use ("Click 'Create' to use this location name") -- looped
+  # forever instead of accepting it.
+  def test_construct_observation_dubious_place_name_approved
+    where = "Bogus, Massachusetts, UAS"
+    params = {
+      naming: { name: "Unknown" },
+      location: { north: 35, south: 34, east: -117, west: -118 },
+      observation: { place_name: where, location_id: -1 }
+    }
+
+    # First submission: dubious, rejected, nothing created.
+    generic_construct_observation(params, 0, 0, 0, 0)
+
+    # Resubmission with approved_where matching the unchanged
+    # place_name: the dubious check is skipped, observation is created.
+    generic_construct_observation(
+      params.merge(approved_where: where), 1, 0, 0, 1
+    )
+  end
+
   def test_name_resolution
     login("rolf")
 

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -757,6 +757,31 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     )
   end
 
+  # Regression (#3032): validate_place_name never passed approved: to
+  # Location.dubious_reasons_for, so resubmitting an unchanged dubious
+  # place_name on edit looped forever showing the same flash instead of
+  # accepting it.
+  def test_update_observation_dubious_place_name_approved
+    params = {
+      location: { north: 35, south: 34, east: -117, west: -118 }
+    }
+    where = "Mt. Molehill, Iowa, USA"
+
+    # First submission: dubious ("Mt." should be "Mount"), rejected.
+    generic_update_observation(
+      params.merge({ observation: { place_name: where, location_id: -1 } }),
+      0
+    )
+
+    # Resubmission with approved_where matching the unchanged
+    # place_name: the dubious check is skipped, update succeeds.
+    generic_update_observation(
+      params.merge(observation: { place_name: where, location_id: -1 },
+                   approved_where: where),
+      1
+    )
+  end
+
   # --------------------------------------------------------------------
   #  Test notes with template
   # --------------------------------------------------------------------

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -607,6 +607,19 @@ class ProjectsControllerTest < FunctionalTestCase
     assert_nil(Project.find_by(title: title))
   end
 
+  # A narrower version of #2248: a title/group-name conflict never
+  # reaches create_project (and thus never sets @raw_place_name) --
+  # the entered location used to revert to blank on this reload even
+  # though the failure had nothing to do with it.
+  def test_create_project_blank_title_preserves_entered_location
+    where = "Springvale, Wyoming, USA"
+    params = build_params("", "a summary")
+    params[:project][:place_name] = where
+    post_requires_login(:create, params)
+
+    assert_select("input[name='project[place_name]'][value=?]", where)
+  end
+
   # Regression (#2248): a dubious place_name used to reload a blank
   # form with just a flash warning and no way to confirm the name --
   # looping forever on any resubmission of the same name. Now it

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -607,6 +607,93 @@ class ProjectsControllerTest < FunctionalTestCase
     assert_nil(Project.find_by(title: title))
   end
 
+  # Regression (#2248): a dubious place_name used to reload a blank
+  # form with just a flash warning and no way to confirm the name --
+  # looping forever on any resubmission of the same name. Now it
+  # reloads with the entered title/place_name intact and an
+  # approved_where hidden field, matching every other model with this
+  # confirm flow.
+  def test_create_project_dubious_place_name_preserves_entries_and_confirms
+    where = "Old Rd, Ohio, USA"
+    title = "Dubious Location Project"
+    params = build_params(title, "a summary")
+    params[:project][:place_name] = where
+    login(rolf.login)
+
+    post(:create, params: params)
+    assert_nil(Project.find_by(title: title))
+    assert_select("#dubious_location_messages")
+    assert_select("input[name='project[title]'][value=?]", title)
+    assert_select("input[name='project[place_name]'][value=?]", where)
+    assert_select("input[name='approved_where'][value=?]", where)
+
+    post(:create, params: params.merge(approved_where: where))
+    project = Project.find_by(title: title)
+    assert_not_nil(project)
+    assert_nil(project.location)
+    assert_redirected_to(
+      new_location_path(where: where, set_project: project.id)
+    )
+  end
+
+  # A clean name with no exact Location match isn't dubious -- Project
+  # can't create a new Location inline (no bounding-box UI), so it
+  # saves without one and sends the user to build it, the same
+  # offramp herbaria/profile use on their own no-match path.
+  def test_create_project_clean_unmatched_location_redirects_to_new_location
+    where = "Springvale, Wyoming, USA"
+    title = "Clean Unmatched Location Project"
+    params = build_params(title, "a summary")
+    params[:project][:place_name] = where
+    post_requires_login(:create, params)
+
+    project = Project.find_by(title: title)
+    assert_not_nil(project)
+    assert_nil(project.location)
+    assert_redirected_to(
+      new_location_path(where: where, set_project: project.id)
+    )
+  end
+
+  # Same #2248 regression, on the update/edit path (Validators#valid_where
+  # shares the bug with Creation#find_location).
+  def test_update_project_dubious_place_name_preserves_entries_and_confirms
+    where = "Old Rd, Ohio, USA"
+    project = projects(:eol_project)
+    params = build_params(project.title, project.summary)
+    params[:id] = project.id
+    params[:project][:place_name] = where
+    login(rolf.login)
+
+    put(:update, params: params)
+    assert_nil(project.reload.location)
+    assert_select("#dubious_location_messages")
+    assert_select("input[name='project[title]'][value=?]", project.title)
+    assert_select("input[name='project[place_name]'][value=?]", where)
+    assert_select("input[name='approved_where'][value=?]", where)
+
+    put(:update, params: params.merge(approved_where: where))
+    assert_nil(project.reload.location)
+    assert_redirected_to(
+      new_location_path(where: where, set_project: project.id)
+    )
+  end
+
+  def test_update_project_clean_unmatched_location_redirects_to_new_location
+    where = "Springvale, Wyoming, USA"
+    project = projects(:eol_project)
+    params = build_params(project.title, project.summary)
+    params[:id] = project.id
+    params[:project][:place_name] = where
+    login(rolf.login)
+
+    put(:update, params: params)
+    assert_nil(project.reload.location)
+    assert_redirected_to(
+      new_location_path(where: where, set_project: project.id)
+    )
+  end
+
   def test_project_save_fail
     title = "Bad Project"
     project = projects(:eol_project)

--- a/test/controllers/species_lists/write_in_controller_test.rb
+++ b/test/controllers/species_lists/write_in_controller_test.rb
@@ -533,6 +533,39 @@ module SpeciesLists
       assert_equal(place_name, spl.observations.last.location.text_name)
     end
 
+    # Regression: the controller read params[:approved_where], but the
+    # form never sent it back -- write_in/form.rb#render_approval_hiddens
+    # only emitted approved_names/approved_deprecated_names. Resubmitting
+    # an unchanged dubious place_name looped forever instead of
+    # accepting it, the same bug class fixed for observations/#3032.
+    def test_create_with_dubious_place_name_approved
+      spl = species_lists(:first_species_list)
+      where = "Old Rd, Ohio, USA"
+      params = {
+        id: spl.id,
+        list: { members: "Coprinus comatus\r\nAgaricus campestris" },
+        place_name: where
+      }
+      login("rolf")
+
+      # First submission: dubious ("Old Rd" is a flagged bad term),
+      # rejected -- no redirect, nothing created. The reload must
+      # itself emit the approved_where hidden field with the unchanged
+      # name, or a real browser resubmit (unlike this test's next call,
+      # which sets approved_where directly) could never carry it back.
+      post(:create, params: params)
+      assert_response(:success)
+      assert_select("#dubious_location_messages")
+      assert_select("input[name='approved_where'][value=?]", where)
+      assert_equal(0, spl.reload.observations.size)
+
+      # Resubmission with approved_where matching the unchanged
+      # place_name: the dubious check is skipped, the list is created.
+      post(:create, params: params.merge(approved_where: where))
+      assert_redirected_to(species_list_path(spl.id))
+      assert_equal(2, spl.reload.observations.size)
+    end
+
     def test_create_species_list_new_name
       spl = species_lists(:unknown_species_list)
       sp_count = spl.observations.size


### PR DESCRIPTION
## Summary

Fixes the bug @JoeCohen found reviewing #5076: entering a non-existent locality and clicking "Create" shows the expected "Unknown country..." flash, but clicking "Create" again to confirm it just redisplays the same flash forever instead of accepting the name.

Also fixes #3032, the same loop on the edit path: editing an Observation, changing Location to a dubious name (their repro used "Mt. Molehill, Iowa, USA" — "Mt." is a flagged bad term), clicking "Save Edits" redisplays the same flash forever instead of accepting it. Both paths share the same `validate_place_name` method, so one fix covers both.

Root cause: `ObservationsController::Validators#validate_place_name` calls `Location.dubious_reasons_for` without the `approved:` keyword, so the "resubmit to confirm" gate can never pass — `approved` defaults to `nil` and the dubious check runs the same way on every submission, no matter how many times the user clicks "Create"/"Save Edits" with an unchanged name.

The form already builds this correctly: `Views::Controllers::Observations::Form#form_action` appends `approved_where=<place_name>` onto the form's action URL once a dubious name has been shown, exactly like `locations_controller`, `species_lists_controller`, and `species_lists/write_in_controller` do for their own equivalent flows (`Location.dubious_reasons_for(..., approved: params[...][:approved_where])`). `observations_controller/validators` was the one caller of `dubious_reasons_for` that never read the param back.

Confirmed this predates both #5076 (no diff to this file on that branch) and #5055 — reproduces identically on `main`, for both `create` and `edit` (both go through the same shared `validate_place_name`).

## DRY-ing the confirm check + fixing #2248

`Location.dubious_reasons_for` was duplicated across four controllers, each hand-rolling its own `approved_where` param read (two different shapes: a bare top-level param vs a namespaced Superform hidden field). Added `Locationable#dubious_where_reasons_for` as the one shared call site and retrofitted all four (`locations_controller`, `species_lists_controller`, `species_lists/write_in_controller`, `observations_controller/validators`) to use it — no behavior change, verified by running each controller's full test file before and after.

Retrofitting `species_lists/write_in_controller` surfaced two more bugs in the same bug class, both fixed here:

- Its form never sent back the `approved_where` the controller read — same bug as observations, just never reported. Added the missing hidden field.
- `init_name_vars_from_sorter` (shared with `species_lists/uploads_controller`, which has no resubmit-to-confirm step of its own) unconditionally reset `@place_name` back to the species_list's already-saved location on every validation-failure reload, clobbering the just-submitted value moments after `validate_place_name` had set it correctly — so even with the hidden field in place, a confirm resubmission would still loop forever, since the echoed `approved_where` could never match what the user had actually typed.

Also fixes #2248 (`ProjectsController` had no dubious-location handling at all — an unmatched name just flashed a warning and reloaded a blank `Project.new` form, with no confirm option and no path to actually create a new Location for it). Project can't build a new Location inline the way Observation/SpeciesList can — no bounding-box UI, and `Project#place_name=` only ever resolves-or-clears the location association, with no free-text fallback. The fix mirrors herbaria/profile's existing pattern instead: once a name is confirmed clean, the project saves without a location and redirects to `Locations::New` (via a new `set_project` param on `locations_controller#return_to_caller`) to actually build one. A dubious name still blocks the save and reloads the form — but now with the user's entered title/summary/place_name intact (the literal #2248 complaint was that it reloaded blank) and an `approved_where` hidden field, matching every other model with this flow. Applies to both create and edit, which shared the same gap.

Not a fix for anything on `HerbariaController`/`Account::ProfileController` — considered adding the same in-form confirm UI there too, but both already redirect to `Locations::New` on any unmatched name, which runs the identical dubious check one screen later; adding it earlier would just be a redundant confirm step in front of the same check, since neither has a bounding-box UI to make the earlier confirm actually accomplish anything.

## Test plan

- [x] New regression tests (observations create + edit): submits a dubious place name (rejected, nothing created), then resubmits with `approved_where` matching (accepted)
- [x] New regression test (`species_lists/write_in`): same shape, plus asserts the rendered form actually emits the `approved_where` hidden field with the *submitted* value, not a stale one
- [x] New regression tests (`Project` create + edit): dubious name reloads with entries preserved + confirms on resubmit; clean-but-unmatched name saves without a location and redirects to `new_location_path`
- [x] New regression test (`locations_controller`): `set_project` redirects back to the project and attaches the location, matching `set_herbarium`/`set_user`
- [x] Full test files: `observations_controller_create_test.rb` (104), `observations_controller_update_test.rb` (47), `locations_controller_test.rb` (68), `species_lists_controller_test.rb` (36), `species_lists/write_in_controller_test.rb` (23), `species_lists/uploads_controller_test.rb` (4, confirms the shared `init_name_vars_from_sorter` fix doesn't affect its other caller), `projects_controller_test.rb` (48), `herbaria_controller_test.rb` (71, confirms untouched) — all green
- [x] Rubocop clean on all touched files
- [x] Regression-proofed every new test: reverted the relevant source fix, confirmed the test fails with the original loop/blank-reload behavior, restored, confirmed passing again

Closes #3032. Closes #2248.
