### PR TITLE
Show importable cap

### DIFF
--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -22,6 +22,7 @@ class Inat
     def import_page(page)
       page["results"].each do |result|
         return false if inat_import.reload.canceled?
+        return false if inat_import.reached_import_cap?
 
         import_one_result(JSON.generate(result))
       end

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -156,6 +156,12 @@ class InatImport < ApplicationRecord
     imported_count.to_i >= MAX_IMPORTABLE
   end
 
+  # Observations beyond MAX_IMPORTABLE that a single run of this size
+  # won't import. 0 when count is at or under the cap.
+  def self.excess_over_cap(count)
+    [count.to_i - MAX_IMPORTABLE, 0].max
+  end
+
   def ignored_total_count
     ignored_not_importable_count +
       ignored_date_missing_count +

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -156,6 +156,12 @@ class InatImport < ApplicationRecord
     imported_count.to_i >= MAX_IMPORTABLE
   end
 
+  # This run will never import more than MAX_IMPORTABLE, regardless of how
+  # many observations are actually available.
+  def capped_total_importables
+    [total_importables.to_i, MAX_IMPORTABLE].min
+  end
+
   # Observations beyond MAX_IMPORTABLE that a single run of this size
   # won't import. 0 when count is at or under the cap.
   def self.excess_over_cap(count)

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -202,7 +202,7 @@ class InatImport < ApplicationRecord
   # If user has no import history, use system-wide average import time.
   # If no system-wide history, use BASE_AVG_IMPORT_SECONDS.
   def total_expected_time
-    total_importables.to_i * initial_avg_import_seconds
+    capped_total_importables * initial_avg_import_seconds
   end
 
   def initial_avg_import_seconds
@@ -234,7 +234,7 @@ class InatImport < ApplicationRecord
 
   def estimated_remaining_time
     return 0 if Done?
-    return nil unless total_importables.to_i.positive? && started_at
+    return nil unless capped_total_importables.positive? && started_at
     return total_expected_time if imported_count.to_i.zero?
 
     [extrapolated_remaining_time, 0].max
@@ -242,8 +242,10 @@ class InatImport < ApplicationRecord
 
   # Observed rate (elapsed per imported obs) times obs still to import, so
   # the estimate tracks real progress instead of a fixed up-front guess.
+  # Uses the capped total, not the raw estimate -- this run will never
+  # import more than MAX_IMPORTABLE regardless of how many are available.
   def extrapolated_remaining_time
-    remaining = total_importables.to_i - imported_count.to_i
+    remaining = capped_total_importables - imported_count.to_i
     (remaining * elapsed_time.to_f / imported_count).round
   end
 

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -51,6 +51,7 @@ module Views::Controllers::InatImports
           end
           render_ignored_section
           count_expected_line
+          render_over_cap_line
           render_nothing_to_import_notice
           br
           unlicensed_obs_line unless import_others?
@@ -230,7 +231,7 @@ module Views::Controllers::InatImports
       plain(": ")
       span(id: "expected_count") do
         url = expected_obs_url
-        count = (@estimate_with_date || @expected).to_s
+        count = capped_expected_count.to_s
         if url
           render(Components::Link::External.new(content: count, path: url))
         else
@@ -240,6 +241,18 @@ module Views::Controllers::InatImports
     end
 
     def expected_obs_url = @urls.expected_obs_url
+
+    def expected_count = (@estimate_with_date || @expected).to_i
+
+    def capped_expected_count
+      [expected_count, InatImport::MAX_IMPORTABLE].min
+    end
+
+    def over_cap_count = InatImport.excess_over_cap(expected_count)
+
+    def render_over_cap_line
+      render(OverCapLine.new(count: over_cap_count))
+    end
 
     def render_nothing_to_import_notice
       # Match the count that drives the display and the Proceed button, so
@@ -266,7 +279,7 @@ module Views::Controllers::InatImports
     end
 
     def estimated_time
-      format_hms((@estimate_with_date || @expected) * avg_import_seconds)
+      format_hms(capped_expected_count * avg_import_seconds)
     end
 
     def format_hms(seconds)

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -51,7 +51,6 @@ module Views::Controllers::InatImports
           end
           render_ignored_section
           count_expected_line
-          render_over_cap_line
           render_nothing_to_import_notice
           br
           unlicensed_obs_line unless import_others?
@@ -102,6 +101,7 @@ module Views::Controllers::InatImports
           render_ignored_row(row[:key], row[:count], row[:url])
         end
         unlicensed_ignored_row if import_others?
+        render_over_cap_line
       end
       br
     end
@@ -110,7 +110,8 @@ module Views::Controllers::InatImports
       ignored_row_data.any? ||
         # Import-others' unlicensed obs are never imported. So they
         # belong here rather than own-import's informational-only line.
-        import_others?
+        import_others? ||
+        over_cap_count.positive?
     end
 
     def ignored_row_data
@@ -159,7 +160,8 @@ module Views::Controllers::InatImports
     def render_ignored_total
       return unless @requested && (@estimate_with_date || @expected)
 
-      total = @requested.to_i - (@estimate_with_date || @expected).to_i
+      total = @requested.to_i - (@estimate_with_date || @expected).to_i +
+              over_cap_count
       b { plain(:inat_import_confirm_ignored_total_caption.l) }
       plain(": ")
       span(id: "total_ignored_count") { plain(total.to_s) }

--- a/app/views/controllers/inat_imports/confirm_form/over_cap_line.rb
+++ b/app/views/controllers/inat_imports/confirm_form/over_cap_line.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Excess-over-MAX_IMPORTABLE line + note on the iNat Import Confirm page.
+# Rendered by ConfirmForm; nothing shown when count is zero.
+class Views::Controllers::InatImports::ConfirmForm::OverCapLine <
+  Components::Base
+  prop :count, ::Integer
+
+  def view_template
+    return unless @count.positive?
+
+    div(class: "mb-1") do
+      b { plain("#{:inat_import_confirm_over_cap_caption.l}: ") }
+      span(id: "over_cap_count") { plain(@count.to_s) }
+      br
+      small(id: "over_cap_note") do
+        plain(:inat_import_confirm_over_cap_note.l)
+      end
+    end
+  end
+end

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -90,7 +90,9 @@ module Views::Controllers::InatImports
       whitespace
       plain(:of.l)
       whitespace
-      plain(@inat_import.total_importables.to_s)
+      span(id: "total_importables_count") do
+        plain(@inat_import.capped_total_importables.to_s)
+      end
       whitespace
       plain(:observations.l)
     end

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -122,6 +122,7 @@ module Views::Controllers::InatImports
       new_inat_import_path(
         inat_username: @inat_import.inat_username.presence,
         all: ("1" if @inat_import.import_all),
+        import_others: ("1" if @inat_import.import_others),
         inat_ids: @inat_import.inat_ids.presence,
         inat_url: @inat_import.inat_url.presence
       )

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -71,6 +71,7 @@ module Views::Controllers::InatImports
         render_status_line
         br
         render_imported_line
+        render_over_cap_line
       end
     end
 
@@ -92,6 +93,38 @@ module Views::Controllers::InatImports
       plain(@inat_import.total_importables.to_s)
       whitespace
       plain(:observations.l)
+    end
+
+    def over_cap_count
+      InatImport.excess_over_cap(@inat_import.total_importables)
+    end
+
+    def render_over_cap_line
+      return unless over_cap_count.positive?
+
+      br
+      span(class: "font-weight-bold") do
+        "#{:inat_import_tracker_over_cap_caption.l}: "
+      end
+      span(id: "over_cap_count") { plain(over_cap_count.to_s) }
+      render_over_cap_reimport if @inat_import.Done?
+    end
+
+    def render_over_cap_reimport
+      whitespace
+      render(Components::Link::Get.new(
+               name: :inat_import_tracker_over_cap_reimport.l,
+               target: over_cap_reimport_path
+             ))
+    end
+
+    def over_cap_reimport_path
+      new_inat_import_path(
+        inat_username: @inat_import.inat_username.presence,
+        all: ("1" if @inat_import.import_all),
+        inat_ids: @inat_import.inat_ids.presence,
+        inat_url: @inat_import.inat_url.presence
+      )
     end
 
     def render_started_line

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2900,6 +2900,8 @@
   inat_import_confirm_unlicensed_obs_caption: Unlicensed observations
   inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
   inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
+  inat_import_confirm_over_cap_caption: Exceeds per-import limit
+  inat_import_confirm_over_cap_note: "You can import these later in a new import."
   inat_import_confirm_time_estimate_caption: Estimated time
   inat_import_confirm_explanation: "MO will import your iNat observations that are identified as a fungus or slime mold and that were neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script. Unlicensed images will be imported with your default MO license. You can work on other things while the import is proceeding."
   inat_import_confirm_prompt: Would you like to proceed with the import?
@@ -2937,6 +2939,8 @@
   inat_import_tracker_ignored_already_imported: Already imported
   inat_import_tracker_ignored_unlicensed: Unlicensed (import-others only)
   inat_import_tracker_ignored_date_missing: No observation date
+  inat_import_tracker_over_cap_caption: Not yet imported (exceeds per-import limit)
+  inat_import_tracker_over_cap_reimport: You can import these now in a new import
   inat_import_tracker_date_missing_reimport: "Re-import [count] observation(s) after adding dates on iNat"
   inat_import_tracker_license_added_heading: Observations Imported with MO Default License
   inat_import_tracker_license_added_note: "[count] observation(s) had no iNat license; your default MO license was applied."

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2900,7 +2900,7 @@
   inat_import_confirm_unlicensed_obs_caption: Unlicensed observations
   inat_import_confirm_unlicensed_obs_note: "(your default MO license will be applied to images)"
   inat_import_confirm_unlicensed_others_note: "(will not be imported — no iNat license)"
-  inat_import_confirm_over_cap_caption: Exceeds per-import limit
+  inat_import_confirm_over_cap_caption: Exceeding per-import limit
   inat_import_confirm_over_cap_note: "You can import these later in a new import."
   inat_import_confirm_time_estimate_caption: Estimated time
   inat_import_confirm_explanation: "MO will import your iNat observations that are identified as a fungus or slime mold and that were neither previously imported by MO, imported by iNat, nor \"mirrored\" to iNat with Jacob Kalichman's Mirror script. Unlicensed images will be imported with your default MO license. You can work on other things while the import is proceeding."

--- a/test/classes/inat_observation_importer_test.rb
+++ b/test/classes/inat_observation_importer_test.rb
@@ -60,4 +60,21 @@ class InatObservationImporterTest < UnitTestCase
       importer.import_page(page)
     end
   end
+
+  def test_reached_import_cap
+    import = inat_imports(:rolf_inat_import)
+    import.update_columns(imported_count: InatImport::MAX_IMPORTABLE)
+    user = import.user
+    mock_inat_response = File.read("test/inat/calostoma_lutescens.txt")
+    page = JSON.parse(mock_inat_response)
+
+    importer = ::Inat::ObservationImporter.new(import, user)
+    assert_no_difference(
+      "Observation.count",
+      "ObservationImporter should stop importing once MAX_IMPORTABLE " \
+      "is reached, even within a single page"
+    ) do
+      importer.import_page(page)
+    end
+  end
 end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -1318,6 +1318,38 @@ class InatImportJobTest < ActiveJob::TestCase
            "Import should remain canceled")
   end
 
+  # reached_import_cap? must be checked per-observation, not just between
+  # pages -- otherwise a page/batch already in progress when the cap is
+  # hit would overshoot it by up to a full page.
+  def test_import_respects_max_importable_mid_page
+    create_ivars_from_filename("listed_ids") # importing multiple observations
+    @inat_import = InatImport.create(user: @user,
+                                     inat_ids: "231104466,195434438",
+                                     token: "MockCode",
+                                     inat_username: "anything")
+    stub_inat_interactions
+
+    saved_max = InatImport.const_get(:MAX_IMPORTABLE)
+    InatImport.send(:remove_const, :MAX_IMPORTABLE)
+    InatImport.const_set(:MAX_IMPORTABLE, 1)
+
+    begin
+      assert_difference(
+        "Observation.count", 1,
+        "Should stop importing once MAX_IMPORTABLE is reached, " \
+        "even mid-page"
+      ) do
+        InatImportJob.perform_now(@inat_import)
+      end
+
+      assert_equal(1, @inat_import.reload.imported_count,
+                   "imported_count should not exceed MAX_IMPORTABLE")
+    ensure
+      InatImport.send(:remove_const, :MAX_IMPORTABLE)
+      InatImport.const_set(:MAX_IMPORTABLE, saved_max)
+    end
+  end
+
   def test_oauth_failure
     create_ivars_from_filename("calostoma_lutescens")
 

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -322,4 +322,32 @@ class InatImportTest < ActiveSupport::TestCase
 
     assert_not(import.reached_import_cap?)
   end
+
+  def test_excess_over_cap_zero_below_cap
+    assert_equal(
+      0, InatImport.excess_over_cap(InatImport::MAX_IMPORTABLE - 1),
+      "Count below MAX_IMPORTABLE should have no excess"
+    )
+  end
+
+  def test_excess_over_cap_zero_at_cap
+    assert_equal(
+      0, InatImport.excess_over_cap(InatImport::MAX_IMPORTABLE),
+      "Count exactly at MAX_IMPORTABLE should have no excess"
+    )
+  end
+
+  def test_excess_over_cap_positive_above_cap
+    assert_equal(
+      1, InatImport.excess_over_cap(InatImport::MAX_IMPORTABLE + 1),
+      "Count 1 above MAX_IMPORTABLE should have excess of 1"
+    )
+  end
+
+  def test_excess_over_cap_zero_when_nil
+    assert_equal(
+      0, InatImport.excess_over_cap(nil),
+      "Nil count should have no excess"
+    )
+  end
 end

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -350,4 +350,34 @@ class InatImportTest < ActiveSupport::TestCase
       "Nil count should have no excess"
     )
   end
+
+  def test_capped_total_importables_below_cap
+    import = inat_imports(:rolf_inat_import)
+    import.update_columns(total_importables: InatImport::MAX_IMPORTABLE - 1)
+
+    assert_equal(
+      InatImport::MAX_IMPORTABLE - 1, import.capped_total_importables,
+      "Total below MAX_IMPORTABLE should be unchanged"
+    )
+  end
+
+  def test_capped_total_importables_above_cap
+    import = inat_imports(:rolf_inat_import)
+    import.update_columns(total_importables: InatImport::MAX_IMPORTABLE + 50)
+
+    assert_equal(
+      InatImport::MAX_IMPORTABLE, import.capped_total_importables,
+      "Total above MAX_IMPORTABLE should be capped"
+    )
+  end
+
+  def test_capped_total_importables_zero_when_nil
+    import = inat_imports(:rolf_inat_import)
+    import.update_columns(total_importables: nil)
+
+    assert_equal(
+      0, import.capped_total_importables,
+      "Nil total_importables should cap to zero"
+    )
+  end
 end

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -79,6 +79,47 @@ class InatImportTest < ActiveSupport::TestCase
     assert_equal(0, inat_imports(:lone_wolf_import).estimated_remaining_time)
   end
 
+  def test_total_expected_time_capped_when_over_cap
+    import = inat_imports(:roy_inat_import)
+    import.update!(total_importables: InatImport::MAX_IMPORTABLE + 50)
+
+    assert_equal(
+      InatImport::MAX_IMPORTABLE * import.initial_avg_import_seconds,
+      import.total_expected_time,
+      "Expected time should reflect the capped target, not the raw " \
+      "(uncapped) total_importables"
+    )
+  end
+
+  def test_estimated_remaining_time_before_any_imported_capped_when_over_cap
+    import = inat_imports(:rolf_inat_import)
+    import.update!(state: "Importing",
+                   total_importables: InatImport::MAX_IMPORTABLE + 50,
+                   imported_count: 0, started_at: Time.zone.now,
+                   ended_at: nil)
+
+    assert_equal(
+      import.total_expected_time, import.estimated_remaining_time,
+      "Before any obs imported, fall back to the up-front (capped) estimate"
+    )
+  end
+
+  def test_extrapolated_remaining_time_uses_capped_total
+    import = inat_imports(:rolf_inat_import)
+    import.update!(total_importables: InatImport::MAX_IMPORTABLE + 50,
+                   imported_count: 5)
+    import.define_singleton_method(:elapsed_time) { 10.0 }
+
+    remaining = InatImport::MAX_IMPORTABLE - 5
+    expected = (remaining * 10.0 / 5).round
+
+    assert_equal(
+      expected, import.send(:extrapolated_remaining_time),
+      "Extrapolation should use the capped total, not the raw " \
+      "(uncapped) total_importables"
+    )
+  end
+
   def test_adequate_constraints
     assert(
       inat_imports(:rolf_inat_import).adequate_constraints?,

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -106,6 +106,19 @@ module Views::Controllers::InatImports
       assert_html(html, "#total_ignored_count")
     end
 
+    def test_ignored_total_includes_over_cap_excess
+      requested = InatImport::MAX_IMPORTABLE + 100
+      estimate_with_date = InatImport::MAX_IMPORTABLE + 50
+      excess = InatImport.excess_over_cap(estimate_with_date)
+      html = render_form(
+        breakdown: { requested: requested,
+                     estimate_with_date: estimate_with_date }
+      )
+
+      assert_html(html, "#total_ignored_count",
+                  text: (requested - estimate_with_date + excess).to_s)
+    end
+
     def test_overlap_note_absent_with_single_ignored_row
       # Only not_importable row: requested(12) - after_taxon(10) = 2 > 0
       # already_imported: after_taxon(10) - not_yet_imported(10) = 0, not

--- a/test/views/controllers/inat_imports/confirm_form_test.rb
+++ b/test/views/controllers/inat_imports/confirm_form_test.rb
@@ -185,6 +185,48 @@ module Views::Controllers::InatImports
       assert_html(html, "#estimated_time")
     end
 
+    def test_expected_count_capped_at_max_importable
+      html = render_form(expected: InatImport::MAX_IMPORTABLE + 100)
+
+      assert_html(html, "#expected_count",
+                  text: InatImport::MAX_IMPORTABLE.to_s)
+    end
+
+    def test_expected_count_uncapped_when_under_max_importable
+      html = render_form(expected: InatImport::MAX_IMPORTABLE - 1)
+
+      assert_html(html, "#expected_count",
+                  text: (InatImport::MAX_IMPORTABLE - 1).to_s)
+    end
+
+    def test_over_cap_line_absent_when_under_cap
+      html = render_form(expected: InatImport::MAX_IMPORTABLE)
+
+      assert_no_html(html, "#over_cap_count")
+      assert_no_html(html, "#over_cap_note")
+    end
+
+    def test_over_cap_line_present_when_over_cap
+      excess = 100
+      html = render_form(expected: InatImport::MAX_IMPORTABLE + excess)
+
+      assert_html(html, "#over_cap_count", text: excess.to_s)
+      assert_html(html, "#over_cap_note",
+                  text: :inat_import_confirm_over_cap_note.l)
+    end
+
+    def test_estimated_time_capped_at_max_importable
+      html = render_form(inat_import: nil,
+                         expected: InatImport::MAX_IMPORTABLE + 100)
+      seconds =
+        InatImport::MAX_IMPORTABLE * InatImport::BASE_AVG_IMPORT_SECONDS
+      expected_time = Kernel.format(
+        "%02d:%02d:%02d", seconds / 3600, seconds % 3600 / 60, seconds % 60
+      )
+
+      assert_html(html, "#estimated_time", text: expected_time)
+    end
+
     private
 
     def render_form(form_model: @form_model, inat_import: @import,

--- a/test/views/controllers/inat_imports/status_test.rb
+++ b/test/views/controllers/inat_imports/status_test.rb
@@ -210,6 +210,26 @@ module Views::Controllers::InatImports
       assert_html(html, "a[href='#{reimport_path}']")
     end
 
+    def test_importables_count_uncapped_when_under_cap
+      @import.update_columns(
+        importables: 4, total_importables: 4, imported_count: 3
+      )
+      html = render_status
+
+      assert_html(html, "#total_importables_count", text: "4")
+    end
+
+    def test_importables_count_capped_when_over_cap
+      @import.update_columns(
+        total_importables: InatImport::MAX_IMPORTABLE + 50,
+        imported_count: InatImport::MAX_IMPORTABLE
+      )
+      html = render_status
+
+      assert_html(html, "#total_importables_count",
+                  text: InatImport::MAX_IMPORTABLE.to_s)
+    end
+
     private
 
     def render_status

--- a/test/views/controllers/inat_imports/status_test.rb
+++ b/test/views/controllers/inat_imports/status_test.rb
@@ -165,6 +165,51 @@ module Views::Controllers::InatImports
       assert_html(html, "a[href='#{reimport_path}']")
     end
 
+    def test_over_cap_line_absent_when_under_cap
+      @import.update_columns(total_importables: InatImport::MAX_IMPORTABLE)
+      html = render_status
+
+      assert_no_html(html, "#over_cap_count")
+    end
+
+    def test_over_cap_line_shown_with_count
+      excess = 50
+      @import.update_columns(
+        total_importables: InatImport::MAX_IMPORTABLE + excess
+      )
+      html = render_status
+
+      assert_html(html, "#over_cap_count", text: excess.to_s)
+    end
+
+    def test_over_cap_reimport_link_absent_when_not_done
+      # katrina_inat_import is in Importing state
+      @import.update_columns(
+        total_importables: InatImport::MAX_IMPORTABLE + 50
+      )
+      html = render_status
+
+      reimport_path = routes.new_inat_import_path(
+        inat_username: @import.inat_username
+      )
+      assert_no_html(html, "a[href='#{reimport_path}']")
+    end
+
+    def test_over_cap_reimport_link_shown_when_done
+      @import.update_columns(
+        state: InatImport.states[:Done],
+        ended_at: Time.zone.now,
+        imported_count: InatImport::MAX_IMPORTABLE,
+        total_importables: InatImport::MAX_IMPORTABLE + 50
+      )
+      html = render_status
+
+      reimport_path = routes.new_inat_import_path(
+        inat_username: @import.inat_username
+      )
+      assert_html(html, "a[href='#{reimport_path}']")
+    end
+
     private
 
     def render_status


### PR DESCRIPTION
Fixes a problem where requesting more than `InatImport::MAX_IMPORTABLE` (2,500) observations
silently truncated the import without explanation.

### Manual test plan

- [x] Since triggering a real >2,500-observation iNat import is impractical for
manual QA, Edit app/models/inat_import.rb:94 from MAX_IMPORTABLE = 2_500 to e.g. MAX_IMPORTABLE = 5, save.
Test through the browser as normal — no restart of bin/rails server or the Solid Queue worker needed.


This lowers the cap to 5 for the running server process (revert by restarting
the dev server). Pick an `inat_username` (or an iNat URL / id list) known to
have more than 5 importable fungi/slime-mold observations for the "over cap"
tests, and one with 5 or fewer for the "under cap" tests.

### Confirm page

- [x] Start a new iNat import for a username with **more** importable observations than the (lowered) cap. On the Confirm page, "Expected imports" shows the cap value (5), not the true higher count.
- [x] On that same Confirm page, a new line shows the number of observations in excess of the cap, with a note that they can be imported later in a new import.
- [x] On that same Confirm page, "Estimated time" reflects only the capped count (5 × the shown per-observation rate), not the full requested count.
- [x] Start a new iNat import for a username with **fewer or equal** importable observations than the cap. The Confirm page shows the true count in "Expected imports" and does **not** show the excess/over-cap line or note.

### Tracker page

- [x] Proceed with the over-cap import from above. While the import is still running (Importing state), the Tracker shows a count of observations not yet imported in excess of the cap.
- [x] While still Importing, the Tracker does **not** show any "import these now" link or message — only the running excess count.
- [x] Let the import finish (Done). The import stops at the capped count (imported count equals the cap), and the Tracker now also shows a link/message saying the remaining observations can be imported now in a new import.
- [x] Click that "import now" link. It lands on the New iNat Import form prefilled with the same username (and any ids/URL/"import all" used in the original import), ready to submit.
- [x] Submit that prefilled new import. It completes without re-importing any observations already imported in the first run (already-imported ones are skipped). (It is expected that Total Ignored, Already imported, and Exceeding per-import limit counts will be incorrect because those counts rely on the iNat `MushroomObserver URL` field, which is generally not written for test purposes.)
- [x] Run (or re-check) an import that stays **under** the cap end to end. The Tracker never shows the excess count or the "import now" line at any point, from start through Done.

### Super-importer scope (if you have super-importer access)

- [x] As a super-importer, run an over-cap import for another user's observations with "Import others" checked. Once Done, the Tracker's "import now" reimport link still has "Import others" set, not lost/reset.

### Cleanup

- [x] Reset set app/models/inat_import.rb#MAX_IMPORTABLE = 2_500. Double-check before committing anything.