### PR TITLE
Dedupe `Query` param URL-merge logic between `add_q_param` and `Tab::Base#with_q_param`

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -408,6 +408,37 @@ class Query
     { model: model.name.to_sym, **params }
   end
 
+  # Merges an already-serialized `q` param value into a path's
+  # existing query string (preserving other params, e.g. `flow=next`).
+  # A plain utility, not tied to any Query instance -- shared by two
+  # callers that source the value differently:
+  # `ApplicationController::Queries#add_q_param` resolves
+  # `q_param_value` from ambient session/request state before calling
+  # this; `Tab::Base#with_q_param` has no such ambient state (a Tab is
+  # a plain PORO, not a controller/view), so its callers resolve the
+  # value themselves and pass it into the Tab's constructor instead.
+  #
+  # `q_param_value` can be a String (the alphabetized-id form --
+  # `?q=ABCDE`) or a Hash (the model+params form `Query#q_param`
+  # itself returns -- `?q[model]=Observation&q[locations][]=1`). Uses
+  # `Hash#to_query`, not `Rack::Utils.build_query` -- Rack stringifies
+  # a nested Hash value as a literal Ruby `inspect` rep, while
+  # `to_query` recurses correctly into nested hashes and arrays.
+  # Caught by the related_records integration tests exercising
+  # `Tab::Location::ObservationsAt`: a newly-created query's `q_param`
+  # is a Hash, and the resulting URL was an unparseable literal Ruby
+  # Hash rep encoded with `+` for whitespace before this used
+  # `to_query`.
+  def self.merge_q_param_into_url(path, q_param_value)
+    return path if q_param_value.blank?
+
+    uri = URI.parse(path)
+    parsed = uri.query ? Rack::Utils.parse_query(uri.query) : {}
+    parsed["q"] = q_param_value
+    uri.query = parsed.to_query
+    uri.to_s
+  end
+
   # Serialize the query params, adding the model, for saving to a QueryRecord.
   # We use this column of QueryRecord to identify an existing query record that
   # matches current params, and sometimes to recompose a query from the string.

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -408,7 +408,7 @@ class Query
     { model: model.name.to_sym, **params }
   end
 
-  # Merges an already-serialized `q` param value into a path's
+  # Merges an already-resolved `q` param value into a path's
   # existing query string (preserving other params, e.g. `flow=next`).
   # A plain utility, not tied to any Query instance -- shared by two
   # callers that source the value differently:

--- a/app/classes/tab/base.rb
+++ b/app/classes/tab/base.rb
@@ -136,27 +136,14 @@ class Tab::Base
   # carry the current Query through (e.g. "back to filtered index"
   # links on a show page).
   #
-  # Accepts either:
-  # - a String q_param (the alphabetized-id form — `?q=ABCDE`), or
-  # - a Hash q_param (the model+params form returned by
-  #   `Query#q_param` — `?q[model]=Observation&q[locations][]=1`)
-  #
-  # Uses Rails' `Hash#to_query` (not `Rack::Utils.build_query`)
-  # because Rack stringifies a nested Hash value as a literal Ruby
-  # `inspect` rep; `to_query` recurses correctly into nested
-  # hashes and arrays. Caught by the related_records integration
-  # tests that exercise `Tab::Location::ObservationsAt` — Query#q_param
-  # returns a Hash for newly-created queries, and the resulting URL
-  # was an unparseable literal Ruby Hash rep encoded with `+` for
-  # whitespace.
+  # The actual merge is `Query.merge_q_param_into_url` -- see there
+  # for the String/Hash value shapes and why it uses `Hash#to_query`.
+  # Shared with `ApplicationController::Queries#add_q_param`, which
+  # resolves `q_param_value` from ambient session/request state before
+  # calling it; a Tab has no such state, so its callers resolve the
+  # value and pass it in here instead.
   def with_q_param(path, q_param_value)
-    return path if q_param_value.blank?
-
-    uri = URI.parse(path)
-    parsed = uri.query ? Rack::Utils.parse_query(uri.query) : {}
-    parsed["q"] = q_param_value
-    uri.query = parsed.to_query
-    uri.to_s
+    Query.merge_q_param_into_url(path, q_param_value)
   end
 
   # Stable key NavTabs matches against `current:` to decide `.active`.

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -289,7 +289,7 @@ module ApplicationController::Queries
     return path_or_params if browser.bot? || !(q_param = q_param(query))
 
     if path_or_params.is_a?(String) # i.e., if "path_or_params" arg is a path
-      append_q_param_to_path(path_or_params, q_param)
+      Query.merge_q_param_into_url(path_or_params, q_param)
     else
       path_or_params[:q] = q_param
       path_or_params
@@ -303,21 +303,6 @@ module ApplicationController::Queries
   def valid_query_model?(model)
     klass = "Query::#{model.to_s.pluralize}".safe_constantize
     klass.is_a?(Class) && klass < Query
-  end
-
-  def append_q_param_to_path(path, q_param)
-    return path unless q_param
-
-    # Figure out if there's an existing URI query_string, like "flow=next"
-    # This query_string is not our q param, it's all the other params.
-    uri = URI.parse(path)
-    query_string = uri.query
-
-    # Parse the query_string as a Ruby hash, and add `q`
-    hash = query_string ? Rack::Utils.parse_query(query_string) : {}
-    hash["q"] = q_param
-    uri.query = hash.to_query
-    uri.to_s
   end
 
   public

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -691,6 +691,35 @@ class QueryTest < UnitTestCase
     assert_equal(query.q_param, { model: :Observation, **params })
   end
 
+  def test_merge_q_param_into_url
+    assert_equal(
+      "/observations", Query.merge_q_param_into_url("/observations", nil)
+    )
+    assert_equal(
+      "/observations", Query.merge_q_param_into_url("/observations", "")
+    )
+    assert_equal(
+      "/observations?q=ABCDE",
+      Query.merge_q_param_into_url("/observations", "ABCDE")
+    )
+    # Preserves an existing (non-q) query param already on the path.
+    assert_equal(
+      "/observations?flow=next&q=ABCDE",
+      Query.merge_q_param_into_url("/observations?flow=next", "ABCDE")
+    )
+    # A Hash q_param (Query#q_param's own return shape) round-trips via
+    # Hash#to_query, not Rack::Utils.build_query -- a nested value
+    # (:locations here) would otherwise serialize as an unparseable
+    # literal Ruby Hash#inspect string.
+    merged = Query.merge_q_param_into_url(
+      "/observations", { model: :Observation, locations: [1] }
+    )
+    assert_equal(
+      "q%5Blocations%5D%5B%5D=1&q%5Bmodel%5D=Observation",
+      URI.parse(merged).query
+    )
+  end
+
   ##############################################################################
   #
   #  :section: Other stuff


### PR DESCRIPTION
## Summary

`ApplicationController::Queries#append_q_param_to_path` and `Tab::Base#with_q_param` independently implemented the same URI-parse-merge-serialize algorithm for appending a `q` param onto a path. Extracted the shared logic into `Query.merge_q_param_into_url(path, q_param_value)`; both call sites are now thin delegations (`append_q_param_to_path` removed entirely, inlined at its one caller in `add_q_param`).

## Why the two methods aren't actually duplicates of each other

`Tab::Base` is a plain Ruby PORO — not a `Components::Base`/`Views::Base` subclass — so it has no access to `add_q_param` (an `ApplicationController` instance method, registered as a Phlex value helper) at all. The two methods source their `q` value differently:

- `ApplicationController::Queries#add_q_param(path_or_params, query = nil)` *derives* the value itself from ambient controller state (`current_query`, session, bot detection, auto-saves an unsaved query), then appends it.
- `Tab::Base#with_q_param(path, q_param_value)` takes an *already-resolved* value as an explicit argument and just appends it — a Tab has no ambient state to derive from. The view that constructs the Tab calls `q_param` (the registered helper) once and passes the result into the Tab's constructor.

That structural split is real and stays. The part that wasn't justified was the two independent copies of the actual merge algorithm — now one.

## Naming

Considered renaming `with_q_param` to something like `append_q_param` to disambiguate further, but "add" and "append" are synonyms — the rename wouldn't distinguish anything the current names don't already, since the real distinction (derives-vs-explicit) isn't a verb-choice problem. `with_q_param`'s "with_" already reads as "given this value" (matching the common `with_x(explicit_value)` idiom), which "add"/"append" don't convey either way. Left the name as-is and tightened the doc comments instead, per single-source-of-truth: the String/Hash value shapes and the `Hash#to_query`-vs-`Rack::Utils.build_query` rationale now live once, on `Query.merge_q_param_into_url`; `Tab::Base#with_q_param`'s comment is a pointer to it.

## Test plan

- [x] `bin/rails test test/classes/query_test.rb` (new `test_merge_q_param_into_url`, covering nil/blank passthrough, String value, existing-query-param preservation, and Hash value round-tripping via `Hash#to_query`)
- [x] `bin/rails test test/classes/tab/location/tabs_test.rb` (the related_records case that originally caught the `Hash#to_query`-vs-`Rack::Utils.build_query` bug)
- [x] `bin/rails test test/classes/tab/object/tabs_test.rb`
- [x] `bin/rails test test/classes/tab/herbarium_record/tabs_test.rb`
- [x] `bin/rails test test/classes/tab/query_link_test.rb`
- [x] `bundle exec rubocop` clean on all touched files
