### PR TITLE
Fix title-bar edit/delete icon alignment via `Components::InlineLinkBlock`

### DIFF
--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
-# Page-title-bar edit/delete icons. Renders a `<ul>` with edit +
-# delete buttons gated by what the viewer can do to the object.
-# Always emits the `<ul>` — empty when the viewer has no permissions —
-# so the parent flex layout in `Views::Layouts::Header::PageTitle`
-# is consistent regardless of permission state.
+# Page-title-bar edit/delete icons. Renders edit + delete buttons
+# gated by what the viewer can do to the object, via the same
+# `Components::InlineLinkBlock` spacing/styling every other inline
+# edit/destroy icon pair in the app uses (see `Components::
+# InlineCRUDLinks`) -- unlike that component's own `TARGET_HANDLERS`
+# dispatch, this stays generic across every model via plain
+# `AbstractModel#can_edit?`/`#destroyable?`, so it needs no per-model
+# handler. The wrapping `div` always renders -- empty when the viewer
+# has no permissions -- so the parent flex layout in `Views::Layouts::
+# Header::PageTitle` is consistent regardless of permission state.
 #
 # Rendered into `content_for(:edit_icons)` by
 # `Views::FullPageBase::Icons#add_edit_icons`.
@@ -18,25 +23,29 @@ module Views::Layouts
     prop :user, _Nilable(::User), default: nil
 
     def view_template
-      ul(class: "nav d-flex align-items-center " \
-                "justify-content-end mt-0 h4 object_edit") do
-        li { render_edit_button } if can_edit_object? && !read_only_reflection?
-        li { render_delete_button } if can_destroy_object?
+      div(class: "h4 my-0 d-flex align-items-center object_edit") do
+        InlineLinkBlock(items: [edit_item, delete_item].compact)
       end
     end
 
     private
 
-    def render_edit_button
-      render(::Components::Button::Edit.new(
-               target: @object, variant: :strip
-             ))
+    def edit_item
+      return nil unless can_edit_object? && !read_only_reflection?
+
+      ::Components::Button::Edit.new(
+        target: @object, variant: :strip,
+        class: ::Components::InlineLinkBlock.item_class
+      )
     end
 
-    def render_delete_button
-      render(::Components::Button::Delete.new(
-               target: @object, variant: :strip
-             ))
+    def delete_item
+      return nil unless can_destroy_object?
+
+      ::Components::Button::Delete.new(
+        target: @object, variant: :strip,
+        class: ::Components::InlineLinkBlock.item_class
+      )
     end
 
     def can_edit_object?

--- a/test/views/layouts/header/edit_delete_icons_test.rb
+++ b/test/views/layouts/header/edit_delete_icons_test.rb
@@ -3,7 +3,7 @@
 require("test_helper")
 
 # Contract tests for `Views::Layouts::Header::EditDeleteIcons` —
-# the edit/delete icon `<ul>` in the show-page title bar.
+# the edit/delete icon pair in the show-page title bar.
 module Views::Layouts
   class Header::EditDeleteIconsTest < ComponentTestCase
     def setup
@@ -13,29 +13,33 @@ module Views::Layouts
       @non_owner = users(:rolf)
     end
 
-    def test_always_renders_ul
+    def test_always_renders_container
       html = render_icons(user: @non_owner)
 
-      assert_html(html, "ul.object_edit")
+      assert_html(html, "div.object_edit")
     end
 
-    def test_renders_empty_ul_when_cannot_edit
+    def test_renders_empty_when_cannot_edit
       html = render_icons(user: @non_owner)
 
-      assert_no_html(html, "ul.object_edit li")
+      assert_no_html(html, "div.object_edit .inline-icon-link")
     end
 
-    def test_renders_empty_ul_with_nil_user
+    def test_renders_empty_with_nil_user
       html = render_icons(user: nil)
 
-      assert_html(html, "ul.object_edit")
-      assert_no_html(html, "ul.object_edit li")
+      assert_html(html, "div.object_edit")
+      assert_no_html(html, "div.object_edit .inline-icon-link")
     end
 
-    def test_renders_edit_and_delete_li_when_owner
+    def test_renders_edit_and_delete_items_when_owner
       html = render_icons(user: @owner)
 
-      assert_html(html, "ul.object_edit li", count: 2)
+      assert_html(html, "div.object_edit .inline-icon-link", count: 2)
+      edit_href = routes.edit_observation_path(@obs.id)
+      destroy_action = routes.observation_path(@obs.id)
+      assert_html(html, "div.object_edit a[href='#{edit_href}']")
+      assert_html(html, "div.object_edit form[action='#{destroy_action}']")
     end
 
     # A read-only reflection (#4214) drops the edit icon (its scalar core
@@ -43,10 +47,13 @@ module Views::Layouts
     def test_reflection_suppresses_edit_icon_but_keeps_delete
       @obs.update_column(:reflected_at, Time.zone.now)
       html = render_icons(user: @owner)
+      edit_href = routes.edit_observation_path(@obs.id)
+      destroy_action = routes.observation_path(@obs.id)
 
-      assert_html(html, "ul.object_edit li", count: 1)
-      assert_no_html(html, "a[href$='/edit']",
+      assert_html(html, "div.object_edit .inline-icon-link", count: 1)
+      assert_no_html(html, "a[href='#{edit_href}']",
                      "a reflection should have no edit-form link")
+      assert_html(html, "div.object_edit form[action='#{destroy_action}']")
     end
 
     private


### PR DESCRIPTION
## Summary

The title-bar edit/delete icon pair (`Views::Layouts::Header::EditDeleteIcons`, on every show page) was visually uneven: the edit icon (an `<a>`) had real padding around it, the destroy icon (a `<form><button>` from Rails' `button_to`) had none.

## Root cause

Bootstrap's `.nav > li > a { padding: 10px 15px; }` rule only targets `<a>` children -- it doesn't reach a `<form>`. `.mo-icon`'s `top: 2px` baseline correction is similarly scoped to `a:not(.btn):not(.inline-icon-link) > .mo-icon`, so the `<form>`-wrapped destroy button missed that too, adding a small vertical offset on top of the padding gap.

## Fix

Route both icons through `Components::InlineLinkBlock` -- the same spacing/styling primitive every other inline edit/destroy icon pair in the app already uses (via `Components::InlineCRUDLinks`, for the observation sub-panel edit/destroy pairs, the comments list, the namings table, etc.). `Components::InlineCRUDLinks` itself isn't the right reuse target here -- its `TARGET_HANDLERS` dispatch solves a harder problem (per-model-class destroy paths and a modal-vs-plain-link edit shape keyed to Tab POROs that don't exist yet for several of the title-bar's ~15 model types). `EditDeleteIcons`'s permission gating is already fully generic via `AbstractModel#can_edit?`/`#destroyable?`, so it needs none of that dispatch -- `Components::InlineLinkBlock` (the plain rendering/spacing component `InlineCRUDLinks` itself delegates to) is the correct-sized reuse.

Also fixed along the way: the rewritten wrapper initially dropped the original's `mt-0` class, which reintroduced Bootstrap's default `.h4` top margin and pushed the icon row below the title's baseline -- restored via `my-0`.

## Test plan

- [x] `bin/rails test test/views/layouts/header/edit_delete_icons_test.rb` (5 tests, 18 assertions)
- [x] `bundle exec rubocop` clean on both changed files
- [x] Verified visually in a running dev server: edit/delete icons now render with equal spacing and consistent baseline alignment
