### PR TITLE
Add index on `observations(log_updated_at, id)`

### DIFF
--- a/db/migrate/20260817193736_add_log_updated_at_index_to_observations.rb
+++ b/db/migrate/20260817193736_add_log_updated_at_index_to_observations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddLogUpdatedAtIndexToObservations < ActiveRecord::Migration[7.2]
+  # The unfiltered /observations index sorts by :rss_log
+  # (log_updated_at DESC, id DESC), the default order. Prep for #5101's
+  # bounded prev/next lookup, which queries this order with a WHERE +
+  # LIMIT 1 -- an index range scan instead of a full table scan.
+  def change
+    add_index(:observations, [:log_updated_at, :id])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_09_175755) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_17_193736) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -639,6 +639,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_09_175755) do
     t.index ["collector_user_id"], name: "index_observations_on_collector_user_id"
     t.index ["inat_import_id"], name: "index_observations_on_inat_import_id"
     t.index ["location_id"], name: "index_observations_on_location_id"
+    t.index ["log_updated_at", "id"], name: "index_observations_on_log_updated_at_and_id"
     t.index ["name_id"], name: "index_observations_on_name_id"
     t.index ["needs_naming"], name: "needs_naming_index"
     t.index ["occurrence_id"], name: "index_observations_on_occurrence_id"


### PR DESCRIPTION
## Summary

Adds `db/migrate/20260817193736_add_log_updated_at_index_to_observations.rb` for `observations(log_updated_at, id)`. Split off from #5115 (the bounded-query prev/next rewrite for #5101) so the two can be reviewed independently.

`log_updated_at` drives `:rss_log` order (`log_updated_at DESC, id DESC`), the **default order** for the unfiltered `/observations` index — and had no index before this PR.

## This PR alone has no effect — read before merging

Measured directly: with this index applied but *without* #5115's query-shape change, `EXPLAIN` on the existing (pre-#5115) prev/next query still shows `type: ALL` (full table scan), `Using filesort` — MySQL's optimizer doesn't choose the index for that query shape at all, and timing confirms it (~654ms with the index vs. ~640ms without, no meaningful difference). The old query has no `WHERE` clause narrowing the row count — it fetches every matching id — and for a "return the whole table" query, the planner apparently judges a full scan + sort as cheap as walking the secondary index, so it skips it.

The index only pays off once #5115 lands, which changes the query shape to a bounded `WHERE ... LIMIT 1` — what an index range scan serves well. With both changes together, `EXPLAIN` shows `type: range`, `Using index condition`, and the full prev+next lookup for the unfiltered-index scenario drops from ~640ms to ~17ms.

| Change | Result |
|---|---|
| This index alone (old query shape) | ~640ms → ~654ms (not used) |
| #5115's bounded query alone (no index) | ~640ms → ~478ms |
| Both together | ~640ms → ~17ms |

Merge order doesn't matter functionally — this migration is inert until #5115 lands, and #5115 works (just slower, ~478ms instead of ~17ms for this specific unfiltered/rss_log case) without this index. Splitting them lets each be reviewed on its own merit rather than as one large, harder-to-review change.

## Test plan

- [x] `bin/rails db:migrate`
- [x] `EXPLAIN` before/after comparison (see above)
- [x] `bundle exec rubocop` clean
