### PR TITLE
Add `MO/NoRenderPhlexMethodName` cop, rename all `render_phlex_*` methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ require:
   - ./lib/rubocop/cop/mo/no_hand_rolled_method_field
   - ./lib/rubocop/cop/mo/no_raw_bootstrap_component
   - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
+  - ./lib/rubocop/cop/mo/no_render_phlex_method_name
   - ./lib/rubocop/cop/mo/no_resolved_errors_add_type
   - ./lib/rubocop/cop/mo/prefer_kit_syntax
   - ./lib/rubocop/cop/mo/redundant_render_view_invalid
@@ -183,6 +184,18 @@ MO/NoRawLinkOrButtonTo:
     # is .btn-family styling/variants, which doesn't fit a badge.
     # Genuinely a different primitive, not a bypass of Button.
     - "app/components/id_badge.rb"
+
+MO/NoRenderPhlexMethodName:
+  Description: >-
+    A controller render-dispatch method named render_phlex_* -- the
+    whole app is Phlex now, so the qualifier carries no information.
+    Use render_<action>_view instead (render_new_view,
+    render_edit_view, render_show_view, ...) -- see
+    lib/rubocop/cop/mo/no_render_phlex_method_name.rb and
+    .claude/rules/turbo_submit_forms.md (issue #5052).
+  Enabled: true
+  Include:
+    - "app/controllers/**/*.rb"
 
 MO/PreferKitSyntax:
   Description: >-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ require:
   - ./lib/rubocop/cop/mo/prefer_kit_syntax
   - ./lib/rubocop/cop/mo/redundant_render_view_invalid
   - ./lib/rubocop/cop/mo/self_status_outside_invalid_method
+  - ./lib/rubocop/cop/mo/status_kwarg_outside_invalid_method
   - ./lib/rubocop/cop/mo/unguarded_params_to_prop
 
 AllCops:
@@ -226,6 +227,18 @@ MO/SelfStatusOutsideInvalidMethod:
     hand-rolled anti-pattern this sweep exists to prevent -- fold it
     into a *_invalid method instead. See
     lib/rubocop/cop/mo/self_status_outside_invalid_method.rb and
+    .claude/rules/turbo_submit_forms.md (issue #5052).
+  Enabled: true
+  Include:
+    - "app/controllers/**/*.rb"
+
+MO/StatusKwargOutsideInvalidMethod:
+  Description: >-
+    status: :unprocessable_content passed as a kwarg outside a
+    *_invalid-named method is the same hand-rolled anti-pattern
+    MO/SelfStatusOutsideInvalidMethod bans for `self.status = ...` --
+    fold it into a *_invalid method instead. See
+    lib/rubocop/cop/mo/status_kwarg_outside_invalid_method.rb and
     .claude/rules/turbo_submit_forms.md (issue #5052).
   Enabled: true
   Include:

--- a/app/controllers/account/login_controller.rb
+++ b/app/controllers/account/login_controller.rb
@@ -64,9 +64,18 @@ module Account
 
     def login_unverified(user)
       @unverified_user = user
+      render_unverified_view_invalid
+    end
+
+    def render_unverified_view(status: :ok, **render_opts)
       render(Views::Controllers::Account::Verifications::Reverify.new(
                unverified_user: @unverified_user
-             ), status: :unprocessable_content)
+             ), status: status, **render_opts)
+    end
+
+    def render_unverified_view_invalid(**)
+      render_unverified_view(**)
+      self.status = :unprocessable_content
     end
   end
 end

--- a/app/controllers/account/profile/images_controller.rb
+++ b/app/controllers/account/profile/images_controller.rb
@@ -54,11 +54,15 @@ module Account::Profile
              status: status, **render_opts)
     end
 
+    def render_reuse_view_invalid(**)
+      render_reuse_view(**)
+      self.status = :unprocessable_content
+    end
+
     def render_reuse_with_invalid_id_error
       flash_error(:runtime_image_reuse_invalid_id.t(id: @img_id))
       load_images_to_reuse
-      render_reuse_view(location: account_profile_select_image_path,
-                        status: :unprocessable_content)
+      render_reuse_view_invalid(location: account_profile_select_image_path)
     end
 
     def attach_image_for_profile_and_flash_notice(image)

--- a/app/controllers/account/verifications_controller.rb
+++ b/app/controllers/account/verifications_controller.rb
@@ -35,7 +35,7 @@ module Account
       # "verified", log user in, and display the "you're verified" page.
       else
         mark_user_verified_and_login(user)
-        render_new_phlex
+        render_new_view
       end
     end
 
@@ -55,7 +55,7 @@ module Account
         redirect_already_used_verification(user)
       else
         mark_user_verified_and_login(user)
-        render_new_phlex(status: :unprocessable_content)
+        render_new_view_invalid
       end
     end
 
@@ -91,7 +91,7 @@ module Account
 
     private
 
-    def render_new_phlex(status: :ok)
+    def render_new_view(status: :ok)
       render(Views::Controllers::Account::Verifications::New.new(
                user: @user
              ), status: status)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -19,7 +19,7 @@ module Admin
       # Parse new set of values.
       @val = params[:val]
       bonuses = calculate_bonuses
-      return render_edit_view(status: :unprocessable_content) if bonuses.nil?
+      return render_edit_view_invalid if bonuses.nil?
 
       update_user_contribution(bonuses)
       redirect_to(user_path(@user2.id))

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -89,7 +89,7 @@ class CollectionNumbersController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream { render_modal_collection_number_form }
-      format.html { render_new_phlex }
+      format.html { render_new_view }
     end
   end
 
@@ -110,7 +110,7 @@ class CollectionNumbersController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream { render_modal_collection_number_form }
-      format.html { render_edit_phlex }
+      format.html { render_edit_view }
     end
   end
 
@@ -158,14 +158,14 @@ class CollectionNumbersController < ApplicationController
       flash_error_and_goto_index(CollectionNumber, params[:id])
   end
 
-  def render_new_phlex
+  def render_new_view
     render(Views::Controllers::CollectionNumbers::New.new(
              collection_number: @collection_number,
              observation: @observation, user: @user
            ))
   end
 
-  def render_edit_phlex
+  def render_edit_view
     render(Views::Controllers::CollectionNumbers::Edit.new(
              collection_number: @collection_number, user: @user,
              back: @back, back_object: @back_object

--- a/app/controllers/concerns/descriptions/merges.rb
+++ b/app/controllers/concerns/descriptions/merges.rb
@@ -152,18 +152,32 @@ module Descriptions::Merges
       # derived from `@src.show_controller`. The model-side
       # `show_controller` returns a leading-slash string (e.g.
       # `/names/descriptions`); strip it before camelizing.
+      render_merge_conflict_view_invalid
+    end
+
+    # Dispatch to the parent controller's Phlex Edit view --
+    # `names/descriptions/edit` or `locations/descriptions/edit`,
+    # derived from `@src.show_controller`. The model-side
+    # `show_controller` returns a leading-slash string (e.g.
+    # `/names/descriptions`); strip it before camelizing.
+    def render_merge_conflict_view(status: :ok, **render_opts)
       controller_segment = @src.show_controller.to_s.sub(%r{^/}, "")
       klass = "Views::Controllers::#{controller_segment.camelize}::Edit".
               constantize
-      # A same-URL 200 render on a Turbo-enabled form hangs Turbo
-      # Drive (confirmed against a real browser -- see
-      # turbo_submit_forms.md); needs a non-2xx status even though
-      # nothing "failed" -- the merge just can't complete without the
-      # user resolving the conflict by hand.
       render(klass.new(description: @description, user: @user,
                        licenses: @licenses, merge: @merge,
                        old_desc_id: @old_desc_id),
-             status: :unprocessable_content)
+             status: status, **render_opts)
+    end
+
+    # A same-URL 200 render on a Turbo-enabled form hangs Turbo Drive
+    # (confirmed against a real browser -- see turbo_submit_forms.md);
+    # needs a non-2xx status even though nothing "failed" -- the merge
+    # just can't complete without the user resolving the conflict by
+    # hand.
+    def render_merge_conflict_view_invalid(**)
+      render_merge_conflict_view(**)
+      self.status = :unprocessable_content
     end
 
     # Tentatively merge the fields by sticking src's notes after dest's wherever

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -34,13 +34,13 @@ class FieldSlipsController < ApplicationController
     else
       flash_notice(:field_slip_cant_join_project.t)
     end
-    render_new_phlex
+    render_new_view
   end
 
   # GET /field_slips/1/edit
   def edit
     @recent_observations = recent_edit_observations
-    render_edit_phlex
+    render_edit_view
   end
 
   # POST /field_slips or /field_slips.json
@@ -59,7 +59,7 @@ class FieldSlipsController < ApplicationController
         end
         format.json { render(:show, status: :created, location: @field_slip) }
       else
-        format.html { render_new_phlex(status: :unprocessable_content) }
+        format.html { render_new_view_invalid }
         format.json do
           render(json: @field_slip.errors, status: :unprocessable_content)
         end
@@ -75,7 +75,7 @@ class FieldSlipsController < ApplicationController
         format.json { render(:show, status: :ok, location: @field_slip) }
       else
         @field_slip.reload
-        format.html { render_edit_phlex(status: :unprocessable_content) }
+        format.html { render_edit_view_invalid }
         format.json do
           render(json: @field_slip.errors, status: :unprocessable_content)
         end
@@ -107,8 +107,7 @@ class FieldSlipsController < ApplicationController
   # the observation is saved, so abandoning the form leaves no orphan slip.
   # An invalid code is rejected here rather than after the whole obs form.
   def create_deferred_for_add_images
-    return render_new_phlex(status: :unprocessable_content) unless
-      @field_slip.valid?
+    return render_new_view_invalid unless @field_slip.valid?
 
     redirect_to(new_observation_url(
                   field_code: @field_slip.code,
@@ -120,7 +119,7 @@ class FieldSlipsController < ApplicationController
                 ))
   end
 
-  def render_new_phlex(**render_opts)
+  def render_new_view(**render_opts)
     # The `:new` action populates these; the `:create` validation-
     # failure path and the project-gaps path enter through render_
     # new_phlex without running `:new`, so backfill from params /
@@ -140,7 +139,7 @@ class FieldSlipsController < ApplicationController
     )
   end
 
-  def render_edit_phlex(**render_opts)
+  def render_edit_view(**render_opts)
     # The `:edit` action populates `@recent_observations`; the
     # `:update` validation-failure and project-gaps re-render
     # paths skip it, so backfill via the same query the action
@@ -180,7 +179,7 @@ class FieldSlipsController < ApplicationController
       # (see turbo_submit_forms.md) -- needs a non-2xx status even
       # though nothing actually "failed" yet; the field slip just
       # isn't fully resolved until the user handles the project gaps.
-      render_edit_phlex(status: :unprocessable_content)
+      render_edit_view_invalid
     else
       redirect_to(field_slip_url(@field_slip),
                   notice: :field_slip_updated.t)
@@ -224,7 +223,7 @@ class FieldSlipsController < ApplicationController
         # (see turbo_submit_forms.md) -- needs a non-2xx status even
         # though nothing actually "failed" yet; the field slip just
         # isn't fully resolved until the user handles the project gaps.
-        render_new_phlex(status: :unprocessable_content)
+        render_new_view_invalid
       elsif obs
         redirect_to(observation_url(obs), notice: msg)
       else

--- a/app/controllers/field_slips_controller/show.rb
+++ b/app/controllers/field_slips_controller/show.rb
@@ -29,12 +29,12 @@ module FieldSlipsController::Show
 
   def render_show_or_keep_redirect
     respond_to do |format|
-      format.html { render_show_phlex }
+      format.html { render_show_view }
       format.json # auto-renders show.json.jbuilder
     end
   end
 
-  def render_show_phlex
+  def render_show_view
     render(Views::Controllers::FieldSlips::Show.new(
              field_slip: @field_slip, notice: flash[:notice]
            ))

--- a/app/controllers/glossary_terms/images_controller.rb
+++ b/app/controllers/glossary_terms/images_controller.rb
@@ -131,9 +131,8 @@ module GlossaryTerms
 
     def rerender_remove_form_with_no_save_error
       flash_error(:runtime_no_save.t(type: :glossary_term))
-      render_remove_view(
-        location: remove_images_from_glossary_term_path(params[:id]),
-        status: :unprocessable_content
+      render_remove_view_invalid(
+        location: remove_images_from_glossary_term_path(params[:id])
       )
     end
 
@@ -142,6 +141,11 @@ module GlossaryTerms
         Views::Controllers::GlossaryTerms::Images::Remove.new(object: @object),
         status: status, **render_opts
       )
+    end
+
+    def render_remove_view_invalid(**)
+      render_remove_view(**)
+      self.status = :unprocessable_content
     end
   end
 end

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -100,7 +100,7 @@ class HerbariumRecordsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream { render_modal_herbarium_record_form }
-      format.html { render_new_phlex }
+      format.html { render_new_view }
     end
   end
 
@@ -121,7 +121,7 @@ class HerbariumRecordsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream { render_modal_herbarium_record_form }
-      format.html { render_edit_phlex }
+      format.html { render_edit_view }
     end
   end
 
@@ -160,14 +160,14 @@ class HerbariumRecordsController < ApplicationController
     find_herbarium_record!
   end
 
-  def render_new_phlex
+  def render_new_view
     render(Views::Controllers::HerbariumRecords::New.new(
              herbarium_record: @herbarium_record,
              observation: @observation, user: @user
            ))
   end
 
-  def render_edit_phlex
+  def render_edit_view
     render(Views::Controllers::HerbariumRecords::Edit.new(
              herbarium_record: @herbarium_record, user: @user,
              back: @back, back_object: @back_object

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -157,17 +157,26 @@ class InatImportsController < ApplicationController
     @inat_import = InatImport.new(user: @user)
     warn_about_listed_previous_imports
     @confirm_form = build_confirm_form
-    # A same-URL 200 render on a Turbo-enabled form hangs Turbo Drive
-    # (see turbo_submit_forms.md) -- needs a non-2xx status even
-    # though nothing "failed"; this is the normal next step after a
-    # valid New-import submission, just not the same page.
+    render_confirm_view_invalid
+  end
+
+  def render_confirm_view(status: :ok, **render_opts)
     render(Views::Controllers::InatImports::Confirm.new(
              confirm_form: @confirm_form,
              expected: @expected,
              unlicensed_obs: @unlicensed_obs,
              inat_import: @inat_import,
              **fetch_confirm_counts
-           ), status: :unprocessable_content)
+           ), status: status, **render_opts)
+  end
+
+  # A same-URL 200 render on a Turbo-enabled form hangs Turbo Drive
+  # (see turbo_submit_forms.md) -- needs a non-2xx status even though
+  # nothing "failed"; this is the normal next step after a valid
+  # New-import submission, just not the same page.
+  def render_confirm_view_invalid(**)
+    render_confirm_view(**)
+    self.status = :unprocessable_content
   end
 
   def fetch_confirm_counts

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -59,8 +59,8 @@ class InfoController < ApplicationController
   # statement that the preview "failed".
   def textile_sandbox_create
     code = params[:code] || params.dig(:textile_sandbox, :code)
-    render_new_view(code: code, submit_type: params.permit(:commit)[:commit],
-                    status: :unprocessable_content)
+    render_new_view_invalid(code: code,
+                            submit_type: params.permit(:commit)[:commit])
   end
 
   # Allow translator to enter a special note linked to from the lower left.

--- a/app/controllers/names/maps_controller.rb
+++ b/app/controllers/names/maps_controller.rb
@@ -20,14 +20,14 @@ module Names
       find_locations_matching_observations
 
       respond_to do |format|
-        format.html { render_phlex_show }
+        format.html { render_show_view }
         format.json { render(json: map_refetch_payload) }
       end
     end
 
     private
 
-    def render_phlex_show
+    def render_show_view
       render(Views::Controllers::Names::Maps::Show.new(
                name: @name, query: @query,
                observations: @observations.to_a,

--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -17,13 +17,13 @@ module Observations::Namings
 
       respond_to do |format|
         format.turbo_stream { render_votes_modal }
-        format.html { render_phlex_index }
+        format.html { render_index_view }
       end
     end
 
     private
 
-    def render_phlex_index
+    def render_index_view
       render(Views::Controllers::Observations::Namings::Votes::Index.new(
                naming: @naming
              ))

--- a/app/controllers/observations/species_lists_controller.rb
+++ b/app/controllers/observations/species_lists_controller.rb
@@ -18,7 +18,7 @@ module Observations
       return unless (@observation = find_observation!)
 
       set_list_ivars
-      render_phlex_edit
+      render_edit_view
     end
 
     # new endpoint for :add_observation_to_species_list and
@@ -40,7 +40,7 @@ module Observations
         remove_observation_from_species_list(@species_list, @observation)
       else
         flash_error("Invalid mode: #{params[:commit].inspect}")
-        render_phlex_edit(
+        render_edit_view(
           location: edit_observation_species_lists_path(
             id: @observation.id
           ),
@@ -51,7 +51,7 @@ module Observations
 
     private
 
-    def render_phlex_edit(**render_opts)
+    def render_edit_view(**render_opts)
       render(
         Views::Controllers::Observations::SpeciesLists::Edit.new(
           observation: @observation,

--- a/app/controllers/observations/species_lists_controller.rb
+++ b/app/controllers/observations/species_lists_controller.rb
@@ -40,11 +40,10 @@ module Observations
         remove_observation_from_species_list(@species_list, @observation)
       else
         flash_error("Invalid mode: #{params[:commit].inspect}")
-        render_edit_view(
+        render_edit_view_invalid(
           location: edit_observation_species_lists_path(
             id: @observation.id
-          ),
-          status: :unprocessable_content
+          )
         )
       end
     end

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -44,10 +44,10 @@ module ObservationsController::Show
     load_occurrence_data
     @images = occurrence_images
 
-    render_phlex_show
+    render_show_view
   end
 
-  def render_phlex_show
+  def render_show_view
     render(Views::Controllers::Observations::Show.new(
              observation: @observation, user: @user,
              consensus: @consensus, comments: @comments.to_a,

--- a/app/controllers/species_lists/uploads_controller.rb
+++ b/app/controllers/species_lists/uploads_controller.rb
@@ -28,7 +28,7 @@ module SpeciesLists
         @species_list.process_file_data(@user, sorter)
         init_name_vars_from_sorter(@species_list, sorter)
         init_project_vars_for_edit(@species_list)
-        render_upload_result_view
+        render_upload_result_view_invalid
       else
         redirect_to(species_list_path(@species_list))
       end
@@ -51,7 +51,7 @@ module SpeciesLists
     # of REST semantics (see turbo_submit_forms.md), so
     # :unprocessable_content is required here purely as a Turbo-
     # mechanics necessity, not a statement that the upload "failed".
-    def render_upload_result_view
+    def render_upload_result_view_invalid
       render(Views::Controllers::SpeciesLists::Edit.new(
                species_list: @species_list,
                projects: @projects,

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -126,7 +126,7 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
     end
 
     init_ivars_for_show
-    render_phlex_show
+    render_show_view
   end
 
   def new
@@ -267,7 +267,7 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
       user: @user }
   end
 
-  def render_phlex_show
+  def render_show_view
     render(Views::Controllers::SpeciesLists::Show.new(
              species_list: @species_list, user: @user, query: @query,
              pagination_data: @pagination_data, objects: @objects,

--- a/lib/rubocop/cop/mo/no_render_phlex_method_name.rb
+++ b/lib/rubocop/cop/mo/no_render_phlex_method_name.rb
@@ -3,12 +3,14 @@
 module RuboCop
   module Cop
     module MO
-      # Flags a controller method named `render_phlex_*`
-      # (`render_phlex_show`, `render_phlex_edit`, `render_phlex_new`,
-      # `render_phlex_index`, ...). The whole app is Phlex now -- there
-      # is no ERB left to disambiguate from -- so the `_phlex_`
-      # qualifier carries no information and just adds noise to a name
-      # that should read as what action the method renders.
+      # Flags a controller method with `phlex` anywhere in its name as
+      # a `render_`-prefixed qualifier -- `render_phlex_*`
+      # (`render_phlex_show`, `render_phlex_edit`, ...) and `*_phlex`
+      # (`render_new_phlex`, `render_edit_phlex`, `render_show_phlex`,
+      # ...) alike. The whole app is Phlex now -- there is no ERB left
+      # to disambiguate from -- so the qualifier carries no information
+      # and just adds noise to a name that should read as what action
+      # the method renders.
       #
       # The established convention is `render_<action>_view`:
       # `render_new_view`, `render_edit_view`, `render_show_view`,
@@ -42,21 +44,28 @@ module RuboCop
       #     render(Views::Controllers::Foo::Show.new(...))
       #   end
       #
+      #   # bad
+      #   def render_show_phlex
+      #     render(Views::Controllers::Foo::Show.new(...))
+      #   end
+      #
       #   # good
       #   def render_show_view
       #     render(Views::Controllers::Foo::Show.new(...))
       #   end
       class NoRenderPhlexMethodName < Base
         MSG = "Don't name a method `%<name>s` -- the whole app is Phlex " \
-              "now, so `_phlex_` carries no information. Use " \
+              "now, so a `phlex` qualifier carries no information. Use " \
               "`render_<action>_view` instead (`render_new_view`, " \
               "`render_edit_view`, `render_show_view`, " \
               "`render_index_view`, ...) -- ApplicationController's " \
               "render_new_view_invalid/render_edit_view_invalid " \
               "dispatchers call the new/edit pair by that exact name."
 
+        PHLEX_QUALIFIER_RE = /\Arender_phlex_|_phlex\z/
+
         def on_def(node)
-          return unless node.method_name.to_s.start_with?("render_phlex_")
+          return unless PHLEX_QUALIFIER_RE.match?(node.method_name.to_s)
 
           add_offense(node, message: format(MSG, name: node.method_name))
         end

--- a/lib/rubocop/cop/mo/no_render_phlex_method_name.rb
+++ b/lib/rubocop/cop/mo/no_render_phlex_method_name.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Flags a controller method named `render_phlex_*`
+      # (`render_phlex_show`, `render_phlex_edit`, `render_phlex_new`,
+      # `render_phlex_index`, ...). The whole app is Phlex now -- there
+      # is no ERB left to disambiguate from -- so the `_phlex_`
+      # qualifier carries no information and just adds noise to a name
+      # that should read as what action the method renders.
+      #
+      # The established convention is `render_<action>_view`:
+      # `render_new_view`, `render_edit_view`, `render_show_view`,
+      # `render_index_view`, etc. -- not just for new/edit.
+      # `render_new_view`/`render_edit_view` specifically (each taking
+      # `status: :ok, **render_opts` and forwarding to
+      # `render(View.new(...), status: status, **render_opts)`) are
+      # called BY THAT EXACT NAME from `ApplicationController`'s
+      # generic `render_new_view_invalid`/`render_edit_view_invalid`
+      # dispatchers (see .claude/rules/turbo_submit_forms.md, issue
+      # #5052) -- a `render_phlex_edit`/`render_phlex_new` breaks that
+      # dispatch silently, since the generic method calls
+      # `render_edit_view`/`render_new_view` and falls through to
+      # `ApplicationController`'s own base implementation instead of
+      # the controller's intended one.
+      #
+      # @example
+      #   # bad
+      #   def render_phlex_edit(**render_opts)
+      #     render(Views::Controllers::Foo::Edit.new(...), **render_opts)
+      #   end
+      #
+      #   # good
+      #   def render_edit_view(status: :ok, **render_opts)
+      #     render(Views::Controllers::Foo::Edit.new(...),
+      #            status: status, **render_opts)
+      #   end
+      #
+      #   # bad
+      #   def render_phlex_show
+      #     render(Views::Controllers::Foo::Show.new(...))
+      #   end
+      #
+      #   # good
+      #   def render_show_view
+      #     render(Views::Controllers::Foo::Show.new(...))
+      #   end
+      class NoRenderPhlexMethodName < Base
+        MSG = "Don't name a method `%<name>s` -- the whole app is Phlex " \
+              "now, so `_phlex_` carries no information. Use " \
+              "`render_<action>_view` instead (`render_new_view`, " \
+              "`render_edit_view`, `render_show_view`, " \
+              "`render_index_view`, ...) -- ApplicationController's " \
+              "render_new_view_invalid/render_edit_view_invalid " \
+              "dispatchers call the new/edit pair by that exact name."
+
+        def on_def(node)
+          return unless node.method_name.to_s.start_with?("render_phlex_")
+
+          add_offense(node, message: format(MSG, name: node.method_name))
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mo/status_kwarg_outside_invalid_method.rb
+++ b/lib/rubocop/cop/mo/status_kwarg_outside_invalid_method.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Flags `status: :unprocessable_content` passed as a keyword
+      # argument to any call (`render(...)`, `render_edit_view(...)`,
+      # a controller's own render helper, etc.) written directly
+      # inside a method whose name doesn't end in `_invalid`. Same
+      # convention as `MO/SelfStatusOutsideInvalidMethod`
+      # (`self.status = ...` outside a `*_invalid` method) -- this
+      # cop exists because the kwarg form is a second way to hand-roll
+      # the exact same anti-pattern that cop already bans, and it
+      # isn't a `self.status = ...` assignment so the other cop's
+      # pattern doesn't see it. See .claude/rules/turbo_submit_forms.md
+      # and issue #5052 -- a status-forcing re-render is supposed to
+      # be ONE call, through `render_new_view_invalid`/
+      # `render_edit_view_invalid` (or a custom `*_invalid` pair),
+      # not a hand-rolled `status:` kwarg tacked onto an otherwise
+      # plain render call.
+      #
+      # Excludes a `status:` sitting alongside an `xml:`/`json:` key in
+      # the same call (`render(json: obj.errors, status: ...)`) -- an
+      # API response, not a Turbo Drive HTML re-render, so the
+      # `_invalid` convention (built specifically around the same-URL
+      # 200-hangs-the-browser Turbo Drive failure mode) doesn't apply.
+      #
+      # @example
+      #   # bad
+      #   def dispatch_commit
+      #     render_edit_view(location: x, status: :unprocessable_content)
+      #   end
+      #
+      #   # good -- one call, status set by the generic dispatcher
+      #   def dispatch_commit
+      #     render_edit_view_invalid(location: x)
+      #   end
+      #
+      #   # good -- a custom-named *_invalid pair for a non-new/edit verb
+      #   def render_index_view_invalid(**)
+      #     render_index_view(**)
+      #     self.status = :unprocessable_content
+      #   end
+      class StatusKwargOutsideInvalidMethod < Base
+        MSG = "Don't pass `status: :unprocessable_content` as a kwarg " \
+              "here -- fold it into a method whose name ends in " \
+              "`_invalid` (or call the existing " \
+              "render_new_view_invalid/render_edit_view_invalid) so " \
+              "the status change travels with the render call, not as " \
+              "a hand-rolled kwarg a later edit can drop unnoticed. " \
+              "See .claude/rules/turbo_submit_forms.md."
+
+        def on_pair(node)
+          return unless status_unprocessable_pair?(node)
+          return if xml_or_json_response?(node)
+
+          enclosing = node.each_ancestor(:def, :defs).first
+          return unless enclosing
+          return if enclosing.method_name.to_s.end_with?("_invalid")
+
+          add_offense(node)
+        end
+
+        private
+
+        def status_unprocessable_pair?(node)
+          node.key.sym_type? && node.key.value == :status &&
+            node.value.sym_type? &&
+            [:unprocessable_content, :unprocessable_entity].
+              include?(node.value.value)
+        end
+
+        # `status:`'s sibling pairs in the same call -- `render(json:
+        # obj.errors, status: ...)`'s `status:` and `json:` are both
+        # direct children of the same kwargs hash.
+        def xml_or_json_response?(node)
+          hash = node.parent
+          return false unless hash&.hash_type?
+
+          hash.pairs.any? do |pair|
+            pair.key.sym_type? && [:xml, :json].include?(pair.key.value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mo/status_kwarg_outside_invalid_method.rb
+++ b/lib/rubocop/cop/mo/status_kwarg_outside_invalid_method.rb
@@ -3,10 +3,11 @@
 module RuboCop
   module Cop
     module MO
-      # Flags `status: :unprocessable_content` passed as a keyword
-      # argument to any call (`render(...)`, `render_edit_view(...)`,
-      # a controller's own render helper, etc.) written directly
-      # inside a method whose name doesn't end in `_invalid`. Same
+      # Flags `status: :unprocessable_content` (or the older Rails
+      # alias, `:unprocessable_entity`) passed as a keyword argument to
+      # any call (`render(...)`, `render_edit_view(...)`, a
+      # controller's own render helper, etc.) written directly inside
+      # a method whose name doesn't end in `_invalid`. Same
       # convention as `MO/SelfStatusOutsideInvalidMethod`
       # (`self.status = ...` outside a `*_invalid` method) -- this
       # cop exists because the kwarg form is a second way to hand-roll
@@ -42,9 +43,9 @@ module RuboCop
       #     self.status = :unprocessable_content
       #   end
       class StatusKwargOutsideInvalidMethod < Base
-        MSG = "Don't pass `status: :unprocessable_content` as a kwarg " \
-              "here -- fold it into a method whose name ends in " \
-              "`_invalid` (or call the existing " \
+        MSG = "Don't pass `status: %<status>s` as a kwarg here -- fold " \
+              "it into a method whose name ends in `_invalid` (or " \
+              "call the existing " \
               "render_new_view_invalid/render_edit_view_invalid) so " \
               "the status change travels with the render call, not as " \
               "a hand-rolled kwarg a later edit can drop unnoticed. " \
@@ -58,7 +59,8 @@ module RuboCop
           return unless enclosing
           return if enclosing.method_name.to_s.end_with?("_invalid")
 
-          add_offense(node)
+          add_offense(node,
+                      message: format(MSG, status: node.value.value.inspect))
         end
 
         private

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -391,7 +391,7 @@ class CommentsControllerTest < FunctionalTestCase
 
   def test_create_comment_with_invalid_params_re_renders_form
     # `reload_form` HTML branch: missing summary fails save and
-    # falls through to `render_phlex_new`.
+    # falls through to `render_new_view`.
     obs = observations(:minimal_unknown_obs)
     params = { target: obs.id, type: "Observation",
                comment: { summary: "", comment: "Body" } }


### PR DESCRIPTION
## Summary

Adds `MO/NoRenderPhlexMethodName`, a RuboCop cop banning controller methods named `render_phlex_*` or `render_*_phlex`, and renames every existing occurrence to the `render_<action>_view` convention.

## Why

To pick up DRY default app-wide methods in `ApplicationController` and avoid duplicate code. 

`render_new_view`/`render_edit_view` (each taking `status: :ok, **render_opts` and forwarding to `render(View.new(...), status: status, **render_opts)`) are the established pair for new/edit actions specifically, called *by that exact name* from `ApplicationController`'s generic `render_new_view_invalid`/`render_edit_view_invalid` dispatchers (`.claude/rules/turbo_submit_forms.md`, issue #5052) — a `render_phlex_edit`/`render_phlex_new` breaks that dispatch silently, since the generic method calls `render_edit_view`/`render_new_view` and falls through to `ApplicationController`'s own base implementation instead of the controller's intended one.

The convention generalizes to every action, not just new/edit: `render_show_view`, `render_index_view`, etc. re: naming, the whole app is Phlex now — there's no ERB left to disambiguate from — so the `_phlex_` qualifier in a method name carries no information. 

## Renames

- `render_phlex_show` → `render_show_view` — `species_lists_controller.rb`, `names/maps_controller.rb`, `observations_controller/show.rb`
- `render_phlex_index` → `render_index_view` — `observations/namings/votes_controller.rb`
- `render_phlex_edit` → `render_edit_view` — `observations/species_lists_controller.rb`

Each rename covers the method definition and every call site within the same file (none of these five were called cross-file). Also fixed a stale comment in `comments_controller_test.rb` still referencing a `render_phlex_new` name that no longer exists anywhere in the code.

## Test plan

- [x] `bundle exec rubocop --only MO/NoRenderPhlexMethodName app/` — 0 offenses after the renames
- [x] Synthetic fixture confirms the cop fires on a `render_phlex_show` method
- [x] `bin/rails test test/controllers/species_lists_controller_test.rb`
- [x] `bin/rails test test/controllers/names/maps_controller_test.rb`
- [x] `bin/rails test test/controllers/observations_controller_show_test.rb`
- [x] `bin/rails test test/controllers/observations/namings/votes_controller_test.rb`
- [x] `bin/rails test test/controllers/observations/species_lists_controller_test.rb`
- [x] `bin/rails test test/controllers/comments_controller_test.rb`
- [x] `bundle exec rubocop` clean on all touched/new files
