### PR TITLE
Wire `Publication` into `InlineCRUDLinks`

### DIFF
--- a/app/classes/tab/publication/edit.rb
+++ b/app/classes/tab/publication/edit.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# "Edit this publication" icon-link, used by Components::InlineCRUDLinks
+# on the publications index's admin column. Caller is responsible for
+# the edit-permission check (`publication.can_edit?(user)` or admin
+# mode) before instantiating.
+class Tab::Publication::Edit < Tab::Base
+  def initialize(publication:)
+    super()
+    @publication = publication
+  end
+
+  def title
+    :edit_object.t(type: Publication)
+  end
+
+  def path
+    edit_publication_path(@publication.id)
+  end
+
+  def html_options
+    { icon: :edit }
+  end
+
+  def model
+    @publication
+  end
+end

--- a/app/components/inline_crud_links.rb
+++ b/app/components/inline_crud_links.rb
@@ -28,13 +28,22 @@
 # names. `destroy_path` defaults to `:path_target` and `destroy_name`
 # to `:name_destroy_object` when absent from a handler -- only
 # genuinely non-standard targets need to override them.
+#
+# Why a Tab-PORO dispatch table here but not on the page-title-bar
+# edit/delete icons (`Header::EditDeleteIcons`): that component is
+# fully generic across every model (always the model's own standard
+# edit page, gated by its own `can_edit?`/`destroyable?`), with no
+# per-model behavior to carry. Here the behavior varies per target --
+# modal edit vs. plain link, detach-not-destroy paths, different
+# permission predicates -- which is what a Tab PORO carries.
 class Components::InlineCRUDLinks < Components::Base
   # Target is polymorphic; the supported classes are exactly the
   # keys of `TARGET_HANDLERS` below. `target:` present/absent is
   # what selects edit/destroy mode vs. add mode.
   prop :target, _Nilable(_Union(::CollectionNumber, ::HerbariumRecord,
                                 ::Sequence, ::ExternalLink,
-                                ::Naming, ::Comment, ::Description)),
+                                ::Naming, ::Comment, ::Description,
+                                ::Publication)),
        default: nil
   # CollectionNumber / HerbariumRecord: required -- permission and/or
   # the detach path need the observation. Every other target derives
@@ -113,6 +122,11 @@ class Components::InlineCRUDLinks < Components::Base
       tab: :tab_description_edit,
       can_edit: :can_edit_via_writer?,
       can_destroy: :can_destroy_via_admin?
+    },
+    ::Publication => {
+      edit: :icon_link_edit,
+      tab: :tab_publication_edit,
+      can_edit: :can_edit_via_target?
     }
   }.freeze
 
@@ -290,6 +304,10 @@ class Components::InlineCRUDLinks < Components::Base
 
   def tab_description_edit
     ::Tab::Description::Edit.new(description: @target)
+  end
+
+  def tab_publication_edit
+    ::Tab::Publication::Edit.new(publication: @target)
   end
 
   # ---- :destroy_path handlers -------------------------------

--- a/app/views/controllers/publications/index.rb
+++ b/app/views/controllers/publications/index.rb
@@ -80,12 +80,8 @@ module Views::Controllers::Publications
     end
 
     def admin_cell(pub)
-      return "" unless in_admin_mode? || pub.can_edit?(current_user)
-
       capture do
-        Link(type: :get, name: :edit.ti, target: edit_publication_path(pub))
-        whitespace
-        Button(type: :delete, target: pub)
+        InlineCRUDLinks(target: pub, user: current_user)
       end
     end
   end

--- a/test/controllers/publications_controller_test.rb
+++ b/test/controllers/publications_controller_test.rb
@@ -16,7 +16,13 @@ class PublicationsControllerTest < FunctionalTestCase
     get(:index)
     assert_response(:success)
     assert_not_nil(assigns(:publications))
-    assert_link_in_html("Edit", action: :edit, id: pub_id)
+    # InlineCRUDLinks (via Tab::Publication::Edit) renders an
+    # icon-only link, not visible "Edit" text -- select on the tab's
+    # own derived class instead of `assert_link_in_html`'s text match.
+    assert_select(
+      "a.edit_publication_link_#{pub_id}" \
+      "[href='#{edit_publication_path(pub_id)}']"
+    )
     # `Button(type: :delete, ...)` renders a POST form (with a hidden
     # `_method=delete` field), not an `<a>` link, so this checks the
     # form/button shape rather than `assert_link_in_html`.


### PR DESCRIPTION
## Summary

Closes #5098.

Scoped down from the issue's title after investigation.

Adds `Tab::Publication::Edit` and wires `Publication` into `Components::InlineCRUDLinks::TARGET_HANDLERS`, then converts `Publications::Index#admin_cell`'s hand-rolled edit+destroy links to `InlineCRUDLinks(target: pub, user: current_user)`.

## Why the scope is one model, not the issue's full framing

The issue's title suggested "Edit and FormEdit" was a naming split for the same concept, plus building Tabs for every model's edit/destroy links. Investigation found:

- `Edit` (single `Tab::Base`) and `FormEdit` (`Tab::Collection`) aren't a naming collision — they're consistently different, coexisting concepts across every model that has both: `Edit` is a title-bar-style link consumed by `InlineCRUDLinks`/specific context-navs; `FormEdit` is the edit-form page's own action-nav (cancel/return + index links).
- The page-title-bar edit/delete icons (`Header::EditDeleteIcons`) don't use Tab POROs and don't need them — they're fully generic across every model via `Button::Edit`/`Button::Delete`'s resourceful path-building, gated by the model's own `can_edit?`/`destroyable?`. Only `InlineCRUDLinks` needs per-model Tab POROs, because its behavior (modal vs. plain link, detach-not-destroy paths, differing permission predicates) varies per target.
- Checked which models lack an `Edit` tab despite having `FormEdit` (field_slip, publication, herbarium, article, name_description, location_description) against where an inline (non-title-bar) edit/destroy link would be needed:
  - `name_description`/`location_description` are already covered — `Tab::Description::Edit` handles both via an ancestor-walk dispatch in `InlineCRUDLinks#handler`.
  - `article`/`field_slip` have no inline edit/destroy link anywhere in the app to convert — building a new Tab for either would be unused code.
  - `Herbaria::Index` hand-rolls an edit+**merge** block, not edit+destroy — `Herbarium#merge` ends in `src.destroy` internally, but the UI-level action targets a different herbarium (`@merge`, separate page state) with a different label, and doesn't fit `InlineCRUDLinks`' single-target destroy shape without dedicated customization.
  - `Publications::Index#admin_cell` hand-rolls an edit+destroy pair — a clean, direct match.

Added a short note to `InlineCRUDLinks`'s own doc comment explaining this split, so the next person doesn't have to re-derive it.

## Visual changes from the conversion

Converting to `InlineCRUDLinks` intentionally brings Publication's admin links in line with every other model's inline edit/destroy styling, which changes their appearance:

- The edit link becomes an icon-only link (`icon_link_edit`, matching Description's own conversion) instead of visible "Edit" text.
- The destroy button becomes `variant: :strip` (bare icon, matching every other `InlineCRUDLinks` destroy button) instead of the standard framed `.btn`.

The confirm dialog is unchanged — `Button::Delete` already defaults `confirm: :are_you_sure.l` when nothing else is passed, so omitting a `destroy_confirm` handler entry preserves the existing behavior.

## Test plan

- [x] `bin/rails test test/controllers/publications_controller_test.rb` — updated the one test asserting visible "Edit" text to select on the tab's derived class instead
- [x] `bin/rails test test/components/inline_crud_links_test.rb`
- [x] `bundle exec rubocop` clean on all touched/new files
