### PR TITLE
prev/next nav: Cached-window lookup with seek-backed fill

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -289,6 +289,7 @@ class Query
   include Query::Modules::Initialization
   include Query::Modules::Results
   include Query::Modules::Sequence
+  include Query::Modules::WindowCache
   include Query::Modules::Validation
 
   attr_writer :record

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -289,6 +289,7 @@ class Query
   include Query::Modules::Initialization
   include Query::Modules::Results
   include Query::Modules::Sequence
+  include Query::Modules::Seek
   include Query::Modules::WindowCache
   include Query::Modules::Validation
 

--- a/app/classes/query/modules/seek.rb
+++ b/app/classes/query/modules/seek.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+##############################################################################
+#
+#  :module: Seek
+#
+#  Keyset ("seek method") predicate machinery for bounded neighbor
+#  fetches, used by `Query::Modules::WindowCache#compute_window` to
+#  fetch a window of ids around the current position with two indexed
+#  `LIMIT` queries instead of a full scan of every matching id. Only
+#  applies when the query's ORDER BY is a plain list of columns --
+#  `seekable_cols` returns nil for shapes a keyset comparison can't
+#  express (aggregates, CASE expressions, FIND_IN_SET-based position
+#  ordering), and the caller falls back to the full-array path.
+#
+##############################################################################
+
+module Query::Modules::Seek
+  private
+
+  # Allow-list: anything not a plain column Ascending/Descending
+  # (aggregate, CASE, FindInSet) falls back to the full-array path.
+  # Memoizes the order columns themselves, not just whether they
+  # qualify, so callers don't need to re-read `scope.order_values` --
+  # `scope` itself is unmemoized and rebuilds the whole relation.
+  def seekable_cols
+    return @seekable_cols if defined?(@seekable_cols)
+
+    values = scope.order_values
+    seekable = values.present? && values.all? do |o|
+      o.respond_to?(:direction) && o.expr.is_a?(Arel::Attributes::Attribute)
+    end
+    @seekable_cols = seekable ? values : nil
+  end
+
+  # Current row's own sort-column values, to seed the keyset
+  # comparison. Memoized by current_id -- prev_id and next_id render
+  # back-to-back for the same current_id (ShowPrevNextNav), and this
+  # value doesn't depend on which direction is being looked up.
+  #
+  # A to-many join (e.g. Image.order_by(:confidence)) can produce more
+  # than one row per id with different column values -- bail to the
+  # fallback rather than seed from an arbitrary one.
+  def current_sort_values(cols)
+    @current_sort_values ||= {}
+    return @current_sort_values[current_id] if
+      @current_sort_values.key?(current_id)
+
+    @current_sort_values[current_id] = fetch_current_sort_values(cols)
+  end
+
+  def fetch_current_sort_values(cols)
+    attrs = cols.map(&:expr)
+    rows = scope.where(model.arel_table[:id].eq(current_id)).
+           limit(2).pluck(*attrs)
+    return nil unless rows.size == 1
+
+    attrs.size == 1 ? [rows.first] : rows.first
+  end
+
+  # Seek-method predicate for a compound order (a, b, ..., id) --
+  # tuple comparison, since ties on the primary column are common.
+  def build_seek_predicate(cols, current_row, forward:)
+    legs = cols.each_index.map do |idx|
+      seek_leg(cols, current_row, idx, forward:)
+    end
+    legs.reduce { |a, b| a.or(b) }
+  end
+
+  # One leg of the tuple comparison: columns before `idx` held equal,
+  # column `idx` past the current row's value.
+  def seek_leg(cols, current_row, idx, forward:)
+    eq_prefix = (0...idx).map { |j| cols[j].expr.eq(current_row[j]) }
+    ascending = cols[idx].is_a?(Arel::Nodes::Ascending)
+    increasing = ascending == forward
+    leg = seek_comparison(cols[idx].expr, current_row[idx], increasing)
+    eq_prefix.reduce(leg) { |acc, eq| eq.and(acc) }
+  end
+
+  # MySQL sorts NULL as the smallest possible value, in both ASC and
+  # DESC. Plain `>`/`<` can't express that: `col > NULL` is always
+  # unknown in SQL, so it can't match "any non-NULL value" when
+  # seeking up from a NULL current value; `col < 5` can't match a NULL
+  # row either, so seeking down from a non-NULL value skips straight
+  # past the transition into NULL territory. Both need an explicit
+  # branch; seeking up from a non-NULL value, or down from NULL
+  # (nothing sorts below it), are already correct with a plain
+  # comparison.
+  def seek_comparison(attr, value, increasing)
+    if increasing
+      value.nil? ? attr.not_eq(nil) : attr.gt(value)
+    else
+      value.nil? ? attr.lt(value) : attr.lt(value).or(attr.eq(nil))
+    end
+  end
+end

--- a/app/classes/query/modules/sequence.rb
+++ b/app/classes/query/modules/sequence.rb
@@ -9,12 +9,11 @@
 #  through the same results via the "next" and "prev" links on the show page,
 #  within the same query — as if you were paging through results in the index.
 #
-#  NOTE: The next and prev sequence operators always grab the entire set of
-#  result_ids.  No attempt is made to reduce the query.  NOTE: we might be
-#  able to if we can turn the ORDER clause into an upper/lower bound.
-#
-#  The first and last sequence operators ignore result_ids.  However, they are
-#  able to execute optimized queries that return only the first or last result.
+#  NOTE: prev_id/next_id/first_id/last_id are served by
+#  Query::Modules::WindowCache -- a cached window of ids around the
+#  current position, avoiding the full result_ids array on cache hits.
+#  The mutate-and-return-self forms (prev/next/first/last) still
+#  always grab the entire result_ids set.
 #
 #  == Instance Methods:
 #
@@ -132,7 +131,7 @@ module Query::Modules::Sequence
   end
 
   def first_id
-    result_ids&.first
+    edge_id(:first)
   end
 
   # Move to previous place.
@@ -152,10 +151,7 @@ module Query::Modules::Sequence
   # Returns the previous id, or nil, without changing the query.
   # Must set current_id= first
   def prev_id
-    index = result_ids.index(current_id)
-    return nil unless index&.positive?
-
-    result_ids[index - 1]
+    windowed_id(:prev)
   end
 
   # Move to next place.
@@ -172,13 +168,10 @@ module Query::Modules::Sequence
     new_self
   end
 
-  # Returns the previous id, or nil, without changing the query.
+  # Returns the next id, or nil, without changing the query.
   # Must set current_id= first
   def next_id
-    index = result_ids.index(current_id)
-    return nil unless index && index < result_ids.length - 1
-
-    result_ids[index + 1]
+    windowed_id(:next)
   end
 
   # Move to last place.
@@ -194,6 +187,6 @@ module Query::Modules::Sequence
   end
 
   def last_id
-    result_ids&.last
+    edge_id(:last)
   end
 end

--- a/app/classes/query/modules/window_cache.rb
+++ b/app/classes/query/modules/window_cache.rb
@@ -154,8 +154,9 @@ module Query::Modules::WindowCache
     window = compute_window(current_id)
     return nil unless window
 
-    Rails.cache.write(window_cache_key, window, expires_in: WINDOW_TTL) if
-      window_cache_key
+    if (key = window_cache_key)
+      Rails.cache.write(key, window, expires_in: WINDOW_TTL)
+    end
     window
   end
 

--- a/app/classes/query/modules/window_cache.rb
+++ b/app/classes/query/modules/window_cache.rb
@@ -4,19 +4,42 @@
 #
 #  :module: WindowCache
 #
-#  Cached-window neighbor lookup for `Query::Modules::Sequence`, used as
-#  an alternative to the bounded-query rewrite (`Query::Modules::Seek`)
-#  -- keeps prev/next/first/last off the full `result_ids` array by
-#  caching a window of ids around the current position, keyed by
-#  `QueryRecord#id`.
+#  Cached-window neighbor lookup for `Query::Modules::Sequence` --
+#  serves prev/next/first/last from a window of ids around the current
+#  position, keyed by `QueryRecord#id` and viewer.
+#
+#  The cached window is what gives prev/next stable snapshot semantics:
+#  the pager walks the ordering as the viewer saw it on the index page,
+#  instead of recomputing "the row after the current row's position
+#  right now" on every click -- under live recomputation, a concurrent
+#  edit that moves the current row within the ordering silently teleports
+#  the viewer (e.g. clicking next from a row another user's vote just
+#  re-sorted to the front lands back at the start of the list). Liveness
+#  leaks back in only at the seams: recentering on walking off a window
+#  edge, and TTL expiry (`WINDOW_TTL`).
+#
+#  Window fills go through a bounded keyset fetch when the query's
+#  ORDER BY is a plain list of columns (`Query::Modules::Seek`) --
+#  `window_radius` rows per direction, indexed -- and fall back to
+#  slicing today's full `result_ids` computation for order shapes a
+#  keyset predicate can't express (aggregates, CASE, FIND_IN_SET) or
+#  when the current row's sort key is ambiguous across a to-many join.
 #
 ##############################################################################
 
 module Query::Modules::WindowCache
-  WINDOW_RADIUS = 504 # multiple of 12 -- ids kept on each side of current
   WINDOW_TTL = 30.minutes
 
   private
+
+  # Ids kept on each side of the current position. Derived from the
+  # viewer: radius >= the viewer's index page size - 1 guarantees the
+  # entire page they drilled in from is inside the window (worst case:
+  # they clicked its first item); 2x gives a full page of margin each
+  # direction. The clamp bounds the cache row at ~2-15KB.
+  def window_radius
+    @window_radius ||= 2 * (viewer&.layout_count || 60).clamp(60, 480)
+  end
 
   # Scoped by viewer as well as QueryRecord -- `QueryRecord` dedups by
   # serialized query params only, so two different users browsing the
@@ -24,7 +47,8 @@ module Query::Modules::WindowCache
   # would otherwise share one cache slot and continually evict each
   # other's window as they browse to different positions. No viewer
   # (a bot, or `create_query`'s callers that don't set one) means no
-  # caching, rather than falling back to a shared anonymous slot.
+  # caching, rather than falling back to a shared anonymous slot --
+  # the seek-backed fill keeps even uncached lookups bounded.
   def window_cache_key
     return nil unless record&.id && viewer&.id
 
@@ -34,29 +58,75 @@ module Query::Modules::WindowCache
   # Ids around `current_id`, `current_id`'s own index within them, and
   # whether each edge is the true edge of the full result set or just
   # where this window happens to stop -- or nil if `current_id` isn't
-  # in the result set at all (deleted, no longer matches the filter).
+  # in the result set (deleted, no longer matches the filter).
   #
-  # v1: one full scan (today's `result_ids`), sliced before returning.
-  # A v2 could instead fetch only `WINDOW_RADIUS` rows per direction
-  # via a keyset predicate (mirroring Query::Modules::Seek's
-  # `seekable_order?`/`current_sort_values`/`build_seek_predicate`),
-  # detecting `at_start`/`at_end` by whether that fetch came up short
-  # of `WINDOW_RADIUS` rows -- everything below this method depends
-  # only on the returned shape, not on how it was computed.
+  # Everything downstream depends only on the returned shape, not on
+  # which of the two fetch strategies computed it.
   def compute_window(current_id)
+    seek_window(current_id) || full_scan_window(current_id)
+  end
+
+  # Bounded fetch: `window_radius` ids per direction via the keyset
+  # predicate (`Query::Modules::Seek`), each edge flagged as true when
+  # its fetch came up short of the radius. Returns nil -- falling back
+  # to `full_scan_window` -- when the order shape isn't seekable or
+  # the current row's sort key is ambiguous across a to-many join.
+  #
+  # The current row's own read and the two directional fetches are
+  # three separate queries -- wrapped in a transaction so they share
+  # one consistent snapshot (MySQL's default REPEATABLE READ). Without
+  # this, a concurrent write to the current row's own sort columns
+  # (e.g. another user's vote) landing between the reads could seed
+  # the window from a value that's already stale by the later queries.
+  def seek_window(current_id)
+    cols = seekable_cols
+    return nil unless cols
+
+    model.transaction do
+      current_row = current_sort_values(cols)
+      current_row && build_window_around(cols, current_row, current_id)
+    end
+  end
+
+  def build_window_around(cols, current_row, current_id)
+    radius = window_radius
+    before = window_leg_ids(cols, current_row, forward: false, radius:)
+    after = window_leg_ids(cols, current_row, forward: true, radius:)
+    { ids: before.reverse + [current_id] + after,
+      offset: before.length,
+      at_start: before.length < radius,
+      at_end: after.length < radius }
+  end
+
+  # Ids on one side of the current row, closest first. Going backward,
+  # the base scope's order is reversed so LIMIT lands on the rows
+  # nearest the current tuple rather than the smallest tuples
+  # satisfying the predicate.
+  def window_leg_ids(cols, current_row, forward:, radius:)
+    predicate = build_seek_predicate(cols, current_row, forward:)
+    rel = scope.where(predicate)
+    rel = rel.reverse_order unless forward
+    rel.limit(radius).pluck(model.arel_table[:id])
+  end
+
+  # Fallback fill for order shapes the keyset predicate can't express,
+  # and for an ambiguous current row: one full scan (today's
+  # `result_ids`), sliced to the window before returning.
+  def full_scan_window(current_id)
     ids = result_ids
     index = ids.index(current_id)
     return nil unless index
 
-    lo = [index - WINDOW_RADIUS, 0].max
-    hi = [index + WINDOW_RADIUS, ids.length - 1].min
+    radius = window_radius
+    lo = [index - radius, 0].max
+    hi = [index + radius, ids.length - 1].min
     { ids: ids[lo..hi], offset: index - lo,
       at_start: lo.zero?, at_end: hi == ids.length - 1 }
   end
 
   # `{ids:, offset:, at_start:, at_end:}` positioned at current_id,
   # from cache or a fresh compute -- or nil if current_id isn't in the
-  # result set at all.
+  # result set.
   def window_position
     cached_window_position || refresh_window
   end
@@ -74,8 +144,8 @@ module Query::Modules::WindowCache
   end
 
   # A persistent, DB-backed cache (Solid Cache) can hand back an entry
-  # written by a pre-deploy version of this code if its shape ever
-  # changes -- treat anything unexpected as a miss rather than raise.
+  # written by a pre-deploy version of this code whose shape no longer
+  # matches -- treat anything unexpected as a miss rather than raise.
   def valid_window?(window)
     window.is_a?(Hash) && window[:ids].is_a?(Array)
   end
@@ -95,8 +165,8 @@ module Query::Modules::WindowCache
   # edge, which is a legitimate nil (no more results).
   #
   # Letter-paginated queries (`need_letters`) reorder at paginate time
-  # in a way this module doesn't account for, and aren't cached --
-  # same reason `Query::Modules::Seek#seek_or` bails on them.
+  # in a way this module doesn't account for, and aren't cached or
+  # seek-fetched.
   def windowed_id(dir)
     return legacy_windowed_id(dir) if need_letters
 

--- a/app/classes/query/modules/window_cache.rb
+++ b/app/classes/query/modules/window_cache.rb
@@ -174,14 +174,19 @@ module Query::Modules::WindowCache
     window = window_position
     return nil unless window
 
-    return boundary_id(window, dir) unless at_window_edge?(window, dir)
-
-    if true_edge?(window, dir)
-      nil
-    else
-      window = refresh_window
-      window ? boundary_id(window, dir) : nil
+    unless at_window_edge?(window, dir)
+      id = boundary_id(window, dir)
+      # A cached id can be destroyed after caching -- without this
+      # check the arrow would point at a dead show page. Refetching
+      # skips it and rewrites the cache: a fresh window is live data,
+      # so its neighbor can't be a destroyed row.
+      return id if model.exists?(id)
     end
+
+    return nil if true_edge?(window, dir)
+
+    window = refresh_window
+    window ? boundary_id(window, dir) : nil
   end
 
   def legacy_windowed_id(dir)

--- a/app/classes/query/modules/window_cache.rb
+++ b/app/classes/query/modules/window_cache.rb
@@ -18,10 +18,17 @@ module Query::Modules::WindowCache
 
   private
 
+  # Scoped by viewer as well as QueryRecord -- `QueryRecord` dedups by
+  # serialized query params only, so two different users browsing the
+  # same logical query (e.g. everyone on the default unfiltered index)
+  # would otherwise share one cache slot and continually evict each
+  # other's window as they browse to different positions. No viewer
+  # (a bot, or `create_query`'s callers that don't set one) means no
+  # caching, rather than falling back to a shared anonymous slot.
   def window_cache_key
-    return nil unless record&.id
+    return nil unless record&.id && viewer&.id
 
-    "query_window/#{record.id}"
+    "query_window/#{record.id}/#{viewer.id}"
   end
 
   # Ids around `current_id`, `current_id`'s own index within them, and

--- a/app/classes/query/modules/window_cache.rb
+++ b/app/classes/query/modules/window_cache.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+##############################################################################
+#
+#  :module: WindowCache
+#
+#  Cached-window neighbor lookup for `Query::Modules::Sequence`, used as
+#  an alternative to the bounded-query rewrite (`Query::Modules::Seek`,
+#  #5115/#5117) -- keeps prev/next/first/last off the full `result_ids`
+#  array by caching a window of ids around the current position, keyed
+#  by `QueryRecord#id`. See #5101.
+#
+##############################################################################
+
+module Query::Modules::WindowCache
+  WINDOW_RADIUS = 504 # multiple of 12 -- ids kept on each side of current
+  WINDOW_TTL = 30.minutes
+
+  private
+
+  def window_cache_key
+    return nil unless record&.id
+
+    "query_window/#{record.id}"
+  end
+
+  # Ids around `current_id`, `current_id`'s own index within them, and
+  # whether each edge is the true edge of the full result set or just
+  # where this window happens to stop -- or nil if `current_id` isn't
+  # in the result set at all (deleted, no longer matches the filter).
+  #
+  # v1: one full scan (today's `result_ids`), sliced before returning.
+  # A v2 could instead fetch only `WINDOW_RADIUS` rows per direction
+  # via a keyset predicate (mirroring Query::Modules::Seek's
+  # `seekable_order?`/`current_sort_values`/`build_seek_predicate`),
+  # detecting `at_start`/`at_end` by whether that fetch came up short
+  # of `WINDOW_RADIUS` rows -- everything below this method depends
+  # only on the returned shape, not on how it was computed.
+  def compute_window(current_id)
+    ids = result_ids
+    index = ids.index(current_id)
+    return nil unless index
+
+    lo = [index - WINDOW_RADIUS, 0].max
+    hi = [index + WINDOW_RADIUS, ids.length - 1].min
+    { ids: ids[lo..hi], offset: index - lo,
+      at_start: lo.zero?, at_end: hi == ids.length - 1 }
+  end
+
+  # [ids, offset, at_start, at_end] positioned at current_id, from
+  # cache or a fresh compute -- or nil if current_id isn't in the
+  # result set at all.
+  def window_position
+    cached_window_position || refresh_window
+  end
+
+  def cached_window_position
+    return nil unless (key = window_cache_key)
+
+    window = Rails.cache.read(key)
+    return nil unless window
+
+    offset = window[:ids].index(current_id)
+    return nil unless offset
+
+    [window[:ids], offset, window[:at_start], window[:at_end]]
+  end
+
+  def refresh_window
+    window = compute_window(current_id)
+    return nil unless window
+
+    Rails.cache.write(window_cache_key, window, expires_in: WINDOW_TTL) if
+      window_cache_key
+    [window[:ids], window[:offset], window[:at_start], window[:at_end]]
+  end
+
+  # Serves prev/next from a cached or freshly-computed window.
+  # Refetches when the lookup would run past a cached edge that isn't
+  # the true edge of the result set -- distinct from being at the true
+  # edge, which is a legitimate nil (no more results).
+  def windowed_id(dir)
+    ids, offset, at_start, at_end = window_position
+    return nil unless ids
+
+    return boundary_id(ids, offset, at_start, at_end, dir) unless
+      at_window_edge?(ids, offset, dir)
+
+    if true_edge?(offset, at_start, at_end, ids, dir)
+      nil
+    else
+      ids, offset, at_start, at_end = refresh_window
+      return nil unless ids
+
+      boundary_id(ids, offset, at_start, at_end, dir)
+    end
+  end
+
+  def at_window_edge?(ids, offset, dir)
+    dir == :prev ? offset.zero? : offset == ids.length - 1
+  end
+
+  def true_edge?(offset, at_start, at_end, ids, dir)
+    return offset.zero? && at_start if dir == :prev
+
+    offset == ids.length - 1 && at_end
+  end
+
+  def boundary_id(ids, offset, at_start, at_end, dir)
+    return nil if true_edge?(offset, at_start, at_end, ids, dir)
+
+    dir == :prev ? ids[offset - 1] : ids[offset + 1]
+  end
+
+  # No caching needed -- a direct LIMIT-1 query is already cheap and
+  # order-shape-agnostic (works for aggregates/CASE/FIND_IN_SET too).
+  def edge_id(dir)
+    return nil if need_letters
+
+    rel = dir == :first ? scope : scope.reverse_order
+    rel.pick(model.arel_table[:id])
+  end
+end

--- a/app/classes/query/modules/window_cache.rb
+++ b/app/classes/query/modules/window_cache.rb
@@ -5,10 +5,10 @@
 #  :module: WindowCache
 #
 #  Cached-window neighbor lookup for `Query::Modules::Sequence`, used as
-#  an alternative to the bounded-query rewrite (`Query::Modules::Seek`,
-#  #5115/#5117) -- keeps prev/next/first/last off the full `result_ids`
-#  array by caching a window of ids around the current position, keyed
-#  by `QueryRecord#id`. See #5101.
+#  an alternative to the bounded-query rewrite (`Query::Modules::Seek`)
+#  -- keeps prev/next/first/last off the full `result_ids` array by
+#  caching a window of ids around the current position, keyed by
+#  `QueryRecord#id`.
 #
 ##############################################################################
 
@@ -47,8 +47,8 @@ module Query::Modules::WindowCache
       at_start: lo.zero?, at_end: hi == ids.length - 1 }
   end
 
-  # [ids, offset, at_start, at_end] positioned at current_id, from
-  # cache or a fresh compute -- or nil if current_id isn't in the
+  # `{ids:, offset:, at_start:, at_end:}` positioned at current_id,
+  # from cache or a fresh compute -- or nil if current_id isn't in the
   # result set at all.
   def window_position
     cached_window_position || refresh_window
@@ -58,12 +58,19 @@ module Query::Modules::WindowCache
     return nil unless (key = window_cache_key)
 
     window = Rails.cache.read(key)
-    return nil unless window
+    return nil unless valid_window?(window)
 
     offset = window[:ids].index(current_id)
     return nil unless offset
 
-    [window[:ids], offset, window[:at_start], window[:at_end]]
+    window.merge(offset:)
+  end
+
+  # A persistent, DB-backed cache (Solid Cache) can hand back an entry
+  # written by a pre-deploy version of this code if its shape ever
+  # changes -- treat anything unexpected as a miss rather than raise.
+  def valid_window?(window)
+    window.is_a?(Hash) && window[:ids].is_a?(Array)
   end
 
   def refresh_window
@@ -72,52 +79,80 @@ module Query::Modules::WindowCache
 
     Rails.cache.write(window_cache_key, window, expires_in: WINDOW_TTL) if
       window_cache_key
-    [window[:ids], window[:offset], window[:at_start], window[:at_end]]
+    window
   end
 
   # Serves prev/next from a cached or freshly-computed window.
   # Refetches when the lookup would run past a cached edge that isn't
   # the true edge of the result set -- distinct from being at the true
   # edge, which is a legitimate nil (no more results).
+  #
+  # Letter-paginated queries (`need_letters`) reorder at paginate time
+  # in a way this module doesn't account for, and aren't cached --
+  # same reason `Query::Modules::Seek#seek_or` bails on them.
   def windowed_id(dir)
-    ids, offset, at_start, at_end = window_position
-    return nil unless ids
+    return legacy_windowed_id(dir) if need_letters
 
-    return boundary_id(ids, offset, at_start, at_end, dir) unless
-      at_window_edge?(ids, offset, dir)
+    window = window_position
+    return nil unless window
 
-    if true_edge?(offset, at_start, at_end, ids, dir)
+    return boundary_id(window, dir) unless at_window_edge?(window, dir)
+
+    if true_edge?(window, dir)
       nil
     else
-      ids, offset, at_start, at_end = refresh_window
-      return nil unless ids
-
-      boundary_id(ids, offset, at_start, at_end, dir)
+      window = refresh_window
+      window ? boundary_id(window, dir) : nil
     end
   end
 
-  def at_window_edge?(ids, offset, dir)
-    dir == :prev ? offset.zero? : offset == ids.length - 1
+  def legacy_windowed_id(dir)
+    ids = result_ids
+    index = ids.index(current_id)
+    return nil unless index
+
+    if dir == :prev
+      ids[index - 1] if index.positive?
+    elsif index < ids.length - 1
+      ids[index + 1]
+    end
   end
 
-  def true_edge?(offset, at_start, at_end, ids, dir)
-    return offset.zero? && at_start if dir == :prev
-
-    offset == ids.length - 1 && at_end
+  def at_window_edge?(window, dir)
+    dir == :prev ? window[:offset].zero? : last_offset?(window)
   end
 
-  def boundary_id(ids, offset, at_start, at_end, dir)
-    return nil if true_edge?(offset, at_start, at_end, ids, dir)
+  def true_edge?(window, dir)
+    return window[:offset].zero? && window[:at_start] if dir == :prev
 
-    dir == :prev ? ids[offset - 1] : ids[offset + 1]
+    last_offset?(window) && window[:at_end]
+  end
+
+  def last_offset?(window)
+    window[:offset] == window[:ids].length - 1
+  end
+
+  def boundary_id(window, dir)
+    return nil if true_edge?(window, dir)
+
+    delta = dir == :prev ? -1 : 1
+    window[:ids][window[:offset] + delta]
   end
 
   # No caching needed -- a direct LIMIT-1 query is already cheap and
   # order-shape-agnostic (works for aggregates/CASE/FIND_IN_SET too).
+  # Falls back to result_ids for need_letters (see windowed_id), or
+  # when it's already memoized -- reuses a caller's existing result
+  # (e.g. search_controller's single-result redirect) instead of
+  # firing another query.
   def edge_id(dir)
-    return nil if need_letters
+    return legacy_edge_id(dir) if need_letters || defined?(@result_ids)
 
     rel = dir == :first ? scope : scope.reverse_order
     rel.pick(model.arel_table[:id])
+  end
+
+  def legacy_edge_id(dir)
+    dir == :first ? result_ids&.first : result_ids&.last
   end
 end

--- a/app/views/layouts/header/show_prev_next_nav.rb
+++ b/app/views/layouts/header/show_prev_next_nav.rb
@@ -25,9 +25,9 @@ module Views::Layouts
     private
 
     def render_adjacent_link(dir)
-      hide = no_more?(dir) ? "disabled opacity-0" : ""
-      classes = class_names(BTN_CLASSES, "#{dir}_object_link", hide)
       adjacent_id = @query.send(:"#{dir}_id")
+      hide = adjacent_id.nil? ? "disabled opacity-0" : ""
+      classes = class_names(BTN_CLASSES, "#{dir}_object_link", hide)
       href = adjacent_id ? adjacent_path(adjacent_id) : "#"
 
       Link(type: :get, name: adjacent_title(dir), target: href,
@@ -39,14 +39,6 @@ module Views::Layouts
 
       Link(type: :get, name: index_title, target: index_path,
            icon: index_icon, button: :link, size: :lg, class: classes)
-    end
-
-    def no_more?(dir)
-      if dir == :prev
-        @query.result_ids.first == @object.id
-      else
-        @query.result_ids.last == @object.id
-      end
     end
 
     def adjacent_path(id)

--- a/db/migrate/20260821010000_add_date_sort_indexes_to_observations.rb
+++ b/db/migrate/20260821010000_add_date_sort_indexes_to_observations.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddDateSortIndexesToObservations < ActiveRecord::Migration[7.2]
+  # The observations index's Date and Date Posted sorts order by
+  # (`when` DESC, id DESC) and (created_at DESC, id DESC). Without
+  # these indexes, the prev/next pager's bounded window fill for those
+  # orders runs at full-scan speed (~450ms measured) -- the same
+  # one-line fix the log_updated_at index was for the :rss_log order.
+  def change
+    add_index(:observations, [:when, :id])
+    add_index(:observations, [:created_at, :id])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_17_193736) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_21_010000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -637,6 +637,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_17_193736) do
     t.integer "inat_import_id"
     t.datetime "reflected_at"
     t.index ["collector_user_id"], name: "index_observations_on_collector_user_id"
+    t.index ["created_at", "id"], name: "index_observations_on_created_at_and_id"
     t.index ["inat_import_id"], name: "index_observations_on_inat_import_id"
     t.index ["location_id"], name: "index_observations_on_location_id"
     t.index ["log_updated_at", "id"], name: "index_observations_on_log_updated_at_and_id"
@@ -645,6 +646,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_17_193736) do
     t.index ["occurrence_id"], name: "index_observations_on_occurrence_id"
     t.index ["reflected_at"], name: "index_observations_on_reflected_at"
     t.index ["user_id", "created_at"], name: "index_observations_on_user_id_and_created_at"
+    t.index ["when", "id"], name: "index_observations_on_when_and_id"
   end
 
   create_table "occurrences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -607,23 +607,26 @@ class QueryTest < UnitTestCase
   # The cache can legitimately disagree with the live DB until the
   # next refetch -- that's the design's snapshot semantics working as
   # intended: prev/next walk the ordering as the viewer saw it, not
-  # the live ordering. A cached entry gets served as-is; only a fresh
-  # `refresh_window` call reflects current data.
+  # the live ordering. A stale entry whose ids still exist gets served
+  # as-is; only a fresh `refresh_window` call reflects current data.
+  # (An id that no longer exists is the exception -- see
+  # test_next_and_prev_window_skips_destroyed_neighbor.)
   def test_next_and_prev_window_cache_can_serve_stale_data
     with_real_cache do
       query = Query.lookup_and_save(:Name, order_by: :id)
       query.viewer = rolf
       ids = query.send(:result_ids)
       query.current_id = ids[10]
-      query.prev_id # populates the cache with the real ids[9] at slot 9
+      query.prev_id # populates the cache with ids[9] at slot 9
 
       key = query.send(:window_cache_key)
       cached = Rails.cache.read(key)
       tampered_ids = cached[:ids].dup
-      tampered_ids[9] = 999_999_999
+      # A live id planted out of order -- stale ordering, existing row.
+      tampered_ids[9] = ids[3]
       Rails.cache.write(key, cached.merge(ids: tampered_ids))
 
-      assert_equal(999_999_999, query.prev_id,
+      assert_equal(ids[3], query.prev_id,
                    "a stale cache entry is served as-is until refreshed")
 
       fresh = query.send(:refresh_window)
@@ -728,6 +731,30 @@ class QueryTest < UnitTestCase
       assert_equal(0, calls,
                    "mary's lookup elsewhere in the same query should " \
                    "not evict rolf's cached window")
+    end
+  end
+
+  # A row destroyed after its id was cached must not be served as a
+  # neighbor -- the arrow would point at a dead show page and bounce
+  # the user to the index, losing their place. The lookup checks the
+  # candidate still exists and refetches past it from live data,
+  # healing the cached window in the same step.
+  def test_next_and_prev_window_skips_destroyed_neighbor
+    with_real_cache do
+      query = Query.lookup_and_save(:Observation, order_by: :id)
+      query.viewer = rolf
+      ids = Observation.order_by(:id).pluck(:id)
+      query.current_id = ids[10]
+      assert_equal(ids[11], query.next_id, "sanity: cache filled")
+
+      # Bypass callbacks -- the point is only that the row is gone.
+      Observation.delete(ids[11])
+
+      assert_equal(ids[12], query.next_id,
+                   "next_id should skip the destroyed neighbor")
+      key = query.send(:window_cache_key)
+      assert_not_includes(Rails.cache.read(key)[:ids], ids[11],
+                          "the refetch should heal the cached window")
     end
   end
 

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -525,41 +525,61 @@ class QueryTest < UnitTestCase
   # result set -- walking past a cached-but-not-true edge must refetch
   # (recentering the window) rather than incorrectly reporting "no
   # more." Walking past the true edge must return nil without looping.
+  # Counts compute_window calls rather than result_ids calls -- a
+  # seekable order's window fill doesn't touch result_ids.
   def test_next_and_prev_window_edge_refetch_and_true_boundary
-    original_radius = Query::Modules::WindowCache::WINDOW_RADIUS
-    Query::Modules::WindowCache.send(:remove_const, :WINDOW_RADIUS)
-    Query::Modules::WindowCache.const_set(:WINDOW_RADIUS, 2)
-
     with_real_cache do
       query = Query.lookup_and_save(:Name, order_by: :id)
       query.viewer = rolf
-      ids = query.send(:result_ids)
+      query.define_singleton_method(:window_radius) { 2 }
+      ids = Name.order_by(:id).pluck(:id)
       query.current_id = ids[10]
 
-      calls = 0
-      query.define_singleton_method(:result_ids) do
-        calls += 1
-        super()
+      fills = 0
+      query.define_singleton_method(:compute_window) do |*args|
+        fills += 1
+        super(*args)
       end
 
       query.current_id = query.prev_id # -> ids[9], cache hit so far
       assert_equal(ids[9], query.current_id)
       query.current_id = query.prev_id # -> ids[8], still within window
       assert_equal(ids[8], query.current_id)
-      assert_equal(1, calls, "still inside the first cached window")
+      assert_equal(1, fills, "still inside the first cached window")
 
       # ids[8] sits at the cached window's left edge (radius 2 from
       # ids[10]) but not the true start -- must refetch, not return nil.
       prev = query.prev_id
       assert_equal(ids[7], prev)
-      assert_equal(2, calls, "walking past a non-true edge refetches")
+      assert_equal(2, fills, "walking past a non-true edge refetches")
 
       query.current_id = ids[0]
       assert_nil(query.prev_id, "the true start has no earlier row")
     end
-  ensure
-    Query::Modules::WindowCache.send(:remove_const, :WINDOW_RADIUS)
-    Query::Modules::WindowCache.const_set(:WINDOW_RADIUS, original_radius)
+  end
+
+  # The per-viewer radius derivation: 2x the viewer's index page size,
+  # clamped to [60, 480] before doubling; no viewer gets the default.
+  def test_next_and_prev_window_radius_derived_from_viewer
+    no_viewer = Query.lookup(:Name, order_by: :id)
+    assert_equal(120, no_viewer.send(:window_radius))
+
+    small = Query.lookup(:Name, order_by: :id)
+    small.viewer = rolf
+    rolf.layout_count = 15
+    assert_equal(120, small.send(:window_radius),
+                 "a page size below 60 clamps up")
+
+    mid = Query.lookup(:Name, order_by: :id)
+    mid.viewer = rolf
+    rolf.layout_count = 100
+    assert_equal(200, mid.send(:window_radius))
+
+    large = Query.lookup(:Name, order_by: :id)
+    large.viewer = rolf
+    rolf.layout_count = 1000
+    assert_equal(960, large.send(:window_radius),
+                 "a page size above 480 clamps down")
   end
 
   def test_next_and_prev_first_and_last_never_use_the_window_cache
@@ -585,8 +605,9 @@ class QueryTest < UnitTestCase
   end
 
   # The cache can legitimately disagree with the live DB until the
-  # next refetch -- that's the documented tradeoff of this design, not
-  # a bug. A stale cache entry gets served as-is; only a fresh
+  # next refetch -- that's the design's snapshot semantics working as
+  # intended: prev/next walk the ordering as the viewer saw it, not
+  # the live ordering. A cached entry gets served as-is; only a fresh
   # `refresh_window` call reflects current data.
   def test_next_and_prev_window_cache_can_serve_stale_data
     with_real_cache do
@@ -708,6 +729,172 @@ class QueryTest < UnitTestCase
                    "mary's lookup elsewhere in the same query should " \
                    "not evict rolf's cached window")
     end
+  end
+
+  # The seek-backed window fill: a plain-column order fills the window
+  # with bounded keyset queries and no result_ids load; an order shape
+  # a keyset predicate can't express (FIND_IN_SET here) falls back to
+  # the full-scan fill.
+  def test_next_and_prev_window_fill_dispatch_by_order_shape
+    simple_query = Query.lookup(:Name, order_by: :id)
+    simple_query.current = names(:fungi)
+    calls = count_result_ids_calls(simple_query) do
+      simple_query.prev_id
+      simple_query.next_id
+    end
+    assert_equal(0, calls,
+                 "Simple column order should fill the window without " \
+                 "loading result_ids")
+
+    fallback_query = Query.lookup(
+      :Name,
+      id_in_set: [names(:fungi).id, names(:agaricus).id, names(:peltigera).id]
+    )
+    fallback_query.current = names(:agaricus)
+    calls = count_result_ids_calls(fallback_query) do
+      fallback_query.prev_id
+      fallback_query.next_id
+    end
+    assert(calls.positive?,
+           "id_in_set order should fall back to loading result_ids")
+  end
+
+  def test_next_and_prev_window_seek_compound_order
+    query = Query.lookup(:Observation, order_by: :name)
+    ids = Observation.order_by(:name).pluck(:id)
+    index = ids.length / 2
+
+    query.current_id = ids[index]
+    assert_equal(ids[index - 1], query.prev_id)
+    assert_equal(ids[index + 1], query.next_id)
+  end
+
+  def test_next_and_prev_window_seek_duplicate_tie
+    obs1 = observations(:agaricus_campestras_obs)
+    obs2 = observations(:agaricus_campestros_obs)
+    assert_equal(obs1.when, obs2.when,
+                 "fixtures must share a `when` to exercise the id tie-break")
+
+    ids = Observation.order_by(:date).pluck(:id)
+    index = ids.index(obs2.id)
+
+    query = Query.lookup(:Observation, order_by: :date)
+    query.current_id = obs2.id
+    assert_equal(ids[index - 1], query.prev_id)
+    assert_equal(ids[index + 1], query.next_id)
+  end
+
+  # An image on multiple observations with differing vote_cache has no
+  # single sort key to seed the keyset predicate from -- the window
+  # fill must fall back to the full-scan fill rather than seed from an
+  # arbitrary join row.
+  def test_next_and_prev_window_seek_ambiguous_join_falls_back
+    image = images(:query_first_image)
+    obs_a = observations(:two_img_obs)
+    obs_b = observations(:vouchered_imged_obs)
+    obs_a.update!(vote_cache: 1.5)
+    obs_b.update!(vote_cache: -1.0)
+
+    query = Query.lookup(:Image, order_by: :confidence)
+    query.current = image
+    cols = query.send(:scope).order_values
+
+    assert_nil(query.send(:current_sort_values, cols),
+               "an image on multiple observations with differing " \
+               "vote_cache should be treated as unseekable")
+    ids = query.send(:result_ids)
+    index = ids.index(image.id)
+    assert_equal(ids[index - 1], query.prev_id)
+    assert_equal(ids[index + 1], query.next_id)
+  end
+
+  # `current_sort_values` (read the current row's own sort columns)
+  # and the two directional window fetches are separate queries -- a
+  # concurrent write to the current row between them could seed the
+  # window from an already-stale value unless the reads share one
+  # transaction/snapshot. Regression test for that guarantee: assert
+  # the read runs inside a transaction opened by `seek_window` itself,
+  # not just whatever the test framework already wraps everything in.
+  def test_next_and_prev_window_seek_wraps_reads_in_a_transaction
+    query = Query.lookup(:Name, order_by: :id)
+    query.current = names(:fungi)
+
+    baseline = ActiveRecord::Base.connection.open_transactions
+    open_during_read = nil
+    query.define_singleton_method(:current_sort_values) do |*args|
+      open_during_read = ActiveRecord::Base.connection.open_transactions
+      super(*args)
+    end
+
+    query.prev_id
+
+    assert_equal(baseline + 1, open_during_read,
+                 "current_sort_values should run inside its own " \
+                 "transaction, not bare autocommit")
+  end
+
+  # MySQL sorts NULL as the smallest possible value regardless of
+  # ASC/DESC -- a plain `col > NULL`/`col < NULL` comparison is always
+  # unknown in SQL, so a naive seek predicate can't cross the boundary
+  # between NULL and non-NULL rows in either direction.
+  def test_next_and_prev_window_seek_null_sort_value_boundary
+    null_image = images(:in_situ_image)
+    others = Image.where.not(id: null_image.id)
+    others.each_with_index { |img, i| img.update!(vote_cache: i + 1.0) }
+    null_image.update!(vote_cache: nil)
+
+    ids = Image.order_by(:image_quality).pluck(:id)
+    prior_id = ids[ids.index(null_image.id) - 1]
+
+    # prev: from NULL, transitioning into non-NULL territory.
+    from_null = Query.lookup(:Image, order_by: :image_quality)
+    from_null.current_id = null_image.id
+    assert_equal(prior_id, from_null.prev_id)
+
+    # next: from non-NULL, transitioning into NULL territory.
+    from_non_null = Query.lookup(:Image, order_by: :image_quality)
+    from_non_null.current_id = prior_id
+    assert_equal(null_image.id, from_non_null.next_id)
+  end
+
+  # Without a viewer there's no cache slot, so prev_id and next_id
+  # each trigger their own window fill -- but the current row's own
+  # sort values shouldn't be fetched twice for the same current_id.
+  def test_next_and_prev_window_seek_memoizes_current_sort_values
+    query = Query.lookup(:Name, order_by: :id)
+    query.current = names(:fungi)
+
+    calls = 0
+    query.define_singleton_method(:fetch_current_sort_values) do |*args|
+      calls += 1
+      super(*args)
+    end
+
+    query.prev_id
+    query.next_id
+
+    assert_equal(1, calls,
+                 "current row's sort values should be fetched once, " \
+                 "not once per direction")
+  end
+
+  # A seekable order with zero matching rows is a legitimate nil
+  # boundary from edge_id's LIMIT-1 query itself -- first_id/last_id
+  # shouldn't fall back to a full result_ids load just because that
+  # nil looks the same as "order shape isn't seekable" (Copilot
+  # review, PR #5115).
+  def test_next_and_prev_window_first_and_last_no_fallback_on_empty_results
+    query = Query.lookup(:Name, order_by: :id,
+                                pattern: "no_name_matches_this_zzzzzz")
+
+    calls = count_result_ids_calls(query) do
+      assert_nil(query.first_id)
+      assert_nil(query.last_id)
+    end
+
+    assert_equal(0, calls,
+                 "empty seekable query should return nil without " \
+                 "falling back to loading result_ids")
   end
 
   ##############################################################################
@@ -959,5 +1146,17 @@ class QueryTest < UnitTestCase
     query = Query.lookup(:User, id_in_set: [rolf.id, 1000, mary.id])
     query.sql
     assert_equal(2, query.results.length)
+  end
+
+  private
+
+  def count_result_ids_calls(query)
+    count = 0
+    query.define_singleton_method(:result_ids) do
+      count += 1
+      super()
+    end
+    yield
+    count
   end
 end

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -504,6 +504,7 @@ class QueryTest < UnitTestCase
   def test_next_and_prev_window_cache_hit_skips_result_ids
     with_real_cache do
       query = Query.lookup_and_save(:Name, order_by: :id)
+      query.viewer = rolf
       ids = query.send(:result_ids)
       query.current_id = ids[10]
       query.prev_id # populates the cache
@@ -531,6 +532,7 @@ class QueryTest < UnitTestCase
 
     with_real_cache do
       query = Query.lookup_and_save(:Name, order_by: :id)
+      query.viewer = rolf
       ids = query.send(:result_ids)
       query.current_id = ids[10]
 
@@ -563,6 +565,7 @@ class QueryTest < UnitTestCase
   def test_next_and_prev_first_and_last_never_use_the_window_cache
     with_real_cache do
       query = Query.lookup_and_save(:Image, order_by: :name)
+      query.viewer = rolf
       ids = Image.order_by(:name).pluck(:id)
 
       calls = 0
@@ -588,6 +591,7 @@ class QueryTest < UnitTestCase
   def test_next_and_prev_window_cache_can_serve_stale_data
     with_real_cache do
       query = Query.lookup_and_save(:Name, order_by: :id)
+      query.viewer = rolf
       ids = query.send(:result_ids)
       query.current_id = ids[10]
       query.prev_id # populates the cache with the real ids[9] at slot 9
@@ -618,6 +622,7 @@ class QueryTest < UnitTestCase
   def test_next_and_prev_window_cache_bypasses_need_letters
     with_real_cache do
       query = Query.lookup_and_save(:Name, order_by: :id)
+      query.viewer = rolf
       query.need_letters = true
       ids = query.send(:result_ids)
       query.current_id = ids[10]
@@ -662,12 +667,46 @@ class QueryTest < UnitTestCase
   def test_next_and_prev_window_cache_ignores_malformed_cache_entry
     with_real_cache do
       query = Query.lookup_and_save(:Name, order_by: :id)
+      query.viewer = rolf
       ids = query.send(:result_ids)
       query.current_id = ids[10]
 
       Rails.cache.write(query.send(:window_cache_key), "not a window hash")
 
       assert_equal(ids[9], query.prev_id)
+    end
+  end
+
+  # Two viewers browsing the same logical query (same QueryRecord) get
+  # separate cache slots -- one shouldn't evict the other's window.
+  # Regression test: window_cache_key used to be scoped only by
+  # QueryRecord#id, so any two viewers of the same query shared one
+  # slot and continually clobbered each other's cached window.
+  def test_next_and_prev_window_cache_keyed_per_viewer
+    with_real_cache do
+      rolfs_query = Query.lookup_and_save(:Name, order_by: :id)
+      rolfs_query.viewer = rolf
+      ids = rolfs_query.send(:result_ids)
+      rolfs_query.current_id = ids[10]
+      rolfs_query.prev_id # populates rolf's own cache slot
+
+      marys_query = Query.lookup_and_save(:Name, order_by: :id)
+      marys_query.viewer = mary
+      assert_not_equal(rolfs_query.send(:window_cache_key),
+                       marys_query.send(:window_cache_key))
+
+      marys_query.current_id = ids[500]
+      marys_query.prev_id # a different position -- must not touch rolf's slot
+
+      calls = 0
+      rolfs_query.define_singleton_method(:result_ids) do
+        calls += 1
+        super()
+      end
+      assert_equal(ids[9], rolfs_query.prev_id)
+      assert_equal(0, calls,
+                   "mary's lookup elsewhere in the same query should " \
+                   "not evict rolf's cached window")
     end
   end
 

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -481,6 +481,132 @@ class QueryTest < UnitTestCase
     assert_equal(@names[2].id, query.current_id)
   end
 
+  # Test env's cache_store is :null_store -- every fetch/read/write is a
+  # no-op there, so tests exercising real caching swap in a MemoryStore.
+  # Established pattern -- see
+  # test/controllers/observations/inat_resyncs_controller_test.rb.
+  def with_real_cache(&block)
+    Rails.stub(:cache, ActiveSupport::Cache::MemoryStore.new, &block)
+  end
+
+  def test_next_and_prev_window_cache_miss
+    with_real_cache do
+      query = Query.lookup_and_save(:Name, order_by: :id)
+      ids = query.send(:result_ids)
+      query.current_id = ids[10]
+
+      assert_equal(ids[9], query.prev_id)
+      query.current_id = ids[10]
+      assert_equal(ids[11], query.next_id)
+    end
+  end
+
+  def test_next_and_prev_window_cache_hit_skips_result_ids
+    with_real_cache do
+      query = Query.lookup_and_save(:Name, order_by: :id)
+      ids = query.send(:result_ids)
+      query.current_id = ids[10]
+      query.prev_id # populates the cache
+
+      calls = 0
+      query.define_singleton_method(:result_ids) do
+        calls += 1
+        super()
+      end
+      assert_equal(ids[11], query.next_id)
+      assert_equal(0, calls,
+                   "a nearby lookup already covered by the cached " \
+                   "window should not recompute result_ids")
+    end
+  end
+
+  # A cached window's edges aren't always the true edges of the full
+  # result set -- walking past a cached-but-not-true edge must refetch
+  # (recentering the window) rather than incorrectly reporting "no
+  # more." Walking past the true edge must return nil without looping.
+  def test_next_and_prev_window_edge_refetch_and_true_boundary
+    original_radius = Query::Modules::WindowCache::WINDOW_RADIUS
+    Query::Modules::WindowCache.send(:remove_const, :WINDOW_RADIUS)
+    Query::Modules::WindowCache.const_set(:WINDOW_RADIUS, 2)
+
+    with_real_cache do
+      query = Query.lookup_and_save(:Name, order_by: :id)
+      ids = query.send(:result_ids)
+      query.current_id = ids[10]
+
+      calls = 0
+      query.define_singleton_method(:result_ids) do
+        calls += 1
+        super()
+      end
+
+      query.current_id = query.prev_id # -> ids[9], cache hit so far
+      assert_equal(ids[9], query.current_id)
+      query.current_id = query.prev_id # -> ids[8], still within window
+      assert_equal(ids[8], query.current_id)
+      assert_equal(1, calls, "still inside the first cached window")
+
+      # ids[8] sits at the cached window's left edge (radius 2 from
+      # ids[10]) but not the true start -- must refetch, not return nil.
+      prev = query.prev_id
+      assert_equal(ids[7], prev)
+      assert_equal(2, calls, "walking past a non-true edge refetches")
+
+      query.current_id = ids[0]
+      assert_nil(query.prev_id, "the true start has no earlier row")
+    end
+  ensure
+    Query::Modules::WindowCache.send(:remove_const, :WINDOW_RADIUS)
+    Query::Modules::WindowCache.const_set(:WINDOW_RADIUS, original_radius)
+  end
+
+  def test_next_and_prev_first_and_last_never_use_the_window_cache
+    with_real_cache do
+      query = Query.lookup_and_save(:Image, order_by: :name)
+      ids = Image.order_by(:name).pluck(:id)
+
+      calls = 0
+      query.define_singleton_method(:result_ids) do
+        calls += 1
+        super()
+      end
+
+      assert_equal(ids.first, query.first_id)
+      assert_equal(ids.last, query.last_id)
+      assert_equal(0, calls,
+                   "first_id/last_id use a direct LIMIT-1 query, " \
+                   "not result_ids")
+      assert_nil(Rails.cache.read(query.send(:window_cache_key)),
+                 "first_id/last_id should never populate the window cache")
+    end
+  end
+
+  # The cache can legitimately disagree with the live DB until the
+  # next refetch -- that's the documented tradeoff of this design, not
+  # a bug. A stale cache entry gets served as-is; only a fresh
+  # `refresh_window` call reflects current data.
+  def test_next_and_prev_window_cache_can_serve_stale_data
+    with_real_cache do
+      query = Query.lookup_and_save(:Name, order_by: :id)
+      ids = query.send(:result_ids)
+      query.current_id = ids[10]
+      query.prev_id # populates the cache with the real ids[9] at slot 9
+
+      key = query.send(:window_cache_key)
+      cached = Rails.cache.read(key)
+      tampered_ids = cached[:ids].dup
+      tampered_ids[9] = 999_999_999
+      Rails.cache.write(key, cached.merge(ids: tampered_ids))
+
+      assert_equal(999_999_999, query.prev_id,
+                   "a stale cache entry is served as-is until refreshed")
+
+      fresh = query.send(:refresh_window)
+      assert_equal(ids[9], fresh[0][fresh[1] - 1],
+                   "a fresh recompute reflects live data again")
+    end
+  end
+
   ##############################################################################
   #
   #  :section: Test Subqueries

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -602,8 +602,72 @@ class QueryTest < UnitTestCase
                    "a stale cache entry is served as-is until refreshed")
 
       fresh = query.send(:refresh_window)
-      assert_equal(ids[9], fresh[0][fresh[1] - 1],
+      assert_equal(ids[9], fresh[:ids][fresh[:offset] - 1],
                    "a fresh recompute reflects live data again")
+    end
+  end
+
+  # need_letters reorders result_ids at paginate time in a way this
+  # module doesn't account for -- prev/next/first/last must bypass the
+  # window cache entirely for these queries, the same way
+  # Query::Modules::Seek#seek_or bails on them. Regression test: the
+  # window cache used to have no need_letters guard at all, so a
+  # need_letters query's ids -- possibly reordered by letter -- could
+  # get cached under a key shared with non-need_letters instances of
+  # the same underlying query.
+  def test_next_and_prev_window_cache_bypasses_need_letters
+    with_real_cache do
+      query = Query.lookup_and_save(:Name, order_by: :id)
+      query.need_letters = true
+      ids = query.send(:result_ids)
+      query.current_id = ids[10]
+
+      assert_equal(ids[9], query.prev_id)
+      query.current_id = ids[10]
+      assert_equal(ids[11], query.next_id)
+      assert_equal(ids.first, query.first_id)
+      assert_equal(ids.last, query.last_id)
+
+      assert_nil(Rails.cache.read(query.send(:window_cache_key)),
+                 "need_letters queries should never populate the " \
+                 "window cache")
+    end
+  end
+
+  # A caller that already checked result_ids.length (e.g. to decide
+  # whether a search matched exactly one thing) shouldn't pay for a
+  # second query when it then asks for first_id/last_id.
+  def test_next_and_prev_window_cache_first_and_last_reuse_memoized_result_ids
+    with_real_cache do
+      query = Query.lookup(:Name, order_by: :id)
+      ids = query.result_ids # memoizes @result_ids, as single_result? does
+
+      calls = 0
+      query.define_singleton_method(:scope) do
+        calls += 1
+        super()
+      end
+
+      assert_equal(ids.first, query.first_id)
+      assert_equal(ids.last, query.last_id)
+      assert_equal(0, calls,
+                   "first_id/last_id should reuse already-memoized " \
+                   "result_ids instead of querying again")
+    end
+  end
+
+  # A persistent cache (Solid Cache) can hand back an entry from a
+  # pre-deploy version of this code whose shape no longer matches --
+  # must be treated as a miss, not raise.
+  def test_next_and_prev_window_cache_ignores_malformed_cache_entry
+    with_real_cache do
+      query = Query.lookup_and_save(:Name, order_by: :id)
+      ids = query.send(:result_ids)
+      query.current_id = ids[10]
+
+      Rails.cache.write(query.send(:window_cache_key), "not a window hash")
+
+      assert_equal(ids[9], query.prev_id)
     end
   end
 


### PR DESCRIPTION
## Summary

Closes #5101.

Direction per [the decision comment](https://github.com/MushroomObserver/mushroom-observer/pull/5118#issuecomment-5358304549): this PR is the baseline, now with #5115's bounded-query machinery folded in as the window-fill strategy, so the whole thing lands together. #5115 stays unmerged; its `Seek` predicate machinery carries over here unchanged.

`Query::Modules::WindowCache` caches a window of ids around the current position — `window_radius` ids on each side, derived from the viewer's index page size — keyed by `QueryRecord#id` and `Query#viewer` via `Rails.cache`.

- **Cache hit**: `prev_id`/`next_id` are an array lookup against the cached window. No DB query.
- **Cache miss**: the window is filled by two bounded keyset queries (`window_radius` rows per direction, ~4ms with #5117's index for the unfiltered `/observations` scenario) when the query's `ORDER BY` is a plain list of columns, falling back to slicing today's full `result_ids` computation for order shapes a keyset predicate can't express (aggregates, `CASE`, `FIND_IN_SET`) or when the current row's sort key is ambiguous across a to-many join. Per the traffic measurement in the decision comment, the seekable path covers >99% of window fills.
- **`first_id`/`last_id`** go through a direct `LIMIT 1` query instead of the window cache — already cheap and order-shape-agnostic, no caching needed.
- **Boundary detection**: each window tracks whether its edges are the true edges of the full result set (`at_start`/`at_end`) — on the seek path, a directional fetch coming up short of the radius; on the fallback path, the slice touching the array's ends. Walking off a non-true edge triggers a refetch that recenters the window; walking off a true edge returns `nil`, same as today.

## Snapshot semantics is the fix, not a tradeoff

Today's pager recomputes `result_ids` fresh on every click, so a concurrent edit that moves the current row within the ordering silently teleports the viewer — clicking next from a row another user's vote just re-sorted to the front lands back at the start of the list. The cached window is what makes prev/next walk the ordering as the viewer saw it on the index page. Staleness within a window is that snapshot behavior working as intended, not a cost being tolerated; liveness re-enters only at the seams (recentering on walking off a window edge, and `WINDOW_TTL` expiry, 30 minutes). `test_next_and_prev_window_cache_can_serve_stale_data` demonstrates the mechanism directly. No write-triggered invalidation, deliberately — precise invalidation would need to track which cached windows any observation write could affect, across every user and filter combination.

One exception to serve-as-cached: a row **destroyed** after its id was cached is not served as a neighbor — its show page no longer exists, so the arrow would bounce the user to the index and lose their place in the walk. `windowed_id` checks the in-window candidate still exists (one primary-key query per lookup) and, when it doesn't, refetches the window from live data — which skips the dead row, serves the surviving neighbor, and heals the cached entry in the same step. Rows that still exist but no longer match the query's filters are served as cached, per the snapshot semantics above; only physically-gone rows get skipped. `test_next_and_prev_window_skips_destroyed_neighbor` covers it.

## The seek-backed fill (from #5115)

`Query::Modules::Seek` (new file, ported from the `nimmo-5101-bounded-query-seek` branch) provides the keyset predicate machinery; the single-step dispatcher it had in #5115 is dropped, since `WindowCache` replaces it:

- `seekable_cols` — allow-list on `scope.order_values`: every node must be a plain column `Ascending`/`Descending`, memoized.
- `current_sort_values` — the current row's own sort values via `LIMIT 2`: two rows back means the id is ambiguous across a to-many join (e.g. `Image.order_by(:confidence)`), and the fill falls back rather than seeding from an arbitrary row. Memoized by `current_id`.
- `build_seek_predicate`/`seek_leg`/`seek_comparison` — the standard multi-column seek predicate, including the NULL-boundary branches (MySQL sorts `NULL` smallest in both directions; `col > NULL` and `col < v` both need explicit `IS NULL`/`IS NOT NULL` handling at the NULL/non-NULL transition).
- The current row's read and the two directional fetches share one `model.transaction` (REPEATABLE READ snapshot), so a concurrent write to the current row's sort columns can't seed the window from a value that's stale by the later queries.

`compute_window`'s return shape (`ids:`, `offset:`, `at_start:`, `at_end:`) is unchanged — everything downstream (caching, in-window lookup, boundary detection) is identical to the pre-v2 version of this PR.

For queries with no viewer there's no cache slot, but fills still go through the bounded seek path — the no-cache path gets the #5115-style bounded lookup instead of a full scan.

## `window_radius`: derived from the viewer

Per the decision comment, the radius is a per-viewer derivation rather than a global constant: `2 * clamp(viewer.layout_count || 60, 60, 480)`. Radius >= page size - 1 guarantees the entire index page the viewer drilled in from is inside one window (worst case: they clicked its first item); 2x gives a full page of margin each direction; the clamp bounds the cache row at ~2-15KB. This works against today's `layout_count` values as-is and converges onto the planned page-size tier model without further change — cache keys are per-viewer and the window payload is self-describing, so a tier change just fills fresh windows at the new radius.

## Timing

Against a production-sized dev DB (620,458-row unfiltered `/observations`, `rss_log` order, #5117's index in place), confirmed with a `MemoryStore` swapped in for `Rails.cache`:

| | Time |
|---|---|
| Cache hit | ~0.04ms |
| Cache miss, seekable order (the >99% case) | ~4ms — two indexed `LIMIT window_radius` queries |
| Cache miss, fallback shapes (aggregates, `CASE`, `FIND_IN_SET`, ambiguous join) | ~430ms — today's full-scan cost, at measured frequencies a handful of hits per year |

Window parity verified directly: the seek-filled window matches the equivalent `result_ids` slice element-for-element at the same position.

A browser-session log comparison (same click sequence — click into the 4th result, next ×2, prev ×4 — across the Activity, Date, and Date Posted sorts, branch vs `main`) confirmed the mechanism end-to-end: on `main`, all 21 show renders ran the full `Observation Ids` pluck at ~320–390ms each; on the branch, that query is absent and show renders dropped from ~650ms to ~260ms typical.

That comparison also caught the Date and Date Posted sorts' cold fills running at full-scan speed (~450ms) — `when` and `created_at` had no leading indexes. This PR now includes `(when, id)` and `(created_at, id)` indexes on observations (same follow-up shape as #5117's `log_updated_at` index was for `:rss_log`), after which all three observation-index sorts fill in 2–6ms against the production DB copy.

## Test plan

- [x] `bin/rails test test/classes/query_test.rb` — the nine existing window-cache tests (edge-refetch test now counts `compute_window` calls, since a seekable order's fill no longer touches `result_ids`, and stubs `window_radius` instead of overriding the removed constant), plus a per-viewer radius derivation test and seven ported from #5115's suite, adapted to the windowed world: fill-dispatch by order shape, compound order, duplicate tie, ambiguous-join fallback, transaction wrap, NULL-boundary crossing in both directions, `current_sort_values` memoization across `prev_id`/`next_id`, and empty-result `first_id`/`last_id` staying off `result_ids`
- [x] `bin/rails test test/views/layouts/header/show_prev_next_nav_test.rb`
- [x] `bin/rails test test/controllers/observations_controller_destroy_test.rb`
- [x] `bundle exec rubocop` clean on all touched/new files
- [x] Timing + window-parity check above via `bin/rails runner` against the production DB copy
- [x] Browser click-through of prev/next across the Activity, Date, and Date Posted sorts, branch vs `main`, with `log/development.log` analysis (the comparison described above)


