### PR TITLE
Project-less field slips: skip the null-project bucket in `users_last_location`

### DIFF
--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -263,13 +263,17 @@ class FieldSlip < AbstractModel
 
   # Location of the user's most recently updated field slip in this
   # project that has a located observation (slips without one are
-  # skipped).
+  # skipped). Requires a project: a nil here would match every
+  # project-less slip the user owns -- an orphaned-spares bucket, not
+  # an event cohort -- and resurrect whatever location a batch job
+  # last touched (a fresh "2026-NAMA-0001" slip once defaulted to a
+  # year-old spare's site this way).
   def users_last_location
-    return nil unless @current_user
+    return nil unless @current_user && project
 
     Location.joins(observations: { occurrence: :field_slip }).
       where(field_slips: { user_id: @current_user.id,
-                           project_id: project&.id }).
+                           project_id: project.id }).
       order(FieldSlip.arel_table[:updated_at].desc,
             FieldSlip.arel_table[:id].desc).first
   end

--- a/test/models/field_slip_test.rb
+++ b/test/models/field_slip_test.rb
@@ -109,6 +109,27 @@ class FieldSlipTest < UnitTestCase
     assert_not_includes(joined.reload.observations, obs)
   end
 
+  # A slip with no project must not inherit from the user's OTHER
+  # project-less slips: that bucket is orphaned spares, not an event
+  # cohort, and its "most recently updated" member is whatever a
+  # batch job touched last. The chain falls through to the user's
+  # latest located observation instead.
+  def test_projectless_slip_skips_other_projectless_slips
+    observations(:minimal_unknown_obs).
+      update_columns(location_id: locations(:albion).id)
+    field_slips(:field_slip_one).update_columns(project_id: nil,
+                                                updated_at: 1.hour.ago)
+    latest = observations(:detailed_unknown_obs)
+    latest.update_columns(location_id: locations(:burbank).id,
+                          created_at: Time.zone.now)
+
+    slip = field_slips(:field_slip_no_obs)
+    slip.update_columns(project_id: nil)
+    slip.current_user = mary
+
+    assert_equal(locations(:burbank), slip.location)
+  end
+
   def test_location_falls_back_to_project_location
     observations(:minimal_unknown_obs).update_columns(location_id: nil)
     observations(:owner_accepts_general_questions).


### PR DESCRIPTION
Fixes a wrong Locality default on the field slip form for project-less slips, found while testing the NAMA 2026 flow: a fresh `2026-NAMA-0001` slip (spare, no project) defaulted its Locality to "Sheffield, Massachusetts, USA" — the site of a year-old CCMS spare slip.

## Root cause

`FieldSlip#calc_location`'s second step, `users_last_location`, is documented as "the user's most recently updated slip **in this project** with a located observation" — but it filtered with `where(field_slips: { user_id: ..., project_id: project&.id })`. For a slip with no project, `project&.id` is `nil`, and that doesn't skip the filter: it matches `project_id IS NULL`, i.e. **every project-less slip the user owns**. That bucket is orphaned spares, not an event cohort, and its "most recently updated" member is whatever a batch job touched last — in this case old CCMS/NEMF slips all batch-touched by the July project-alias scripts, putting `CCMS-00041` (located at Sheffield) on top.

## Fix

`users_last_location` now requires a project. A project-less slip falls through the #4907 precedence chain — no cohort of slips, no project location — to `users_last_observation_location`, the user's latest located observation, which is fresh personal history rather than arbitrary orphaned history. Verified against the dev DB: the `2026-NAMA-0001` slip's default is now "Telluride, San Miguel Co., Colorado, USA" (the reporting user's most recent located observation) instead of Sheffield.

Slips **with** a project are unchanged — the cohort step still ranks above the project location and last observation, per #4907.

## Test plan

- On a dev DB with old project-less slips: open the field slip form for a project-less code (e.g. a spare like `2026-NAMA-0001`); the Locality default should be your most recent located observation's site, not an old spare's.
- Automated: `bin/rails test test/models/field_slip_test.rb` — new `test_projectless_slip_skips_other_projectless_slips` fails on the old code (returns the null-bucket slip's location) and passes on the fix; the rest of the #4907 precedence tests pin the with-project behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
