### PR TITLE
Fix pattern-search icon rendering outside the input

### DIFF
--- a/app/assets/stylesheets/mo/_icons.scss
+++ b/app/assets/stylesheets/mo/_icons.scss
@@ -4,6 +4,12 @@
 // --------------------------------------------------
 
 .has-search .form-control-feedback {
+  // `.mo-icon`'s own `position: relative` (below, for icon+text
+  // baseline alignment) ties with Bootstrap's `.form-control-feedback
+  // { position: absolute }` on specificity, so source order decides
+  // -- and `.mo-icon` loses that tie since it's declared later. Redeclare
+  // here, where the selector's higher specificity wins reliably.
+  position: absolute;
   right: initial;
   left: 0;
   background-color: transparent;

--- a/app/assets/stylesheets/mo/_icons.scss
+++ b/app/assets/stylesheets/mo/_icons.scss
@@ -13,7 +13,10 @@
   right: initial;
   // Icon is an SVG sized by .mo-icon, not a glyph Bootstrap can center via
   // line-height -- center the icon's own box instead. 15px is half the
-  // 30px padding-left below (icon is hidden-xs, so only sm+ matters).
+  // 30px padding-left below. Not every `.has-search` icon is hidden-xs
+  // (Observations::Identify::Form's isn't), so this left offset has to
+  // hold at every breakpoint -- the padding below can't drop back to 6px
+  // at xs without the icon overlapping typed text.
   top: 50%;
   left: 15px;
   transform: translate(-50%, -50%);
@@ -21,15 +24,8 @@
 }
 
 .has-search .form-control {
-  padding-right: 6px;
-  padding-left: 6px;
-}
-
-@media screen and (min-width: $screen-sm-min) {
-  .has-search .form-control {
-    padding-right: 12px;
-    padding-left: 30px;
-  }
+  padding-right: 12px;
+  padding-left: 30px;
 }
 
 .page-input .form-control-feedback {

--- a/app/assets/stylesheets/mo/_icons.scss
+++ b/app/assets/stylesheets/mo/_icons.scss
@@ -3,15 +3,20 @@
 // .has-feedback { position: relative; }
 // --------------------------------------------------
 
-.has-search .form-control-feedback {
-  // `.mo-icon`'s own `position: relative` (below, for icon+text
-  // baseline alignment) ties with Bootstrap's `.form-control-feedback
-  // { position: absolute }` on specificity, so source order decides
-  // -- and `.mo-icon` loses that tie since it's declared later. Redeclare
-  // here, where the selector's higher specificity wins reliably.
+// Overrides Bootstrap's `.navbar-form .has-feedback .form-control-feedback`
+// (same selector -- wins the specificity tie by loading after Bootstrap).
+// Also forces position: absolute, since .mo-icon's own position: relative
+// (below) would otherwise win that tie against the plain
+// .form-control-feedback rule.
+.navbar-form .has-feedback .form-control-feedback {
   position: absolute;
   right: initial;
-  left: 0;
+  // Icon is an SVG sized by .mo-icon, not a glyph Bootstrap can center via
+  // line-height -- center the icon's own box instead. 15px is half the
+  // 30px padding-left below (icon is hidden-xs, so only sm+ matters).
+  top: 50%;
+  left: 15px;
+  transform: translate(-50%, -50%);
   background-color: transparent;
 }
 


### PR DESCRIPTION
## Summary

The pattern-search bar's magnifying-glass icon (`Icon(type: :search, class: "form-control-feedback ...")` in `Components::Form::PatternSearch` and `Views::Controllers::Observations::Identify::Form`) was rendering outside the text input, to its left, instead of overlaid inside the input's left-padded area — a regression from the SVG-icon migration.

## Root cause

Bootstrap's own `.navbar-form .has-feedback .form-control-feedback { top: 0; }` (from its navbar-form mixin) targets this element exactly, and Bootstrap's plain `.form-control-feedback { position: absolute; ... }` centers a glyph via a fixed box width/height + `line-height`. Neither works for MO's SVG icon:

- `.mo-icon { position: relative; ... }` (`app/assets/stylesheets/mo/_icons.scss`) ties with Bootstrap's `position: absolute` on specificity, and since MO's custom SCSS loads after Bootstrap, `.mo-icon` won that tie by source order, breaking the overlay positioning.
- The icon's own size comes from `.mo-icon`, not a wrapped glyph, so Bootstrap's `line-height`/`text-align` centering trick doesn't apply — the icon needs its own box centered directly.

## Fix

Override the exact same selector Bootstrap emits (`.navbar-form .has-feedback .form-control-feedback`) so the specificity tie is won reliably by source order, forcing `position: absolute` and centering the icon's own box with `top: 50%; left: 15px; transform: translate(-50%, -50%)` (15px is half the 30px `padding-left` reserved for the icon at `sm+`, matching the existing `hidden-xs` breakpoint scoping).

## Test plan

- [x] Verified visually in a running dev server: search icon now renders centered inside the input's left-padded area on both `/observations` (pattern search) and `/observations/identify` (identify filter form), matching pre-SVG-icon behavior
- [x] No test coverage exists or is warranted for this pure-CSS positioning detail (see `.claude/rules/ui_spacing.md`)
