### PR TITLE
Make observation show page's "About this Taxon" panel Turbo lazy-loaded

### DIFF
--- a/app/controllers/observations/name_info_panels_controller.rb
+++ b/app/controllers/observations/name_info_panels_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Observations
+  # Turbo Frame content for the observation show page's "About this
+  # Taxon" panel (#5093). The panel starts collapsed with an empty
+  # placeholder frame; expanding it sends a real GET carrying a
+  # `Turbo-Frame` request header, fetched here instead of eager-loading
+  # the name subtree (synonyms/descriptions/interests) on every
+  # observation page view. A direct (non-frame) visit falls back to
+  # redirecting to the observation instead of rendering a bare fragment.
+  class NameInfoPanelsController < ApplicationController
+    before_action :login_required
+    before_action :find_observation!
+
+    # `Descriptions::List#visible?` reads each description's `.user`,
+    # so `descriptions: :user` avoids N+1 per description in the panel.
+    # This subtree used to live in `Observation.show_includes_tree` --
+    # moved here since this frame is now its only consumer.
+    NAME_INCLUDES = {
+      name: [{ synonym: :names }, { descriptions: :user },
+             :interests, :description]
+    }.freeze
+
+    def show
+      if request.headers["Turbo-Frame"]
+        render(Views::Controllers::Observations::NameInfoPanels::Show.new(
+                 obs: @observation, user: @user
+               ), layout: false)
+      else
+        redirect_to(permanent_observation_path(@observation))
+      end
+    end
+
+    private
+
+    def find_observation!
+      @observation = Observation.includes(NAME_INCLUDES).
+                     safe_find(params[:id])
+      return @observation if @observation
+
+      flash_error(:runtime_object_not_found.t(type: :observation,
+                                              id: params[:id]))
+      redirect_to(observations_path)
+      nil
+    end
+  end
+end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -294,10 +294,13 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   # Subtree consumed by `Observation.show_includes`. The
-  # `Descriptions::List#visible?` path reads each description's
-  # `.user`, so `name: { descriptions: :user }` avoids N+1 per
-  # description on the show page. The `observation_images: :image`
-  # polymorphic preload skips the `images.delete` cascade query.
+  # `observation_images: :image` polymorphic preload skips the
+  # `images.delete` cascade query. `name: { synonym: :names }` is read
+  # by `ConsensusNameLink#preferred_synonym` (title bar, every viewer)
+  # -- stays here. `name`'s descriptions/interests/description subtree
+  # moved to `Observations::NameInfoPanelsController::NAME_INCLUDES`
+  # (#5093) -- the "About this Taxon" panel that used it is now lazily
+  # Turbo-fetched instead of eager-rendered here.
   def self.show_includes_tree
     [:collector_user,
      { collection_numbers: :user },
@@ -307,8 +310,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
      { images: [:image_votes, :license, :projects, :user] },
      { interests: :user },
      :location,
-     { name: [{ synonym: :names }, { descriptions: :user },
-              :interests, :description] },
+     { name: { synonym: :names } },
      { namings: Naming.index_includes_tree },
      { observation_images: :image },
      :observation_collection_numbers,

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -590,17 +590,13 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       joins(:sequences).subquery(:Sequence, hash)
     }
 
-    # `Descriptions::List#visible?` reads each description's `.user`
-    # to decide visibility — without `name: { descriptions: :user }`
-    # this is N+1 per description on the show page.
     scope :show_includes, -> { strict_loading.includes(show_includes_tree) }
     scope :not_logged_in_show_includes, lambda {
       strict_loading.includes(
         { comments: Comment.index_includes_tree },
         { images: [:image_votes, :license, :user] },
         :location,
-        { name: [{ synonym: :names }, { descriptions: :user },
-                 :interests, :description] },
+        { name: { synonym: :names } },
         { namings: Naming.index_includes_tree },
         { projects: :image },
         :thumb_image,

--- a/app/views/controllers/observations/name_info_panels/show.rb
+++ b/app/views/controllers/observations/name_info_panels/show.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Turbo Frame body for the observation show page's "About this Taxon"
+# panel (#5093) -- the response `Observations::NameInfoPanelsController
+# #show` renders when the panel's collapse toggle fetches it. Two
+# columns: "On MO" (related-name links + alt-descriptions list +
+# distribution map) and "On the web" (external taxonomic search sites
+# the user has enabled). Content moved here, unchanged, from the
+# formerly-eager `Views::Controllers::Observations::Show::NameInfoPanel`.
+module Views::Controllers::Observations::NameInfoPanels
+  class Show < Views::Base
+    prop :obs, ::Observation
+    prop :user, _Nilable(::User), default: nil
+
+    def view_template
+      turbo_frame_tag(frame_id) { render_body }
+    end
+
+    private
+
+    # Must match the placeholder frame id in `Views::Controllers::
+    # Observations::Show::NameInfoPanel#render_frame`.
+    def frame_id = "name_info_frame_#{@obs.id}"
+
+    def render_body
+      Row do
+        Column(xs: 6) do
+          div(class: "font-weight-bold") { plain("#{:on_mo.l}:") }
+          render_links_on_mo
+        end
+        Column(xs: 6) do
+          div(class: "font-weight-bold") { plain("#{:on_the_web.l}:") }
+          render_links_on_web
+        end
+      end
+    end
+
+    # Three groups, each rendered as a block-level div wrapping the link:
+    # related-name filtered indexes, alt-descriptions list, and
+    # the per-name distribution map link.
+    def render_links_on_mo
+      related_name_tabs.each { |tab| render_tab_link(tab) }
+      render_alt_descriptions
+      render_tab_link(occurrence_map_tab)
+    end
+
+    def render_links_on_web
+      web_name_tabs.each { |tab| render_tab_link(tab) }
+    end
+
+    def related_name_tabs
+      ::Tab::Observation::RelatedNameTabs.new(
+        user: @user, name: @obs.name
+      ).reject { |tab| tab.to_a.empty? }
+    end
+
+    def web_name_tabs
+      ::Tab::Observation::WebNameTabs.new(
+        user: @user, name: @obs.name
+      ).reject { |tab| tab.to_a.empty? }
+    end
+
+    def occurrence_map_tab
+      ::Tab::Name::OccurrenceMap.new(name: @obs.name)
+    end
+
+    # Renders the alt-description list inline — same view used by
+    # the names / locations show pages, just no panel chrome here.
+    def render_alt_descriptions
+      render(::Views::Controllers::Descriptions::List.new(
+               user: @user, object: @obs.name, type: :name
+             ))
+    end
+
+    def render_tab_link(tab)
+      div do
+        if tab.html_options[:external]
+          Link(type: :external, tab: tab)
+        else
+          content, path, opts = tab.to_a
+          a(href: url_for(path),
+            class: opts[:class]) { trusted_html(content) }
+        end
+      end
+    end
+  end
+end

--- a/app/views/controllers/observations/name_info_panels/show.rb
+++ b/app/views/controllers/observations/name_info_panels/show.rb
@@ -12,8 +12,12 @@ module Views::Controllers::Observations::NameInfoPanels
     prop :obs, ::Observation
     prop :user, _Nilable(::User), default: nil
 
+    # `target: "_top"` -- links rendered inside a `<turbo-frame>` are
+    # frame-scoped by default, so without it, clicking e.g. "About
+    # <name>" would try to swap the Names page's content into this
+    # small panel frame instead of navigating there.
     def view_template
-      turbo_frame_tag(frame_id) { render_body }
+      turbo_frame_tag(frame_id, target: "_top") { render_body }
     end
 
     private

--- a/app/views/controllers/observations/name_info_panels/show.rb
+++ b/app/views/controllers/observations/name_info_panels/show.rb
@@ -39,17 +39,22 @@ module Views::Controllers::Observations::NameInfoPanels
       end
     end
 
-    # Three groups, each rendered as a block-level div wrapping the link:
+    # Three groups, each an `li.hanging-indent` -- same list shape as
+    # `Observations::Show::Details#render_body` -- wrapping the link:
     # related-name filtered indexes, alt-descriptions list, and
     # the per-name distribution map link.
     def render_links_on_mo
-      related_name_tabs.each { |tab| render_tab_link(tab) }
-      render_alt_descriptions
-      render_tab_link(occurrence_map_tab)
+      ul(class: "list-unstyled mb-0") do
+        related_name_tabs.each { |tab| render_tab_link(tab) }
+        render_alt_descriptions
+        render_tab_link(occurrence_map_tab)
+      end
     end
 
     def render_links_on_web
-      web_name_tabs.each { |tab| render_tab_link(tab) }
+      ul(class: "list-unstyled mb-0") do
+        web_name_tabs.each { |tab| render_tab_link(tab) }
+      end
     end
 
     def related_name_tabs
@@ -71,13 +76,15 @@ module Views::Controllers::Observations::NameInfoPanels
     # Renders the alt-description list inline — same view used by
     # the names / locations show pages, just no panel chrome here.
     def render_alt_descriptions
-      render(::Views::Controllers::Descriptions::List.new(
-               user: @user, object: @obs.name, type: :name
-             ))
+      li(class: "hanging-indent") do
+        render(::Views::Controllers::Descriptions::List.new(
+                 user: @user, object: @obs.name, type: :name
+               ))
+      end
     end
 
     def render_tab_link(tab)
-      div do
+      li(class: "hanging-indent") do
         if tab.html_options[:external]
           Link(type: :external, tab: tab)
         else

--- a/app/views/controllers/observations/show/name_info_panel.rb
+++ b/app/views/controllers/observations/show/name_info_panel.rb
@@ -1,82 +1,55 @@
 # frozen_string_literal: true
 
-# "About this taxon" panel on the observation show page. Two
-# columns: "On MO" (related-name links + alt-descriptions list +
-# distribution map) and "On the web" (external taxonomic search
-# sites the user has enabled).
+# "About this taxon" panel on the observation show page. Collapsed by
+# default -- an empty Turbo Frame placeholder -- to keep the page's
+# initial load from paying for the name subtree (synonyms, alt
+# descriptions, interests) on every view (#5093). Expanding the panel
+# sends a real GET to `Observations::NameInfoPanelsController#show`
+# carrying a `Turbo-Frame` header, fetching the two-column "On MO" /
+# "On the web" content rendered by `Views::Controllers::Observations::
+# NameInfoPanels::Show`.
 class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
   prop :obs, ::Observation
   prop :user, _Nilable(::User), default: nil
 
+  BODY_ID = "observation_name_info_body"
+
   def view_template
-    Panel(panel_id: "observation_name_info",
-          panel_class: "small") do |panel|
+    Panel(panel_id: "observation_name_info", panel_class: "small",
+          collapse_target: "##{BODY_ID}", expanded: false) do |panel|
       panel.with_heading { :about_this_taxon.l }
-      panel.with_body { render_body }
+      panel.with_heading_links { render_toggle }
+      panel.with_body(collapse: true) { render_frame }
     end
   end
 
   private
 
-  def render_body
-    Row do
-      Column(xs: 6) do
-        div(class: "font-weight-bold") { plain("#{:on_mo.l}:") }
-        render_links_on_mo
-      end
-      Column(xs: 6) do
-        div(class: "font-weight-bold") { plain("#{:on_the_web.l}:") }
-        render_links_on_web
-      end
+  # Must match `Views::Controllers::Observations::NameInfoPanels::
+  # Show#frame_id`.
+  def frame_id = "name_info_frame_#{@obs.id}"
+
+  # Bootstrap's collapse.js only calls preventDefault() when
+  # `data-target` is absent -- passing `fallback_href:` makes
+  # `Link::CollapseToggle` set `data-target` explicitly (see
+  # `Components::Panel#collapse_toggle_data`'s comment), so this
+  # click's real `href` navigation goes through to Turbo, which
+  # intercepts it via `data-turbo-frame` and fetches instead of doing
+  # a full-page nav. Not using Panel's own `collapsible:` auto-toggle
+  # here since it deliberately skips `data-target` for id-based
+  # targets, blocking exactly this fetch.
+  def render_toggle
+    Link(type: :collapse_toggle,
+         target_id: BODY_ID,
+         fallback_href: name_info_panel_for_observation_path(@obs.id),
+         class: "panel-collapse-trigger ml-3",
+         data: { turbo_frame: frame_id }) do
+      Icon(type: :chevron_down, title: :open.ti, class: "active-icon")
+      Icon(type: :chevron_up, title: :close.ti)
     end
   end
 
-  # Three groups, each rendered as a block-level div wrapping the link:
-  # related-name filtered indexes, alt-descriptions list, and
-  # the per-name distribution map link.
-  def render_links_on_mo
-    related_name_tabs.each { |tab| render_tab_link(tab) }
-    render_alt_descriptions
-    render_tab_link(occurrence_map_tab)
-  end
-
-  def render_links_on_web
-    web_name_tabs.each { |tab| render_tab_link(tab) }
-  end
-
-  def related_name_tabs
-    ::Tab::Observation::RelatedNameTabs.new(
-      user: @user, name: @obs.name
-    ).reject { |tab| tab.to_a.empty? }
-  end
-
-  def web_name_tabs
-    ::Tab::Observation::WebNameTabs.new(
-      user: @user, name: @obs.name
-    ).reject { |tab| tab.to_a.empty? }
-  end
-
-  def occurrence_map_tab
-    ::Tab::Name::OccurrenceMap.new(name: @obs.name)
-  end
-
-  # Renders the alt-description list inline — same view used by
-  # the names / locations show pages, just no panel chrome here.
-  def render_alt_descriptions
-    render(::Views::Controllers::Descriptions::List.new(
-             user: @user, object: @obs.name, type: :name
-           ))
-  end
-
-  def render_tab_link(tab)
-    div do
-      if tab.html_options[:external]
-        Link(type: :external, tab: tab)
-      else
-        content, path, opts = tab.to_a
-        a(href: url_for(path),
-          class: opts[:class]) { trusted_html(content) }
-      end
-    end
+  def render_frame
+    turbo_frame_tag(frame_id)
   end
 end

--- a/app/views/controllers/observations/show/name_info_panel.rb
+++ b/app/views/controllers/observations/show/name_info_panel.rb
@@ -49,7 +49,13 @@ class Views::Controllers::Observations::Show::NameInfoPanel < Views::Base
     end
   end
 
+  # `target: "_top"` -- Turbo's frame swap keeps this placeholder
+  # element's own attributes, not the fetched response's frame
+  # attributes, so the escape-the-frame target has to live here too
+  # (see `Observations::NameInfoPanels::Show#view_template`) for
+  # links inside the fetched content to navigate normally instead of
+  # trying to swap into this frame.
   def render_frame
-    turbo_frame_tag(frame_id)
+    turbo_frame_tag(frame_id, target: "_top")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -630,6 +630,8 @@ MushroomObserver::Application.routes.draw do
       get("field_slip_scan", to: "observations/field_slip_scans#show")
       get("map", to: "observations/maps#show")
       get("map_popup", to: "observations/maps#popup")
+      get("name_info_panel", to: "observations/name_info_panels#show",
+                             as: "name_info_panel_for")
       get("suggestions", to: "observations/namings/suggestions#show",
                          as: "naming_suggestions_for")
       get("emails/new", to: "observations/emails#new",

--- a/test/controllers/observations/name_info_panels_controller_test.rb
+++ b/test/controllers/observations/name_info_panels_controller_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Observations
+  class NameInfoPanelsControllerTest < FunctionalTestCase
+    def test_show_turbo_frame_renders_panel_content
+      obs = observations(:coprinus_comatus_obs)
+
+      login
+      simulate_turbo_frame_request(obs)
+      get(:show, params: { id: obs.id })
+
+      assert_response(:success)
+      assert_select("turbo-frame#name_info_frame_#{obs.id}")
+      assert_select("a[href *= 'mycobank.org']")
+    end
+
+    # A direct (non-frame) visit falls back to the observation page
+    # instead of rendering a bare fragment.
+    def test_show_without_turbo_frame_header_redirects_to_observation
+      obs = observations(:coprinus_comatus_obs)
+
+      login
+      get(:show, params: { id: obs.id })
+
+      assert_redirected_to(permanent_observation_path(obs.id))
+    end
+
+    def test_show_requires_login
+      obs = observations(:coprinus_comatus_obs)
+
+      simulate_turbo_frame_request(obs)
+      get(:show, params: { id: obs.id })
+
+      assert_redirected_to(new_account_login_path)
+    end
+
+    def test_show_observation_not_found
+      login
+      simulate_turbo_frame_request_for_id(0)
+      get(:show, params: { id: 0 })
+
+      assert_redirected_to(observations_path)
+    end
+
+    private
+
+    def simulate_turbo_frame_request(obs)
+      simulate_turbo_frame_request_for_id(obs.id)
+    end
+
+    def simulate_turbo_frame_request_for_id(id)
+      @request.headers["Turbo-Frame"] = "name_info_frame_#{id}"
+    end
+  end
+end

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -460,12 +460,9 @@ class ObservationsControllerShowTest < FunctionalTestCase
     obs_id = observations(:coprinus_comatus_obs).id
     get(:show, params: { id: obs_id })
 
-    assert_select("a[href *= 'images.google.com']")
-
-    # There is a MycoBank link which includes taxon name and MycoBank language
-    assert_select("a[href *= 'mycobank.org']") do
-      assert_select("a[href *= '/Coprinus%20comatus']")
-    end
+    # Google Images / MycoBank links now live in the "About this Taxon"
+    # panel's lazily-fetched Turbo Frame (#5093), not inline on the show
+    # page -- see name_info_panels_controller_test.rb for that coverage.
 
     # MycoPortal link now lives behind the "Shared with" MCP badge's info
     # modal, not inline on the page -- see external_links_controller_test.rb

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -47,13 +47,11 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     # back at Observation
     assert_match(/#{:app_title.l}: Observation/, page.title, "Wrong page")
 
-    # Go back to observation and click on "About...".
-    click_link("About ")
-    assert_match(/#{:app_title.l}: Name/, page.title, "Wrong page")
-
-    # Take a look at the occurrence map.
-    click_link("Occurrence Map")
-    assert_match(/#{:app_title.l}: Occurrence Map/, page.title, "Wrong page")
+    # "About..." and the occurrence map are now behind the "About
+    # this Taxon" panel's lazy-loaded Turbo Frame -- covered in
+    # ObservationShowSystemTest#test_name_info_panel_lazy_load
+    # instead, since this test's rack_test driver has no JS to fetch
+    # the frame's content (#5093).
 
     # Check out a few links from left-hand panel.
     click_on("How To Use")
@@ -95,7 +93,6 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     lurker = users(:katrina)
     obs = observations(:detailed_unknown_obs)
     owner = obs.user
-    name = obs.name
 
     # First login
     reset_session!
@@ -152,21 +149,12 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     end
     # back at Observation
 
-    # Check out Name
-    go_back_after do
-      # (Should be at least two links to show the Name.)
-      assert(assert_selector("#content a[href^='/names/#{name.id}']",
-                             minimum: 2))
-
-      click_link("About #{name.text_name}")
-      # (Make sure the page contains create_name_description.)
-      assert(
-        assert_selector(
-          "#content a[href^='/names/#{name.id}/descriptions/new']"
-        )
-      )
-    end
-    # back at Observation
+    # Check out Name -- the "About this Taxon" panel (including the
+    # 2nd link to the Name page and the "About <name>" link) is now
+    # behind a lazy-loaded Turbo Frame; this rack_test-driven test
+    # has no JS to fetch it. Covered in
+    # ObservationShowSystemTest#test_name_info_panel_lazy_load
+    # instead (#5093).
 
     # Check out images
     # Observation has at least 2 images

--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -23,6 +23,36 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
     assert_selector(".print_label_observation_#{@obs.id}")
   end
 
+  # The "About this Taxon" panel starts collapsed as an empty Turbo
+  # Frame placeholder; content only exists once expanded (#5093). A
+  # non-JS test (lurker_integration_test.rb, rack_test driver) can't
+  # exercise this -- moved here so Turbo's fetch actually runs.
+  def test_name_info_panel_lazy_load
+    rolf = users("rolf")
+    login!(rolf)
+    visit(observation_path(@obs))
+    assert_selector("body.observations__show")
+
+    name = @obs.name
+    frame_id = "name_info_frame_#{@obs.id}"
+
+    # Not fetched yet -- panel starts collapsed.
+    assert_no_selector("##{frame_id} a", visible: :all)
+
+    within("#observation_name_info") { find(".panel-collapse-trigger").click }
+
+    # Turbo fetches the frame's content on expand.
+    assert_selector("##{frame_id} a", wait: 6)
+    # Title bar's own name link, plus the panel's "About <name>" link.
+    assert_selector("#content a[href^='#{name_path(name)}']", minimum: 2)
+
+    within("##{frame_id}") { click_link("About #{name.text_name}") }
+    assert_selector("body.names__show")
+
+    click_link("Occurrence Map")
+    assert_selector("body.maps__show")
+  end
+
   def test_add_and_edit_collection_numbers
     rolf = users("rolf")
     login!(rolf)

--- a/test/views/controllers/observations/name_info_panels/show_test.rb
+++ b/test/views/controllers/observations/name_info_panels/show_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+module Views::Controllers::Observations::NameInfoPanels
+  class ShowTest < ComponentTestCase
+    def setup
+      super
+      @user = users(:rolf)
+      @obs = observations(:coprinus_comatus_obs)
+    end
+
+    def test_wraps_content_in_the_matching_turbo_frame
+      html = render(view_for(@obs))
+
+      assert_html(html, "turbo-frame##{frame_id}")
+    end
+
+    def test_renders_on_mo_and_on_the_web_links
+      html = render(view_for(@obs))
+
+      assert_html(html, "a[href *= 'mycobank.org']")
+      assert_html(html, "a[href *= 'images.google.com']")
+    end
+
+    private
+
+    def frame_id = "name_info_frame_#{@obs.id}"
+
+    def view_for(obs)
+      Views::Controllers::Observations::NameInfoPanels::Show.new(
+        obs: obs, user: @user
+      )
+    end
+  end
+end

--- a/test/views/controllers/observations/show/name_info_panel_test.rb
+++ b/test/views/controllers/observations/show/name_info_panel_test.rb
@@ -10,13 +10,30 @@ class Views::Controllers::Observations::Show::NameInfoPanelTest <
     @obs = observations(:detailed_unknown_obs)
   end
 
-  def test_renders_panel_id
+  def test_renders_collapsed_placeholder
     html = render(panel_with(@obs))
 
     assert_html(html, "#observation_name_info")
+    # Collapsed by default -- no "in" class, no fetched content yet.
+    assert_html(html, "#observation_name_info_body.collapse")
+    assert_no_html(html, "#observation_name_info_body.in")
+    assert_html(html, "turbo-frame##{frame_id}:empty")
+  end
+
+  def test_toggle_targets_the_lazy_fetch_route
+    html = render(panel_with(@obs))
+
+    assert_html(
+      html,
+      "a[href='#{routes.name_info_panel_for_observation_path(@obs.id)}']" \
+      "[data-target='#observation_name_info_body']" \
+      "[data-turbo-frame='#{frame_id}']"
+    )
   end
 
   private
+
+  def frame_id = "name_info_frame_#{@obs.id}"
 
   def panel_with(obs)
     Views::Controllers::Observations::Show::NameInfoPanel.new(


### PR DESCRIPTION
Fixes #5093.

## Summary

The "About this Taxon" panel on the observation show page on this branch is skipped on page load and collapsed by default. If a user opens the panel, its content is fetched lazily via Turbo, instead of being eager-rendered on every page load. This addresses both the info-overload/visual-clutter goal from the issue and the DB cost the audit found (~100ms / 8 queries per load, previously always paid whether or not the panel was ever opened).

## Approach

- `Views::Controllers::Observations::Show::NameInfoPanel` now renders a collapsed panel shell with an empty `turbo_frame_tag` placeholder. The heading's collapse toggle carries `fallback_href:` (so `Link::CollapseToggle` sets `data-target` explicitly, per `Components::Panel#collapse_toggle_data`'s comment) plus `data-turbo-frame:`, mirroring the existing `Observations::ExternalLinksController`/accordion-badge pattern -- not Panel's own `collapsible:` auto-toggle, which deliberately omits `data-target` for id-based targets and would block Turbo from ever firing.
- New `Observations::NameInfoPanelsController#show` renders the panel's actual content (moved unchanged into `Views::Controllers::Observations::NameInfoPanels::Show`) into the matching Turbo Frame when the request carries a `Turbo-Frame` header; a direct non-frame visit redirects to the observation page instead of rendering a bare fragment.
- `Observation.show_includes_tree` / `not_logged_in_show_includes` drop the `descriptions`/`interests`/`description` keys from the `name:` subtree -- that preload moved to the new controller's own lightweight find, since the panel is now its only consumer. `name: { synonym: :names }` stays, since `ConsensusNameLink` (the page title, shown to every viewer, not just when the panel is open) still needs it -- confirmed by running the full observation-show test suite, which caught this via `ActiveRecord::StrictLoadingViolationError` before the fix.

## Test plan

- [x] `bin/rails test test/controllers/observations/name_info_panels_controller_test.rb` -- Turbo-Frame request renders content; non-frame request redirects; login required; not-found handling
- [x] `bin/rails test test/views/controllers/observations/name_info_panels/show_test.rb` -- fragment wraps content in the matching frame, renders both On MO / On the web link groups
- [x] `bin/rails test test/views/controllers/observations/show/name_info_panel_test.rb` -- placeholder renders collapsed with an empty frame, toggle link targets the fetch route
- [x] `bin/rails test test/controllers/observations_controller_show_test.rb` -- full obs-show suite green (also updated one assertion whose content moved into the lazy frame)
- [x] `bundle exec rubocop` clean on all touched files
- [x] Verified in a running dev server: panel renders collapsed on page load; clicking the toggle expands it and the real content (On MO / On the web links) loads via the Turbo Frame fetch
