### PR TITLE
Fix `.inline-icon-link` baseline and `.input-group-btn` icon-button height

### DIFF
--- a/app/assets/stylesheets/mo/_icons.scss
+++ b/app/assets/stylesheets/mo/_icons.scss
@@ -250,6 +250,13 @@ a:not(.btn):not(.inline-icon-link) > .mo-icon,
   align-items: center;
 }
 
+// Flex sizes the button to its icon + padding alone, which falls short
+// of its sibling .form-control's line-height-driven height inside the
+// same table-cell row -- .form-control is sized off this same variable.
+.input-group-btn .btn:has(.mo-icon) {
+  min-height: $input-height-base;
+}
+
 .spinner-right {
   line-height: 1.1 !important;
   animation: spin-r 1s infinite linear;

--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -129,10 +129,6 @@
 // baseline (the default) leaves room below it for a descender it
 // doesn't have, which stretches the surrounding line's height and
 // throws off spacing vs. sibling lines with no icon-link on them.
-// The icon glyph and any visible text (e.g. an "Add" label) get the
-// same treatment so they line up with EACH OTHER too, instead of
-// each defaulting to its own baseline (which put visible text below
-// the icon).
 //
 // .mo-icon's `top: 3px` (see _icons.scss) is a relative offset
 // tuned for icons in their usual (untethered) contexts; inside
@@ -158,7 +154,6 @@
     top: 0;
     width: 1em;
     height: 1em;
-    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
## Summary

Two small icon-CSS fixes, split out from `nimmo-name-info-panel-turbo-lazy-load` (#5104) since they're unrelated to that PR's Turbo lazy-load work.

- `.inline-icon-link .mo-icon` no longer sets `vertical-align: middle` — it was pulling the icon below its sibling text's baseline instead of centering against it.
- `.input-group-btn .btn:has(.mo-icon)` (the pagination "goto page" button) gets `min-height: $input-height-base`. The flex centering rule added for `.mo-icon` buttons (`.btn:has(.mo-icon) { display: inline-flex; align-items: center; }`) sizes the button to its icon + padding alone, which falls short of its sibling `.form-control`'s line-height-driven height inside the same table-cell row — `.form-control` is sized off the same `$input-height-base` variable, so this guarantees the two match. Scoped to `.input-group-btn` specifically so `.theater-btn` and the pagination prev/next `.btn-link`s (which also match `.btn:has(.mo-icon)`, but aren't sitting next to a `.form-control`) are unaffected.

## Test plan

- [x] Browser check: confirmed both fixes visually in dev, including that `.theater-btn` is unchanged after scoping the height fix to `.input-group-btn`.
