### PR TITLE
Fix the dubious-locality approval loop and the sticky free-text Locality default (`approved_where` / `field_slip_for_code`)

### DIFF
--- a/app/controllers/observations_controller/create.rb
+++ b/app/controllers/observations_controller/create.rb
@@ -292,6 +292,12 @@ module ObservationsController::Create
   def init_location_var_for_reload
     # Preserve the user's place_name input for form re-render
     @default_place_name = @observation.place_name(@user)
+    # A flagged name re-renders with `approved_where` embedded in the
+    # form action (Form#form_action reads @place_name), so resubmitting
+    # unchanged passes `dubious_reasons_for`'s approved gate. Without
+    # this the "Click Create to use this location name" confirmation
+    # loops forever -- nothing else ever assigns @place_name.
+    @place_name = @default_place_name if @dubious_where_reasons.present?
 
     # keep location_id if it's -1 (new)
     if @location || @observation.location_id.nil? ||

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -264,6 +264,11 @@ module ObservationsController::EditAndUpdate
     @exif_data    ||= get_exif_data(@good_images)
     @location     ||= @observation.location
     @field_code     = params[:field_code]
+    # See init_location_var_for_reload: the approved_where round-trip
+    # needs @place_name set on a dubious-name re-render.
+    if @dubious_where_reasons.present?
+      @place_name = @observation.place_name(@user)
+    end
     init_project_vars
     init_project_vars_for_reload
     init_list_vars_for_reload
@@ -284,7 +289,8 @@ module ObservationsController::EditAndUpdate
   def edit_view_obs_attrs
     {
       observation: @observation, user: @user, location: @location,
-      dubious_where_reasons: @dubious_where_reasons
+      dubious_where_reasons: @dubious_where_reasons,
+      place_name: @place_name
     }
   end
 

--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -138,7 +138,14 @@ module ObservationsController::FieldSlips
     return nil if code.blank?
 
     existing = FieldSlip.find_by(code: code)
-    return existing if existing
+    if existing
+      # current_user gates FieldSlip#calc_location's two user-dependent
+      # steps (latest slip in the project, latest located observation);
+      # without it an existing slip's Locality default silently loses
+      # them and falls back to the previous observation's free text.
+      existing.current_user = @user
+      return existing
+    end
 
     slip = FieldSlip.new
     slip.current_user = @user

--- a/app/controllers/observations_controller/new.rb
+++ b/app/controllers/observations_controller/new.rb
@@ -183,10 +183,10 @@ module ObservationsController::New
     # it every time, while someone out collecting for the day had to
     # check it every time. What the same user did last is a better
     # predictor than the presence of a code. See #4932.
-    %w[where location_id is_collection_location gps_hidden
-       specimen].each do |attr|
+    %w[is_collection_location gps_hidden specimen].each do |attr|
       @observation.send(:"#{attr}=", last_observation.send(attr))
     end
+    apply_default_locality(last_observation)
     @location = @observation.location
 
     if last_observation.created_at > 1.hour.ago
@@ -207,6 +207,40 @@ module ObservationsController::New
     @lists << list unless @lists.include?(list)
     ids = @observation.species_list_ids
     @observation.species_list_ids = ids | [list.id]
+  end
+
+  # A located (or clean free-text) locality is worth carrying forward;
+  # one that would itself trip the dubious-name confirmation is not --
+  # as a default it re-prompts on every subsequent create until
+  # dislodged (reported: one slip's unrecognized "Sunshine Foray/ ..."
+  # haunting every following observation). Fall back to the most
+  # recent located observation, or no default at all.
+  def apply_default_locality(last_observation)
+    source = locality_default_source(last_observation)
+    return unless source
+
+    @observation.where = source.where
+    @observation.location_id = source.location_id
+  end
+
+  def locality_default_source(last_observation)
+    return last_observation if usable_default_locality?(last_observation)
+
+    @user.observations.where.not(location_id: nil).
+      order(created_at: :desc, id: :desc).first
+  end
+
+  def usable_default_locality?(obs)
+    return true if obs.location_id
+    return false if obs.where.blank?
+
+    # check_db: false, deliberately -- the DB-backed check treats ANY
+    # previously used `where` as known (Observation.pluck(:where) is
+    # in location_name_cache), which would bless the very free text
+    # this guard exists to stop propagating. The syntactic check is
+    # deterministic.
+    !Location.dubious_name?(Location.user_format(@user, obs.where),
+                            false, false)
   end
 
   # Adding a field-slip project: always check it; for other already-

--- a/app/views/controllers/observations/edit.rb
+++ b/app/views/controllers/observations/edit.rb
@@ -14,6 +14,7 @@ module Views::Controllers::Observations
     prop :exif_data, Hash, default: -> { {} }
     prop :dubious_where_reasons, _Nilable(_Array(_Tuple(Symbol, Hash))),
          default: nil
+    prop :place_name, _Nilable(String), default: nil
     prop :projects, _Array(::Project), default: -> { [] }
     prop :submitted_project_ids, _Nilable(_Array(Integer)),
          default: nil, &TO_ID_ARRAY
@@ -40,6 +41,7 @@ module Views::Controllers::Observations
                sibling_images: @sibling_images,
                exif_data: @exif_data,
                dubious_where_reasons: @dubious_where_reasons,
+               place_name: @place_name,
                projects: @projects,
                submitted_project_ids: @submitted_project_ids,
                lists: @lists,

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -2302,6 +2302,56 @@ class ObservationsControllerCreateTest < FunctionalTestCase
     assert_no_match(/field_slip_extract/, @response.location.to_s)
   end
 
+  # Reported at the 2026 SMHF event: confirming a flagged free-text
+  # locality looped forever. The validator gate (dubious_reasons_for
+  # approved:) was fine -- the RE-RENDERED form never embedded
+  # approved_where, because nothing assigned @place_name on the
+  # dubious reload, so the resubmit never carried the approval.
+  def test_create_dubious_place_rerender_embeds_approved_where
+    login("rolf")
+    where = "Sunshine Foray/ Dunton Medows"
+
+    params = create_params_with_name
+    params[:observation] = params[:observation].merge(place_name: where)
+    post(:create, params: params)
+
+    assert_select("form#observation_form[action*=?]", "approved_where",
+                  true, "the reloaded form must carry the approval")
+
+    params[:approved_where] = where
+    post(:create, params: params)
+
+    obs = assigns(:observation)
+
+    assert_predicate(obs, :persisted?,
+                     "the approved resubmit must go through")
+    assert_equal(where, obs.where)
+  end
+
+  # The other half of the sticky-garbage report: an EXISTING slip code
+  # never got current_user set, which nil-guarded away the location
+  # cascade's user-dependent steps -- so after one free-text
+  # observation, the form kept defaulting to that free text instead of
+  # the user's last real location.
+  def test_new_with_existing_slip_code_prefers_last_located_observation
+    located = rolf.observations.where.not(location_id: nil).
+              order(created_at: :desc, id: :desc).first
+
+    assert_not_nil(located, "premise: rolf has a located observation")
+
+    Observation.create!(user: rolf, when: Time.zone.today,
+                        where: "Sunshine Foray/ Dunton Medows")
+    slip = FieldSlip.find_or_create_by_code("OPEN-0930", rolf)
+    slip.update_columns(project_id: nil)
+
+    login("rolf")
+    get(:new, params: { field_code: "OPEN-0930" })
+
+    assert_equal(located.location, assigns(:observation).location,
+                 "the cascade's last-located step must win over " \
+                 "the previous observation's free text")
+  end
+
   private
 
   def make_slip_project_admin(user)

--- a/test/controllers/observations_controller_create_test.rb
+++ b/test/controllers/observations_controller_create_test.rb
@@ -2352,6 +2352,43 @@ class ObservationsControllerCreateTest < FunctionalTestCase
                  "the previous observation's free text")
   end
 
+  # The reported path had NO field code: a plain new-observation form
+  # (slip arrives as a photo later) defaulted Locality from the
+  # previous observation even when that was dubious free text -- so
+  # one unrecognized slip location re-prompted the confirmation on
+  # every following create. A dubious free-text locality is never
+  # carried forward; the last located observation is used instead.
+  def test_new_locality_default_skips_dubious_free_text
+    located = rolf.observations.where.not(location_id: nil).
+              order(created_at: :desc, id: :desc).first
+
+    assert_not_nil(located, "premise: rolf has a located observation")
+
+    Observation.create!(user: rolf, when: Time.zone.today,
+                        where: "Sunshine Foray/ Dunton Medows")
+
+    login("rolf")
+    get(:new)
+
+    assert_equal(located.location, assigns(:observation).location)
+  end
+
+  # Clean free text (a well-formed name MO just does not know) is a
+  # legitimate repeated locality and still carries forward.
+  def test_new_locality_default_keeps_clean_free_text
+    where = "Somewhere Nice, Massachusetts, USA"
+
+    assert_not(Location.dubious_name?(where, false, false),
+               "premise: the name is clean, just unknown")
+
+    Observation.create!(user: rolf, when: Time.zone.today, where: where)
+
+    login("rolf")
+    get(:new)
+
+    assert_equal(where, assigns(:observation).where)
+  end
+
   private
 
   def make_slip_project_admin(user)

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -778,6 +778,22 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     )
   end
 
+  # The render half of the approval round-trip (see the companion
+  # validator test above): the dubious reload must embed approved_where
+  # in the form action, or the browser never sends the approval and
+  # the confirmation loops forever (reported at the 2026 SMHF event).
+  def test_update_dubious_place_rerender_embeds_approved_where
+    generic_update_observation(
+      { location: { north: 35, south: 34, east: -117, west: -118 },
+        observation: { place_name: "Mt. Molehill, Iowa, USA",
+                       location_id: -1 } },
+      0
+    )
+
+    assert_select("form#observation_form[action*=?]", "approved_where",
+                  true, "the reloaded form must carry the approval")
+  end
+
   # --------------------------------------------------------------------
   #  Test notes with template
   # --------------------------------------------------------------------


### PR DESCRIPTION
Part of the #5042 umbrella; reported by Andy at the 2026 SMHF event. Two bugs compounding: a slip with an unrecognized location ("Sunshine Foray/ Dunton Medows") saves fine as free text, but the *next* scanned observation defaults its Locality to that free text, saving it fails with "Unknown country … Click 'Create' to use this location name", and clicking Create again shows the same warning forever.

## Bug 1: the approval round-trip was structurally broken

The confirmation loop's validator side works — `validate_place_name` passes `approved: params[:approved_where]` to `Location.dubious_reasons_for`, and an existing test proves a hand-crafted `approved_where` param is accepted. The broken half is the **render**: the form only embeds `approved_where` in its action when `@place_name` is present, and *nothing anywhere in the create or update controllers ever assigned `@place_name`* (the reload paths set `@default_place_name`, whose comment even notes `@place_name` is reserved for `approved_where`). So the browser never sent the approval, and "Click Create to use this location name" could never work.

Both reload paths now set `@place_name` when `@dubious_where_reasons` is present, and the Edit view gains the `place_name` prop the New view already had. New tests assert the re-rendered form's action contains `approved_where` on both create and update (the create test verified red pre-fix), plus the full create round trip ending with the free-text `where` saved.

## Bug 2: why the garbage default appeared at all

`field_slip_for_code` set `current_user` only on *newly built* slips. For an **existing** slip's code, the returned record had no `current_user`, which nil-guards away the location cascade's two user-dependent steps (`users_last_location`, `users_last_observation_location`) in `FieldSlip#calc_location`. With those gone and the project's own location unset, the cascade yielded nothing and the form kept `defaults_from_last_observation_created`'s copy of the previous observation's free-text `where` — so one unrecognized slip location haunted every following scan. The existing slip now gets `current_user` too (side-effect-free: `current_user=` only writes `slip.user` when blank). New test: with the user's most recent observation being free text, an existing slip code defaults to their last *located* observation instead.


## Bug 3 (found in Nathan's retest): the photo path bypasses both earlier fixes

The reported repro attaches the slip as a **photo** on a plain create — no `field_code` exists at form-render time, so `apply_field_slip_location` (and bug 2's fix) never runs, and the Locality default comes straight from `defaults_from_last_observation_created`, free text included. The default now skips a locality that fails the **syntactic** dubious check (`Location.dubious_name?(name, false, check_db: false)`), falling back to the user's last located observation; clean free text (a well-formed name MO just doesn't know) still carries forward for legitimate repeat use.

`check_db: false` is load-bearing, and explains some production weirdness: the DB-backed check counts every previously used `where` as "known" (`Observation.pluck(:where)` feeds `location_name_cache`), so one save of the garbage string blesses it — which also means the dubious *prompt itself* silently disappears for a bad name ~15 minutes after its first save (cache TTL). The syntactic check is deterministic. It also explains why the FIRST observation saved without any dubious prompt: the slip review's `Applier#assign_place_name` writes `where` directly, bypassing the form validation entirely.

## Test plan

- Scan/enter a slip whose location box is unrecognized text; save (it stores as written, with the unknown-abbreviation warning). Create the next observation BOTH ways -- via a slip photo on a plain create, and via a scanned/typed code: neither defaults the Locality to the previous free text.
- Force the dubious warning (type a locality with an unknown country) and click Create again unchanged: the observation saves with the name as written — one confirmation, no loop.
- Same confirmation flow on the edit form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

