### PR TITLE
Filtered search: accept comma date ranges in `DateRangeParser`; never silently drop an unparseable date

### DIFF
--- a/app/classes/date_range_parser.rb
+++ b/app/classes/date_range_parser.rb
@@ -20,9 +20,9 @@ class DateRangeParser
   end
 
   def parse_date_range
-    return parse_comma_range if @string.include?(",")
+    return parse_separated_range(",") if @string.include?(",")
 
-    match_date_patterns(parse_date_words)
+    match_date_patterns(parse_date_words) || space_separated_range
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
@@ -59,13 +59,22 @@ class DateRangeParser
   # and phrases like "last_month,today" work too); the range runs from
   # the left side's start to the right side's end. nil when either side
   # doesn't parse.
-  def parse_comma_range
-    left, right = @string.split(",", 2).map(&:strip)
+  def parse_separated_range(sep)
+    left, right = @string.split(sep, 2).map(&:strip)
     from = self.class.new(left).range
     to = self.class.new(right).range
     return nil unless from && to
 
     [Array(from).first, Array(to).last]
+  end
+
+  # A space separates endpoints too ("2026-08-12 2026-08-16") -- but
+  # only as a last resort, since spaces also occur inside date words
+  # ("2 days ago" is one date, not a range).
+  def space_separated_range
+    return nil unless @string.include?(" ")
+
+    parse_separated_range(" ")
   end
 
   def yyyymmdd(from, to)

--- a/app/classes/date_range_parser.rb
+++ b/app/classes/date_range_parser.rb
@@ -14,12 +14,17 @@
 class DateRangeParser
   attr_reader :range
 
-  def initialize(string)
+  # `endpoint:` is internal, set when parsing one side of a separated
+  # range: endpoints don't nest, so "2026-08-12,2026-08-16,2026-08-17"
+  # is rejected rather than silently spanned first-to-last.
+  def initialize(string, endpoint: false)
     @string = string.to_s
+    @endpoint = endpoint
     @range = parse_date_range
   end
 
   def parse_date_range
+    return endpoint_range if @endpoint
     return parse_separated_range(",") if @string.include?(",")
 
     match_date_patterns(parse_date_words) || space_separated_range
@@ -61,8 +66,8 @@ class DateRangeParser
   # doesn't parse.
   def parse_separated_range(sep)
     left, right = @string.split(sep, 2).map(&:strip)
-    from = self.class.new(left).range
-    to = self.class.new(right).range
+    from = self.class.new(left, endpoint: true).range
+    to = self.class.new(right, endpoint: true).range
     return nil unless from && to
 
     [Array(from).first, Array(to).last]
@@ -75,6 +80,14 @@ class DateRangeParser
     return nil unless @string.include?(" ")
 
     parse_separated_range(" ")
+  end
+
+  # An endpoint may still contain spaces ("2 days ago") but never a
+  # comma, and never another separated range.
+  def endpoint_range
+    return nil if @string.include?(",")
+
+    match_date_patterns(parse_date_words)
   end
 
   def yyyymmdd(from, to)

--- a/app/classes/date_range_parser.rb
+++ b/app/classes/date_range_parser.rb
@@ -3,7 +3,8 @@
 # Parses user-input date ranges (or strings) into a range of Ruby dates that
 # MO's date AR scopes can handle.
 #
-# Can parse ranges like "2008-01-05-2008-03-14", "2009-2011",
+# Can parse ranges like "2008-01-05,2008-03-14" (comma between the two
+# endpoints) or the dash-only "2008-01-05-2008-03-14", "2009-2011",
 # "02-08" (month range), "09-03" (month range wrapping new year),
 # and underscored Ruby-style phrases like "last_year", "1_day_ago", etc.
 #
@@ -18,9 +19,14 @@ class DateRangeParser
     @range = parse_date_range
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def parse_date_range
-    val = parse_date_words
+    return parse_comma_range if @string.include?(",")
+
+    match_date_patterns(parse_date_words)
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def match_date_patterns(val)
     a, b, c, d, e, f = val.split("-")
     case val
     when /^\d{4}$/
@@ -48,6 +54,19 @@ class DateRangeParser
   ##########################################################################
 
   private
+
+  # "2026-08-12,2026-08-16": each side parses on its own (so "2026,2027"
+  # and phrases like "last_month,today" work too); the range runs from
+  # the left side's start to the right side's end. nil when either side
+  # doesn't parse.
+  def parse_comma_range
+    left, right = @string.split(",", 2).map(&:strip)
+    from = self.class.new(left).range
+    to = self.class.new(right).range
+    return nil unless from && to
+
+    [Array(from).first, Array(to).last]
+  end
 
   def yyyymmdd(from, to)
     [format("%04<year>d-%02<month>d-%02<day>d",

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -189,13 +189,28 @@ module Searchable
     end
 
     def parse_date_ranges
+      @unparsed_dates = []
       [:date, :created_at, :updated_at].each { |field| parse_date_range(field) }
     end
 
+    # A date the parser doesn't understand must fail the search, not
+    # silently broaden it -- dropping the nil here used to run the
+    # query with the date filter quietly gone.
     def parse_date_range(field)
       return if (date = @query_params[field]).blank?
 
-      @query_params[field] = ::DateRangeParser.new(date).range
+      parsed = ::DateRangeParser.new(date).range
+      @unparsed_dates << date if parsed.nil?
+      @query_params[field] = parsed
+    end
+
+    def dates_parseable?
+      return true if @unparsed_dates.blank?
+
+      @unparsed_dates.each do |value|
+        flash_error(:search_term_date_unparseable.t(value: value))
+      end
+      false
     end
 
     # Note that this @search query instance is not the one that gets saved and
@@ -203,6 +218,8 @@ module Searchable
     # NOTE: We can't call @query_params.compact_blank, because we need to
     # preserve `false` values.
     def validate_search_instance?
+      return false unless dates_parseable?
+
       @query_params.reject! { |_k, v| v == "" }
       @search = Query.create_query(query_model, @query_params)
       return true unless @search.invalid?

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1000,7 +1000,7 @@
   search_value_this_year: this year
   search_value_last_year: last year
   search_value_years_ago: N years ago
-  search_term_date_unparseable: "Did not understand the date \"[value]\". Try YYYY-MM-DD, YYYY or MM; for a range, two dates separated by a comma: YYYY-MM-DD,YYYY-MM-DD."
+  search_term_date_unparseable: "Did not understand the date \"[value]\". Try YYYY-MM-DD, YYYY or MM; for a range, two dates separated by a comma or space: YYYY-MM-DD,YYYY-MM-DD."
 
   # Rss log messages.
   log_ancient: "[String]"
@@ -3577,7 +3577,7 @@
   # We're borrowing these for the help popups on the search forms, thus the
   # similar entries. In the case of apparent duplicates, one will be the
   # pattern search keyword, the other the query param.
-  observation_term_when: "Date mushroom was observed: YYYY-MM-DD, YYYY or MM; ranges okay: YYYY-MM-DD,YYYY-MM-DD, YYYY-YYYY, MM-MM."
+  observation_term_when: "Date mushroom was observed: YYYY-MM-DD, YYYY or MM; ranges okay: YYYY-MM-DD,YYYY-MM-DD (comma or space between the dates), YYYY-YYYY, MM-MM."
   observation_term_date: "[:observation_term_when]"
   observation_term_created: Date observation was first posted.
   observation_term_created_at: "[:observation_term_created]"

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1000,6 +1000,7 @@
   search_value_this_year: this year
   search_value_last_year: last year
   search_value_years_ago: N years ago
+  search_term_date_unparseable: "Did not understand the date \"[value]\". Try YYYY-MM-DD, YYYY or MM; for a range, two dates separated by a comma: YYYY-MM-DD,YYYY-MM-DD."
 
   # Rss log messages.
   log_ancient: "[String]"
@@ -3576,7 +3577,7 @@
   # We're borrowing these for the help popups on the search forms, thus the
   # similar entries. In the case of apparent duplicates, one will be the
   # pattern search keyword, the other the query param.
-  observation_term_when: "Date mushroom was observed: YYYY-MM-DD, YYYY or MM; ranges okay: YYYY-MM-DD-YYYY-MM-DD, YYYY-YYYY, MM-MM."
+  observation_term_when: "Date mushroom was observed: YYYY-MM-DD, YYYY or MM; ranges okay: YYYY-MM-DD,YYYY-MM-DD, YYYY-YYYY, MM-MM."
   observation_term_date: "[:observation_term_when]"
   observation_term_created: Date observation was first posted.
   observation_term_created_at: "[:observation_term_created]"

--- a/test/classes/date_range_parser_test.rb
+++ b/test/classes/date_range_parser_test.rb
@@ -37,6 +37,19 @@ class DateRangeParserTest < UnitTestCase
     assert_equal([first, today], parse("this_month,today"))
   end
 
+  # A space works as the separator too -- but only after the whole
+  # string fails to parse, so spaced date words ("2 days ago") stay
+  # one date, not a range.
+  def test_space_ranges
+    assert_equal(%w[2026-08-12 2026-08-16], parse("2026-08-12 2026-08-16"))
+    assert_equal(%w[2026-01-01 2027-12-31], parse("2026 2027"))
+    assert_equal(%w[2026-08-01 2026-09-30], parse("2026-08 2026-09"))
+
+    two_days_ago = 2.days.ago.strftime("%Y-%m-%d")
+
+    assert_equal([two_days_ago, two_days_ago], parse("2 days ago"))
+  end
+
   def test_unparseable_values_are_nil
     assert_nil(parse("garbage"))
     assert_nil(parse("nonsense,2026"))

--- a/test/classes/date_range_parser_test.rb
+++ b/test/classes/date_range_parser_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class DateRangeParserTest < UnitTestCase
+  def parse(string)
+    DateRangeParser.new(string).range
+  end
+
+  def test_single_values
+    assert_equal(%w[2026-08-12 2026-08-12], parse("2026-08-12"))
+    assert_equal(%w[2026-01-01 2026-12-31], parse("2026"))
+    assert_equal(%w[08-01 08-31], parse("8"))
+  end
+
+  def test_dash_ranges
+    assert_equal(%w[2026-08-12 2026-08-16], parse("2026-08-12-2026-08-16"))
+    assert_equal(%w[2026-01-01 2027-12-31], parse("2026-2027"))
+    assert_equal(%w[02-01 08-31], parse("02-08"))
+  end
+
+  # Two full dates separated by a comma is the natural way to write a
+  # range; the dash-only grammar used to return nil for it, and the
+  # search silently dropped the filter (reported: a locality + date
+  # search returning observations from every year).
+  def test_comma_ranges
+    assert_equal(%w[2026-08-12 2026-08-16], parse("2026-08-12,2026-08-16"))
+    assert_equal(%w[2026-08-12 2026-08-16], parse("2026-08-12, 2026-08-16"))
+    assert_equal(%w[2026-01-01 2027-12-31], parse("2026,2027"))
+    assert_equal(%w[2026-08-01 2026-09-30], parse("2026-08,2026-09"))
+  end
+
+  def test_comma_range_with_date_words
+    today = Time.zone.today.strftime("%Y-%m-%d")
+    first = Time.zone.today.beginning_of_month.strftime("%Y-%m-%d")
+
+    assert_equal([first, today], parse("this_month,today"))
+  end
+
+  def test_unparseable_values_are_nil
+    assert_nil(parse("garbage"))
+    assert_nil(parse("nonsense,2026"))
+    assert_nil(parse("2026-08-12,"))
+    assert_nil(parse(""))
+    assert_nil(parse(nil))
+  end
+end

--- a/test/classes/date_range_parser_test.rb
+++ b/test/classes/date_range_parser_test.rb
@@ -57,4 +57,12 @@ class DateRangeParserTest < UnitTestCase
     assert_nil(parse(""))
     assert_nil(parse(nil))
   end
+
+  # Exactly two endpoints: a list of three dates is rejected, not
+  # silently spanned first-to-last.
+  def test_separators_do_not_nest
+    assert_nil(parse("2026-08-12,2026-08-16,2026-08-17"))
+    assert_nil(parse("2026-08-12 2026-08-16 2026-08-17"))
+    assert_nil(parse("2026-08-12,2026-08-16 2026-08-17"))
+  end
 end

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -252,6 +252,41 @@ module Observations
              "clear_form? should result in a blank query")
     end
 
+    # A comma-separated pair of dates is a range; the filter must reach
+    # the query (the dash-only parser used to return nil and the search
+    # silently ran without the date).
+    def test_create_observations_search_with_comma_date_range
+      login
+      params = {
+        region: "Colorado, USA",
+        date: "2026-08-12,2026-08-16"
+      }
+      post(:create, params: { query_observations: params })
+
+      validated_params = {
+        region: ["Colorado, USA"],
+        date: %w[2026-08-12 2026-08-16]
+      }
+      assert_redirected_to(controller: "/observations", action: :index,
+                           params: {
+                             q: { model: :Observation, **validated_params }
+                           })
+    end
+
+    # A date the parser can't read must fail the search with an error,
+    # never run it with the filter quietly gone.
+    def test_create_observations_search_with_unparseable_date
+      login
+      params = {
+        region: "Colorado, USA",
+        date: "next Tuesday"
+      }
+      post(:create, params: { query_observations: params })
+
+      assert_flash_error
+      assert_redirected_to(action: :new)
+    end
+
     def test_create_observations_search_with_has_field_slips
       login
       params = {


### PR DESCRIPTION
Fixes the observation filtered search ignoring the date field: a search with locality "Colorado, USA" and date "2026-08-12,2026-08-16" returned observations from every year.

## Root cause

Two layers, both fixed:

1. `DateRangeParser`'s range grammar was dash-only ("2026-08-12-2026-08-16"), so the comma-separated form returned **nil**.
2. `Searchable#parse_date_range` assigned that nil into the query params, where it was silently dropped — the query ran with the date filter quietly gone, no error, no hint. The region filter still applied, so the results looked plausible enough to trust.

## Fix

- **`DateRangeParser` accepts a comma or a space between two endpoints.** Each side parses on its own, so `2026-08-12,2026-08-16`, `2026-08-12 2026-08-16`, `2026,2027`, `2026-08,2026-09`, and even `last_month,today` all work — the range runs from the left side's start to the right side's end. The space form is tried only after the whole string fails to parse, so spaced date words (`2 days ago`) stay a single date rather than splitting into a bogus range. The dash grammar is unchanged.
- **An unparseable date fails the search out loud.** `Searchable` collects any date field the parser couldn't read and flashes "Did not understand the date …" with the accepted formats, redirecting back to the form instead of running a broadened query. A filter the user typed is never silently ignored. This applies to `date`, `created_at`, and `updated_at` on every `Searchable` controller (observations, names, locations, herbaria, projects, species lists).
- The observation date help text now shows the comma form (`YYYY-MM-DD,YYYY-MM-DD`, noting a space works too) as the range example.

Verified against the dev DB: the exact reported search now returns 54 observations, all with `when` between 2026-08-12 and 2026-08-16.

## Test plan

- Filtered observation search with locality "Colorado, USA" + date `2026-08-12,2026-08-16`: results are limited to that window.
- Same search with date `next Tuesday` (or any junk): error flash naming the value and formats, back on the form — not a full unfiltered result set.
- Automated: new `test/classes/date_range_parser_test.rb` (single values, dash ranges, comma and space ranges, date words, nil for garbage) and two controller tests (comma range reaches the query params; unparseable date flashes and redirects). All six `Searchable` controllers' suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
