### PR TITLE
Fix `size:` being silently ignored on `Button(type: :modal, ...)`

### DIFF
--- a/app/components/link/modal.rb
+++ b/app/components/link/modal.rb
@@ -14,16 +14,19 @@ class Components::Link::Modal < Components::Link
   prop :icon, _Nilable(_Union(*Components::Button::ICONS)), default: nil
   prop :icon_class, _Nilable(String), default: nil
   prop :label, _Nilable(_Boolean), default: nil
+  prop :size, _Nilable(_Union(*Components::Button::SIZES)), default: nil
   prop :attributes, _Hash(Symbol, _Any?), :**
 
   def initialize(modal_id:, name:, target:, **opts)
     icon       = opts.delete(:icon)
     icon_class = opts.delete(:icon_class)
     label      = opts.delete(:label)
+    size       = opts.delete(:size)
     button     = opts.delete(:button)
     validate_no_btn_classes!(opts[:class])
     super(modal_id: modal_id, name: name, path: target, icon: icon,
-          icon_class: icon_class, label: label, button: button, **opts)
+          icon_class: icon_class, label: label, size: size, button: button,
+          **opts)
   end
 
   def view_template
@@ -50,7 +53,7 @@ class Components::Link::Modal < Components::Link
   end
 
   def merged_class
-    class_names(btn_styling, @attributes[:class])
+    class_names(btn_styling, size_class(@size), @attributes[:class])
   end
 
   def modal_data

--- a/test/components/link/modal_test.rb
+++ b/test/components/link/modal_test.rb
@@ -50,6 +50,12 @@ class ModalLinkTest < ComponentTestCase
     assert_html(html, "a.extra-class[href='/edit']")
   end
 
+  def test_size_kwarg_adds_btn_size_class
+    html = render_modal(button: :outline, size: :lg)
+
+    assert_html(html, "a.btn.btn-lg[href='/edit']")
+  end
+
   private
 
   def render_modal(**)


### PR DESCRIPTION
## Summary

Found while looking at the project show page's `#project_join_trust_edit` buttons: `size: :lg` was already being passed to the trust-settings and add-observation buttons, but had no effect — both rendered at default size.

Root cause: `Components::Link::Modal` (what `Button(type: :modal, ...)` renders through) never declared a `size` prop and never called `size_class`. A `size:` kwarg threaded through `Button::ModalToggle#initialize`'s `**` splat into `Link::Modal#initialize`'s own `**opts`, and from there straight into the catch-all `attributes` prop — never consumed, never added to the class list. `Link::Get` (the icon-link variant) already had working `size:` support; `Link::Modal` just never got the same treatment.

Fix: added `prop :size` to `Link::Modal`, extract it in `initialize` the same way `icon`/`label`/`button` already are, and call `size_class(@size)` in `merged_class`.

Confirmed two live call sites were already passing `size:` expecting it to work, silently broken until now:
- `Projects::Show#render_trust_settings_button` / `#render_add_obs_button` (`size: :lg`) — the bug this PR was found while investigating.
- `Observations::Show::Namings::FooterButtons#render_propose_button` (`size: :sm`) — the "Propose New Name" button.

No caller-side changes needed — the fix is entirely in `Link::Modal`, so these existing `size:` kwargs just start working.

## Test plan

- [x] `bin/rails test test/components/link/modal_test.rb` — new `test_size_kwarg_adds_btn_size_class`, verified it fails without the fix (temporarily reverted locally, confirmed the test catches it, restored)
- [x] `bundle exec rubocop app/components/link/modal.rb test/components/link/modal_test.rb`
