### PR TITLE
Reduce observations "Sort by" options for unfiltered index

### DIFF
--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -48,8 +48,18 @@ class ObservationsController
 
     private
 
+    # A bookmarked/permalinked unfiltered index can still carry an
+    # `order_by` that isn't in the unfiltered allowlist (e.g.
+    # `q[order_by]=name` with no other params) -- treat that as
+    # filtered for the dropdown too, or `Sorter#toggle_title` can't
+    # find a label for the current sort and the toggle goes blank.
     def unfiltered_index_for_sort?
-      @query.params.except(:order_by).blank?
+      @query.params.except(:order_by).blank? && current_order_sort_safe?
+    end
+
+    def current_order_sort_safe?
+      order = @query.params[:order_by].to_s.sub(/^reverse_/, "")
+      order.blank? || unfiltered_index_sort_options.map(&:first).include?(order)
     end
 
     def unfiltered_index_sort_options

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -34,7 +34,33 @@ class ObservationsController
 
     # Sort options for the index page. Read by `add_sorter` in the
     # view. Each key must resolve to `Observation.order_by_<key>`.
+    # An unfiltered index (browsing the whole table) only offers
+    # plain-column sorts with no join/aggregate -- name/user/
+    # confidence/thumbnail_quality/num_views all cost a join or
+    # aggregate over the full table otherwise.
     def index_sort_options
+      if unfiltered_index_for_sort?
+        unfiltered_index_sort_options
+      else
+        filtered_index_sort_options
+      end
+    end
+
+    private
+
+    def unfiltered_index_for_sort?
+      @query.params.except(:order_by).blank?
+    end
+
+    def unfiltered_index_sort_options
+      [
+        ["rss_log",    :sort_by_activity.l],
+        ["date",       :sort_by_date.l],
+        ["created_at", :sort_by_posted.l]
+      ].freeze
+    end
+
+    def filtered_index_sort_options
       [
         ["rss_log",           :sort_by_activity.l],
         ["date",              :sort_by_date.l],
@@ -46,8 +72,6 @@ class ObservationsController
         ["num_views",         :sort_by_num_views.l]
       ].freeze
     end
-
-    private
 
     # Default on home is :rss_log (:log_updated_at), not :date.
     # Maybe other filters should explicitly specify :date?

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -25,6 +25,33 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_response(:redirect)
   end
 
+  # Unfiltered index (browsing the whole table) only offers sorts with
+  # no join/aggregate over that many rows.
+  def test_index_unfiltered_offers_only_column_sorts
+    login
+    get(:index)
+
+    assert_select("a.observations_by_rss_log_link", true)
+    assert_select("a.observations_by_date_link", true)
+    assert_select("a.observations_by_created_at_link", true)
+    assert_select("a.observations_by_name_link", false)
+    assert_select("a.observations_by_user_link", false)
+    assert_select("a.observations_by_confidence_link", false)
+    assert_select("a.observations_by_thumbnail_quality_link", false)
+    assert_select("a.observations_by_num_views_link", false)
+  end
+
+  def test_index_filtered_offers_all_sorts
+    login(rolf.login)
+    get(:index, params: { by_user: rolf.id })
+
+    assert_select("a.observations_by_name_link", true)
+    assert_select("a.observations_by_user_link", true)
+    assert_select("a.observations_by_confidence_link", true)
+    assert_select("a.observations_by_thumbnail_quality_link", true)
+    assert_select("a.observations_by_num_views_link", true)
+  end
+
   # Regression for #4492: the top-nav `search-type` Stimulus controller
   # reads its help/form type lists as Array values, which Stimulus parses
   # as JSON. Phlexifying top_nav emitted the arrays space-joined ("a b")

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -52,6 +52,22 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_select("a.observations_by_num_views_link", true)
   end
 
+  # A bookmarked/permalinked unfiltered index carrying an order_by
+  # that's not in the unfiltered allowlist (no other filter params)
+  # must still offer the full sort list -- otherwise the current sort
+  # has no matching option and the dropdown's toggle label goes blank.
+  def test_index_unfiltered_with_unsafe_order_offers_all_sorts
+    login
+    get(:index, params: { q: { model: "Observation", order_by: "name" } })
+
+    assert_select("a.observations_by_name_link", true)
+    assert_select("a.observations_by_user_link", true)
+    assert_select("a.observations_by_confidence_link", true)
+    assert_select("a.observations_by_thumbnail_quality_link", true)
+    assert_select("a.observations_by_num_views_link", true)
+    assert_select("#sort_nav_toggle", text: :sort_by_name.l)
+  end
+
   # Regression for #4492: the top-nav `search-type` Stimulus controller
   # reads its help/form type lists as Array values, which Stimulus parses
   # as JSON. Phlexifying top_nav emitted the arrays space-joined ("a b")


### PR DESCRIPTION
## Summary

Split off from #5115 — this piece is independent of the prev/next pager work and can be reviewed and merged on its own.

Filters the observations index "Sort by" dropdown: an unfiltered index (no substantive filter params) only offers `rss_log`/`date`/`created_at`. 

`user`/`name`/`confidence`/`thumbnail_quality`/`num_views` all cost a join or aggregate over the whole table when there's no filter narrowing the row count first — the same "unbounded scan on the unfiltered index" concern #5101/#5115 are about, just applied to the sort dropdown rather than the prev/next pager.

`unfiltered_index_for_sort?` reuses the exact predicate already established in the same file's `index_display_opts` (`query.params.except(:order_by).blank?`), for the same "is this index substantively filtered" check used there for letter-pagination gating.

## Test plan

- [x] `bin/rails test test/controllers/observations_controller_index_test.rb` — 2 new tests: unfiltered index only renders the 3 column-sort links, filtered index (`by_user`) renders all of them
- [x] `bundle exec rubocop` clean
