### PR TITLE
Show the "reopen announcements" banner icon on mobile too

### DIFF
--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -286,7 +286,7 @@ class Views::Layouts::TopNav < Views::Base
 
     Button(
       variant: :success, size: :sm,
-      class: "mr-0 ml-0 ml-sm-2 top_nav_button top_nav_icon_button d-none",
+      class: "mr-0 ml-2 top_nav_button top_nav_icon_button d-none",
       data: { banner_target: "showButton" }
     ) do
       Icon(type: :interests, title: :banner_show_tooltip.t,

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -277,9 +277,7 @@ class Views::Layouts::TopNav < Views::Base
     )
   end
 
-  # Toggles the dismissed site banner back open. Tablet/desktop only
-  # (hidden-xs) -- the mobile nav is already tight on space, and the
-  # banner itself is reachable by scrolling. Starts `d-none`; the
+  # Toggles the dismissed site banner back open. Starts `d-none`; the
   # `banner` Stimulus controller (see `Views::Layouts::App::Banners`
   # and `Views::Layouts::Application#main_container_data`) flips it
   # to `d-block` only when the banner is currently dismissed.
@@ -288,8 +286,7 @@ class Views::Layouts::TopNav < Views::Base
 
     Button(
       variant: :success, size: :sm,
-      class: "mr-0 ml-0 ml-sm-2 top_nav_button top_nav_icon_button " \
-             "d-none hidden-xs",
+      class: "mr-0 ml-0 ml-sm-2 top_nav_button top_nav_icon_button d-none",
       data: { banner_target: "showButton" }
     ) do
       Icon(type: :interests, title: :banner_show_tooltip.t,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_17_193736) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_09_175755) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -639,12 +639,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_17_193736) do
     t.index ["collector_user_id"], name: "index_observations_on_collector_user_id"
     t.index ["inat_import_id"], name: "index_observations_on_inat_import_id"
     t.index ["location_id"], name: "index_observations_on_location_id"
-    t.index ["log_updated_at", "id"], name: "index_observations_on_log_updated_at_and_id"
     t.index ["name_id"], name: "index_observations_on_name_id"
     t.index ["needs_naming"], name: "needs_naming_index"
     t.index ["occurrence_id"], name: "index_observations_on_occurrence_id"
     t.index ["reflected_at"], name: "index_observations_on_reflected_at"
-    t.index ["user_id", "created_at"], name: "index_observations_on_user_id_and_created_at"
   end
 
   create_table "occurrences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_09_175755) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_17_193736) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -639,10 +639,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_09_175755) do
     t.index ["collector_user_id"], name: "index_observations_on_collector_user_id"
     t.index ["inat_import_id"], name: "index_observations_on_inat_import_id"
     t.index ["location_id"], name: "index_observations_on_location_id"
+    t.index ["log_updated_at", "id"], name: "index_observations_on_log_updated_at_and_id"
     t.index ["name_id"], name: "index_observations_on_name_id"
     t.index ["needs_naming"], name: "needs_naming_index"
     t.index ["occurrence_id"], name: "index_observations_on_occurrence_id"
     t.index ["reflected_at"], name: "index_observations_on_reflected_at"
+    t.index ["user_id", "created_at"], name: "index_observations_on_user_id_and_created_at"
   end
 
   create_table "occurrences", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/views/layouts/top_nav_test.rb
+++ b/test/views/layouts/top_nav_test.rb
@@ -163,7 +163,7 @@ class Views::Layouts::TopNavTest < ComponentTestCase
     html = render(top_nav(user: @user, banner: banners(:one)))
 
     assert_html(html,
-                "button.top_nav_button.top_nav_icon_button.hidden-xs" \
+                "button.top_nav_button.top_nav_icon_button" \
                 "[data-banner-target='showButton'] " \
                 "svg.mo-icon-interests[aria-label='#{:banner_show_tooltip.t}']")
   end


### PR DESCRIPTION
## Summary

Fixes #5116.

`Views::Layouts::TopNav#render_show_banner_button` (the "reopen announcements" icon, shown when a site banner has been dismissed) had `hidden-xs` alongside its `d-none` — restricting it to tablet/desktop even after the Stimulus `banner` controller un-hides it. The mobile top nav has room for it now, so the qualifier is dropped; the button still starts `d-none` and only the JS controller's dismiss/show toggle controls visibility, unchanged.

## Test plan

- [x] `bin/rails test test/views/layouts/top_nav_test.rb`
- [x] `bundle exec rubocop app/views/layouts/top_nav.rb test/views/layouts/top_nav_test.rb`
