### PR TITLE
Create obs slowness: Add missing `observations.user_id` index; fix project-checkbox N+1

### DIFF
--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -154,9 +154,13 @@ module ObservationsController::SharedFormMethods
     @accession_number = herb_params[:accession_number]
   end
 
+  # `user_group: :users` (not just `:user_group`) -- the projects form's
+  # per-checkbox `Project#user_can_change_membership?` reads `member?`,
+  # which is `user_group.users.member?(user)`. Without the deeper
+  # preload that's a fresh query per checkbox (#5103).
   def init_project_vars
     @projects = @user.projects_member(order: :title,
-                                      include: :user_group)
+                                      include: { user_group: :users })
   end
 
   # Failure-reload path: capture the user's just-submitted project_ids

--- a/db/migrate/20260817133242_add_user_id_index_to_observations.rb
+++ b/db/migrate/20260817133242_add_user_id_index_to_observations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddUserIDIndexToObservations < ActiveRecord::Migration[7.2]
+  # `observations` had no index on `user_id` at all -- every "this
+  # user's own/most recent observations" query (Observation.
+  # recent_by_user, @user.observations, various by_user scopes) was a
+  # full table scan. Composite with `created_at` so recent_by_user's
+  # `ORDER BY created_at` is an index-order scan, not a filesort.
+  def change
+    add_index(:observations, [:user_id, :created_at])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_09_175755) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_17_133242) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -643,6 +643,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_09_175755) do
     t.index ["needs_naming"], name: "needs_naming_index"
     t.index ["occurrence_id"], name: "index_observations_on_occurrence_id"
     t.index ["reflected_at"], name: "index_observations_on_reflected_at"
+    t.index ["user_id", "created_at"], name: "index_observations_on_user_id_and_created_at"
   end
 
   create_table "occurrences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
Fixes #5103.

## Summary

Two independent performance bugs on the create-observation page (`/observations/new`), fixed together since #5103 tracks both for one PR.

### Bug 1: missing `observations.user_id` index

`observations` had no index on `user_id` at all -- every "this user's own/most recent observations" query (`Observation.recent_by_user`, `@user.observations`, various `by_user` scopes) did a full table scan. Added a composite `(user_id, created_at)` index so `recent_by_user`'s `ORDER BY created_at` is satisfied by index order instead of a filesort.

Before:
```
type: ALL, possible_keys: NULL, key: NULL, rows: 544048, Extra: Using where; Using filesort
```
After:
```
type: ref, key: index_observations_on_user_id_and_created_at, rows: 54 (barky's own count), Extra: (none)
```

### Bug 2: N+1 in project-checkbox form rendering

`ObservationsController::SharedFormMethods#init_project_vars` only preloaded `include: :user_group`, not the deeper `user_group.users` that `Project#member?` reads (`user_group.users.member?(user)`) for every project checkbox's disabled state. Deepened the preload to `include: { user_group: :users }` -- one extra query avoided per project the user belongs to, instead of one query per checkbox.

## Combined effect

`/observations/new` for a user with 28 projects / 45 species-lists (the case that motivated #5093's original audit):

| | Before | After |
|---|---|---|
| Total request | ~1325ms | ~352ms |
| Queries | 94 | 68 |

## Test plan

- [x] `bin/rails test test/controllers/observations_controller_project_list_test.rb` (project/list checkbox rendering, 14 tests)
- [x] `bin/rails test test/controllers/observations_controller_create_test.rb` (110 tests, all touch `init_project_vars` via the create form)
- [x] `bin/rails test test/controllers/observations_controller_update_test.rb` (48 tests, edit form shares the same preload)
- [x] `bundle exec rubocop` clean on all touched files
- [x] Verified the index fix via `EXPLAIN` (full scan -> indexed lookup) and the N+1 fix via direct query counting (28 projects: ~28+ queries -> 4)
- [x] Verified end-to-end in a running dev server, logged in as a 28-project/45-list user: `/observations/new` dropped from ~1325ms/94 queries to ~352ms/68 queries
