### PR TITLE
Allow iNat imported data Place to be Private

### DIFF
--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -318,7 +318,7 @@ class Inat
         user: self[:user][:login],
         observed: self.when,
         show_observation_inat_lat_lng: lat_lon_accuracy,
-        place: self[:place_guess],
+        place: snapshot_place,
         id: inat_taxon_name,
         dqa: dqa,
         show_observation_inat_suggested_ids: suggested_id_names,
@@ -330,6 +330,15 @@ class Inat
         chomp # prevent blank line between Snapshot and :Other Notes fields
     end
     private :snapshot_raw_str
+
+    def snapshot_place
+      if @obs[:geoprivacy] == "private"
+        :inat_geoprivacy_private.l
+      else
+        self[:place_guess]
+      end
+    end
+    private :snapshot_place
 
     def copyright
       name = self[:user][:name].presence || self[:user][:login]

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2879,6 +2879,7 @@
   inat_leading_id: Leading ID as of
   inat_corrected_spelling: (corrected spelling)
   inat_snapshot_caption: iNat imported data
+  inat_geoprivacy_private: Private
   inat_dqa_casual: Casual
   inat_dqa_needs_id: Needs ID
   inat_dqa_research: Research Grade

--- a/test/classes/inat_obs_test.rb
+++ b/test/classes/inat_obs_test.rb
@@ -120,6 +120,35 @@ class InatObsTest < UnitTestCase
   end
   # rubocop:enable Style/NumericLiterals
 
+  def test_snapshot_place_private_geoprivacy
+    mock_inat_obs = mock_observation("somion_unicolor")
+    place_guess = mock_inat_obs[:place_guess]
+    mock_inat_obs[:geoprivacy] = "private"
+
+    assert_equal(
+      :inat_geoprivacy_private.l, mock_inat_obs.send(:snapshot_place),
+      "Snapshot Place should read 'Private' when iNat geoprivacy is private"
+    )
+    assert_includes(
+      mock_inat_obs.snapshot,
+      "#{:place.l.upcase_first}: #{:inat_geoprivacy_private.l}",
+      "Notes snapshot should show 'Private' Place when geoprivacy is private"
+    )
+    assert_equal(
+      place_guess, mock_inat_obs[:place_guess],
+      "geoprivacy handling should not mutate the underlying place_guess"
+    )
+  end
+
+  def test_snapshot_place_non_private_geoprivacy
+    mock_inat_obs = mock_observation("distantes")
+
+    assert_equal(
+      mock_inat_obs[:place_guess], mock_inat_obs.send(:snapshot_place),
+      "Snapshot Place should show iNat's place_guess when not private"
+    )
+  end
+
   def test_when
     fname = "somion_unicolor"
     mock_inat_obs = mock_observation(fname)


### PR DESCRIPTION
Fixes # 5037

### Manual Tests

- [x] 1. Import a fungal observation which has a Private Place. (See https://www.inaturalist.org/observations?subview=table&verifiable=any&iconic_taxa=Fungi&without_field=Mushroom%20Observer%20URL&geoprivacy=private)
Expected Result
Notes, iNat imported data `Place: Private`

- [x] 2. Import a fungal observation which has a obscured, non-Private Place. (See https://www.inaturalist.org/observations?subview=table&verifiable=any&iconic_taxa=Fungi&without_field=Mushroom%20Observer%20URL&geoprivacy=obscured_private)
Expected Result
Notes, iNat imported data `Place: <Place shown in the iNat obs>`

