### PR TITLE
Fix flaky `observation_show_system_test` race on "Your Observations"

### DIFF
--- a/test/system/observation_show_system_test.rb
+++ b/test/system/observation_show_system_test.rb
@@ -15,6 +15,14 @@ class ObservationShowSystemTest < ApplicationSystemTestCase
     assert_link("Your Observations")
     click_on("Your Observations")
 
+    # `body.observations__index` alone matches both the filtered target
+    # page AND the unfiltered `/observations` page Turbo may still be
+    # showing mid-navigation (login redirects to bare `observations_path`,
+    # so that's genuinely on screen before this click's own page loads) --
+    # a login-warmed vs. cold Puma/Chrome start made this race visible
+    # only sometimes. Assert on the URL actually landing on `by_user=`
+    # so Capybara's own retry waits for the real navigation to finish.
+    assert_current_path(observations_path(by_user: rolf.id))
     assert_selector("body.observations__index")
     assert_link(text: /#{@obs.text_name}/)
     click_link(text: /#{@obs.text_name}/)


### PR DESCRIPTION
## Summary

`ObservationShowSystemTest#test_visit_show_observation` was flaky -- failing when run in isolation (e.g. `-n test_visit_show_observation`) while passing when run as part of the full file.

## Root cause

```ruby
click_on("Your Observations")
assert_selector("body.observations__index")   # <- too weak
assert_link(text: /#{@obs.text_name}/)
```

`body.observations__index` matches *any* observations index page, filtered or not. `Account::LoginController#login_success` redirects to bare `observations_path` (`redirect_back_or_default(observations_path)`) after login, so that unfiltered page is genuinely on screen the moment `login!` finishes -- and it already carries the same `observations__index` body class the real, filtered target page will have.

When Turbo's navigation to `/observations?by_user=<id>` (the actual click target) hasn't finished yet, `assert_selector("body.observations__index")` is satisfied immediately by the *stale pre-click* page instead of waiting for the new one. The next assertion, `assert_link` for the observation's name, then races against that navigation actually completing.

Traced with temporary debug output (`page.current_url` polled every second): right after the body-class assertion passed, the URL was still bare `/observations`; it updated to `/observations?by_user=...` about a second later. That's why isolated runs (cold Puma/Chrome startup, slower first requests) failed while full-file runs (warmed up by earlier tests) passed -- both were racing the same navigation, just with different odds of losing.

## Fix

Assert on the URL actually landing on the filtered path first (`assert_current_path(observations_path(by_user: rolf.id))`), so Capybara's own retry/wait mechanism waits for the *real* navigation instead of being satisfied by a same-body-class page that predates the click.

## Test plan

- [x] `bin/rails test test/system/observation_show_system_test.rb -n test_visit_show_observation`, run 3x in isolation back-to-back -- all pass, ~3s each (previously: reliably failed after a ~23s timeout when run this way)
- [x] `bin/rails test test/system/observation_show_system_test.rb` (full file, 5 tests) -- still green
- [x] `bundle exec rubocop` clean
