### PR TITLE
Fix user autocompleter dropping login-only matches (issue #3537)

### DIFF
--- a/app/javascript/controllers/autocompleter/base_controller.js
+++ b/app/javascript/controllers/autocompleter/base_controller.js
@@ -1091,13 +1091,16 @@ export default class BaseAutocompleterController extends Controller {
       matches = [];
 
     if (token != '' && primer.length > 1) {
+      // Compile each token's regex once, not once per (row, token) pair --
+      // primer can have up to 5000 rows (server-side limit).
+      const tokenRegexes = tokens.map((t) => this.wordStartRegex(t))
       for (let i = 1; i < primer.length; i++) {
         let s = primer_nm[i]['name'] || '',
           k;
-        for (k = 0; k < tokens.length; k++) {
-          if (!this.wordStartMatch(s, tokens[k])) break;
+        for (k = 0; k < tokenRegexes.length; k++) {
+          if (!tokenRegexes[k].test(s)) break;
         }
-        if (k >= tokens.length) {
+        if (k >= tokenRegexes.length) {
           matches.push(primer[i]);
         }
       }
@@ -1115,19 +1118,18 @@ export default class BaseAutocompleterController extends Controller {
     this.matches = matches;
   }
 
-  // Word-start check for populateUnordered(). Mirrors
-  // Autocomplete::PUNCTUATION (app/classes/autocomplete.rb) so a
-  // match right after e.g. "(" -- the login in "Name (login)" --
+  // Builds the word-start regex for one token, for populateUnordered().
+  // Mirrors Autocomplete::PUNCTUATION (app/classes/autocomplete.rb) so
+  // a match right after e.g. "(" -- the login in "Name (login)" --
   // counts as a word start, not just after a literal space.
   // The double backslash before x2F etc. is required: this is a JS
   // string literal, not a regex literal, so it needs its own escaping
   // before RegExp() parses the result as a hex range -- do not
   // "simplify" to a single backslash.
-  wordStartMatch(name, token) {
+  wordStartRegex(token) {
     const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const regex = new RegExp('(^|[ -\\x2F\\x3A-\\x40\\x5B-\\x60\\x7B-\\x7F])' +
+    return new RegExp('(^|[ -\\x2F\\x3A-\\x40\\x5B-\\x60\\x7B-\\x7F])' +
       escaped)
-    return regex.test(name)
   }
 
   populateCollapsed() {

--- a/app/javascript/controllers/autocompleter/base_controller.js
+++ b/app/javascript/controllers/autocompleter/base_controller.js
@@ -1093,10 +1093,9 @@ export default class BaseAutocompleterController extends Controller {
     if (token != '' && primer.length > 1) {
       for (let i = 1; i < primer.length; i++) {
         let s = primer_nm[i]['name'] || '',
-          s2 = ' ' + s + ' ',
           k;
         for (k = 0; k < tokens.length; k++) {
-          if (s2.indexOf(' ' + tokens[k]) < 0) break;
+          if (!this.wordStartMatch(s, tokens[k])) break;
         }
         if (k >= tokens.length) {
           matches.push(primer[i]);
@@ -1114,6 +1113,17 @@ export default class BaseAutocompleterController extends Controller {
       }
     }
     this.matches = matches;
+  }
+
+  // Word-start check for populateUnordered(). Mirrors
+  // Autocomplete::PUNCTUATION (app/classes/autocomplete.rb) so a
+  // match right after e.g. "(" -- the login in "Name (login)" --
+  // counts as a word start, not just after a literal space.
+  wordStartMatch(name, token) {
+    const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp('(^|[ -\\x2F\\x3A-\\x40\\x5B-\\x60\\x7B-\\x7F])' +
+      escaped)
+    return regex.test(name)
   }
 
   populateCollapsed() {

--- a/app/javascript/controllers/autocompleter/base_controller.js
+++ b/app/javascript/controllers/autocompleter/base_controller.js
@@ -1119,6 +1119,10 @@ export default class BaseAutocompleterController extends Controller {
   // Autocomplete::PUNCTUATION (app/classes/autocomplete.rb) so a
   // match right after e.g. "(" -- the login in "Name (login)" --
   // counts as a word start, not just after a literal space.
+  // The double backslash before x2F etc. is required: this is a JS
+  // string literal, not a regex literal, so it needs its own escaping
+  // before RegExp() parses the result as a hex range -- do not
+  // "simplify" to a single backslash.
   wordStartMatch(name, token) {
     const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     const regex = new RegExp('(^|[ -\\x2F\\x3A-\\x40\\x5B-\\x60\\x7B-\\x7F])' +

--- a/test/system/autocompleter_system_test.rb
+++ b/test/system/autocompleter_system_test.rb
@@ -62,6 +62,27 @@ class AutocompleterSystemTest < ApplicationSystemTestCase
     assert_field("query_observations_by_users", with: "Roy Halling (roy)")
   end
 
+  # Regression: a login that shares no word with the user's name (e.g.
+  # "second_roy" for "Roy Rogers") must still surface the user. The
+  # client-side word-boundary filter used to require a literal space
+  # before a match, but the login sits inside parens in the displayed
+  # "Name (login)" string -- "(second_roy" -- so it was silently
+  # dropped even though the server-side query matched it correctly.
+  def test_observation_search_user_autocompleter_matches_by_login
+    login!(@roy)
+
+    visit("/observations/search/new")
+    assert_selector("body.search__new")
+
+    find_field("query_observations_by_users").click
+    @browser.keyboard.type("second")
+    assert_selector(".auto_complete") # wait
+    assert_selector(".auto_complete ul li a", text: "Roy Rogers")
+    @browser.keyboard.type(:down, :tab)
+    assert_field("query_observations_by_users",
+                 with: "Roy Rogers (second_roy)")
+  end
+
   # https://github.com/MushroomObserver/mushroom-observer/issues/3374
   def test_clearing_autocompleter_clears_hidden_id
     login!(@roy)


### PR DESCRIPTION
## Summary

Fixes part of issue #3537: the user autocompleter dropdown only ever showed matches by name, never by login.

- Verified the server-side query first (`Autocomplete::ForUser#rough_matches`) — it already matches on login or name correctly. Confirmed empirically via `bin/rails runner` against a real fixture user.
- Found the actual bug client-side, in `populateUnordered()` (`app/javascript/controllers/autocompleter/base_controller.js`), used by every `UNORDERED: true` autocompleter (User, Project, Herbarium, Location, Region, SpeciesList). It required a literal space immediately before a matched token to count it as a word start. A user's displayed name is `"Full Name (login)"` — the login is preceded by `(`, never a space — so any match that only existed in the login (no shared word with the name) was silently dropped from the results on every keystroke, including the very first, even though the server had already returned it correctly.
- Replaced the space-only check with a word-boundary regex that mirrors `Autocomplete::PUNCTUATION` (`app/classes/autocomplete.rb`), which already treats `(` as a valid boundary character server-side in `refine_token`. The fix is a strict superset of the old matching behavior — it can only surface matches that were incorrectly hidden before, never hide ones that matched previously (verified by hand against several tokens, including a mid-word substring that correctly still doesn't match).
- Added a system test (`test_observation_search_user_autocompleter_matches_by_login`) using a fixture user whose login shares no word with their name (`second_roy` / "Roy Rogers"), isolating the login-only-match case. Confirmed it fails without the fix (dropdown never appears) and passes with it.

## Note on scope

The original report suspected the bug was server-side, in `Autocomplete::ForUser`, and floated a possible follow-up refactor — moving `Autocomplete` subclass queries to named scopes on the models (e.g. `User.autocomplete(string)`) for testability. Since the actual bug turned out to be client-side and the server-side query already works correctly, that refactor isn't needed to fix this issue. Leaving it as an open question for a separate discussion rather than deciding it here.

## Test plan

- [x] `bin/rails test test/system/autocompleter_system_test.rb` — full file, 15 tests; one unrelated pre-existing flake (`test_autocompleter_in_naming_modal`, a `Name`-type/`COLLAPSE` autocompleter untouched by this change) confirmed to pass in isolation
- [x] `bin/rails test test/system/project_alias_form_system_test.rb` — exercises autocompleter type-switching, unaffected
- [x] New regression test confirmed to fail against the pre-fix JS and pass against the fix (revert/restore cycle)
- [x] Author to run the full `bin/rails test` + `test:system` suite before merge
