### PR TITLE
Fix `Location.contains_point` for boxes straddling the antimeridian

### DIFF
--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -138,11 +138,19 @@ module Location::Scopes
       in_box(**args).invert_where
     }
     # Use named parameters (lat:, lng:), any order
+    # A location whose box straddles longitude 180 has west > east (e.g.
+    # Kiribati: west=169, east=-145) -- containment there means the point
+    # is east of west OR west of east, not between them. Getting this
+    # backwards (AND instead of OR) previously matched points nowhere
+    # near the location (issue #5080: (0, 0) "contained" by Kiribati).
     scope :contains_point, lambda { |**args|
       args => { lat:, lng: }
+      west = Location[:west]
+      east = Location[:east]
+      not_straddling = west.lteq(east).and(west.lteq(lng)).and(east.gteq(lng))
+      straddling = west.gt(east).and(west.lteq(lng).or(east.gteq(lng)))
       where(Location[:south].lteq(lat).and(Location[:north].gteq(lat)).
-            and(Location[:west].lteq(lng).and(Location[:east].gteq(lng)).
-                or(Location[:west].gteq(lng).and(Location[:east].lteq(lng)))))
+            and(not_straddling.or(straddling)))
     }
     # Use named parameters (lat:, lng:), any order
     scope :with_minimum_bounding_box_containing_point, lambda { |**args|

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -691,6 +691,26 @@ class LocationTest < UnitTestCase
       include?(loc), "#{loc.name} should contain its SW corner")
   end
 
+  # Regression (issue #5080): a straddling box's containment check used
+  # to be AND-based instead of OR-based, which happened to still pass
+  # the exact-corner assertions above (the buggy clause coincides with
+  # the correct answer right at the boundary) but matched points nowhere
+  # near the location everywhere else -- e.g. (0, 0) "contained" by
+  # Kiribati. east_lt_west_location (Wrangel Island, west=178.648,
+  # east=-177.433) straddles 180 with a narrow gap; (0, 0) is on the
+  # opposite side of the globe from it.
+  def test_scope_contains_point_excludes_points_outside_straddling_box
+    loc = locations(:east_lt_west_location)
+    # Same latitude as the box (so only the longitude logic is under
+    # test), but a longitude on the opposite side of the globe from
+    # its narrow straddling gap (west=178.648 to east=-177.433).
+    lat = (loc.north + loc.south) / 2
+
+    assert_not(Location.contains_point(lat:, lng: 0).include?(loc),
+               "#{loc.name} should not contain a point on the far side " \
+               "of the globe from its straddling box")
+  end
+
   def cal
     locations(:california)
   end


### PR DESCRIPTION
## Summary

Fixes #5080: entering `0, 0` ("Null Island") as an observation's coordinates got the observation assigned `Kiribati` as its location, and the map pin for the observation's own displayed coordinates ended up rendering at `(0, 180)` instead of `(0, 0)`.

Root cause is a pure backend/SQL bug, unrelated to #5076's JS coordinate-entry work — no JS is touched here.

`Location.contains_point` (`app/models/location/scopes.rb`) tests whether a point falls inside a location's bounding box. A box that straddles longitude 180 has `west > east` (e.g. Kiribati: `west=169, east=-145`) — containment there means the point is east of `west` *or* west of `east`. The scope used `AND` instead of `OR` for this case:

```ruby
# before
where(... .and(west.lteq(lng).and(east.gteq(lng)).
    or(west.gteq(lng).and(east.lteq(lng)))))
```

That inverted the check: for a straddling box, `west >= lng AND east <= lng` is true for the *wide gap* between `east` and `west` (everywhere the box doesn't cover), not the narrow wrapped region it actually spans. Confirmed against Kiribati directly — `Location.contains_point(lat: 0, lng: 0)` returned Kiribati before the fix and correctly excludes it after.

The observation-creation flow's `Observation#prefer_minimum_bounding_box_to_earth` callback (`before_save`) calls `Location.with_minimum_bounding_box_containing_point`, which is built on this scope — that's the path that assigned Kiribati to a `(0, 0)` observation instead of falling through to `Location.unknown` (the documented fallback when no real bounding box matches).

## Test plan

- [x] New regression test in `test/models/location_test.rb`, using the existing `east_lt_west_location` (Wrangel Island) straddling-box fixture — confirms a point on the far side of the globe from its narrow straddling gap is correctly excluded
- [x] `test/models/location_test.rb` — 38/38
- [x] Rubocop clean on both touched files
- [x] Regression-proofed: reverted the fix, confirmed the new test fails with the same false-positive containment the bug report describes, restored, confirmed passing again
- [x] Manually confirmed via `bin/rails runner` against the local dev DB: `Location.contains_point(lat: 0, lng: 0)` includes Kiribati before the fix, excludes it after

Closes #5080.