### PR TITLE
Fix mcp backfill test warnings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -94,6 +94,10 @@ module MushroomObserver
     # Just starting to use Rails caching on 7.1, so we're current
     config.active_support.cache_format_version = 7.1
 
+    # Opt in to the Rails 8.0 #to_time behavior now (preserves the
+    # receiver's timezone offset instead of converting to system local).
+    config.active_support.to_time_preserves_timezone = true
+
     # Set up memcached as the cache store everywhere
     # config.cache_store = :mem_cache_store
     config.cache_store = :solid_cache_store

--- a/script/transfer_image_dhashes.rb
+++ b/script/transfer_image_dhashes.rb
@@ -45,8 +45,11 @@ class TransferImageDhashes
     @apply = opts[:apply]
     @limit = opts[:limit]
     @report_interval = opts[:report_interval] || 10
-    abort("Give exactly one of --export FILE or --apply FILE") unless
-      @export.nil? ^ @apply.nil?
+    unless @export.nil? ^ @apply.nil?
+      raise(ArgumentError.new(
+              "Give exactly one of --export FILE or --apply FILE"
+            ))
+    end
     @stats = Hash.new(0)
     @started_at = Time.current
     @last_report_at = @started_at
@@ -142,21 +145,27 @@ class TransferImageDhashes
   end
 end
 
-options = {}
-OptionParser.new do |opts|
-  opts.on("--export FILE", "Write id,dhash CSV of local hashes") do |f|
-    options[:export] = f
-  end
-  opts.on("--apply FILE", "Apply id,dhash CSV (fill-NULL-only)") do |f|
-    options[:apply] = f
-  end
-  opts.on("--limit N", Integer, "Apply only the first N rows") do |n|
-    options[:limit] = n
-  end
-  opts.on("--report-interval N", Integer,
-          "Seconds between progress reports (default 10)") do |n|
-    options[:report_interval] = n
-  end
-end.parse!
+if $PROGRAM_NAME == __FILE__
+  options = {}
+  OptionParser.new do |opts|
+    opts.on("--export FILE", "Write id,dhash CSV of local hashes") do |f|
+      options[:export] = f
+    end
+    opts.on("--apply FILE", "Apply id,dhash CSV (fill-NULL-only)") do |f|
+      options[:apply] = f
+    end
+    opts.on("--limit N", Integer, "Apply only the first N rows") do |n|
+      options[:limit] = n
+    end
+    opts.on("--report-interval N", Integer,
+            "Seconds between progress reports (default 10)") do |n|
+      options[:report_interval] = n
+    end
+  end.parse!
 
-TransferImageDhashes.new(options).run
+  begin
+    TransferImageDhashes.new(options).run
+  rescue ArgumentError => e
+    abort(e.message)
+  end
+end

--- a/script/transfer_image_dhashes.rb
+++ b/script/transfer_image_dhashes.rb
@@ -146,26 +146,26 @@ class TransferImageDhashes
 end
 
 if $PROGRAM_NAME == __FILE__
-  options = {}
-  OptionParser.new do |opts|
-    opts.on("--export FILE", "Write id,dhash CSV of local hashes") do |f|
-      options[:export] = f
-    end
-    opts.on("--apply FILE", "Apply id,dhash CSV (fill-NULL-only)") do |f|
-      options[:apply] = f
-    end
-    opts.on("--limit N", Integer, "Apply only the first N rows") do |n|
-      options[:limit] = n
-    end
-    opts.on("--report-interval N", Integer,
-            "Seconds between progress reports (default 10)") do |n|
-      options[:report_interval] = n
-    end
-  end.parse!
-
   begin
+    options = {}
+    OptionParser.new do |opts|
+      opts.on("--export FILE", "Write id,dhash CSV of local hashes") do |f|
+        options[:export] = f
+      end
+      opts.on("--apply FILE", "Apply id,dhash CSV (fill-NULL-only)") do |f|
+        options[:apply] = f
+      end
+      opts.on("--limit N", Integer, "Apply only the first N rows") do |n|
+        options[:limit] = n
+      end
+      opts.on("--report-interval N", Integer,
+              "Seconds between progress reports (default 10)") do |n|
+        options[:report_interval] = n
+      end
+    end.parse!
+
     TransferImageDhashes.new(options).run
-  rescue ArgumentError => e
+  rescue ArgumentError, RuntimeError => e
     abort(e.message)
   end
 end

--- a/script/transfer_mycoportal_export_links.rb
+++ b/script/transfer_mycoportal_export_links.rb
@@ -69,7 +69,7 @@ class TransferMycoportalExportLinks
 
     def run_cli(argv)
       new(parse_argv(argv)).run
-    rescue ArgumentError => e
+    rescue ArgumentError, RuntimeError => e
       abort(e.message)
     end
   end

--- a/script/transfer_mycoportal_export_links.rb
+++ b/script/transfer_mycoportal_export_links.rb
@@ -66,6 +66,12 @@ class TransferMycoportalExportLinks
 
       options
     end
+
+    def run_cli(argv)
+      new(parse_argv(argv)).run
+    rescue ArgumentError => e
+      abort(e.message)
+    end
   end
 
   def initialize(opts)
@@ -213,12 +219,4 @@ class TransferMycoportalExportLinks
   end
 end
 
-if $PROGRAM_NAME == __FILE__
-  begin
-    TransferMycoportalExportLinks.new(
-      TransferMycoportalExportLinks.parse_argv(ARGV)
-    ).run
-  rescue ArgumentError => e
-    abort(e.message)
-  end
-end
+TransferMycoportalExportLinks.run_cli(ARGV) if $PROGRAM_NAME == __FILE__

--- a/script/transfer_mycoportal_export_links.rb
+++ b/script/transfer_mycoportal_export_links.rb
@@ -71,8 +71,11 @@ class TransferMycoportalExportLinks
   def initialize(opts)
     @export = opts[:export]
     @apply = opts[:apply]
-    abort("Give exactly one of --export FILE or --apply FILE") unless
-      @export.nil? ^ @apply.nil?
+    unless @export.nil? ^ @apply.nil?
+      raise(ArgumentError.new(
+              "Give exactly one of --export FILE or --apply FILE"
+            ))
+    end
     @site = ExternalSite.mycoportal
     @admin = User.admin
     @stats = Hash.new(0)
@@ -211,7 +214,11 @@ class TransferMycoportalExportLinks
 end
 
 if $PROGRAM_NAME == __FILE__
-  TransferMycoportalExportLinks.new(
-    TransferMycoportalExportLinks.parse_argv(ARGV)
-  ).run
+  begin
+    TransferMycoportalExportLinks.new(
+      TransferMycoportalExportLinks.parse_argv(ARGV)
+    ).run
+  rescue ArgumentError => e
+    abort(e.message)
+  end
 end

--- a/test/controllers/admin/blocked_ips_controller_test.rb
+++ b/test/controllers/admin/blocked_ips_controller_test.rb
@@ -18,7 +18,6 @@ module Admin
     end
 
     def test_blocked_ips
-      ActiveSupport.to_time_preserves_timezone = true
       new_ip = "5.4.3.2"
       IpStats.remove_blocked_ips([new_ip])
       # make sure there is an API key logged to test that part of view

--- a/test/script/transfer_mycoportal_export_links_test.rb
+++ b/test/script/transfer_mycoportal_export_links_test.rb
@@ -188,6 +188,22 @@ class TransferMycoportalExportLinksTest < UnitTestCase
     end
   end
 
+  def test_run_cli_success
+    image = images(:in_situ_image)
+    make_link(target: image, external_id: "1")
+    path = temp_csv_path("export")
+
+    capture_io { TransferMycoportalExportLinks.run_cli(["--export", path]) }
+
+    rows = CSV.read(path, headers: true)
+    assert_not_nil(rows.find { |r| r["target_type"] == "Image" },
+                   "Expected run_cli(--export) to write the export CSV")
+  end
+
+  def test_run_cli_aborts_on_invalid_args
+    assert_raises(SystemExit) { TransferMycoportalExportLinks.run_cli([]) }
+  end
+
   def test_export_then_apply_round_trip
     image = images(:in_situ_image)
     make_link(target: image, external_id: "1",

--- a/test/script/transfer_mycoportal_export_links_test.rb
+++ b/test/script/transfer_mycoportal_export_links_test.rb
@@ -201,7 +201,9 @@ class TransferMycoportalExportLinksTest < UnitTestCase
   end
 
   def test_run_cli_aborts_on_invalid_args
-    assert_raises(SystemExit) { TransferMycoportalExportLinks.run_cli([]) }
+    capture_io do
+      assert_raises(SystemExit) { TransferMycoportalExportLinks.run_cli([]) }
+    end
   end
 
   def test_export_then_apply_round_trip

--- a/test/script/transfer_mycoportal_export_links_test.rb
+++ b/test/script/transfer_mycoportal_export_links_test.rb
@@ -182,9 +182,9 @@ class TransferMycoportalExportLinksTest < UnitTestCase
   end
 
   def test_run_requires_exactly_one_of_export_or_apply
-    assert_raises(SystemExit) { TransferMycoportalExportLinks.new({}).run }
-    assert_raises(SystemExit) do
-      TransferMycoportalExportLinks.new(export: "e.csv", apply: "a.csv").run
+    assert_raises(ArgumentError) { TransferMycoportalExportLinks.new({}) }
+    assert_raises(ArgumentError) do
+      TransferMycoportalExportLinks.new(export: "e.csv", apply: "a.csv")
     end
   end
 


### PR DESCRIPTION
- Fixes noisy test-run warnings induced by https://github.com/MushroomObserver/mushroom-observer/pull/4877
- Also implements Copilot suggestion on script/transfer_image_dhashes.rb, which had same issue as MCP backfill script.
See [Copilot PR Overview](https://github.com/MushroomObserver/mushroom-observer/pull/5109#pullrequestreview-4952712241}
