### PR TITLE
Fix field-slip review loop: duplicate `_method` made Turbo submit the save as a bare POST

### DIFF
--- a/app/components/application_form.rb
+++ b/app/components/application_form.rb
@@ -226,6 +226,18 @@ class Components::ApplicationForm < Superform::Rails::Form
     super
   end
 
+  # No `_method` hidden on a plain POST form (Superform emits one
+  # unconditionally). POST needs no override -- and a stray
+  # `_method=post` breaks any form that adds its own `_method` later:
+  # turbo-rails' encodeMethodIntoRequestBody reads only the FIRST
+  # `_method` in the body, then strips them all, so a duplicate turns
+  # a Turbo PATCH submission into a bare POST.
+  def _method_field
+    return if _method_field_value.to_s.casecmp("post").zero?
+
+    super
+  end
+
   # Every non-Turbo form disables its submit buttons once submitted
   # (see form-feedback_controller.js; Turbo forms are skipped there,
   # since Turbo manages its own in-flight state). Appended so a form's

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -18,13 +18,15 @@ module Views::Controllers::Images::FieldSlipExtracts
     # being held as a separate prop -- `model` reaches it everywhere
     # below instead of a dedicated `@review` ivar.
     def initialize(image:, extract:, review:, approved_name: nil, **attrs)
+      # `method: :patch`, not a hand-rolled `_method` hidden: Superform
+      # emits its own `_method` field, and a second one turns a Turbo
+      # submission into a bare POST (see ApplicationForm#_method_field).
       super(review, image: image, extract: extract,
-                    approved_name: approved_name, **attrs)
+                    approved_name: approved_name, method: :patch, **attrs)
     end
 
     def view_template
       super do
-        hidden_field("_method", value: "patch")
         div(class: "table-responsive") { render_table }
         render_location_section
         render_name_section

--- a/test/components/application_form_test.rb
+++ b/test/components/application_form_test.rb
@@ -93,6 +93,38 @@ class ApplicationFormTest < ComponentTestCase
     assert_no_html(form, "form[data-turbo]")
   end
 
+  # No `_method` hidden on a plain POST form. Superform emits one
+  # unconditionally, and a stray `_method=post` turns a Turbo PATCH
+  # submission into a bare POST when a second `_method` joins it --
+  # turbo-rails reads only the first, then strips them all (this
+  # looped the field-slip review page back onto itself).
+  def test_post_form_emits_no_method_override_field
+    form = ApplicationFormFieldTestHelpers::TestFormClass.new(
+      CollectionNumber.new, action: "/test_form_path"
+    )
+    form.field_block = proc { text_field(:name, label: "Name") }
+    html = render(form)
+
+    assert_no_html(html, "input[name='_method']")
+  end
+
+  # Non-POST forms still get their override field, exactly once:
+  # inferred from a persisted model, or forced with `method:`.
+  def test_non_post_form_emits_single_method_override_field
+    persisted = render_form { text_field(:name, label: "Name") }
+
+    assert_html(persisted, "input[name='_method'][value='patch']",
+                count: 1)
+
+    forced = ApplicationFormFieldTestHelpers::TestFormClass.new(
+      CollectionNumber.new, action: "/test_form_path", method: :patch
+    )
+    forced.field_block = proc { text_field(:name, label: "Name") }
+    html = render(forced)
+
+    assert_html(html, "input[name='_method'][value='patch']", count: 1)
+  end
+
   # `between_class` (FieldWithHelp) mirrors ERB:
   # inline rows pick "mr-3"; block rows pick "form-between".
   def test_between_class_block_field_with_help

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -78,6 +78,17 @@ module Views::Controllers::Images::FieldSlipExtracts
       assert_html(html, "label[for*='value_ID']")
     end
 
+    # Exactly one `_method`, and it says patch: a second `_method`
+    # hidden (Superform's own `post`) made Turbo submit the review as
+    # a bare POST -- routed to `create`, which re-queued the scan and
+    # bounced straight back to this page instead of saving.
+    def test_review_form_submits_as_patch
+      html = render_page(fields: { "Collector" => "Scott Shapiro" })
+
+      assert_html(html, "form[data-turbo='true']")
+      assert_html(html, "input[name='_method'][value='patch']", count: 1)
+    end
+
     # Ticked only when the ID already resolves to a name MO holds, so
     # creating a Name is always a deliberate act.
     def test_name_tick_defaults_on_for_a_known_name

--- a/test/views/controllers/species_lists/form_test.rb
+++ b/test/views/controllers/species_lists/form_test.rb
@@ -22,9 +22,9 @@ module Views::Controllers::SpeciesLists
       assert_html(html,
                   "form#species_list_form[action='/species_lists']" \
                   "[method='post']")
-      # Superform: non-persisted → `_method=post` (no method override).
-      assert_html(html,
-                  "input[type='hidden'][name='_method'][value='post']")
+      # POST is the form's native method, so no `_method` override
+      # renders (see ApplicationForm#_method_field).
+      assert_no_html(html, "input[name='_method']")
     end
 
     def test_edit_flow_form_action_and_patch_method


### PR DESCRIPTION
Fixes the field-slip review loop: pressing "Save to Observation" re-queued the extraction and bounced straight back to the review page instead of applying the review.

## Diagnosis (from the development log)

The save arrived as `POST /images/:id/field_slip_extract` with **no `_method` param at all**, so it routed to `create` — which by design re-runs the scan and redirects to `edit`. The review form is supposed to submit as PATCH via a `_method=patch` hidden.

Rendering the form showed why the param vanished: it carried **two** `_method` hiddens — `_method=post` first (Superform 0.7.0 emits a `_method` field unconditionally, `post` for a non-persisted model), then the form's own hand-rolled `_method=patch`. turbo-rails' `encodeMethodIntoRequestBody` resolves the request method with `body.get("_method")` — `FormData#get` returns the **first** value — so it decided the method was POST, and its POST branch then **deletes every `_method` entry from the body** before submitting. Result: a bare POST with the override stripped.

## When it broke

Commit `e7a07321f3` ("Turbo-submit sweep: `Images::FieldSlipExtractsController`"), merged to main 2026-08-15 in PR #5061 (Turbo-submit sweep batch 2). The duplicate `_method` had been there since the review form was born (`1fe25c2c78`), but harmlessly: a plain browser POST sends both values and Rack keeps the **last** one (`patch`), so `local: true` submissions routed to `update` correctly. Flipping the form to `local: false` put Turbo's first-value-then-strip logic in the path, and the same markup started submitting as POST.

## Fix

- `Components::ApplicationForm#_method_field` now suppresses the field when its value is `post` — POST is the form's native method, so the override is pure noise (Rails' own `form_with` omits it for POST too). This removes the duplicate-`_method` trap for every form app-wide, not just this one.
- The review form declares `method: :patch` to Superform (whose `_method_field_value` prefers it) instead of hand-rolling a second hidden. The rendered form now carries exactly one `_method=patch`.

A grep found no other form in the app hand-rolling a `_method` hidden, so this was the only page the trap could currently spring on — but any future one would have hit it the same way.

## Tests

- `ApplicationFormTest`: a POST form emits no `_method` hidden; persisted-model and `method: :patch` forms emit exactly one `_method=patch`.
- `FieldSlipExtracts::EditTest`: the review form is Turbo-enabled and carries exactly one `_method=patch`.
- `SpeciesLists::FormTest` had pinned the old Superform quirk (`_method=post` present on the create flow) — updated to assert its absence.
- Full suite: 8475 tests, 0 failures.

## Test plan

- Scan a field slip photo into an observation, open the review page, press "Save to Observation" with no edits: the review should apply and land on the observation page (before this fix it looped back to the review page with the scan re-queued).
- Confirm a review edit (e.g. correcting the locality) still round-trips through the name-approval re-render when the ID needs confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
