### PR TITLE
Flip Turbo `forms.mode` to opt-out (#5100), eliminate remaining hand-rolled forms

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ require:
   - ./lib/rubocop/cop/mo/initialize_without_prop
   - ./lib/rubocop/cop/mo/lowercase_translation_tag
   - ./lib/rubocop/cop/mo/no_active_record_relation_prop
+  - ./lib/rubocop/cop/mo/no_hand_rolled_form_tag
   - ./lib/rubocop/cop/mo/no_hand_rolled_method_field
   - ./lib/rubocop/cop/mo/no_raw_bootstrap_component
   - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
@@ -102,6 +103,37 @@ MO/NoActiveRecordRelationProp:
   Include:
     - "app/components/**/*.rb"
     - "app/views/**/*.rb"
+
+MO/NoHandRolledFormTag:
+  Description: >-
+    Phlex views/components must not call the bare form(...) tag helper
+    directly -- use Components::ApplicationForm (Superform) instead --
+    see lib/rubocop/cop/mo/no_hand_rolled_form_tag.rb and issue #5100.
+  Enabled: true
+  Include:
+    - "app/components/**/*.rb"
+    - "app/views/**/*.rb"
+  Exclude:
+    # ApplicationForm subclasses that legitimately override form_tag
+    # to build their own GET-method (or, for BlockedIps, POST-method)
+    # <form> -- these ARE the Superform-sanctioned way to hand-roll a
+    # form tag, not a bypass of it.
+    - "app/components/form/live_data_filter.rb"
+    - "app/components/form/search.rb"
+    - "app/views/controllers/projects/updates/excluded_toggle_form.rb"
+    - "app/views/controllers/admin/blocked_ips/manager.rb"
+    - "app/views/controllers/visual_groups/filter_form.rb"
+    - "app/views/controllers/field_slips/form.rb"
+    - "app/views/controllers/observations/identify/form.rb"
+    # Reusable raw-form primitive -- GET-only index filters have no
+    # model to bind and no CSRF to send, so Components::IndexFilter is
+    # deliberately not a Superform. This IS the primitive every other
+    # index-filter form should reuse, not a bypass of it.
+    - "app/components/index_filter.rb"
+    # A one-off bespoke filter-button row (not a fit for IndexFilter's
+    # single-field-plus-submit shape); reviewed and kept explicitly
+    # Turbo-off (data-turbo="false").
+    - "app/views/controllers/rss_logs/type_filters.rb"
 
 MO/NoHandRolledMethodField:
   Description: >-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,31 +109,15 @@ MO/NoHandRolledFormTag:
     Phlex views/components must not call the bare form(...) tag helper
     directly -- use Components::ApplicationForm (Superform) instead --
     see lib/rubocop/cop/mo/no_hand_rolled_form_tag.rb and issue #5100.
+    Every legitimate raw form(...) call site is inline-disabled at the
+    call site itself, not file-excluded here -- a file-level Exclude
+    would give the whole file blanket immunity to any FUTURE raw
+    form(...) call added anywhere else in it, not just the one
+    reviewed site.
   Enabled: true
   Include:
     - "app/components/**/*.rb"
     - "app/views/**/*.rb"
-  Exclude:
-    # ApplicationForm subclasses that legitimately override form_tag
-    # to build their own GET-method (or, for BlockedIps, POST-method)
-    # <form> -- these ARE the Superform-sanctioned way to hand-roll a
-    # form tag, not a bypass of it.
-    - "app/components/form/live_data_filter.rb"
-    - "app/components/form/search.rb"
-    - "app/views/controllers/projects/updates/excluded_toggle_form.rb"
-    - "app/views/controllers/admin/blocked_ips/manager.rb"
-    - "app/views/controllers/visual_groups/filter_form.rb"
-    - "app/views/controllers/field_slips/form.rb"
-    - "app/views/controllers/observations/identify/form.rb"
-    # Reusable raw-form primitive -- GET-only index filters have no
-    # model to bind and no CSRF to send, so Components::IndexFilter is
-    # deliberately not a Superform. This IS the primitive every other
-    # index-filter form should reuse, not a bypass of it.
-    - "app/components/index_filter.rb"
-    # A one-off bespoke filter-button row (not a fit for IndexFilter's
-    # single-field-plus-submit shape); reviewed and kept explicitly
-    # Turbo-off (data-turbo="false").
-    - "app/views/controllers/rss_logs/type_filters.rb"
 
 MO/NoHandRolledMethodField:
   Description: >-

--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -245,7 +245,15 @@ form.button_to {
     flex: 0 0 auto;
     width: auto;
     display: flex;
-    align-items: center;
+    // `stretch` (not `center`) -- a `.btn`-classed child (a plain
+    // <button>/<input type=submit>, or a Link-rendered <a>, e.g. the
+    // pagination goto icon) needs to fill this span's own height
+    // (which the outer `.input-group`'s stretch already sized to
+    // match the sibling `.form-control`), not just center at its own
+    // shorter intrinsic content height -- confirmed empirically: an
+    // <a class="btn"> here sat ~2px short of the input's height with
+    // `center`, flush with `stretch`.
+    align-items: stretch;
 
     > .btn {
       display: inline-flex;

--- a/app/classes/form_object/project_exclusions.rb
+++ b/app/classes/form_object/project_exclusions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Form object for the "show excluded observations" toggle on a
+# project's Updates tab. Params namespaced as
+# project_exclusions[show].
+class FormObject::ProjectExclusions < FormObject::Base
+  attribute :show, :boolean, default: false
+end

--- a/app/classes/form_object/project_exclusions.rb
+++ b/app/classes/form_object/project_exclusions.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# Form object for the "show excluded observations" toggle on a
-# project's Updates tab. Params namespaced as
-# project_exclusions[show].
-class FormObject::ProjectExclusions < FormObject::Base
-  attribute :show, :boolean, default: false
-end

--- a/app/classes/form_object/visual_group_filter.rb
+++ b/app/classes/form_object/visual_group_filter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Form object for the status/filter-text controls on a visual group's
+# edit page. Params namespaced as visual_group_filter[status],
+# visual_group_filter[filter].
+class FormObject::VisualGroupFilter < FormObject::Base
+  attribute :status, :string, default: "needs_review"
+  attribute :filter, :string
+end

--- a/app/components/form/live_data_filter.rb
+++ b/app/components/form/live_data_filter.rb
@@ -24,6 +24,21 @@ class Components::Form::LiveDataFilter < Components::ApplicationForm
   prop :page_param, String, default: "page"
   prop :filter_param, String, default: "text_filter"
 
+  # `action:`/`method:`/`id:`/`class:`/`data:` are ordinary
+  # Superform::Rails::Form constructor kwargs, extracted by
+  # ApplicationForm#after_initialize -- unlike the route-helper-backed
+  # forms elsewhere in this sweep, `filter_path` is already a resolved
+  # path string supplied by the caller, so there's no
+  # HelpersCalledBeforeRenderError risk computing these here.
+  def initialize(model, turbo_frame:, filter_path:, **props)
+    super(model, turbo_frame:, filter_path:,
+                 action: filter_path, method: :get,
+                 id: "#{turbo_frame.tr("_", "-")}-filter-form",
+                 class: "d-inline-block",
+                 data: { controller: "autosubmit", turbo_frame: turbo_frame },
+                 **props)
+  end
+
   def around_template(&block)
     nav(class: "d-flex justify-content-between align-items-center p-3",
         style: "order: 2") do
@@ -45,23 +60,6 @@ class Components::Form::LiveDataFilter < Components::ApplicationForm
   end
 
   private
-
-  def form_tag(&block)
-    form(action: @filter_path, method: :get, **form_attributes, &block)
-  end
-
-  def form_attributes
-    {
-      id: "#{@turbo_frame.tr("_", "-")}-filter-form",
-      class: "d-inline-block",
-      # Merge in @attributes[:data] so ApplicationForm's data-turbo
-      # actually reaches this overridden form_tag.
-      data: (@attributes[:data] || {}).merge(
-        controller: "autosubmit",
-        turbo_frame: @turbo_frame
-      )
-    }
-  end
 
   # GET forms don't need authenticity tokens or _method fields
   def authenticity_token_field; end

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -26,17 +26,43 @@ class Components::Form::Search < Components::ApplicationForm
   # Additional wrapper options for search-specific fields
   SEARCH_WRAPPER_OPTIONS = [:selected, :between].freeze
 
-  # This form is always Turbo-submitted (see `form_attributes` below)
-  # regardless of the base class's `turbo:` prop, which this class
-  # doesn't use at all -- `form_tag`/`form_attributes` build the
-  # `<form>` tag's own `data:` hash from scratch rather than calling
-  # `super`. `context:` is a separate, unrelated concern: which of
-  # the two places this form renders (the standalone search page, or
-  # the nav-dropdown, loaded via a turbo_stream swap) -- it decides
-  # whether the in-form header/collapse-toggle renders and whether
-  # the nav-dropdown's turbo_stream swap-target marker is added.
+  # `context:` decides which of the two places this form renders (the
+  # standalone search page, or the nav-dropdown, loaded via a
+  # turbo_stream swap) -- whether the in-form header/collapse-toggle
+  # renders and whether the nav-dropdown's turbo_stream swap-target
+  # marker is added.
   prop :search_controller, _Interface(:search_type)
   prop :context, _Union(:page, :dropdown), default: :page
+
+  # `search_type`/`context` don't need a route helper (every search
+  # controller nests under `namespace :<search_type> do resource
+  # :search, only: [:new, :create] end`, so the action is always
+  # `/<search_type>/search`, built by hand) -- so action/method/id/
+  # class/data all pass straight through as ordinary
+  # Superform::Rails::Form constructor kwargs, no form_tag override
+  # needed. This form is always Turbo-submitted (`turbo: true`,
+  # unconditionally -- Searchable#create always redirects, so there's
+  # no same-URL-200 risk either way), via the base class's own
+  # `turbo:` prop rather than a hand-built `data:` hash -- which also
+  # lets ApplicationForm#around_template's own form-feedback
+  # controller merge in normally instead of being silently dropped by
+  # a data hash built from scratch.
+  def initialize(model, search_controller:, context: :page, **props)
+    type = search_controller.search_type
+    data = {
+      controller: "search-length-validator",
+      search_length_validator_max_length_value:
+        Searchable::MAX_SEARCH_INPUT_LENGTH,
+      search_length_validator_search_type_value: type
+    }
+    data[:turbo_stream] = "true" if context == :dropdown
+    super(model, search_controller:, context:, turbo: true,
+                 action: "/#{type}/search", method: :post,
+                 id: "#{type}_search_form",
+                 class: "faceted-search-form pb-4",
+                 data:,
+                 **props)
+  end
 
   def view_template
     render_header if dropdown?
@@ -46,39 +72,6 @@ class Components::Form::Search < Components::ApplicationForm
   end
 
   private
-
-  # Form configuration
-
-  def form_tag(&block)
-    form(action: form_action, method: :post, **form_attributes, &block)
-  end
-
-  # Every search controller nests under `namespace :<search_type> do
-  # resource :search, only: [:new, :create] end`, so this is always
-  # `/<search_type>/search` — no need for `url_for`, which also
-  # sidesteps needing a real Rails request/routing context (tests
-  # construct `search_controller` as a bare, un-rendered instance).
-  def form_action
-    "/#{search_type}/search"
-  end
-
-  def form_attributes
-    attrs = {
-      id: "#{search_type}_search_form",
-      class: "faceted-search-form pb-4",
-      data: {
-        controller: "search-length-validator",
-        search_length_validator_max_length_value:
-          Searchable::MAX_SEARCH_INPUT_LENGTH,
-        search_length_validator_search_type_value: search_type,
-        # Always on, regardless of context -- Searchable#create always
-        # redirects, so there's no same-URL-200 risk either way.
-        turbo: "true"
-      }
-    }
-    attrs[:data].merge!(turbo_stream_data) if dropdown?
-    attrs
-  end
 
   def dropdown? = @context == :dropdown
 

--- a/app/components/index_filter.rb
+++ b/app/components/index_filter.rb
@@ -48,6 +48,12 @@ class Components::IndexFilter < Components::Base
   prop :form_id, _Nilable(String), default: nil
   prop :extra_class, _Nilable(String), default: nil
 
+  # Not a Superform -- this filter's params need to land as flat,
+  # unnamespaced top-level URL params (e.g. ?project=123) for the
+  # index controller to read directly off request.params, not boxed
+  # under a FormObject namespace the way every Superform GET filter
+  # elsewhere in the app is.
+  # rubocop:disable MO/NoHandRolledFormTag
   def view_template(&block)
     form(action: url_for(@to), method: "get",
          class: form_class, id: @form_id,
@@ -59,6 +65,7 @@ class Components::IndexFilter < Components::Base
       end
     end
   end
+  # rubocop:enable MO/NoHandRolledFormTag
 
   private
 

--- a/app/controllers/projects/updates_controller.rb
+++ b/app/controllers/projects/updates_controller.rb
@@ -44,7 +44,7 @@ module Projects
       count = bulk_add_candidates(current_scope)
       flash_notice(:project_updates_added_all.t(count: count))
       redirect_to(project_updates_path(project_id: @project.id,
-                                       show_excluded: show_excluded?))
+                                       **filter_query_params))
     end
 
     private
@@ -54,9 +54,19 @@ module Projects
     end
 
     def show_excluded?
-      params[:show_excluded].present? &&
-        params[:show_excluded] != "false" &&
-        params[:show_excluded] != "0"
+      project_exclusions.show
+    end
+
+    def project_exclusions
+      @project_exclusions ||= FormObject::ProjectExclusions.new(filter_params)
+    end
+
+    def filter_params
+      params.fetch(:project_exclusions, {}).permit(:show)
+    end
+
+    def filter_query_params
+      { project_exclusions: { show: show_excluded? } }
     end
 
     # The observation list the Updates tab is currently showing.
@@ -75,8 +85,7 @@ module Projects
       { observations: obs_page,
         pagination: pagination,
         current_count: pagination.num_total,
-        request_url: request.fullpath,
-        form_action_url: request.path }
+        request_url: request.fullpath }
     end
 
     def build_pagination(scope)
@@ -115,9 +124,8 @@ module Projects
         end
         format.html do
           redirect_back_or_to(
-            project_updates_path(
-              project_id: @project.id, show_excluded: show_excluded?
-            )
+            project_updates_path(project_id: @project.id,
+                                 **filter_query_params)
           )
         end
       end

--- a/app/controllers/projects/updates_controller.rb
+++ b/app/controllers/projects/updates_controller.rb
@@ -54,19 +54,11 @@ module Projects
     end
 
     def show_excluded?
-      project_exclusions.show
-    end
-
-    def project_exclusions
-      @project_exclusions ||= FormObject::ProjectExclusions.new(filter_params)
-    end
-
-    def filter_params
-      params.fetch(:project_exclusions, {}).permit(:show)
+      ActiveModel::Type::Boolean.new.cast(params[:show_excluded]) == true
     end
 
     def filter_query_params
-      { project_exclusions: { show: show_excluded? } }
+      { show_excluded: show_excluded? }
     end
 
     # The observation list the Updates tab is currently showing.

--- a/app/controllers/visual_groups_controller.rb
+++ b/app/controllers/visual_groups_controller.rb
@@ -37,9 +37,9 @@ class VisualGroupsController < ApplicationController
   # GET /visual_groups/1/edit
   def edit
     @visual_group = VisualGroup.find(params[:id])
-    @filter = params.permit(:filter)[:filter]
+    @filter = edit_filter.filter
     @filter = @visual_group.name unless @filter && @filter != ""
-    @status = status_from_params(params)
+    @status = edit_filter.status
     @vals = calc_edit_vals
     setup_pagination
     render(Views::Controllers::VisualGroups::Edit.new(
@@ -59,11 +59,12 @@ class VisualGroupsController < ApplicationController
     @subset = @vals[@pagination_data.from..@pagination_data.to]
   end
 
-  def status_from_params(params)
-    return "included" if params[:commit] == :visual_group_included.t
-    return "excluded" if params[:commit] == :visual_group_excluded.t
+  def edit_filter
+    @edit_filter ||= FormObject::VisualGroupFilter.new(edit_filter_params)
+  end
 
-    params.permit(:status)[:status] || "needs_review"
+  def edit_filter_params
+    params.fetch(:visual_group_filter, {}).permit(:status, :filter)
   end
 
   # POST /visual_groups or /visual_groups.json

--- a/app/controllers/visual_groups_controller.rb
+++ b/app/controllers/visual_groups_controller.rb
@@ -63,8 +63,14 @@ class VisualGroupsController < ApplicationController
     @edit_filter ||= FormObject::VisualGroupFilter.new(edit_filter_params)
   end
 
+  # `?visual_group_filter=foo` (a String, not a nested hash) would
+  # otherwise reach `.permit` and raise NoMethodError -- guard the
+  # type before calling it.
   def edit_filter_params
-    params.fetch(:visual_group_filter, {}).permit(:status, :filter)
+    raw = params[:visual_group_filter]
+    return {} unless raw.is_a?(ActionController::Parameters)
+
+    raw.permit(:status, :filter)
   end
 
   # POST /visual_groups or /visual_groups.json

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -8,11 +8,13 @@ import "jquery" // this import first, then your other imports that use `$`
 import "bootstrap"
 
 import "@hotwired/turbo-rails"
-// Must setFormMode("optin") or all forms will need to provide a turbo response.
-// https://stackoverflow.com/questions/70921317/how-can-i-disable-hotwire-turbo-the-turbolinks-replacement-for-all-forms-in
-// form, or button like delete/patch: set data-turbo="true" to opt in
-// link_to with GET: set data-turbo-stream="true" to opt in
-Turbo.config.forms.mode = "optin"
+// Rails 8 default: every form submits via Turbo unless it (or an
+// ancestor) carries data-turbo="false". Components::ApplicationForm's
+// `turbo:` prop always emits an explicit data-turbo attribute per
+// form, so this global mode only matters for the handful of raw
+// <form> tags outside that framework -- each of those already sets
+// data-turbo="false" explicitly where needed.
+Turbo.config.forms.mode = "on"
 // https://stackoverflow.com/a/77434363/3357635
 // use: <%= turbo_stream.close_modal("modal_#{obs.id}_naming") %>
 Turbo.StreamActions.close_modal = function () {

--- a/app/javascript/controllers/page-input_controller.js
+++ b/app/javascript/controllers/page-input_controller.js
@@ -18,10 +18,13 @@ export default class extends Controller {
     // Cache the server-rendered tooltip so it can be restored (rather
     // than left stale, pointing at a value no longer being typed) if
     // the field gets cleared back to empty -- see updateGotoLink.
+    // aria-label (set unconditionally by Components::Icon whenever a
+    // title: is given) is the stable source: unlike title, it's never
+    // moved/removed by Bootstrap's tooltip init, so it reads the same
+    // whether that init has run yet or not.
     if (this.hasGoToLinkTarget) {
       const icon = this.goToLinkTarget.querySelector("svg")
-      this.originalTooltip = icon?.getAttribute("data-original-title") ||
-        icon?.getAttribute("title") || null
+      this.originalTooltip = icon?.getAttribute("aria-label") || null
     }
   }
 
@@ -83,17 +86,14 @@ export default class extends Controller {
   // Rewrite a goto link's href to point at the new param value (empty
   // string clears the param, matching how the page widget resets
   // when no letter is set). When `replacePattern` is given and there's
-  // a value to substitute, also updates the icon's Bootstrap tooltip
-  // text by finding-and-replacing the old number/letter directly in
-  // the already-rendered (translated) tooltip string, rather than
-  // needing a separate template. `data-original-title` is where
-  // Bootstrap 3 stashes the tooltip text after `fixTitle()`
-  // neutralizes the native `title` attribute on init, and updating it
-  // live is Bootstrap's own supported way to change an
-  // already-initialized tooltip's text. When the value is cleared
-  // (empty), restores the cached server-rendered tooltip (see
-  // connect) instead of leaving stale text naming the last-typed
-  // value the href no longer points at.
+  // a value to substitute, also updates the icon's tooltip text (both
+  // the Bootstrap tooltip and its aria-label accessible name) by
+  // finding-and-replacing the old number/letter directly in the
+  // already-rendered (translated) text, rather than needing a
+  // separate template. When the value is cleared (empty), restores
+  // the cached server-rendered tooltip (see connect) instead of
+  // leaving stale text naming the last-typed value the href no longer
+  // points at.
   updateGotoLink(link, param, value, replacePattern) {
     const url = new URL(link.href, window.location.origin)
     if (value === "" || value === null || value === undefined) {
@@ -108,17 +108,29 @@ export default class extends Controller {
     if (!icon) return
 
     if (!value) {
-      if (this.originalTooltip) {
-        icon.setAttribute("data-original-title", this.originalTooltip)
-      }
+      if (this.originalTooltip) this.setTooltipText(icon, this.originalTooltip)
       return
     }
 
-    const current = icon.getAttribute("data-original-title") ||
-      icon.getAttribute("title")
-    if (current) {
-      icon.setAttribute("data-original-title",
-        current.replace(replacePattern, value))
+    const current = icon.getAttribute("aria-label")
+    if (current) this.setTooltipText(icon, current.replace(replacePattern, value))
+  }
+
+  // Keeps the Bootstrap tooltip text and the icon's own accessible
+  // name in sync. aria-label is always present (see connect) and
+  // never touched by Bootstrap's tooltip init, so it's updated
+  // unconditionally; whichever of `data-original-title` (Bootstrap's
+  // post-init stash, per fixTitle()) or `title` (pre-init) is
+  // currently present carries the Bootstrap tooltip text and is
+  // updated too -- updating a `title` that's already been moved to
+  // `data-original-title` would silently do nothing, since Bootstrap
+  // reads the tooltip text from the latter once initialized.
+  setTooltipText(icon, text) {
+    icon.setAttribute("aria-label", text)
+    if (icon.hasAttribute("data-original-title")) {
+      icon.setAttribute("data-original-title", text)
+    } else if (icon.hasAttribute("title")) {
+      icon.setAttribute("title", text)
     }
   }
 }

--- a/app/javascript/controllers/page-input_controller.js
+++ b/app/javascript/controllers/page-input_controller.js
@@ -1,9 +1,14 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="page-input"
-// Sanitizes the page number to min/max values
+// Sanitizes the page number / letter inputs, and keeps this
+// instance's "Goto" link (a plain <a>, not inside a <form>) pointed
+// at the right page/letter as the user types -- no submission
+// needed. Instantiated once per page-input/letter-input widget (two
+// separate elements each carry their own data-controller="page-input"),
+// so `goToLink` is unambiguous within either instance's own scope.
 export default class extends Controller {
-  static targets = ["numberInput", "letterInput", "letterHiddenInput"]
+  static targets = ["numberInput", "letterInput", "goToLink"]
   static values = { max: Number, letters: String }
 
   connect() {
@@ -19,6 +24,10 @@ export default class extends Controller {
     if (numberInput > this.maxValue) { numberInput = this.maxValue }
     this.numberInputTarget.value = numberInput
     this.numberInputTarget.setAttribute("value", numberInput)
+
+    if (this.hasGoToLinkTarget) {
+      this.updateGotoLink(this.goToLinkTarget, "page", numberInput, /\d+/)
+    }
   }
 
   // When letter input changes, make it a letter or a dash.
@@ -28,9 +37,19 @@ export default class extends Controller {
     if (!this.isLetter(letterInput)) letterInput = ""
 
     this.letterInputTarget.value = letterInput
-    // if (letterInput == "") {
     this.letterInputTarget.setAttribute("value", letterInput)
-    // emit the letterUpdated event
+
+    if (this.hasGoToLinkTarget) {
+      this.updateGotoLink(this.goToLinkTarget, "letter", letterInput,
+        /[A-Z]$/)
+    }
+
+    // emit the letterUpdated event -- the page-number widget's own
+    // page-input controller instance listens for this (see
+    // syncLetter below) to keep ITS goto link's `letter` param in
+    // sync too. No reverse sync: jumping to a new letter always
+    // resets to page 1, so the letter widget never needs to know
+    // the current page.
     const event = new CustomEvent("letterUpdated", {
       detail: {
         letter: letterInput
@@ -47,6 +66,39 @@ export default class extends Controller {
 
   syncLetter(event) {
     const letterInput = event?.detail?.letter
-    this.letterHiddenInputTarget.setAttribute("value", letterInput)
+    if (this.hasGoToLinkTarget) {
+      this.updateGotoLink(this.goToLinkTarget, "letter", letterInput)
+    }
+  }
+
+  // Rewrite a goto link's href to point at the new param value (empty
+  // string clears the param, matching how the page widget resets
+  // when no letter is set). When `replacePattern` is given and there's
+  // a value to substitute, also updates the icon's Bootstrap tooltip
+  // text by finding-and-replacing the old number/letter directly in
+  // the already-rendered (translated) tooltip string, rather than
+  // needing a separate template. `data-original-title` is where
+  // Bootstrap 3 stashes the tooltip text after `fixTitle()`
+  // neutralizes the native `title` attribute on init, and updating it
+  // live is Bootstrap's own supported way to change an
+  // already-initialized tooltip's text.
+  updateGotoLink(link, param, value, replacePattern) {
+    const url = new URL(link.href, window.location.origin)
+    if (value === "" || value === null || value === undefined) {
+      url.searchParams.delete(param)
+    } else {
+      url.searchParams.set(param, value)
+    }
+    link.href = url.toString()
+
+    if (!replacePattern || !value) return
+    const icon = link.querySelector("svg")
+    if (!icon) return
+    const current = icon.getAttribute("data-original-title") ||
+      icon.getAttribute("title")
+    if (current) {
+      icon.setAttribute("data-original-title",
+        current.replace(replacePattern, value))
+    }
   }
 }

--- a/app/javascript/controllers/page-input_controller.js
+++ b/app/javascript/controllers/page-input_controller.js
@@ -14,6 +14,15 @@ export default class extends Controller {
   connect() {
     // Just a "sanity check" convention, so you can tell "is this thing on?"
     this.element.dataset.pageInput = "connected"
+
+    // Cache the server-rendered tooltip so it can be restored (rather
+    // than left stale, pointing at a value no longer being typed) if
+    // the field gets cleared back to empty -- see updateGotoLink.
+    if (this.hasGoToLinkTarget) {
+      const icon = this.goToLinkTarget.querySelector("svg")
+      this.originalTooltip = icon?.getAttribute("data-original-title") ||
+        icon?.getAttribute("title") || null
+    }
   }
 
   // When page number input changes, sanitize the value of the input.
@@ -81,7 +90,10 @@ export default class extends Controller {
   // Bootstrap 3 stashes the tooltip text after `fixTitle()`
   // neutralizes the native `title` attribute on init, and updating it
   // live is Bootstrap's own supported way to change an
-  // already-initialized tooltip's text.
+  // already-initialized tooltip's text. When the value is cleared
+  // (empty), restores the cached server-rendered tooltip (see
+  // connect) instead of leaving stale text naming the last-typed
+  // value the href no longer points at.
   updateGotoLink(link, param, value, replacePattern) {
     const url = new URL(link.href, window.location.origin)
     if (value === "" || value === null || value === undefined) {
@@ -91,9 +103,17 @@ export default class extends Controller {
     }
     link.href = url.toString()
 
-    if (!replacePattern || !value) return
+    if (!replacePattern) return
     const icon = link.querySelector("svg")
     if (!icon) return
+
+    if (!value) {
+      if (this.originalTooltip) {
+        icon.setAttribute("data-original-title", this.originalTooltip)
+      }
+      return
+    }
+
     const current = icon.getAttribute("data-original-title") ||
       icon.getAttribute("title")
     if (current) {

--- a/app/views/controllers/admin/blocked_ips/manager.rb
+++ b/app/views/controllers/admin/blocked_ips/manager.rb
@@ -63,9 +63,16 @@ module Views::Controllers::Admin::BlockedIps
       @list.page.present? && @list.total_pages.present?
     end
 
+    # `action_path` calls a Rails route helper, which Phlex-Rails
+    # forbids from `initialize` (HelpersCalledBeforeRenderError) --
+    # it's only reachable once rendering has started, which means the
+    # whole tag has to be built here in form_tag, not passed as a
+    # constructor kwarg the base class's own form_tag could use.
+    # rubocop:disable MO/NoHandRolledFormTag
     def form_tag(&block)
       form(action: action_path, method: :post, **form_attributes, &block)
     end
+    # rubocop:enable MO/NoHandRolledFormTag
 
     def form_attributes
       {

--- a/app/views/controllers/field_slips/form.rb
+++ b/app/views/controllers/field_slips/form.rb
@@ -31,7 +31,15 @@ module Views::Controllers::FieldSlips
 
     private
 
-    # Override form_tag so we can use GET for the code-only entry form.
+    # When model.code is absent, the target route depends on
+    # model.new_record? (new_field_slip_path/field_slips_path/
+    # field_slip_path) -- Rails route helpers, which Phlex-Rails
+    # forbids calling from `initialize` (HelpersCalledBeforeRenderError).
+    # form_action is only reachable once rendering has started, which
+    # means the whole tag has to be built here in form_tag for that
+    # branch, not passed as a constructor kwarg. The model.code branch
+    # uses the base class's own default form_tag unchanged.
+    # rubocop:disable MO/NoHandRolledFormTag
     def form_tag(&block)
       if model.code
         super
@@ -40,6 +48,7 @@ module Views::Controllers::FieldSlips
              **form_attributes, &block)
       end
     end
+    # rubocop:enable MO/NoHandRolledFormTag
 
     def form_attributes
       # Forward @attributes[:data] so ApplicationForm's data-turbo

--- a/app/views/controllers/observations/identify/form.rb
+++ b/app/views/controllers/observations/identify/form.rb
@@ -34,10 +34,18 @@ module Views::Controllers::Observations::Identify
 
     private
 
+    # form_action calls identify_observations_path, a Rails route
+    # helper, which Phlex-Rails forbids from `initialize`
+    # (HelpersCalledBeforeRenderError) -- only reachable once
+    # rendering has started, which means the whole tag has to be
+    # built here in form_tag, not passed as a constructor kwarg the
+    # base class's own form_tag could use.
+    # rubocop:disable MO/NoHandRolledFormTag
     def form_tag(&block)
       form(action: form_action, method: :get,
            **form_attributes, &block)
     end
+    # rubocop:enable MO/NoHandRolledFormTag
 
     def form_attributes
       {

--- a/app/views/controllers/projects/updates/excluded_toggle_form.rb
+++ b/app/views/controllers/projects/updates/excluded_toggle_form.rb
@@ -3,57 +3,45 @@
 module Views::Controllers::Projects::Updates
   # Autosubmitting GET checkbox that toggles whether excluded
   # observations show on a project's Updates tab.
-  class ExcludedToggleForm < Components::ApplicationForm
+  class ExcludedToggleForm < Views::Base
     prop :project, ::Project
-
-    # Accept optional model arg for ModalForm compatibility (ignored
-    # -- we create our own FormObject). Pattern B: form creates
-    # FormObject internally.
-    def initialize(_model = nil, project:, show_excluded:, **)
-      super(FormObject::ProjectExclusions.new(show: show_excluded),
-            project: project, turbo: false, **)
-    end
+    prop :show_excluded, _Boolean
 
     def view_template
-      super do
-        checkbox_field(:show, label: :project_updates_show_excluded.t,
-                              wrap_class: "checkbox-inline mb-0",
-                              data: { action: "change->autosubmit#submit" })
+      # Not a Components::ApplicationForm -- the only field is a
+      # standalone checkbox with no model to bind (Superform's
+      # form_tag/CSRF/_method machinery, and the model: prop it
+      # requires, would all be unused here), so this builds a plain
+      # GET form by hand, styled via FieldProxy + CheckboxField (the
+      # established way to reuse ApplicationForm's field markup
+      # outside a Superform-bound form).
+      # rubocop:disable MO/NoHandRolledFormTag
+      form(action: project_updates_path(project_id: @project.id),
+           method: :get,
+           class: "form-inline show-excluded-form",
+           data: { turbo: "false", controller: "autosubmit",
+                   autosubmit_delay_value: "0" }) do
+        render_show_excluded_checkbox
       end
+      # rubocop:enable MO/NoHandRolledFormTag
     end
 
     private
 
-    # `action:`/`method:`/`class:`/`data:` are ordinary constructor
-    # kwargs the base class would otherwise handle without an
-    # override -- but form_action needs `project_updates_path`, a
-    # Rails route helper, and Phlex-Rails raises
-    # HelpersCalledBeforeRenderError if a route helper runs from
-    # `initialize` (confirmed directly: moving this call into the
-    # constructor throws). `form_tag` runs during rendering, after
-    # helpers become available, so the route-helper call has to live
-    # here, which means the whole tag has to be built here too.
-    # rubocop:disable MO/NoHandRolledFormTag
-    def form_tag(&block)
-      form(action: form_action, method: :get, **form_attributes, &block)
-    end
-    # rubocop:enable MO/NoHandRolledFormTag
-
-    def form_action
-      project_updates_path(project_id: @project.id)
+    def render_show_excluded_checkbox
+      proxy = Components::ApplicationForm::FieldProxy.new(
+        nil, "show_excluded"
+      )
+      render(Components::ApplicationForm::CheckboxField.new(
+               proxy, checked: @show_excluded,
+                      wrapper_options: checkbox_wrapper_options,
+                      data: { action: "change->autosubmit#submit" }
+             ))
     end
 
-    def form_attributes
-      {
-        class: "form-inline show-excluded-form",
-        data: (@attributes[:data] || {}).merge(
-          controller: "autosubmit", autosubmit_delay_value: "0"
-        )
-      }
+    def checkbox_wrapper_options
+      { label: :project_updates_show_excluded.t,
+        wrap_class: "checkbox-inline mb-0" }
     end
-
-    # GET forms don't need authenticity tokens or _method fields
-    def authenticity_token_field; end
-    def _method_field; end
   end
 end

--- a/app/views/controllers/projects/updates/excluded_toggle_form.rb
+++ b/app/views/controllers/projects/updates/excluded_toggle_form.rb
@@ -24,9 +24,20 @@ module Views::Controllers::Projects::Updates
 
     private
 
+    # `action:`/`method:`/`class:`/`data:` are ordinary constructor
+    # kwargs the base class would otherwise handle without an
+    # override -- but form_action needs `project_updates_path`, a
+    # Rails route helper, and Phlex-Rails raises
+    # HelpersCalledBeforeRenderError if a route helper runs from
+    # `initialize` (confirmed directly: moving this call into the
+    # constructor throws). `form_tag` runs during rendering, after
+    # helpers become available, so the route-helper call has to live
+    # here, which means the whole tag has to be built here too.
+    # rubocop:disable MO/NoHandRolledFormTag
     def form_tag(&block)
       form(action: form_action, method: :get, **form_attributes, &block)
     end
+    # rubocop:enable MO/NoHandRolledFormTag
 
     def form_action
       project_updates_path(project_id: @project.id)

--- a/app/views/controllers/projects/updates/excluded_toggle_form.rb
+++ b/app/views/controllers/projects/updates/excluded_toggle_form.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Views::Controllers::Projects::Updates
+  # Autosubmitting GET checkbox that toggles whether excluded
+  # observations show on a project's Updates tab.
+  class ExcludedToggleForm < Components::ApplicationForm
+    prop :project, ::Project
+
+    # Accept optional model arg for ModalForm compatibility (ignored
+    # -- we create our own FormObject). Pattern B: form creates
+    # FormObject internally.
+    def initialize(_model = nil, project:, show_excluded:, **)
+      super(FormObject::ProjectExclusions.new(show: show_excluded),
+            project: project, turbo: false, **)
+    end
+
+    def view_template
+      super do
+        checkbox_field(:show, label: :project_updates_show_excluded.t,
+                              wrap_class: "checkbox-inline mb-0",
+                              data: { action: "change->autosubmit#submit" })
+      end
+    end
+
+    private
+
+    def form_tag(&block)
+      form(action: form_action, method: :get, **form_attributes, &block)
+    end
+
+    def form_action
+      project_updates_path(project_id: @project.id)
+    end
+
+    def form_attributes
+      {
+        class: "form-inline show-excluded-form",
+        data: (@attributes[:data] || {}).merge(
+          controller: "autosubmit", autosubmit_delay_value: "0"
+        )
+      }
+    end
+
+    # GET forms don't need authenticity tokens or _method fields
+    def authenticity_token_field; end
+    def _method_field; end
+  end
+end

--- a/app/views/controllers/projects/updates/index.rb
+++ b/app/views/controllers/projects/updates/index.rb
@@ -69,7 +69,7 @@ module Views::Controllers::Projects::Updates
         name: :project_updates_add_all.t,
         target: add_all_project_updates_path(
           project_id: @project.id,
-          project_exclusions: { show: @show_excluded }
+          show_excluded: @show_excluded
         ),
         confirm: :project_updates_confirm_add_all.t
       )

--- a/app/views/controllers/projects/updates/index.rb
+++ b/app/views/controllers/projects/updates/index.rb
@@ -7,18 +7,16 @@ module Views::Controllers::Projects::Updates
     prop :observations, _Array(::Observation)
     prop :pagination, ::PaginationData
     prop :request_url, String
-    prop :form_action_url, String
     prop :current_count, Integer
     prop :show_excluded, _Boolean
 
-    # `results:` bundles five values the controller computes together
+    # `results:` bundles four values the controller computes together
     # (see Projects::UpdatesController#build_index_results) -- split
     # them into individual props here so callers still pass one hash.
     def initialize(results:, **)
       super(observations: results[:observations],
             pagination: results[:pagination],
             request_url: results[:request_url],
-            form_action_url: results[:form_action_url],
             current_count: results[:current_count],
             **)
     end
@@ -49,7 +47,9 @@ module Views::Controllers::Projects::Updates
         span(id: "project_updates_count", class: "mr-3") do
           plain(count_label)
         end
-        render_show_excluded_toggle
+        render(ExcludedToggleForm.new(
+                 project: @project, show_excluded: @show_excluded
+               ))
       end
     end
 
@@ -63,31 +63,13 @@ module Views::Controllers::Projects::Updates
       :project_updates_count
     end
 
-    def render_show_excluded_toggle
-      form(
-        action: project_updates_path(project_id: @project.id),
-        method: "get",
-        class: "form-inline mb-0 show-excluded-form",
-        data: { controller: "autosubmit",
-                autosubmit_delay_value: "0",
-                turbo: "false" }
-      ) do
-        label(class: "checkbox-inline") do
-          input(type: "checkbox", name: "show_excluded", value: "1",
-                checked: @show_excluded,
-                data: { action: "change->autosubmit#submit" })
-          plain(" #{:project_updates_show_excluded.t}")
-        end
-      end
-    end
-
     def render_add_all_button
       Button(
         type: :post,
         name: :project_updates_add_all.t,
         target: add_all_project_updates_path(
           project_id: @project.id,
-          show_excluded: @show_excluded
+          project_exclusions: { show: @show_excluded }
         ),
         confirm: :project_updates_confirm_add_all.t
       )
@@ -98,9 +80,7 @@ module Views::Controllers::Projects::Updates
 
       render(Views::Layouts::Header::IndexPaginationNav.new(
                pagination_data: @pagination,
-               request_url: @request_url,
-               form_action_url: @form_action_url,
-               letter_param: nil
+               request_url: @request_url
              ))
     end
 

--- a/app/views/controllers/rss_logs/type_filters.rb
+++ b/app/views/controllers/rss_logs/type_filters.rb
@@ -8,6 +8,14 @@ module Views::Controllers::RssLogs
     prop :query, _Nilable(::Query)
     prop :types, _Array(::String)
 
+    # Not a Superform -- a multi-select checkbox filter (RssLogsController
+    # explicitly validates "array of types, from form checkboxes"), not a
+    # single-model-bound field set. Submitting the combined state of
+    # several independently-toggled checkboxes as one q[type][] array
+    # needs a submit, unlike IndexPaginationNav's single-value goto
+    # controls, which each fully specify their own destination and so
+    # reduce to plain links.
+    # rubocop:disable MO/NoHandRolledFormTag
     def view_template
       form(action: activity_logs_path, method: :get,
            class: "filter-form", id: "log_filter_form",
@@ -16,6 +24,7 @@ module Views::Controllers::RssLogs
         render_filter_buttons
       end
     end
+    # rubocop:enable MO/NoHandRolledFormTag
 
     private
 

--- a/app/views/controllers/support/confirm.rb
+++ b/app/views/controllers/support/confirm.rb
@@ -41,9 +41,12 @@ module Views::Controllers::Support
     end
 
     def render_paypal_form
+      # Cross-origin POST straight to PayPal's own checkout -- Turbo
+      # Drive would intercept this via fetch() and break the hand-off
+      # instead of letting the browser navigate there directly.
       form(id: "donate_form", name: "_xclick",
            action: "https://www.paypal.com/cgi-bin/webscr",
-           method: "post") do
+           method: "post", data: { turbo: "false" }) do
         render_paypal_hidden_fields
         render_paypal_submit_button
       end

--- a/app/views/controllers/support/confirm.rb
+++ b/app/views/controllers/support/confirm.rb
@@ -43,13 +43,17 @@ module Views::Controllers::Support
     def render_paypal_form
       # Cross-origin POST straight to PayPal's own checkout -- Turbo
       # Drive would intercept this via fetch() and break the hand-off
-      # instead of letting the browser navigate there directly.
+      # instead of letting the browser navigate there directly. Not a
+      # Components::ApplicationForm because there's no local model to
+      # bind and no CSRF token to send to an external host.
+      # rubocop:disable MO/NoHandRolledFormTag
       form(id: "donate_form", name: "_xclick",
            action: "https://www.paypal.com/cgi-bin/webscr",
            method: "post", data: { turbo: "false" }) do
         render_paypal_hidden_fields
         render_paypal_submit_button
       end
+      # rubocop:enable MO/NoHandRolledFormTag
     end
 
     def render_paypal_hidden_fields

--- a/app/views/controllers/visual_groups/edit.rb
+++ b/app/views/controllers/visual_groups/edit.rb
@@ -17,12 +17,6 @@ module Views::Controllers::VisualGroups
     prop :subset, _Array(_Tuple(::Image, _Nilable(_Boolean))),
          default: -> { [] }
 
-    STATUSES = [
-      ["needs_review", :visual_group_needs_review],
-      ["included", :visual_group_included],
-      ["excluded", :visual_group_excluded]
-    ].freeze
-
     def view_template
       add_edit_title(@visual_group)
       container_class(:full)
@@ -85,91 +79,15 @@ module Views::Controllers::VisualGroups
     end
 
     def distinct_name_filter_path(name)
-      edit_visual_group_path(@visual_group, filter: name,
-                                            anchor: "filter_options")
+      edit_visual_group_path(@visual_group,
+                             visual_group_filter: { filter: name },
+                             anchor: "filter_options")
     end
 
-    # Combined filter form: status (button-group) + filter text input.
-    # Both are inside one form so clicking a status submit button
-    # carries the current text along, and submitting the text input
-    # preserves the current status via the hidden status field.
     def render_filter_form
-      form(action: edit_visual_group_path(@visual_group), method: "get",
-           id: "visual_group_filters_form", class: "form-inline mb-4",
-           data: { turbo: "false" }) do
-        # Hidden status field: preserves the current status when the
-        # user submits via the text-input's submit. The status submit
-        # buttons below carry their own `name="status" value="<s>"`;
-        # because the hidden field appears FIRST in the DOM, the
-        # button's value (later in DOM) wins in Rails' last-value-wins
-        # param parsing.
-        input(type: "hidden", name: "status", value: @status,
-              autocomplete: "off")
-        render_status_button_row
-        render_filter_text_row
-      end
-    end
-
-    def render_status_button_row
-      div(class: "d-flex gap-2 align-items-center mb-3") do
-        strong(class: "mb-0") do
-          plain("#{:edit_visual_group_filter_options.t}:")
-        end
-        ButtonGroup do
-          STATUSES.each do |(value, label_key)|
-            render_status_button(value, label_key.t)
-          end
-        end
-        render_reload_link if @status == "needs_review"
-      end
-    end
-
-    def render_status_button(value, label)
-      if @status == value
-        Button(
-          name: label, variant: :outline,
-          tag: :span, aria_disabled: "true",
-          class: "active disabled"
-        )
-      else
-        Button(
-          type: :submit,
-          name: label,
-          html_name: "status",
-          value: value,
-          variant: :outline
-        )
-      end
-    end
-
-    # Force-reload button for the needs_review view, which pulls
-    # fresh inference data on each load. We need a true cache-bypass
-    # reload: a same-URL self-link would let Turbo Drive serve its
-    # snapshot (stale data), and HTTP-layer caching is less reliable
-    # than the explicit `reload(true)` for force-refetch. Phlex's
-    # native `a` strips `javascript:` hrefs as a safety measure, but
-    # the registered Rails `link_to` helper keeps them.
-    def render_reload_link
-      Button(
-        name: :reload.ti,
-        class: "ml-2",
-        onclick: "window.location.reload(true)"
-      )
-    end
-
-    def render_filter_text_row
-      div(class: "d-flex gap-2 align-items-end") do
-        div(class: "form-group mb-0") do
-          label(for: "filter") { plain("Filter text:") }
-          input(type: "text", name: "filter", id: "filter",
-                value: @filter, size: 40, class: "form-control")
-        end
-        Button(
-          type: :submit,
-          name: :edit_visual_group_update_filter.t,
-          html_name: "commit"
-        )
-      end
+      render(FilterForm.new(
+               visual_group: @visual_group, status: @status, filter: @filter
+             ))
     end
 
     def render_status_count

--- a/app/views/controllers/visual_groups/filter_form.rb
+++ b/app/views/controllers/visual_groups/filter_form.rb
@@ -27,10 +27,10 @@ module Views::Controllers::VisualGroups
       super do
         # Hidden status field: preserves the current status when the
         # user submits via the text-input's submit. The status submit
-        # buttons below carry their own `name="status" value="<s>"`;
-        # because the hidden field appears FIRST in the DOM, the
-        # button's value (later in DOM) wins in Rails' last-value-wins
-        # param parsing.
+        # buttons below carry their own
+        # `name="visual_group_filter[status]" value="<s>"`; because the
+        # hidden field appears FIRST in the DOM, the button's value
+        # (later in DOM) wins in Rails' last-value-wins param parsing.
         hidden_field(:status)
         render_status_button_row
         render_filter_text_row

--- a/app/views/controllers/visual_groups/filter_form.rb
+++ b/app/views/controllers/visual_groups/filter_form.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Views::Controllers::VisualGroups
+  # Combined filter form on a visual group's edit page: status
+  # (button-group) + filter text input. Both are inside one form so
+  # clicking a status submit button carries the current text along,
+  # and submitting the text input preserves the current status via
+  # the hidden status field.
+  class FilterForm < Components::ApplicationForm
+    STATUSES = [
+      ["needs_review", :visual_group_needs_review],
+      ["included", :visual_group_included],
+      ["excluded", :visual_group_excluded]
+    ].freeze
+
+    prop :visual_group, ::VisualGroup
+
+    # Accept optional model arg for ModalForm compatibility (ignored
+    # -- we create our own FormObject). Pattern B: form creates
+    # FormObject internally.
+    def initialize(_model = nil, visual_group:, status:, filter:, **)
+      super(FormObject::VisualGroupFilter.new(status:, filter:),
+            visual_group: visual_group, turbo: false, **)
+    end
+
+    def view_template
+      super do
+        # Hidden status field: preserves the current status when the
+        # user submits via the text-input's submit. The status submit
+        # buttons below carry their own `name="status" value="<s>"`;
+        # because the hidden field appears FIRST in the DOM, the
+        # button's value (later in DOM) wins in Rails' last-value-wins
+        # param parsing.
+        hidden_field(:status)
+        render_status_button_row
+        render_filter_text_row
+      end
+    end
+
+    private
+
+    def form_tag(&block)
+      form(action: form_action, method: :get,
+           **form_attributes, &block)
+    end
+
+    def form_action
+      edit_visual_group_path(@visual_group)
+    end
+
+    def form_attributes
+      {
+        id: "visual_group_filters_form",
+        class: "form-inline mb-4",
+        data: @attributes[:data] || {}
+      }
+    end
+
+    # GET forms don't need authenticity tokens or _method fields
+    def authenticity_token_field; end
+    def _method_field; end
+
+    def render_status_button_row
+      div(class: "d-flex gap-2 align-items-center mb-3") do
+        strong(class: "mb-0") do
+          plain("#{:edit_visual_group_filter_options.t}:")
+        end
+        ButtonGroup do
+          STATUSES.each do |(value, label_key)|
+            render_status_button(value, label_key.t)
+          end
+        end
+        render_reload_link if model.status == "needs_review"
+      end
+    end
+
+    def render_status_button(value, label)
+      if model.status == value
+        Button(
+          name: label, variant: :outline,
+          tag: :span, aria_disabled: "true",
+          class: "active disabled"
+        )
+      else
+        Button(
+          type: :submit,
+          name: label,
+          html_name: "visual_group_filter[status]",
+          value: value,
+          variant: :outline
+        )
+      end
+    end
+
+    # Force-reload button for the needs_review view, which pulls
+    # fresh inference data on each load. We need a true cache-bypass
+    # reload: a same-URL self-link would let Turbo Drive serve its
+    # snapshot (stale data), and HTTP-layer caching is less reliable
+    # than the explicit `reload(true)` for force-refetch. Phlex's
+    # native `a` strips `javascript:` hrefs as a safety measure, but
+    # the registered Rails `link_to` helper keeps them.
+    def render_reload_link
+      Button(
+        name: :reload.ti,
+        class: "ml-2",
+        onclick: "window.location.reload(true)"
+      )
+    end
+
+    def render_filter_text_row
+      div(class: "d-flex gap-2 align-items-end") do
+        text_field(:filter, label: "Filter text", wrap_class: "mb-0",
+                            size: 40)
+        submit(:edit_visual_group_update_filter.t)
+      end
+    end
+  end
+end

--- a/app/views/controllers/visual_groups/filter_form.rb
+++ b/app/views/controllers/visual_groups/filter_form.rb
@@ -39,10 +39,18 @@ module Views::Controllers::VisualGroups
 
     private
 
+    # form_action calls edit_visual_group_path, a Rails route helper,
+    # which Phlex-Rails forbids from `initialize`
+    # (HelpersCalledBeforeRenderError) -- only reachable once
+    # rendering has started, which means the whole tag has to be
+    # built here in form_tag, not passed as a constructor kwarg the
+    # base class's own form_tag could use.
+    # rubocop:disable MO/NoHandRolledFormTag
     def form_tag(&block)
       form(action: form_action, method: :get,
            **form_attributes, &block)
     end
+    # rubocop:enable MO/NoHandRolledFormTag
 
     def form_action
       edit_visual_group_path(@visual_group)

--- a/app/views/controllers/visual_groups/filter_form.rb
+++ b/app/views/controllers/visual_groups/filter_form.rb
@@ -101,17 +101,22 @@ module Views::Controllers::VisualGroups
     end
 
     # Force-reload button for the needs_review view, which pulls
-    # fresh inference data on each load. We need a true cache-bypass
-    # reload: a same-URL self-link would let Turbo Drive serve its
-    # snapshot (stale data), and HTTP-layer caching is less reliable
-    # than the explicit `reload(true)` for force-refetch. Phlex's
-    # native `a` strips `javascript:` hrefs as a safety measure, but
-    # the registered Rails `link_to` helper keeps them.
+    # fresh inference data on each load. A same-URL self-link would
+    # let Turbo Drive serve its snapshot (stale data); calling
+    # `window.location.reload()` from onclick bypasses that, since
+    # Turbo Drive only intercepts <a> click-to-navigate, not a
+    # programmatic reload call. The `forceGet` boolean parameter
+    # `reload()` historically accepted is deprecated and ignored by
+    # current browsers, so it's omitted -- HTTP cache freshness is
+    # governed by the response's own cache-control headers, not a JS-
+    # level flag. Phlex's native `a` strips `javascript:` hrefs as a
+    # safety measure, but the registered Rails `link_to` helper keeps
+    # them.
     def render_reload_link
       Button(
         name: :reload.ti,
         class: "ml-2",
-        onclick: "window.location.reload(true)"
+        onclick: "window.location.reload()"
       )
     end
 

--- a/app/views/full_page_base/index_nav.rb
+++ b/app/views/full_page_base/index_nav.rb
@@ -58,9 +58,7 @@ module Views::FullPageBase::IndexNav
              pagination_data: pagination_data,
              position: position,
              anchor: args[:anchor],
-             request_url: request_url_for_links,
-             form_action_url: form_action_url,
-             letter_param: string_param(:letter)
+             request_url: request_url_for_links
            )) do |component|
       if content_for?(:sorter)
         component.with_sorter { trusted_html(content_for(:sorter)) }
@@ -71,13 +69,5 @@ module Views::FullPageBase::IndexNav
   # Full request URL (without host) for generating pagination link URLs.
   def request_url_for_links
     request.url.sub(%r{^\w+:/+[^/]+}, "")
-  end
-
-  # For the page-input form, give it the current URL without query
-  # string — the form serializes its own query params.
-  def form_action_url
-    parsed = URI.parse(request.url)
-    parsed.fragment = parsed.query = nil
-    parsed.to_s
   end
 end

--- a/app/views/layouts/header/index_pagination_nav.rb
+++ b/app/views/layouts/header/index_pagination_nav.rb
@@ -9,11 +9,12 @@
 # after a page load). Only `NamesController#index` currently passes
 # it; the rest use the default of nil.
 #
-# The view reads `q_param(current_query)` directly — index pages
-# always have an `@query` set, so this collapses to the same Hash
-# the helper used to pass explicitly. Tests stub `current_query`
-# (via `controller.define_singleton_method`) when they want to
-# verify the q-param hidden fields render.
+# The page-number/letter inputs aren't inside a `<form>` -- each
+# "Goto" control is a plain link carrying the full current query
+# state (via `request_url`), same as the prev/next/max-page links.
+# `page-input_controller.js` rewrites a goto link's own `page`/
+# `letter` param (and its tooltip text) as the user types, so no
+# submission round-trip is needed.
 module Views::Layouts
   class Header::IndexPaginationNav < Views::Base
     include Phlex::Slotable
@@ -24,9 +25,7 @@ module Views::Layouts
     prop :position, ::Symbol, default: -> { :top }
     prop :anchor, _Nilable(::String), default: nil
     # Passed from the helper which has access to request/params.
-    prop :request_url, ::String     # Full URL w/ query params, for links
-    prop :form_action_url, ::String # URL w/o query params, for form actions
-    prop :letter_param, _Nilable(::String)
+    prop :request_url, ::String # Full URL w/ query params, for links
 
     def view_template
       div(class: "pagination-#{@position} flex-bar mb-2") do
@@ -126,23 +125,19 @@ module Views::Layouts
       url
     end
 
+    # No <form> -- the input is a free element, and "Goto" is a plain
+    # link like the prev/next/max-page links, carrying the full
+    # current query state (via pagination_link_url's request_url base)
+    # from the moment it's rendered. page-input_controller.js rewrites
+    # the link's own `page`/`letter` param (and its tooltip text) as
+    # the user types, so no submission round-trip is needed.
     def render_goto_page_input(this_page, max_page)
-      form(
-        action: @form_action_url, method: :get,
-        class: class_names(Components::Navbar::FORM_CLASS, "px-0 page_input"),
-        data: { controller: "page-input", page_input_max_value: max_page,
-                turbo: "false" }
-      ) do
-        render_page_input_group(this_page, max_page)
-        render_q_hidden_fields
-        render_letter_hidden_field
-      end
-    end
-
-    def render_page_input_group(this_page, max_page)
-      InputGroup(class: "page-input mx-2") do
+      InputGroup(class: "page-input mx-2",
+                 data: { controller: "page-input",
+                         page_input_max_value: max_page }) do
         input(**page_input_attrs(this_page, max_page))
-        render_goto_button
+        render_goto_link(href: pagination_link_url(this_page),
+                         tooltip: :goto_page_tooltip.t(number: this_page))
       end
     end
 
@@ -156,13 +151,18 @@ module Views::Layouts
       }
     end
 
-    def render_goto_button
+    # `goToLink` target name is shared by both the page and letter
+    # widgets -- safe since page-input is instantiated once per
+    # InputGroup (two separate elements each carry their own
+    # data-controller="page-input"), so each instance's
+    # `this.goToLinkTarget` sees only the one link in its own DOM
+    # scope.
+    def render_goto_link(href:, tooltip:)
       render(Components::InputGroup::Addon.new) do
-        Button(
-          type: :submit,
-          variant: :outline,
-          class: "px-2"
-        ) { Icon(type: :goto, title: :goto.ti) }
+        Link(
+          type: :get, name: :goto.ti, target: href, button: :outline,
+          class: "px-2", data: { page_input_target: "goToLink" }
+        ) { Icon(type: :goto, title: tooltip) }
       end
     end
 
@@ -183,45 +183,36 @@ module Views::Layouts
     end
 
     def render_letter_input(this_letter, used_letters)
-      form(
-        action: @form_action_url, method: :get,
-        class: class_names(Components::Navbar::FORM_CLASS, "px-0 page_input"),
-        data: { controller: "page-input",
-                page_input_letters_value: used_letters,
-                turbo: "false" }
-      ) do
-        InputGroup(class: "page-input ml-2") do
-          input(
-            type: :text, name: :letter, value: this_letter,
-            class: "form-control text-right",
-            size: 1, placeholder: "—",
-            data: { page_input_target: "letterInput",
-                    action: "page-input#sanitizeLetter" }
-          )
-          render_goto_button
-        end
-        render_q_hidden_fields
+      InputGroup(class: "page-input ml-2",
+                 data: { controller: "page-input",
+                         page_input_letters_value: used_letters }) do
+        input(
+          type: :text, name: :letter, value: this_letter,
+          class: "form-control text-right",
+          size: 1, placeholder: "—",
+          data: { page_input_target: "letterInput",
+                  action: "page-input#sanitizeLetter" }
+        )
+        render_goto_link(href: letter_link_url(this_letter),
+                         tooltip: :goto_letter_tooltip.t(letter: this_letter))
       end
     end
 
-    def render_q_hidden_fields
-      q_params = q_param(current_query)
-      return unless q_params
-
-      query_string = Rack::Utils.build_nested_query({ q: q_params })
-      pairs = query_string.split(Rack::Utils::DEFAULT_SEP)
-      pairs.each do |pair|
-        key, value = pair.split("=", 2).map { |str| Rack::Utils.unescape(str) }
-        input(type: :hidden, name: key, value: value)
+    # Mirrors pagination_link_url, but for the letter-jump link: keys
+    # on letter_arg instead of page_arg, and always clears the page
+    # number -- jumping to a new letter resets pagination position
+    # within that letter's subset, matching the old form's behavior
+    # (it had no page field, so submitting it always dropped whatever
+    # page the address bar had).
+    def letter_link_url(letter)
+      params = { @pagination_data.letter_arg => letter,
+                 @pagination_data.number_arg => nil }
+      url = add_args_to_url(@request_url, params.merge(id: nil))
+      if @anchor
+        url.sub!(/#.*/, "")
+        url += "##{@anchor}"
       end
-    end
-
-    def render_letter_hidden_field
-      input(
-        type: :hidden, name: :letter, value: @letter_param,
-        data: { page_input_target: "letterHiddenInput",
-                action: "letterUpdated@window->page-input#syncLetter" }
-      )
+      url
     end
   end
 end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -506,6 +506,8 @@
   page: page
   by_letter: By letter
   goto: go
+  goto_page_tooltip: Go to page [number]
+  goto_letter_tooltip: Go to letter [letter]
   menu: menu
   area: area
 

--- a/lib/rubocop/cop/mo/no_hand_rolled_form_tag.rb
+++ b/lib/rubocop/cop/mo/no_hand_rolled_form_tag.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Phlex views/components must not call the bare `form(...)` tag
+      # helper directly -- use `Components::ApplicationForm` (Superform)
+      # instead, so CSRF tokens, `_method` overrides, and Turbo wiring
+      # all stay centralized in one place instead of drifting per call
+      # site (issue #5100).
+      #
+      # Scoped via this cop's Include/Exclude in .rubocop.yml, not in
+      # this file: applies to app/components + app/views, excluding the
+      # handful of files whose entire purpose is to legitimately build a
+      # raw-form primitive (an `ApplicationForm` subclass's own GET-form
+      # `form_tag` override, or a reusable raw-form component like
+      # `Components::IndexFilter`). A one-off deviation inside an
+      # otherwise-ordinary view (e.g. a cross-origin POST straight to an
+      # external payment processor) should disable this cop inline at
+      # the call site instead of being added to the file-level Exclude
+      # list -- see `app/views/controllers/support/confirm.rb`.
+      #
+      # @example
+      #   # bad
+      #   form(action: foo_path, method: :post) { ... }
+      #
+      #   # good
+      #   class Components::FooForm < Components::ApplicationForm
+      #     def view_template
+      #       super do
+      #         # fields...
+      #       end
+      #     end
+      #   end
+      class NoHandRolledFormTag < Base
+        MSG = "Don't call the bare `form(...)` tag helper directly -- " \
+              "use Components::ApplicationForm (Superform) instead, so " \
+              "CSRF tokens, _method overrides, and Turbo wiring stay " \
+              "centralized in one place."
+
+        RESTRICT_ON_SEND = [:form].freeze
+
+        def on_send(node)
+          return unless bare_call?(node)
+
+          add_offense(node)
+        end
+
+        private
+
+        # `form(...)` is only the Phlex tag helper when called bare (or
+        # on an explicit `self`) -- `some_object.form(...)` is some
+        # other API's `#form` method, not the tag helper this cop
+        # exists to ban.
+        def bare_call?(node)
+          node.receiver.nil? || node.receiver.self_type?
+        end
+      end
+    end
+  end
+end

--- a/test/components/form/live_data_filter_test.rb
+++ b/test/components/form/live_data_filter_test.rb
@@ -9,9 +9,12 @@ class LiveDataFilterFormTest < ComponentTestCase
     # Nav wrapper with flex layout
     assert_html(html, "nav.d-flex.justify-content-between")
 
-    # Form with autosubmit controller
+    # Form with autosubmit controller. `~=` (word-match), not `=`
+    # (exact-match) -- ApplicationForm's own form-feedback controller
+    # is also always present, space-joined alongside autosubmit.
     assert_html(html, "form[action='/test/filter']")
-    assert_html(html, "[data-controller='autosubmit']")
+    assert_html(html, "[data-controller~='autosubmit']")
+    assert_html(html, "[data-controller~='form-feedback']")
     assert_html(html, "[data-turbo-frame='test_frame']")
     # GET forms aren't Turbo-safe by default either (see
     # .claude/rules/turbo_submit_forms.md).

--- a/test/components/form/search_test.rb
+++ b/test/components/form/search_test.rb
@@ -579,7 +579,11 @@ class SearchFormTest < ComponentTestCase
   def test_form_has_length_validator_stimulus_controller
     html = render_form
 
-    assert_html(html, "form[data-controller='search-length-validator']")
+    # `~=` (word-match), not `=` (exact-match) -- ApplicationForm's
+    # own form-feedback controller is also always present,
+    # space-joined alongside search-length-validator.
+    assert_html(html, "form[data-controller~='search-length-validator']")
+    assert_html(html, "form[data-controller~='form-feedback']")
   end
 
   def test_form_has_max_length_value_attribute

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -613,8 +613,13 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     end
     # On page 1, prev link should be disabled (has opacity-0 class)
     assert_select("a.prev_page_link.disabled.opacity-0")
-    assert_select("form.page_input[action='#{observations_url}']")
-    assert_select("input[type='hidden'][name='q[model]'][value='Observation']")
+    # The goto-page link (no <form> -- see IndexPaginationNav) carries
+    # the full current query state in its own href.
+    assert_select("a[data-page-input-target='goToLink']") do |links|
+      href = links.first["href"]
+      assert_includes(href, q_model,
+                      "Goto link should have q[model]=Observation")
+    end
   end
 
   # Regression test for https://github.com/MushroomObserver/mushroom-observer/pull/3528
@@ -648,13 +653,17 @@ class ObservationsControllerIndexTest < FunctionalTestCase
                       "Next link should preserve third by_users value")
     end
 
-    # Also check the page input form has hidden fields for all three values
-    assert_select("input[type='hidden'][name='q[by_users][]']" \
-                  "[value='#{user1.id}']")
-    assert_select("input[type='hidden'][name='q[by_users][]']" \
-                  "[value='#{user2.id}']")
-    assert_select("input[type='hidden'][name='q[by_users][]']" \
-                  "[value='#{user3.id}']")
+    # Also check the goto-page link's own href preserves all three
+    # values (no <form>/hidden fields -- see IndexPaginationNav).
+    assert_select("a[data-page-input-target='goToLink']") do |links|
+      href = links.first["href"]
+      assert_includes(href, by_user_1,
+                      "Goto link should preserve first by_users value")
+      assert_includes(href, by_user_2,
+                      "Goto link should preserve second by_users value")
+      assert_includes(href, by_user_3,
+                      "Goto link should preserve third by_users value")
+    end
 
     # Search form prefilling is tested in
     # test/controllers/observations/search_controller_test.rb

--- a/test/controllers/projects/updates_controller_test.rb
+++ b/test/controllers/projects/updates_controller_test.rb
@@ -56,7 +56,7 @@ module Projects
       @project.exclude_observation(@matching_obs)
 
       get(:index, params: { project_id: @project.id,
-                            project_exclusions: { show: "1" } })
+                            show_excluded: "1" })
 
       assert_response(:success)
     end
@@ -141,7 +141,7 @@ module Projects
 
       assert_redirected_to(
         project_updates_path(project_id: @project.id,
-                             project_exclusions: { show: false })
+                             show_excluded: false)
       )
       assert_flash(:project_updates_added_all, count: count)
     end
@@ -151,7 +151,7 @@ module Projects
 
       post(:add_all,
            params: { project_id: @project.id,
-                     project_exclusions: { show: "1" } })
+                     show_excluded: "1" })
 
       assert_includes(@project.observations.reload, @matching_obs)
       assert_not_includes(@project.excluded_observations.reload, @matching_obs)

--- a/test/controllers/projects/updates_controller_test.rb
+++ b/test/controllers/projects/updates_controller_test.rb
@@ -55,7 +55,8 @@ module Projects
     def test_index_show_excluded
       @project.exclude_observation(@matching_obs)
 
-      get(:index, params: { project_id: @project.id, show_excluded: "1" })
+      get(:index, params: { project_id: @project.id,
+                            project_exclusions: { show: "1" } })
 
       assert_response(:success)
     end
@@ -140,7 +141,7 @@ module Projects
 
       assert_redirected_to(
         project_updates_path(project_id: @project.id,
-                             show_excluded: false)
+                             project_exclusions: { show: false })
       )
       assert_flash(:project_updates_added_all, count: count)
     end
@@ -148,8 +149,9 @@ module Projects
     def test_add_all_with_show_excluded
       @project.exclude_observation(@matching_obs)
 
-      post(:add_all, params: { project_id: @project.id,
-                               show_excluded: "1" })
+      post(:add_all,
+           params: { project_id: @project.id,
+                     project_exclusions: { show: "1" } })
 
       assert_includes(@project.observations.reload, @matching_obs)
       assert_not_includes(@project.excluded_observations.reload, @matching_obs)

--- a/test/controllers/support_controller_test.rb
+++ b/test/controllers/support_controller_test.rb
@@ -44,6 +44,7 @@ class SupportControllerTest < FunctionalTestCase
     post(:confirm, params: params)
     assert_unprocessable
     assert_select("body.support__confirm")
+    assert_select("form#donate_form[data-turbo='false']")
     assert_donations(donations + 1, final_amount, false, params[:donation])
   end
 

--- a/test/controllers/visual_groups_controller_test.rb
+++ b/test/controllers/visual_groups_controller_test.rb
@@ -149,6 +149,15 @@ class VisualGroupsControllerTest < FunctionalTestCase
     assert_select("button[onclick]", text: :reload.ti)
   end
 
+  # A malformed visual_group_filter param (a String, not a nested
+  # hash) must not 500 -- found by Copilot review on PR #5141.
+  def test_edit_with_malformed_filter_param_does_not_500
+    login
+    get(:edit, params: { id: @visual_group.id, visual_group_filter: "foo" })
+
+    assert_response(:success)
+  end
+
   def test_edit_filter_form_reload_link_hidden_on_included
     login
     get(:edit, params: { id: @visual_group.id,

--- a/test/controllers/visual_groups_controller_test.rb
+++ b/test/controllers/visual_groups_controller_test.rb
@@ -97,7 +97,8 @@ class VisualGroupsControllerTest < FunctionalTestCase
 
   def test_should_get_edit_page_with_excluded_images
     login
-    get(:edit, params: { id: @visual_group.id, status: "excluded" })
+    get(:edit, params: { id: @visual_group.id,
+                         visual_group_filter: { status: "excluded" } })
     assert_response(:success)
   end
 
@@ -117,7 +118,8 @@ class VisualGroupsControllerTest < FunctionalTestCase
       # Hidden status field carries the current status when the user
       # submits via the text-input's submit button.
       assert_select(
-        "input[type=hidden][name=status][value=needs_review]", count: 1
+        "input[type=hidden][name='visual_group_filter[status]']" \
+        "[value=needs_review]", count: 1
       )
       # Three status submit buttons; the current one ("needs_review")
       # is a non-clickable `<span>` (aria-disabled) so the user can't
@@ -127,15 +129,17 @@ class VisualGroupsControllerTest < FunctionalTestCase
         text: :visual_group_needs_review.t
       )
       assert_select(
-        "button[type=submit][name=status][value=included]",
+        "button[type=submit][name='visual_group_filter[status]']" \
+        "[value=included]",
         text: :visual_group_included.t
       )
       assert_select(
-        "button[type=submit][name=status][value=excluded]",
+        "button[type=submit][name='visual_group_filter[status]']" \
+        "[value=excluded]",
         text: :visual_group_excluded.t
       )
       # Text filter input + its dedicated submit button.
-      assert_select("input[type=text][name=filter]#filter")
+      assert_select("input[type=text][name='visual_group_filter[filter]']")
       assert_select(
         "button[type=submit]",
         text: :edit_visual_group_update_filter.t
@@ -147,7 +151,8 @@ class VisualGroupsControllerTest < FunctionalTestCase
 
   def test_edit_filter_form_reload_link_hidden_on_included
     login
-    get(:edit, params: { id: @visual_group.id, status: "included" })
+    get(:edit, params: { id: @visual_group.id,
+                         visual_group_filter: { status: "included" } })
 
     # Active button is the "Included" span (aria-disabled) now.
     assert_select(
@@ -170,8 +175,8 @@ class VisualGroupsControllerTest < FunctionalTestCase
     # the LAST value when the same key appears twice, so order
     # matters: hidden first, button second.
     get(:edit, params: { id: @visual_group.id,
-                         status: "included",
-                         filter: "Trametes" })
+                         visual_group_filter: { status: "included",
+                                                filter: "Trametes" } })
 
     assert_response(:success)
     assert_equal("included", assigns(:status))
@@ -185,8 +190,8 @@ class VisualGroupsControllerTest < FunctionalTestCase
     # (since the user didn't click a status button), preserving
     # whatever status they were on.
     get(:edit, params: { id: @visual_group.id,
-                         status: "excluded",
-                         filter: "Cantharellus" })
+                         visual_group_filter: { status: "excluded",
+                                                filter: "Cantharellus" } })
 
     assert_response(:success)
     assert_equal("excluded", assigns(:status))

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -390,9 +390,12 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     click_link(text: "Observations at this Location")
     assert_match("Observations", page.title, "Wrong title")
 
-    within(first("form.page_input")) do
+    # No <form> -- the goto control is a plain link that
+    # page-input_controller.js keeps pointed at the typed page number
+    # (see IndexPaginationNav).
+    within(first(".input-group.page-input")) do
       fill_in("page", with: 2)
-      click_commit
+      find("a[data-page-input-target='goToLink']").click
     end
     assert_match("Observations", page.title, "Wrong title")
 

--- a/test/views/layouts/header/index_pagination_nav_test.rb
+++ b/test/views/layouts/header/index_pagination_nav_test.rb
@@ -7,7 +7,6 @@ module Views::Layouts
     def setup
       super
       @request_url = "/observations?q%5Bmodel%5D=Observation"
-      @form_action_url = "http://test.host/observations"
     end
 
     def test_renders_basic_structure_with_position_top
@@ -32,7 +31,7 @@ module Views::Layouts
       assert_includes(html, 'class="paginate pagination_numbers flex-bar')
       assert_includes(html, "prev_page_link")
       assert_includes(html, "next_page_link")
-      assert_includes(html, 'class="navbar-form px-0 page_input"')
+      assert_includes(html, 'class="input-group page-input mx-2"')
       # Should have the max page link (5 pages = 50/10)
       assert_nested(
         html, parent_selector: "nav.pagination_numbers",
@@ -77,44 +76,36 @@ module Views::Layouts
       assert_html(html, "a.next_page_link:not(.disabled)")
     end
 
-    def test_page_input_form_has_correct_structure
+    # No <form> -- the goto input is a free element and "Goto" is a
+    # plain link (page-input_controller.js keeps it in sync
+    # client-side). MO's suite is Ruby-only, so the Stimulus behavior
+    # itself isn't covered here.
+    def test_page_input_group_has_correct_structure
       html = render_nav(pagination_data: paginated(50, 2))
 
-      assert_html(html, "form.page_input",
-                  attribute: { action: @form_action_url })
-      assert_includes(html, 'data-controller="page-input"')
-      # GET forms aren't Turbo-safe by default either (see
-      # .claude/rules/turbo_submit_forms.md).
-      assert_html(html, "form.page_input[data-turbo='false']")
-      assert_nested(
-        html, parent_selector: "form.page_input",
-              child_selector: "div.input-group.page-input"
+      assert_no_html(html, "form.page_input")
+      assert_html(
+        html, "div.input-group.page-input[data-controller='page-input']",
+        count: 1
       )
       # Input should have current page value
       assert_html(html, "input[name='page']", attribute: { value: "2" })
     end
 
-    # Reads through `q_param(current_query)`: stub current_query with
-    # a saved Query whose params include `order_by`, and the hidden
-    # fields should match the model + order_by shape.
-    def test_renders_q_hidden_fields
-      query = ::Query.lookup(:Observation, order_by: :created_at)
-      query.save
-      stub_current_query(query)
+    def test_page_goto_link_points_at_current_page
+      html = render_nav(pagination_data: paginated(50, 2))
 
-      html = render_nav(pagination_data: paginated(50, 1))
-
-      assert_html(html, "input[type='hidden'][name='q[model]']",
-                  attribute: { value: "Observation" })
-      assert_html(html, "input[type='hidden'][name='q[order_by]']",
-                  attribute: { value: "created_at" })
+      assert_html(html, "a[href='/observations?page=2" \
+                        "&q%5Bmodel%5D=Observation']")
     end
 
-    # Default current_query (nil) → no q-hidden-fields rendered.
-    def test_renders_no_q_hidden_fields_without_current_query
-      html = render_nav(pagination_data: paginated(50, 1))
+    def test_page_goto_link_has_translated_tooltip
+      html = render_nav(pagination_data: paginated(50, 2))
 
-      assert_no_html(html, "input[type='hidden'][name^='q[']")
+      assert_html(
+        html, "a[data-page-input-target='goToLink'] svg",
+        attribute: { title: :goto_page_tooltip.t(number: 2) }
+      )
     end
 
     def test_renders_letter_pagination_when_needed
@@ -127,7 +118,25 @@ module Views::Layouts
 
       assert_includes(html, 'class="paginate pagination_letters flex-bar')
       assert_html(html, "input[name='letter']", attribute: { value: "A" })
-      assert_html(html, "form.page_input[data-turbo='false']")
+      assert_no_html(html, "form.page_input")
+      assert_html(
+        html, "div.input-group.page-input[data-controller='page-input']"
+      )
+    end
+
+    def test_letter_goto_link_clears_page_number
+      pagination_data = ::PaginationData.new(
+        number: 1, num_per_page: 10, num_total: 50, number_arg: :page,
+        letter_arg: :letter, letter: "B", used_letters: %w[A B C]
+      )
+
+      html = render_nav(pagination_data: pagination_data,
+                        request_url: "/observations?page=3&letter=A")
+
+      assert_nested(
+        html, parent_selector: "nav.pagination_letters",
+              child_selector: "a[href='/observations?letter=B']"
+      )
     end
 
     def test_does_not_render_letter_pagination_when_not_needed
@@ -153,24 +162,9 @@ module Views::Layouts
       assert_nested(html, parent_selector: "nav.pagination_numbers",
                           child_selector: "a.prev_page_link")
       assert_nested(html, parent_selector: "nav.pagination_numbers",
-                          child_selector: "form.page_input")
+                          child_selector: "div.input-group.page-input")
       assert_nested(html, parent_selector: "nav.pagination_numbers",
                           child_selector: "a.next_page_link")
-    end
-
-    def test_renders_letter_hidden_field_in_page_form
-      pagination_data = ::PaginationData.new(
-        number: 1, num_per_page: 10, num_total: 50, number_arg: :page,
-        letter_arg: :letter, letter: "B", used_letters: %w[A B C]
-      )
-
-      html = render_nav(pagination_data: pagination_data,
-                        letter_param: "B")
-
-      assert_nested(
-        html, parent_selector: "nav.pagination_numbers form.page_input",
-              child_selector: "input[type='hidden'][name='letter'][value='B']"
-      )
     end
 
     def test_renders_nothing_when_pagination_data_nil
@@ -225,17 +219,12 @@ module Views::Layouts
       Views::Layouts::Header::IndexPaginationNav.new(
         position: :top,
         request_url: @request_url,
-        form_action_url: @form_action_url,
         **overrides
       )
     end
 
     def render_nav(**overrides)
       render(build_nav(**overrides))
-    end
-
-    def stub_current_query(query)
-      controller.instance_variable_set(:@query, query)
     end
   end
 end

--- a/test/views/layouts/header/index_pagination_nav_test.rb
+++ b/test/views/layouts/header/index_pagination_nav_test.rb
@@ -95,8 +95,9 @@ module Views::Layouts
     def test_page_goto_link_points_at_current_page
       html = render_nav(pagination_data: paginated(50, 2))
 
-      assert_html(html, "a[href='/observations?page=2" \
-                        "&q%5Bmodel%5D=Observation']")
+      # Two attribute-contains selectors, not one exact-match string --
+      # add_args_to_url's param order isn't part of the contract.
+      assert_html(html, "a[href*='page=2'][href*='q%5Bmodel%5D=Observation']")
     end
 
     def test_page_goto_link_has_translated_tooltip


### PR DESCRIPTION
## Summary

Completes #5100.

Flips `Turbo.config.forms.mode` from `"optin"` to `"on"` (Rails 8's default, opt-out) in `app/javascript/application.js` — every form submits via Turbo unless it (or an ancestor) carries `data-turbo="false"`.

Auditing every raw `form()` outside `Components::ApplicationForm` for this flip surfaced four follow-on pieces of work, all included here:

1. `support/confirm.rb`'s PayPal donation hand-off needed an explicit `data-turbo="false"` fix — detailed below.
2. `projects/updates/index.rb`'s show-excluded toggle and `visual_groups/edit.rb`'s status+filter form were converted off their old hand-rolled forms — the toggle to a plain `Views::Base` component, the filter form to a proper `Components::ApplicationForm` subclass.
3. `IndexPaginationNav`'s goto-page/goto-letter forms turned out to be a bigger, higher-blast-radius case (shared by every index page site-wide) — instead of converting them to Superform, the goto controls don't need a `<form>` anymore: each one is now a plain link that an existing Stimulus controller now keeps in sync as the user types.
4. Added `MO/NoHandRolledFormTag`, a new RuboCop cop banning bare `form(...)` calls outside the reviewed set of legitimate raw-form sites — so this class of drift can't creep back in unaudited.

## Why the Turbo flip is safe

- **Every `Superform`-based form already carries an explicit `data-turbo` attribute.** `Components::ApplicationForm` is the only direct `Superform::Rails::Form` subclass in the app, and its `turbo:` prop always writes `data-turbo="true"`/`"false"` in `around_template`, independent of the global mode.
- **The only `button_to` call site already hardcodes Turbo on.** `Components::Button::CRUDBase` sets `form_data = { turbo: true }` unconditionally.
- **Every raw Phlex `form(...)` call outside that framework was checked individually.** `index_pagination_nav.rb`'s two are gone entirely (see below); `visual_groups/edit.rb`'s is now an `ApplicationForm` subclass; `projects/updates/index.rb`'s toggle, `Components::IndexFilter`, and `rss_logs/type_filters.rb` build `data-turbo="false"` by hand; `support/confirm.rb`'s PayPal form needed the explicit fix (a cross-origin POST to an external payment processor — Turbo Drive's `fetch()` would otherwise break the hand-off).

## `projects/updates` show-excluded toggle and `visual_groups/edit`

`visual_groups/edit.rb`'s status+filter form is a proper `Components::ApplicationForm` subclass (`FormObject::VisualGroupFilter` + `FilterForm`), namespaced params `visual_group_filter[status]`/`[filter]`. Also drops `status_from_params`'s two `params[:commit]` checks — verified via the live DOM that the page's only `name="commit"` button doesn't carry either compared label, so those branches were unreachable.

`projects/updates`'s show-excluded toggle (`ExcludedToggleForm`) is a plain `Views::Base` component, matching `IndexFilter`/`RssLogs::TypeFilters`' shape — no Superform involved, since none of its machinery applies here (no model, GET-only, no CSRF). Uses `FieldProxy` + `CheckboxField` directly for the styled checkbox. The checkbox submits the flat `show_excluded` param, matching every hand-built link on the page.

## `IndexPaginationNav`: the goto forms are gone

Shared by every index page in the app, so it got its own approach rather than a Superform conversion: the page-number and letter-jump inputs are free elements (not inside a form), and each "Goto" control is a plain `<a>` link carrying the full current query state — the same `add_args_to_url(request_url, ...)` mechanism the prev/next/max-page links already use. Field names stay flat top-level params (`page`/`letter`), unchanged from today.

`page-input_controller.js`'s `sanitizeNumber`/`sanitizeLetter` rewrite the goto link's own `href` and its icon's tooltip text as the user types, so clicking "Goto" always reflects the sanitized in-progress value with no submission round-trip. Both widgets share one Stimulus target name (`goToLink`) since each is its own controller instance, scoped to its own DOM subtree. Also fixed a CSS height mismatch this surfaced (`.input-group-btn`'s `align-items: center` → `stretch`).

## New cop: `MO/NoHandRolledFormTag`

Bans bare `form(...)` calls in `app/components/`/`app/views/` outside a reviewed set of sites — see `lib/rubocop/cop/mo/no_hand_rolled_form_tag.rb`. Every legitimate site is inline-disabled (`# rubocop:disable`/`# rubocop:enable`) at the exact call, not file-excluded in `.rubocop.yml` — a file-level exclude would give the whole file blanket immunity to any future raw `form(...)` added elsewhere in it, not just the reviewed one.

- 5 `Components::ApplicationForm` subclasses (`admin/blocked_ips/manager.rb`, `visual_groups/filter_form.rb`, `field_slips/form.rb`, `observations/identify/form.rb`, `projects/updates/excluded_toggle_form.rb`) whose action target calls a Rails route helper — Phlex-Rails raises `HelpersCalledBeforeRenderError` if a route helper runs from `initialize`, confirmed directly, so `form_tag` has to stay overridden.
- `Components::IndexFilter` and `rss_logs/type_filters.rb`: not Superform subclasses. `IndexFilter`'s params need to land as flat top-level URL params, not boxed under a FormObject namespace. `RssLogs::TypeFilters` is a multi-select checkbox filter (confirmed via `RssLogsController`'s own validator comment) — submitting several independently-toggled checkboxes as one array needs a submit, unlike a single-value goto link.
- `support/confirm.rb`'s PayPal form: a single deliberate deviation inside an otherwise-ordinary view, inline-disabled rather than file-excluded.

Two forms (`live_data_filter.rb`, `search.rb`) didn't need the override — their action targets don't call a route helper, so action/method/id/class/data pass through as ordinary constructor kwargs.

## Bugs found and fixed along the way

- **`form-feedback` Stimulus controller (submit-button double-click protection) was silently dropped** on `live_data_filter.rb` and `search.rb` (the site-wide faceted search form) — both hand-built their own `data:` hash instead of using the base class's own merge, so `ApplicationForm#around_template`'s `form-feedback` controller either got overwritten (`Hash#merge`) or was missing entirely. Fixed as a side effect of removing the `form_tag` overrides; two exact-match `data-controller=` test assertions updated to `~=` word-match accordingly.
- **`obs_footer.rb`'s Add/Exclude buttons and the Add All button were building broken links** — they targeted the flat `?show_excluded=` param, which the controller had stopped reading after an earlier pass in this PR moved to a namespaced `project_exclusions[show]` shape. Not just a bookmark-compat concern (as originally flagged in review), an active broken redirect target. Resolved by putting the toggle form and every link on the same flat `show_excluded` param.

## Test plan

- [x] `bin/rails test test/controllers/support_controller_test.rb -n /confirm/` — asserts `form#donate_form[data-turbo='false']`
- [x] `bin/rails test test/controllers/projects/updates_controller_test.rb`
- [x] `bin/rails test test/views/controllers/projects/updates/obs_footer_test.rb`
- [x] `bin/rails test test/controllers/visual_groups_controller_test.rb`
- [x] `bin/rails test test/views/layouts/header/index_pagination_nav_test.rb` — rewritten for the no-`<form>` structure
- [x] `bin/rails test test/controllers/observations_controller_index_test.rb -n /test_index_prev_next_page_links\|test_index_pagination_preserves_array_params/`
- [x] `bin/rails test test/integration/capybara/lurker_integration_test.rb -n test_goto_page_input`
- [x] `bin/rails test test/components/form/live_data_filter_test.rb` / `test/components/form/search_test.rb` — updated `data-controller` assertions to word-match
- [x] `bundle exec rubocop --only MO/NoHandRolledFormTag app/` — zero violations app-wide
- [x] `bundle exec rubocop` clean on all touched/new Ruby files
- [x] Manual browser checks: donate → confirm flow, pagination goto-link href/tooltip, `.input-group-btn` height fix, `projects/updates` show-excluded toggle and `visual_groups/edit` status+filter form both verified end-to-end
