### PR TITLE
Add `MO/NoHandRolledMethodField` rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ require:
   - ./lib/rubocop/cop/mo/initialize_without_prop
   - ./lib/rubocop/cop/mo/lowercase_translation_tag
   - ./lib/rubocop/cop/mo/no_active_record_relation_prop
+  - ./lib/rubocop/cop/mo/no_hand_rolled_method_field
   - ./lib/rubocop/cop/mo/no_raw_bootstrap_component
   - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
   - ./lib/rubocop/cop/mo/no_resolved_errors_add_type
@@ -95,6 +96,19 @@ MO/NoActiveRecordRelationProp:
     materialize with .to_a at the call site and use _Array(<Model>)
     instead, so the element type is checked too -- see
     lib/rubocop/cop/mo/no_active_record_relation_prop.rb.
+  Enabled: true
+  Include:
+    - "app/components/**/*.rb"
+    - "app/views/**/*.rb"
+
+MO/NoHandRolledMethodField:
+  Description: >-
+    Superform-based forms must not hand-roll a `_method` hidden field
+    via `hidden_field("_method", ...)` -- Superform already emits one,
+    driven by `persisted?`/an explicit `method:` on the constructor.
+    A second one produces two `_method` hiddens, and turbo-rails
+    silently strips the override rather than picking either -- see
+    lib/rubocop/cop/mo/no_hand_rolled_method_field.rb and #5088.
   Enabled: true
   Include:
     - "app/components/**/*.rb"

--- a/lib/rubocop/cop/mo/no_hand_rolled_method_field.rb
+++ b/lib/rubocop/cop/mo/no_hand_rolled_method_field.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Flags a Superform (`Components::ApplicationForm`) subclass that
+      # hand-rolls its own `_method` hidden field via
+      # `hidden_field("_method", ...)`. Superform emits a `_method`
+      # hidden automatically (`_method_field`, driven by the model's
+      # `persisted?` or an explicit `method:` on the constructor) --
+      # adding a second one produces two `_method` hiddens in the
+      # rendered form.
+      #
+      # Found live (#5088): the field-slip review form hand-rolled its
+      # own `_method=patch` hidden ALONGSIDE Superform's own
+      # unconditional `_method=post` (emitted for any non-persisted
+      # model). turbo-rails' `encodeMethodIntoRequestBody` resolves the
+      # request method from the FIRST `_method` value in the form data,
+      # then strips every `_method` entry from the body before
+      # submitting -- so it read "post", then stripped the override
+      # entirely, turning a Turbo PATCH submission into a bare POST
+      # with no override at all. A plain (non-Turbo) browser POST
+      # masked this: Rack keeps the LAST value of a duplicated form
+      # field, so `local: true` submissions happened to route
+      # correctly regardless of the duplicate -- only Turbo's
+      # first-value-then-strip logic actually breaks.
+      #
+      # The fix is never a second hidden field -- force the method
+      # Superform itself emits instead: pass `method: :patch` (or
+      # `:put`) to the constructor, or override `persisted?` (see
+      # `FormObject::AdminSession`) so Superform's own `_method_field`
+      # picks the right value on its own.
+      #
+      # @example
+      #   # bad
+      #   hidden_field("_method", value: "patch")
+      #
+      #   # good -- let Superform's own _method_field emit it
+      #   def initialize(model, **)
+      #     super(model, method: :patch, **)
+      #   end
+      class NoHandRolledMethodField < Base
+        MSG = "Don't hand-roll a `_method` hidden field via " \
+              "`hidden_field(\"_method\", ...)` -- Superform already " \
+              "emits one (driven by the model's `persisted?` or an " \
+              "explicit `method:` on the constructor). A second one " \
+              "produces two `_method` hiddens, and turbo-rails silently " \
+              "strips the override entirely rather than picking either " \
+              "(#5088)."
+
+        RESTRICT_ON_SEND = [:hidden_field].freeze
+
+        def on_send(node)
+          return unless bare_call?(node)
+
+          first_arg = node.first_argument
+          return unless method_field_name?(first_arg)
+
+          add_offense(node)
+        end
+
+        private
+
+        def bare_call?(node)
+          node.receiver.nil? || node.receiver.self_type?
+        end
+
+        def method_field_name?(arg)
+          arg && (arg.str_type? || arg.sym_type?) &&
+            arg.value.to_s == "_method"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #5091 (from #5088).

Adds `MO/NoHandRolledMethodField`, a RuboCop cop flagging `hidden_field("_method", ...)` (or the Symbol form, `hidden_field(:_method, ...)`) inside a Superform-based (`Components::ApplicationForm`) form.

## Why

`Components::ApplicationForm#_method_field` already emits a `_method` hidden automatically — driven by the model's `persisted?` or an explicit `method:` passed to the constructor. A form that hand-rolls its own `hidden_field("_method", ...)` on top of that produces **two** `_method` hiddens in the rendered form.

That's exactly what caused #5088: the field-slip review form hand-rolled its own `_method=patch` hidden alongside Superform's own unconditional `_method=post` (emitted for any non-persisted model). turbo-rails' `encodeMethodIntoRequestBody` resolves the request method from the *first* `_method` value in the form data, then strips every `_method` entry from the body before submitting — so it read "post", then stripped the override entirely, turning a Turbo PATCH submission into a bare POST with no override at all. A plain (non-Turbo) browser POST masked this, since Rack keeps the *last* value of a duplicated form field — only Turbo's first-value-then-strip logic actually breaks.

#5088's own fix was a one-off (the review form now declares `method: :patch` to Superform instead of hand-rolling a second hidden). This cop is the general prevention #5088 called for.

## Implementation

- Restricted to bare/self `hidden_field` calls (mirrors `MO/NoRawLinkOrButtonTo`'s `bare_call?` check), so an unrelated `some_object.hidden_field(...)` on a different API doesn't false-positive.
- Matches both the String and Symbol forms of the field name (`"_method"`/`:_method`).
- Scoped to `app/components/**/*.rb` + `app/views/**/*.rb`, matching every other Superform-related cop in this file.

## Verification

- `bundle exec rubocop --only MO/NoHandRolledMethodField app/` — 1889 files, 0 offenses (matches #5088's own grep finding that no other form in the app currently hand-rolls this pattern — this is prevention, not cleanup).
- Confirmed the cop actually fires: a synthetic fixture with `hidden_field("_method", value: "patch")` inside a `Components::ApplicationForm` subclass is flagged; the Symbol form is also flagged; an unrelated `hidden_field("approved_rank", ...)` and a non-bare `some_object.hidden_field("_method", ...)` are both correctly left alone.
- No dedicated test file — matches the existing convention for every other `MO/*` cop in this repo (none of them have one; they're validated by running against the real codebase, same as above).

## Test plan

- [x] `bundle exec rubocop --only MO/NoHandRolledMethodField app/` — 0 offenses
- [x] Synthetic fixture confirms the cop fires on both String and Symbol forms, and correctly ignores unrelated field names and non-bare calls
- [x] `bundle exec rubocop lib/rubocop/cop/mo/no_hand_rolled_method_field.rb` clean
