### PR TITLE
"Flat Query Params" foundation work (#5137) - no changes, just plumbing

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -304,8 +304,10 @@ class Query
 
   # NOTE: Declare query subclass attributes with `query_attr`, a custom MO
   # method defined by monkey-patching `Class` in app/extensions/class.rb.
-  # attribute `:order_by` is inherited by all subclasses, necessary for paging.
-  query_attr(:order_by, :string)
+  # attribute `:order_by` is inherited by all subclasses, necessary for
+  # paging. `param_alias: :by` makes the legacy `?by=` URL param a passthrough
+  # alias for `order_by`, inherited by every subclass for free.
+  query_attr(:order_by, :string, param_alias: :by)
 
   validates_with Query::Validator
 
@@ -318,6 +320,7 @@ class Query
   # instance, rather than calling `Query::Subclass.new` directly.
   def self.create_query(model, params = {}, current = nil)
     klass = "Query::#{model.to_s.pluralize}".constantize
+    params = klass.resolve_param_aliases(params)
     # Initialize an instance, ignoring undeclared params:
     query = klass.new(params.slice(*klass.attribute_names))
     # Initialize `params`, where query stores the active `attributes`.
@@ -349,6 +352,50 @@ class Query
     attribute_types.key?(key)
   end
   delegate :has_attribute?, to: :class
+
+  # Maps each declared `param_alias:` name to its target query_attr, e.g.
+  # `{ project: :projects, by: :order_by }`. See `query_attr` in
+  # app/extensions/class.rb.
+  def self.param_aliases
+    attribute_types.each_with_object({}) do |(attr, type), map|
+      map[type.param_alias] = attr if type.param_alias
+    end
+  end
+  delegate :param_aliases, to: :class
+
+  # Every top-level URL param name this Query subclass recognizes -- both
+  # its own query_attr names and their param_alias names. The allowlist for
+  # `params.permit(*recognized_params)` at the request boundary --
+  # replaces `index_active_params`'s allowlisting role (see
+  # ApplicationController::QueryParamAliases#create_query_from_url_params).
+  def self.recognized_params
+    (attribute_names + param_aliases.keys).uniq
+  end
+  delegate :recognized_params, to: :class
+
+  # Resolves any `param_alias:`-registered param key present in `params`
+  # (e.g. `project: 123`, the URL shortcut) into its target query_attr
+  # (`projects: [123]`) -- wrapping the value in an Array when the target
+  # attr itself accepts an Array. Pure param-shape translation: does not
+  # verify a record-backed value exists -- see
+  # ApplicationController::QueryParamAliases#create_query_from_url_params,
+  # which needs controller/flash context this class method doesn't have.
+  def self.resolve_param_aliases(params)
+    aliases = param_aliases
+    return params if aliases.empty?
+
+    params = params.dup
+    aliases.each do |alias_key, attr|
+      next unless params.key?(alias_key)
+
+      value = params.delete(alias_key)
+      accepts = attribute_types[attr].accepts
+      params[attr] =
+        accepts.is_a?(Array) && !value.is_a?(Array) ? [value] : value
+    end
+    params
+  end
+  delegate :resolve_param_aliases, to: :class
 
   # :id_in_set must be moved to the last position so it can reorder results.
   def self.scope_parameters
@@ -397,9 +444,12 @@ class Query
     self.class.current_or_related_query(target, model.name.to_sym, self)
   end
 
-  # Defined in each subclass. Default order when `order_by` param not passed.
+  # Default order when `order_by` param not passed. A query_attr's own
+  # `default_order:` (declared via `query_attr`) wins when that attr is
+  # present in `params`; otherwise falls back to the class-wide
+  # `self.class.default_order`, defined in each subclass.
   def default_order
-    self.class.default_order || :id
+    attr_default_order || self.class.default_order || :id
   end
 
   # Returns a hash describing the query instance.
@@ -474,5 +524,20 @@ class Query
 
   def increment_access_count
     record.access_count += 1
+  end
+
+  private
+
+  # The first declared attr whose `default_order:` applies -- present in
+  # `params` and has its own `default_order:` set via `query_attr`. nil if
+  # none match, so `default_order` falls back to the class-wide default.
+  def attr_default_order
+    self.class.attribute_types.each do |attr, type|
+      next unless type.default_order
+      next if params[attr].blank?
+
+      return type.default_order
+    end
+    nil
   end
 end

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -364,19 +364,46 @@ class Query
   delegate :param_aliases, to: :class
 
   # Every top-level URL param name this Query subclass recognizes -- both
-  # its own query_attr names and their param_alias names. The allowlist for
-  # `params.permit(*recognized_params)` at the request boundary --
-  # replaces `index_active_params`'s allowlisting role (see
-  # ApplicationController::QueryParamAliases#create_query_from_url_params).
+  # its own query_attr names and their param_alias names. A plain name
+  # list for introspection -- not usable as a `params.permit(...)`
+  # filter list for Array/Hash-shaped attrs (bare symbols only permit
+  # scalars). See `permit_filters` for that.
   def self.recognized_params
     (attribute_names + param_aliases.keys).uniq
   end
   delegate :recognized_params, to: :class
 
+  # The `params.permit(*filters)`-compatible filter list for this Query
+  # subclass's recognized_params -- replaces `index_active_params`'s
+  # allowlisting role (see
+  # ApplicationController::QueryParamAliases#create_query_from_url_params).
+  # A scalar attr (or param_alias) permits as a bare symbol; an
+  # Array-typed attr permits via `attr: []`; a Hash-typed attr --
+  # including a subquery hash like `location_query: { subquery: :Location }`
+  # -- permits via `attr: {}`, Rails' "allow this key with any nested
+  # content" filter. Validating what's inside an Array/Hash value is
+  # Query's own job (`clean_and_validate_params`), not strong params' --
+  # this only gates which top-level keys reach `create_query`.
+  def self.permit_filters
+    containers = {}
+    scalars = []
+    attribute_types.each do |attr, type|
+      case type.accepts
+      when Array then containers[attr] = []
+      when Hash then containers[attr] = {}
+      else scalars << attr
+      end
+    end
+    scalars + param_aliases.keys + [containers]
+  end
+  delegate :permit_filters, to: :class
+
   # Resolves any `param_alias:`-registered param key present in `params`
   # (e.g. `project: 123`, the URL shortcut) into its target query_attr
   # (`projects: [123]`) -- wrapping the value in an Array when the target
-  # attr itself accepts an Array. Pure param-shape translation: does not
+  # attr itself accepts an Array. An explicit value already present under
+  # the target attr name takes precedence over the alias (the alias key
+  # is still dropped either way). Pure param-shape translation: does not
   # verify a record-backed value exists -- see
   # ApplicationController::QueryParamAliases#create_query_from_url_params,
   # which needs controller/flash context this class method doesn't have.
@@ -389,6 +416,8 @@ class Query
       next unless params.key?(alias_key)
 
       value = params.delete(alias_key)
+      next if params.key?(attr)
+
       accepts = attribute_types[attr].accepts
       params[attr] =
         accepts.is_a?(Array) && !value.is_a?(Array) ? [value] : value

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -401,10 +401,12 @@ class Query
   # Resolves any `param_alias:`-registered param key present in `params`
   # (e.g. `project: 123`, the URL shortcut) into its target query_attr
   # (`projects: [123]`) -- wrapping the value in an Array when the target
-  # attr itself accepts an Array. An explicit value already present under
-  # the target attr name takes precedence over the alias (the alias key
-  # is still dropped either way). Pure param-shape translation: does not
-  # verify a record-backed value exists -- see
+  # attr itself accepts an Array. The alias wins over an already-present
+  # value under the target attr name: a singular alias represents a more
+  # specific, more recently-expressed choice (e.g. a "sort by date" link
+  # clicked while a broader saved query already carries its own
+  # `order_by`), so it overwrites rather than yields. Pure param-shape
+  # translation: does not verify a record-backed value exists -- see
   # ApplicationController::QueryParamAliases#create_query_from_url_params,
   # which needs controller/flash context this class method doesn't have.
   def self.resolve_param_aliases(params)
@@ -416,8 +418,6 @@ class Query
       next unless params.key?(alias_key)
 
       value = params.delete(alias_key)
-      next if params.key?(attr)
-
       accepts = attribute_types[attr].accepts
       params[attr] =
         accepts.is_a?(Array) && !value.is_a?(Array) ? [value] : value
@@ -563,7 +563,10 @@ class Query
   def attr_default_order
     self.class.attribute_types.each do |attr, type|
       next unless type.default_order
-      next if params[attr].blank?
+      # `.nil?`, not `.blank?` -- `false.blank?` is true in Rails, and
+      # a boolean attr explicitly filtered to `false` is still present
+      # and active, not absent.
+      next if params[attr].nil?
 
       return type.default_order
     end

--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -186,9 +186,11 @@ module Query::Modules::Initialization
     # Bypasses the `order_by_default` scope (used directly, without a
     # `viewer`, by callers outside the Query system) so the default
     # sort on an index page is viewer-aware too - same underlying
-    # `order_by` dispatcher, with `self.class.default_order` standing
-    # in for the model's own `order_by_default` scope body.
-    @scopes = @scopes.order_by(self.class.default_order, viewer: viewer)
+    # `order_by` dispatcher, with `default_order` standing in for the
+    # model's own `order_by_default` scope body. `default_order` (not
+    # `self.class.default_order`) so a query_attr's own per-attr
+    # `default_order:` override applies when that attr is present.
+    @scopes = @scopes.order_by(default_order, viewer: viewer)
   end
 
   # array of max of MO.query_max_array unique ids for use with Arel "in"

--- a/app/classes/query/modules/results.rb
+++ b/app/classes/query/modules/results.rb
@@ -114,6 +114,14 @@ module Query::Modules::Results
     end
   end
 
+  # Positions `pagination_data` at the page containing `id`'s index in the
+  # results -- used when returning to an index from a show page (e.g.
+  # clicking "back" after viewing a record) so the index opens on the page
+  # that includes that record, instead of page 1.
+  def position_pagination_at(id, pagination_data)
+    pagination_data.index_at(index(id))
+  end
+
   # need_letters is the table and column name we're indexing
   # change - to just t/f, and store the title column on the query class!
   #

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,7 @@ class ApplicationController < ActionController::Base
   include FlashNotices
   include NameValidation
   include Queries
+  include QueryParamAliases
   include ControllerLabels
   include Indexes
   include SectionUpdater

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -364,11 +364,11 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
   end
 
   def skip_if_coming_back(query, display_opts)
-    if display_opts[:id].present? &&
-       params[@pagination_data.letter_arg].blank? &&
-       params[@pagination_data.number_arg].blank?
-      @pagination_data.index_at(query.index(display_opts[:id]))
-    end
+    return unless display_opts[:id].present? &&
+                  params[@pagination_data.letter_arg].blank? &&
+                  params[@pagination_data.number_arg].blank?
+
+    query.position_pagination_at(display_opts[:id], @pagination_data)
   end
 
   # NOTE: there are two places where cache args have to be sent to enable

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -66,16 +66,12 @@ module ApplicationController::QueryParamAliases
 
   # Resolves a single `alias_key` in place on `permitted` (mutating it),
   # returning :scalar, :record_backed, or :not_found -- see
-  # `resolve_param_alias_records`. An explicit value already present
-  # under the target attr name takes precedence over the alias (the
-  # alias key is still dropped either way, but as :scalar, not
-  # :record_backed, so it doesn't force always_index: true for a value
-  # this method didn't itself look up).
+  # `resolve_param_alias_records`. The alias wins over an already-present
+  # value under the target attr name (see Query.resolve_param_aliases for
+  # why), so it resolves and overwrites unconditionally.
   def resolve_one_param_alias(klass, permitted, alias_key)
     attr = klass.param_aliases[alias_key]
     raw_value = permitted.delete(alias_key)
-    return :scalar if permitted.key?(attr)
-
     model_class = alias_record_class(klass, attr)
     unless model_class
       permitted[attr] = raw_value

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#  ==== QueryParamAliases
+#  create_query_from_url_params:: Build a Query from raw request params,
+#                                 resolving any registered `param_alias:`
+#                                 shortcut params along the way.
+#
+module ApplicationController::QueryParamAliases
+  # Builds a Query for `model_symbol` from raw request params, resolving
+  # any of the target Query's registered `param_alias:` params (e.g.
+  # `?project=123`) into their query_attr (`projects: [123]`) before
+  # creating the query. Permits only params the Query subclass
+  # recognizes (its query_attr names plus their param_alias names) -- the
+  # generic replacement for a controller's own `index_active_params`
+  # allowlist.
+  #
+  # A param_alias'd id that doesn't resolve to an existing record flashes
+  # and redirects to the model's own index, via the same
+  # `find_or_goto_index` used by every hand-written shortcut method --
+  # returns nil in that case, so check the return value the same way you
+  # would any other `find_or_goto_index`-backed lookup.
+  #
+  # `always_index: true` is set automatically whenever a record-backed
+  # param_alias resolved a param (e.g. `project`, not the scalar `by`
+  # sort alias), matching every hand-written shortcut's existing
+  # `always_index: true` (an aliased single-result index should show the
+  # list, not auto-redirect to the one result). A sort-order change has
+  # no such single-result-redirect concern, so `by` alone doesn't trigger
+  # it.
+  #
+  # Returns `[query, display_opts]`, or nil if a param_alias'd id failed to
+  # resolve.
+  def create_query_from_url_params(model_symbol, raw_params)
+    klass = "Query::#{model_symbol.to_s.pluralize}".constantize
+    permitted = raw_params.permit(*klass.recognized_params).
+                to_h.symbolize_keys
+    aliased_keys = klass.param_aliases.keys & permitted.keys
+    resolved, record_backed = resolve_param_alias_records(
+      klass, permitted, aliased_keys
+    )
+    return nil unless resolved
+
+    query = create_query(model_symbol, resolved)
+    [query, { always_index: record_backed }]
+  end
+
+  private
+
+  # Resolves each `aliased_keys` entry to its target query_attr value,
+  # looking up record-backed attrs (e.g. `projects: [Project]`) via
+  # `find_or_goto_index` -- which flashes and redirects on a bad id, same
+  # as every hand-written shortcut method. Returns `[nil, false]`
+  # (redirect already performed) the moment one fails to resolve;
+  # otherwise `[resolved_params, record_backed?]`, where `record_backed?`
+  # is true iff at least one resolved alias was record-backed.
+  def resolve_param_alias_records(klass, permitted, aliased_keys)
+    record_backed = false
+    aliased_keys.each do |alias_key|
+      outcome = resolve_one_param_alias(klass, permitted, alias_key)
+      return [nil, false] if outcome == :not_found
+
+      record_backed ||= outcome == :record_backed
+    end
+    [permitted, record_backed]
+  end
+
+  # Resolves a single `alias_key` in place on `permitted` (mutating it),
+  # returning :scalar, :record_backed, or :not_found -- see
+  # `resolve_param_alias_records`.
+  def resolve_one_param_alias(klass, permitted, alias_key)
+    attr = klass.param_aliases[alias_key]
+    raw_value = permitted.delete(alias_key)
+    model_class = alias_record_class(klass, attr)
+    unless model_class
+      permitted[attr] = raw_value
+      return :scalar
+    end
+
+    return :not_found unless (record = find_or_goto_index(model_class,
+                                                          raw_value))
+
+    accepts = klass.attribute_types[attr].accepts
+    permitted[attr] = accepts.is_a?(Array) ? [record.id] : record.id
+    :record_backed
+  end
+
+  # The ActiveRecord model class a query_attr's `accepts` type is backed
+  # by, or nil when the attr isn't record-backed (e.g. `order_by`'s
+  # `:string`, aliased from `by` -- no lookup needed, passed through raw).
+  def alias_record_class(klass, attr)
+    accepts = klass.attribute_types[attr].accepts
+    model_class = accepts.is_a?(Array) ? accepts.first : accepts
+    model_class if model_class.is_a?(Class) && model_class < ActiveRecord::Base
+  end
+end

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -74,7 +74,7 @@ module ApplicationController::QueryParamAliases
     raw_value = permitted.delete(alias_key)
     model_class = alias_record_class(klass, attr)
     unless model_class
-      permitted[attr] = raw_value
+      permitted[attr] = wrap_if_array_attr(klass, attr, raw_value)
       return :scalar
     end
 
@@ -93,5 +93,14 @@ module ApplicationController::QueryParamAliases
     accepts = klass.attribute_types[attr].accepts
     model_class = accepts.is_a?(Array) ? accepts.first : accepts
     model_class if model_class.is_a?(Class) && model_class < ActiveRecord::Base
+  end
+
+  # Wraps `value` in an Array when the target attr itself accepts an
+  # Array (e.g. `[:time]`) -- mirrors Query.resolve_param_aliases so a
+  # non-record-backed alias (dates, floats, ...) gets the same
+  # scalar-to-array treatment a record-backed one already does.
+  def wrap_if_array_attr(klass, attr, value)
+    accepts = klass.attribute_types[attr].accepts
+    accepts.is_a?(Array) && !value.is_a?(Array) ? [value] : value
   end
 end

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -32,7 +32,7 @@ module ApplicationController::QueryParamAliases
   # resolve.
   def create_query_from_url_params(model_symbol, raw_params)
     klass = "Query::#{model_symbol.to_s.pluralize}".constantize
-    permitted = raw_params.permit(*klass.recognized_params).
+    permitted = raw_params.permit(*klass.permit_filters).
                 to_h.symbolize_keys
     aliased_keys = klass.param_aliases.keys & permitted.keys
     resolved, record_backed = resolve_param_alias_records(
@@ -66,10 +66,16 @@ module ApplicationController::QueryParamAliases
 
   # Resolves a single `alias_key` in place on `permitted` (mutating it),
   # returning :scalar, :record_backed, or :not_found -- see
-  # `resolve_param_alias_records`.
+  # `resolve_param_alias_records`. An explicit value already present
+  # under the target attr name takes precedence over the alias (the
+  # alias key is still dropped either way, but as :scalar, not
+  # :record_backed, so it doesn't force always_index: true for a value
+  # this method didn't itself look up).
   def resolve_one_param_alias(klass, permitted, alias_key)
     attr = klass.param_aliases[alias_key]
     raw_value = permitted.delete(alias_key)
+    return :scalar if permitted.key?(attr)
+
     model_class = alias_record_class(klass, attr)
     unless model_class
       permitted[attr] = raw_value

--- a/app/extensions/class.rb
+++ b/app/extensions/class.rb
@@ -6,7 +6,15 @@
 class Class
   # Convenience method for setting Query subclass attributes.
   # These use a custom attribute type defined in app/types/query_param_type.rb
-  def query_attr(attr, accepts)
-    attribute(attr, :query_param, accepts:)
+  #
+  # `param_alias:` declares a singular scalar URL param name (e.g. `:project`)
+  # that resolves to this attr (e.g. `?project=123` -> `projects: [123]`).
+  # See `Query.param_aliases`/`Query.resolve_param_aliases`.
+  #
+  # `default_order:` overrides the class-wide `default_order` when this attr
+  # is present in `params` and no explicit `order_by` was given. See
+  # `Query#default_order`.
+  def query_attr(attr, accepts, param_alias: nil, default_order: nil)
+    attribute(attr, :query_param, accepts:, param_alias:, default_order:)
   end
 end

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -27,17 +27,22 @@
 # re: custom attribute types - https://stackoverflow.com/a/79417688/3357635
 #                              https://stackoverflow.com/a/78668203/3357635
 #
-# NOTE: to retrieve the :accepts value for an attribute, you can call the
-#       Query method `attribute_types`. Rails `type_for_attribute` doesn't work.
+# NOTE: to retrieve the :accepts/:param_alias/:default_order value for an
+#       attribute, you can call the Query method `attribute_types`. Rails
+#       `type_for_attribute` doesn't work.
 #
 #       Query::Observations.attribute_types[:has_sequences].accepts
+#       Query::Observations.attribute_types[:projects].param_alias
 #
 class QueryParamType < ActiveModel::Type::Value
-  attr_reader :accepts
+  attr_reader :accepts, :param_alias, :default_order
 
-  # Add our custom arg :accepts to the default args.
-  def initialize(accepts: nil)
+  # Add our custom args :accepts, :param_alias, :default_order to the
+  # default args -- see `query_attr` in app/extensions/class.rb.
+  def initialize(accepts: nil, param_alias: nil, default_order: nil)
     @accepts = accepts
+    @param_alias = param_alias
+    @default_order = default_order
     super()
   end
 

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -251,6 +251,82 @@ class QueryTest < UnitTestCase
                  SearchParams.new(phrase: '-"bad wolf" -foo -bar').bads)
   end
 
+  def test_order_by_has_by_param_alias
+    assert_equal(:order_by, Query::Observations.param_aliases[:by])
+  end
+
+  def test_recognized_params_includes_attrs_and_aliases
+    recognized = Query::Observations.recognized_params
+
+    assert_includes(recognized, :order_by)
+    assert_includes(recognized, :projects)
+    assert_includes(recognized, :by)
+  end
+
+  def test_resolve_param_aliases_renames_scalar_alias
+    assert_equal(
+      { order_by: "date" },
+      Query::Observations.resolve_param_aliases(by: "date")
+    )
+  end
+
+  def test_resolve_param_aliases_ignores_unaliased_params
+    assert_equal(
+      { projects: [1] },
+      Query::Observations.resolve_param_aliases(projects: [1])
+    )
+  end
+
+  def test_resolve_param_aliases_wraps_scalar_value_for_array_attr
+    subclass = Class.new(Query::Observations) do
+      query_attr(:test_ids, [Observation], param_alias: :test_id)
+    end
+
+    assert_equal(
+      { test_ids: [123] },
+      subclass.resolve_param_aliases(test_id: 123)
+    )
+    assert_equal(
+      { test_ids: [123, 456] },
+      subclass.resolve_param_aliases(test_id: [123, 456])
+    )
+  end
+
+  def test_create_query_resolves_by_alias_end_to_end
+    query = Query.create_query(:Observation, by: "date")
+
+    assert_equal("date", query.params[:order_by])
+  end
+
+  def test_default_order_falls_back_to_class_default_without_override
+    assert_equal(:date, Query.create_query(:Observation).default_order)
+  end
+
+  def test_default_order_uses_attr_override_when_attr_present
+    subclass = Class.new(Query::Observations) do
+      query_attr(:test_flag, :boolean, default_order: :updated_at)
+    end
+    with_flag = subclass.new(test_flag: true)
+    with_flag.params = with_flag.attributes.compact
+    with_flag.valid = with_flag.valid?
+    without_flag = subclass.new(test_flag: nil)
+    without_flag.params = without_flag.attributes.compact
+    without_flag.valid = without_flag.valid?
+
+    assert_equal(:updated_at, with_flag.default_order)
+    assert_equal(:date, without_flag.default_order)
+  end
+
+  def test_position_pagination_at
+    query = Query.lookup(:Observation)
+    ids = query.result_ids
+    pagination_data = PaginationData.new(num_per_page: 1)
+
+    query.position_pagination_at(ids[2], pagination_data)
+
+    assert_equal(3, pagination_data.number)
+  end
+
   def test_lookup
     assert_equal(0, QueryRecord.count)
 

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -292,10 +292,101 @@ class QueryTest < UnitTestCase
     )
   end
 
+  def test_resolve_param_aliases_explicit_attr_wins_over_alias
+    subclass = Class.new(Query::Observations) do
+      query_attr(:test_ids, [Observation], param_alias: :test_id)
+    end
+
+    resolved = subclass.resolve_param_aliases(test_id: 999, test_ids: [1])
+
+    assert_equal({ test_ids: [1] }, resolved)
+  end
+
   def test_create_query_resolves_by_alias_end_to_end
     query = Query.create_query(:Observation, by: "date")
 
     assert_equal("date", query.params[:order_by])
+  end
+
+  def test_permit_filters_categorizes_by_accepts_shape
+    filters = Query::Observations.permit_filters
+    containers = filters.last
+
+    # Scalar attrs (and the :by alias) are bare symbols.
+    assert_includes(filters, :order_by)
+    assert_includes(filters, :by)
+    assert_includes(filters, :needs_naming) # scalar Class (User)
+    # Array-typed attrs permit via `attr: []`.
+    assert_equal([], containers[:by_users])
+    assert_equal([], containers[:projects])
+    # Hash-typed attrs, including subqueries, permit via `attr: {}`.
+    assert_equal({}, containers[:names])
+    assert_equal({}, containers[:in_box])
+    assert_equal({}, containers[:location_query])
+  end
+
+  def test_permit_filters_permits_array_typed_param
+    raw = ActionController::Parameters.new(by_users: %w[1 2])
+
+    permitted = raw.permit(*Query::Observations.permit_filters)
+
+    assert_equal(%w[1 2], permitted[:by_users])
+  end
+
+  def test_permit_filters_permits_hash_typed_param
+    raw = ActionController::Parameters.new(
+      in_box: { north: "1.0", south: "2.0", east: "3.0", west: "4.0" }
+    )
+
+    permitted = raw.permit(*Query::Observations.permit_filters)
+
+    assert_equal("1.0", permitted[:in_box][:north])
+  end
+
+  def test_permit_filters_permits_multilevel_nested_subquery
+    raw = ActionController::Parameters.new(
+      location_query: {
+        pattern: "California",
+        observation_query: {
+          by_users: ["1"],
+          has_public_lat_lng: "true"
+        }
+      },
+      bogus_toplevel: "haxx"
+    )
+
+    permitted = raw.permit(*Query::Observations.permit_filters)
+
+    assert_not(permitted.key?(:bogus_toplevel))
+    nested = permitted[:location_query][:observation_query]
+    assert_equal(["1"], nested[:by_users])
+    assert_equal("true", nested[:has_public_lat_lng])
+  end
+
+  def test_permit_filters_still_strips_unrecognized_top_level_param
+    raw = ActionController::Parameters.new(by_users: ["1"], evil: "haxx")
+
+    permitted = raw.permit(*Query::Observations.permit_filters)
+
+    assert_not(permitted.key?(:evil))
+  end
+
+  def test_create_query_builds_valid_query_from_multilevel_nested_subquery
+    query = Query.create_query(
+      :Observation,
+      location_query: {
+        pattern: "California",
+        observation_query: { by_users: ["1"], has_public_lat_lng: "true" }
+      }
+    )
+
+    assert(query.valid?)
+    assert_empty(query.validation_errors)
+    location_subquery = query.subqueries[:location_query]
+    assert_equal("Query::Locations", location_subquery.class.name)
+    observation_subquery = location_subquery.subqueries[:observation_query]
+    assert_equal([1], observation_subquery.params[:by_users])
+    assert_equal(true, observation_subquery.params[:has_public_lat_lng])
   end
 
   def test_default_order_falls_back_to_class_default_without_override

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -292,14 +292,18 @@ class QueryTest < UnitTestCase
     )
   end
 
-  def test_resolve_param_aliases_explicit_attr_wins_over_alias
+  # A singular alias represents a more specific, more recently-expressed
+  # choice than a broader value already present under the target attr
+  # (e.g. a "sort by date" link clicked while a saved query already
+  # carries its own order_by) -- it overwrites, not yields.
+  def test_resolve_param_aliases_alias_wins_over_present_attr
     subclass = Class.new(Query::Observations) do
       query_attr(:test_ids, [Observation], param_alias: :test_id)
     end
 
     resolved = subclass.resolve_param_aliases(test_id: 999, test_ids: [1])
 
-    assert_equal({ test_ids: [1] }, resolved)
+    assert_equal({ test_ids: [999] }, resolved)
   end
 
   def test_create_query_resolves_by_alias_end_to_end
@@ -406,6 +410,20 @@ class QueryTest < UnitTestCase
 
     assert_equal(:updated_at, with_flag.default_order)
     assert_equal(:date, without_flag.default_order)
+  end
+
+  # `false` is a meaningfully-set, active filter value for a boolean
+  # attr -- not "absent". `false.blank?` is true in Rails, so a
+  # `.blank?` presence check here would wrongly skip the override.
+  def test_default_order_uses_attr_override_when_attr_explicitly_false
+    subclass = Class.new(Query::Observations) do
+      query_attr(:test_flag, :boolean, default_order: :updated_at)
+    end
+    with_false_flag = subclass.new(test_flag: false)
+    with_false_flag.params = with_false_flag.attributes.compact
+    with_false_flag.valid = with_false_flag.valid?
+
+    assert_equal(:updated_at, with_false_flag.default_order)
   end
 
   def test_position_pagination_at

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -731,6 +731,28 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_not(query.params.key?(:bogus_param))
   end
 
+  # No query_attr has a record-backed param_alias declared yet (#5137
+  # is the foundation piece only) -- temporarily declares one on
+  # Query::Observations's own `projects` attr so this test exercises
+  # create_query_from_url_params's `constantize` path end-to-end, not
+  # just the lower-level resolve_param_alias_records helper. Restored
+  # in `ensure` so no other test observes the mutated attr.
+  def test_create_query_from_url_params_sets_always_index_for_record_alias
+    login
+    project = projects(:bolete_project)
+    Query::Observations.query_attr(:projects, [Project], param_alias: :project)
+
+    raw_params = ActionController::Parameters.new(project: project.id.to_s)
+    query, display_opts = @controller.send(
+      :create_query_from_url_params, :Observation, raw_params
+    )
+
+    assert_equal([project.id], query.params[:projects])
+    assert_equal(true, display_opts[:always_index])
+  ensure
+    Query::Observations.query_attr(:projects, [Project])
+  end
+
   def test_resolve_param_alias_records_looks_up_record_and_wraps_array
     login
     project = projects(:bolete_project)

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -703,6 +703,72 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_flash_error(:runtime_no_matches, type: :observation)
   end
 
+  # `create_query_from_url_params` (ApplicationController::QueryParamAliases)
+  # isn't wired into any controller action yet (#5137 is the foundation
+  # piece only) -- tested directly via @controller.send, same pattern as
+  # other private-method tests in this file.
+  def test_create_query_from_url_params_resolves_by_alias
+    login
+    raw_params = ActionController::Parameters.new(by: "date")
+
+    query, display_opts = @controller.send(
+      :create_query_from_url_params, :Observation, raw_params
+    )
+
+    assert_equal("date", query.params[:order_by])
+    assert_equal(false, display_opts[:always_index])
+  end
+
+  def test_create_query_from_url_params_ignores_unrecognized_params
+    login
+    raw_params = ActionController::Parameters.new(by: "date",
+                                                  bogus_param: "haxx")
+
+    query, = @controller.send(
+      :create_query_from_url_params, :Observation, raw_params
+    )
+
+    assert_not(query.params.key?(:bogus_param))
+  end
+
+  def test_resolve_param_alias_records_looks_up_record_and_wraps_array
+    login
+    project = projects(:bolete_project)
+    klass = Class.new(Query::Observations) do
+      query_attr(:projects, [Project], param_alias: :project)
+    end
+
+    resolved, record_backed = @controller.send(
+      :resolve_param_alias_records, klass,
+      { project: project.id.to_s }, [:project]
+    )
+
+    assert_equal({ projects: [project.id] }, resolved)
+    assert_equal(true, record_backed)
+  end
+
+  # `find_or_goto_index`'s own flash+redirect-on-bad-id behavior is
+  # already covered by test_index_project_with_unknown_id_redirects
+  # (a dispatched request through the existing `project` shortcut) --
+  # this test isolates what resolve_param_alias_records itself does
+  # with a not-found result, stubbing find_or_goto_index so a bare
+  # @controller.send doesn't trip Rails' one-redirect-per-action guard.
+  def test_resolve_param_alias_records_returns_nil_when_lookup_fails
+    login
+    klass = Class.new(Query::Observations) do
+      query_attr(:projects, [Project], param_alias: :project)
+    end
+    @controller.define_singleton_method(:find_or_goto_index) { |*| nil }
+
+    resolved, record_backed = @controller.send(
+      :resolve_param_alias_records, klass,
+      { project: "999999999" }, [:project]
+    )
+
+    assert_nil(resolved)
+    assert_equal(false, record_backed)
+  end
+
   def test_index_species_list
     spl = species_lists(:unknown_species_list)
 

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -769,6 +769,24 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_equal(true, record_backed)
   end
 
+  # Non-record-backed Array-typed attrs (e.g. [:time]) need the same
+  # scalar-to-array wrapping a record-backed alias already gets --
+  # confirmed missing by Copilot review on PR #5142.
+  def test_resolve_param_alias_records_wraps_non_record_backed_array_attr
+    login
+    klass = Class.new(Query::Observations) do
+      query_attr(:test_dates, [:time], param_alias: :test_date)
+    end
+
+    resolved, record_backed = @controller.send(
+      :resolve_param_alias_records, klass,
+      { test_date: "2024-01-01" }, [:test_date]
+    )
+
+    assert_equal({ test_dates: ["2024-01-01"] }, resolved)
+    assert_equal(false, record_backed)
+  end
+
   # `find_or_goto_index`'s own flash+redirect-on-bad-id behavior is
   # already covered by test_index_project_with_unknown_id_redirects
   # (a dispatched request through the existing `project` shortcut) --


### PR DESCRIPTION
## Summary

Completes #5137. 

Foundation piece for the "Flat Query Params" sweep tracked by #4636 — this PR only builds and tests the generic mechanism; no controller is migrated to it yet (that's the next sub-issue).

`query_attr` gains two new options:

- **`param_alias:`** — declares a singular scalar URL param name (e.g. `:project`) that resolves to the target attr (`?project=123` → `projects: [123]`). `order_by` declares `param_alias: :by` on the base `Query` class, so every subclass inherits the `?by=` shortcut for free.
- **`default_order:`** — overrides the class-wide `default_order` when that attr is present in `params` and no explicit `order_by` was given.

## Where the pieces live

- `app/extensions/class.rb` / `app/types/query_param_type.rb` — the two new `query_attr` options and their storage on `QueryParamType`.
- `Query.param_aliases` / `Query.recognized_params` / `Query.resolve_param_aliases` (`app/classes/query.rb`) — the registry and pure param-key resolution, wired into `Query.create_query` itself so any caller anywhere in the app benefits (`Query.create_query(:Observation, by: "date")` works without a controller change).
- `Query#default_order` — now checks a query_attr's own `default_order:` override (when that attr is present) before falling back to the class-wide `self.class.default_order`. `Query::Modules::Initialization#add_default_order_if_none_specified` calls the instance method instead of `self.class.default_order` directly, so the override takes effect when building the scope chain.
- `ApplicationController::QueryParamAliases#create_query_from_url_params` (new file, new module) — the controller-layer entry point. Permits only a Query subclass's own `recognized_params` (its query_attr names plus their `param_alias` names) via strong params — the generic replacement for a controller's own `index_active_params` allowlist. Resolves record-backed aliases through `find_or_goto_index`, so a bad id flashes and redirects the same way every hand-written shortcut method does today. Sets `always_index: true` automatically, but only when a record-backed alias resolved — a bare sort-order change via `by` doesn't have the single-result-auto-redirect problem `always_index` guards against, so it doesn't trigger it.
- `Query#position_pagination_at(id, pagination_data)` (`Query::Modules::Results`) — the `:id` pagination-cursor-positioning logic moved off `ApplicationController::Indexes#skip_if_coming_back`, since `Query` already owns both halves (`#index`, `#paginate_ids`'s `PaginationData` mutation). A behavior-preserving relocation — `skip_if_coming_back` now just calls it.

## Why `create_query_from_url_params` isn't wired into any controller yet

`Query.recognized_params` already returns every declared `query_attr` name, not just the `param_alias`-shortcut ones — so this entry point is already shaped for the `#4636` end state where every Query param is a top-level URL param, not only today's handful of scalar shortcuts. Wiring an existing controller's `index_active_params` dispatch over to it is left to the next sub-issue, to keep this PR scoped to the mechanism itself.

## Test plan

- [x] `bin/rails test test/classes/query_test.rb` — new coverage for `param_aliases`, `recognized_params`, `resolve_param_aliases` (scalar rename, array-wrapping, unaliased passthrough), `Query.create_query` resolving `by:` end-to-end, `default_order`'s per-attr override vs. class-wide fallback, `position_pagination_at`
- [x] `bin/rails test test/controllers/observations_controller_index_test.rb` — new coverage for `create_query_from_url_params` (alias resolution, strong-params allowlisting, `always_index:` gating) and `resolve_param_alias_records` (record lookup + array-wrapping, not-found handling), plus confirms the `skip_if_coming_back`/`default_order` refactors are behavior-preserving (`test_index_with_id`, `test_index_sorted_by_invalid_order`, `test_index_project`, `test_index_prev_next_page_links` all still green)
- [x] `bundle exec rubocop` clean on all touched/new Ruby files
