### PR TITLE
Truncate oversized import digests

### DIFF
--- a/app/classes/inat/import_digest.rb
+++ b/app/classes/inat/import_digest.rb
@@ -36,7 +36,7 @@ class Inat
       by_observation = namings.group_by(&:observation_id)
       total = by_observation.size
       capped = capped_namings(by_observation)
-      log_truncation(user, total) if capped.size < total
+      log_truncation(user, total) if total > MAX_DIGEST_OBSERVATIONS
 
       InatImportDigestMailer.build(
         receiver: user, namings: capped, total_observations: total

--- a/app/classes/inat/import_digest.rb
+++ b/app/classes/inat/import_digest.rb
@@ -11,18 +11,60 @@ class Inat
       new(inat_import).deliver
     end
 
+    # Caps a single digest's namings so the mailer's ActiveJob arguments
+    # (a GlobalID per Naming, serialized into solid_queue_jobs.arguments)
+    # stay well under MySQL's 65,535-byte TEXT column limit -- an import
+    # with enough interested-user namings overflowed it, raising
+    # Trilogy::ProtocolError 1406 and silently dropping every digest
+    # after the offending one in iteration order (issue #5129).
+    MAX_DIGEST_OBSERVATIONS = 500
+
     def initialize(inat_import)
       @inat_import = inat_import
     end
 
     def deliver
-      namings_by_user.each do |user, namings|
-        InatImportDigestMailer.build(receiver: user, namings: namings).
-          deliver_later
-      end
+      namings_by_user.each { |user, namings| deliver_one(user, namings) }
     end
 
     private
+
+    # Isolated per user so one failure (oversized args or otherwise)
+    # can't abort the rest of the loop the way an unrescued exception
+    # inside `each` would.
+    def deliver_one(user, namings)
+      by_observation = namings.group_by(&:observation_id)
+      total = by_observation.size
+      capped = capped_namings(by_observation)
+      log_truncation(user, total) if capped.size < total
+
+      InatImportDigestMailer.build(
+        receiver: user, namings: capped, total_observations: total
+      ).deliver_later
+    rescue StandardError => e
+      Rails.logger.error(
+        "InatImportDigestMailer enqueue failed for user #{user.id} " \
+        "(inat_import #{@inat_import.id}): #{e.class}: #{e.message}"
+      )
+    end
+
+    # Keeps whole observations intact -- never splits one observation's
+    # namings across the cap -- trimming from the end once the cap is hit.
+    def capped_namings(by_observation)
+      if by_observation.size <= MAX_DIGEST_OBSERVATIONS
+        return by_observation.values.flatten
+      end
+
+      by_observation.first(MAX_DIGEST_OBSERVATIONS).flat_map { |_id, ns| ns }
+    end
+
+    def log_truncation(user, total)
+      Rails.logger.warn(
+        "InatImportDigestMailer: truncating digest for user #{user.id} " \
+        "from #{total} to #{MAX_DIGEST_OBSERVATIONS} observations " \
+        "(inat_import #{@inat_import.id})"
+      )
+    end
 
     # { User => [Naming, ...] } for the import's namings, keyed by the users
     # each naming would have notified, minus anyone who opted out of email.

--- a/app/mailers/inat_import_digest_mailer.rb
+++ b/app/mailers/inat_import_digest_mailer.rb
@@ -6,12 +6,13 @@
 # imported naming — the batching that keeps a large import from flooding
 # the mail queue. See #4757.
 class InatImportDigestMailer < ApplicationMailer
-  def build(receiver:, namings:)
+  def build(receiver:, namings:, total_observations: nil)
     setup_user(receiver)
-    count = namings.map(&:observation_id).uniq.size
-    subject = :email_subject_inat_import_digest.l(count: count)
-    debug_log(:inat_import_digest, nil, receiver, count: count.to_s)
+    total = total_observations || namings.map(&:observation_id).uniq.size
+    subject = :email_subject_inat_import_digest.l(count: total)
+    debug_log(:inat_import_digest, nil, receiver, count: total.to_s)
     mo_mail(subject, to: receiver,
-                     view_params: { subject:, receiver:, namings: })
+                     view_params: { subject:, receiver:, namings:,
+                                    total_observations: total })
   end
 end

--- a/app/views/mailers/inat_import_digest_mailer.rb
+++ b/app/views/mailers/inat_import_digest_mailer.rb
@@ -6,6 +6,7 @@ class Views::Mailers::InatImportDigestMailer < Views::Mailers::Base
   prop :subject, ::String
   prop :receiver, ::User
   prop :namings, ::Array
+  prop :total_observations, ::Integer
 
   class Html < self
     def view_template
@@ -19,6 +20,7 @@ class Views::Mailers::InatImportDigestMailer < Views::Mailers::Base
     def render_body
       trusted_html(intro)
       trusted_html(observation_list)
+      render_truncation_note
       emit_tp(handy_links)
       render_links_section(links)
     end
@@ -30,6 +32,7 @@ class Views::Mailers::InatImportDigestMailer < Views::Mailers::Base
       gap
       trusted_html(observation_list.html_to_ascii)
       gap
+      render_truncation_note
       emit_tp(handy_links)
       gap
       render_links_section(links)
@@ -39,7 +42,26 @@ class Views::Mailers::InatImportDigestMailer < Views::Mailers::Base
   private
 
   def intro
-    :email_inat_import_digest_intro.tp(count: grouped.size)
+    :email_inat_import_digest_intro.tp(count: @total_observations)
+  end
+
+  def truncated?
+    grouped.size < @total_observations
+  end
+
+  # No-op (besides the always-safe no-op `gap`) when the digest wasn't
+  # truncated -- callable unconditionally from both Html and Text bodies.
+  def render_truncation_note
+    return unless truncated?
+
+    emit_tp(truncation_note)
+    gap
+  end
+
+  def truncation_note
+    :email_inat_import_digest_truncated.tp(
+      shown: grouped.size, count: @total_observations
+    )
   end
 
   # The receiver's matching namings grouped by observation, id-ordered.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3457,6 +3457,7 @@
   email_name_change_request: "User wants to change Name having dependents:\n\nuser : [user]\nold name : [old_name]\nnew name : [new_name]\nshow url : [show_url]\nedit url : [edit_url]\nnotes : [notes]"
   email_name_proposal_intro: "h2. *Name Proposal*\n\nA name was proposed for observation #[id]:"
   email_inat_import_digest_intro: "h2. *iNaturalist Import*\n\nA recent import from iNaturalist added [count] [:observations] matching names you follow:"
+  email_inat_import_digest_truncated: "This email shows the first [shown] of [count] matching [:observations]. Visit your [:notifications] to see the rest."
   email_name_tracker_body: "Dear [user],\n\nWe have approved your request to have MO send automated research request emails to observers whenever someone posts an observation of [name].\n\nYou can see your name-tracking notifications here: [link].\n\nPlease do not hesitate to let us know if there is any other ways MO can help support your research.\n\nBest wishes,\n-MO Admins"
   email_naming_for_observer_intro: "h2. *Research Request*\n\n[user] ([email]) asked the [:app_title] website to forward the following message to you about your [type] <u>[name]</u>:"
   email_naming_for_tracker_intro: "h2. *Tracking Alert*\n\nAn [obs] on the [:app_title] website has been given the name [name], which you are currently tracking. You can contact either the [:observer] or the [:identifier] by going to the appropriate link below and clicking the email link near the top of the page."

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3457,7 +3457,7 @@
   email_name_change_request: "User wants to change Name having dependents:\n\nuser : [user]\nold name : [old_name]\nnew name : [new_name]\nshow url : [show_url]\nedit url : [edit_url]\nnotes : [notes]"
   email_name_proposal_intro: "h2. *Name Proposal*\n\nA name was proposed for observation #[id]:"
   email_inat_import_digest_intro: "h2. *iNaturalist Import*\n\nA recent import from iNaturalist added [count] [:observations] matching names you follow:"
-  email_inat_import_digest_truncated: "This email shows the first [shown] of [count] matching [:observations]. Visit your [:notifications] to see the rest."
+  email_inat_import_digest_truncated: "This email shows the first [shown] of [count] matching [:observations]."
   email_name_tracker_body: "Dear [user],\n\nWe have approved your request to have MO send automated research request emails to observers whenever someone posts an observation of [name].\n\nYou can see your name-tracking notifications here: [link].\n\nPlease do not hesitate to let us know if there is any other ways MO can help support your research.\n\nBest wishes,\n-MO Admins"
   email_naming_for_observer_intro: "h2. *Research Request*\n\n[user] ([email]) asked the [:app_title] website to forward the following message to you about your [type] <u>[name]</u>:"
   email_naming_for_tracker_intro: "h2. *Tracking Alert*\n\nAn [obs] on the [:app_title] website has been given the name [name], which you are currently tracking. You can contact either the [:observer] or the [:identifier] by going to the appropriate link below and clicking the email link near the top of the page."

--- a/test/classes/inat/import_digest_test.rb
+++ b/test/classes/inat/import_digest_test.rb
@@ -10,6 +10,10 @@ class Inat::ImportDigestTest < UnitTestCase
     # Start from a clean notification slate so only the recipients we add
     # below are notified: no trackers, no name/observation interests, and
     # the observation owner is the namer (so the owner is excluded).
+    # ActionMailer::Base.deliveries isn't auto-cleared between tests in
+    # this process, so a truncation test's `perform_enqueued_jobs` run
+    # would otherwise find a stray mail left by an earlier test.
+    ActionMailer::Base.deliveries.clear
     NameTracker.all.map(&:destroy)
     Interest.where(target_type: %w[Name Observation]).destroy_all
     @import = inat_imports(:rolf_inat_import)
@@ -45,5 +49,89 @@ class Inat::ImportDigestTest < UnitTestCase
     assert_no_enqueued_jobs do
       Inat::ImportDigest.deliver_for(@import)
     end
+  end
+
+  def test_truncates_when_over_the_cap_and_reports_true_total
+    second_obs = observations(:minimal_unknown_obs)
+    second_obs.update_columns(inat_import_id: @import.id, user_id: mary.id)
+    Naming.suppress_notifications do
+      Naming.create!(observation: second_obs, name: @name, user: mary)
+    end
+    katrina.update!(email_html: true)
+    Interest.create!(target: @name, user: katrina, state: true)
+
+    mail = with_max_digest_observations(1) do
+      perform_enqueued_jobs do
+        Inat::ImportDigest.deliver_for(@import)
+      end
+      ActionMailer::Base.deliveries.find { |m| m.to.include?(katrina.email) }
+    end
+
+    assert_not_nil(mail, "Katrina should still have received a digest")
+    assert_includes(mail.subject, "2",
+                    "Subject should report the true total, not the " \
+                    "capped count")
+    body = mail.body.to_s
+    # Scope to the observation list -- the "handy links" section at the
+    # bottom of the email is also a <ul><li>...</li></ul>.
+    observation_items = Nokogiri::HTML5(body).css("ul:not([type]) li")
+    assert_equal(1, observation_items.size,
+                 "Digest body should list only the capped number of " \
+                 "observations")
+    assert_includes(
+      body, :email_inat_import_digest_truncated.l(shown: 1, count: 2),
+      "Truncated digest should tell the recipient it was truncated"
+    )
+  end
+
+  def test_does_not_truncate_at_or_under_the_cap
+    katrina.update!(email_html: true)
+    Interest.create!(target: @name, user: katrina, state: true)
+
+    mail = with_max_digest_observations(1) do
+      perform_enqueued_jobs do
+        Inat::ImportDigest.deliver_for(@import)
+      end
+      ActionMailer::Base.deliveries.find { |m| m.to.include?(katrina.email) }
+    end
+
+    assert_not_nil(mail, "Katrina should have received a digest")
+    body = mail.body.to_s
+    truncated_text = :email_inat_import_digest_truncated.l(shown: 1, count: 1)
+    assert_not_includes(
+      body, truncated_text,
+      "An untruncated digest should not carry a truncation note"
+    )
+  end
+
+  def test_isolates_one_users_mailer_failure_from_the_rest
+    Interest.create!(target: @name, user: katrina, state: true)
+    Interest.create!(target: @name, user: dick, state: true)
+    original_build = InatImportDigestMailer.method(:build)
+    failing_build = lambda do |receiver:, **kwargs|
+      raise(StandardError.new("boom")) if receiver == katrina
+
+      original_build.call(receiver:, **kwargs)
+    end
+
+    # Dick's digest should still be enqueued even though Katrina's
+    # mailer build raised.
+    assert_enqueued_jobs(1, only: ActionMailer::MailDeliveryJob) do
+      InatImportDigestMailer.stub(:build, failing_build) do
+        Inat::ImportDigest.deliver_for(@import)
+      end
+    end
+  end
+
+  private
+
+  def with_max_digest_observations(value)
+    original = Inat::ImportDigest::MAX_DIGEST_OBSERVATIONS
+    Inat::ImportDigest.send(:remove_const, :MAX_DIGEST_OBSERVATIONS)
+    Inat::ImportDigest.const_set(:MAX_DIGEST_OBSERVATIONS, value)
+    yield
+  ensure
+    Inat::ImportDigest.send(:remove_const, :MAX_DIGEST_OBSERVATIONS)
+    Inat::ImportDigest.const_set(:MAX_DIGEST_OBSERVATIONS, original)
   end
 end

--- a/test/mailers/inat_import_digest_mailer_test.rb
+++ b/test/mailers/inat_import_digest_mailer_test.rb
@@ -30,4 +30,35 @@ class InatImportDigestMailerTest < MailerTestCase
     assert_includes(mail.body.to_s,
                     "#{MO.http_domain}/#{naming.observation_id}")
   end
+
+  def test_build_defaults_total_observations_to_the_namings_given
+    rolf.update!(email_html: true)
+    naming = namings(:coprinus_comatus_other_naming)
+
+    mail = InatImportDigestMailer.build(receiver: rolf, namings: [naming]).
+           message
+
+    # No total_observations passed -> subject falls back to counting the
+    # (untruncated) namings array itself, and no truncation note appears.
+    assert_includes(mail.subject, "1")
+    assert_not_includes(
+      mail.body.to_s,
+      :email_inat_import_digest_truncated.l(shown: 1, count: 1)
+    )
+  end
+
+  def test_build_reports_truncation_when_total_exceeds_namings_given
+    rolf.update!(email_html: true)
+    naming = namings(:coprinus_comatus_other_naming)
+
+    mail = InatImportDigestMailer.build(
+      receiver: rolf, namings: [naming], total_observations: 3
+    ).message
+
+    assert_includes(mail.subject, "3")
+    assert_includes(
+      mail.body.to_s,
+      :email_inat_import_digest_truncated.l(shown: 1, count: 3)
+    )
+  end
 end


### PR DESCRIPTION
- Caps each digest at 500 observations to prevent overflowing`solid_queue_jobs.arguments.
- Isolates each user's `deliver_later` call in its own rescue so one failure can't cascade.
- Delivers #5129 

### Manual Test ✅

I ran the exact large import which surfaced the bug.
It completed with 4 truncated digests ("This email shows the first 500 of [n] matching observations ... ." )
and without an Import Digest failure. 