### PR TITLE
Carry project context to species-list checklists; add `Missing taxa` panel

### DIFF
--- a/app/classes/checklist.rb
+++ b/app/classes/checklist.rb
@@ -247,6 +247,14 @@ class Checklist
     @counts
   end
 
+  # Taxa in this checklist whose name does not appear in `other`
+  # (compared by name id). Used for the "Missing Taxa" panel on a
+  # species-list checklist with project context.
+  def taxa_not_in(other)
+    other_ids = other.taxa.to_set { |tuple| tuple[1] }
+    taxa.reject { |tuple| other_ids.include?(tuple[1]) }
+  end
+
   private
 
   def calc_checklist

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -327,6 +327,9 @@ class ApplicationController < ActionController::Base
     tab = controller_name
     # Checklist page with location_id is really a locations tab
     tab = "locations" if tab == "checklists" && params.include?("location_id")
+    # A species-list checklist is really an observation-lists tab
+    tab = "species_lists" if tab == "checklists" &&
+                             params.include?("species_list_id")
     tab
   end
   helper_method :active_project_tab

--- a/app/controllers/checklists_controller.rb
+++ b/app/controllers/checklists_controller.rb
@@ -15,6 +15,10 @@ class ChecklistsController < ApplicationController
     user_id = params[:user_id] || params[:id]
     proj_id = params[:project_id]
     list_id = params[:species_list_id]
+    # Picks up a `project` param (or single-project query) so a
+    # checklist reached from a project-scoped page keeps the project
+    # banner -- same context passing as SpeciesListsController#show.
+    set_project_ivar
 
     @data = if user_id.present?
               user_checklist(user_id)

--- a/app/controllers/checklists_controller.rb
+++ b/app/controllers/checklists_controller.rb
@@ -32,7 +32,8 @@ class ChecklistsController < ApplicationController
     return unless @data
 
     render(Views::Controllers::Checklists::Show.new(
-             data: @data, context: checklist_context
+             data: @data, context: checklist_context,
+             project_data: @project_checklist
            ))
   end
 
@@ -66,6 +67,9 @@ class ChecklistsController < ApplicationController
   def species_list_checklist(list_id)
     return unless (@species_list = find_or_goto_index(SpeciesList, list_id))
 
+    # Feeds the "Missing Taxa" panel (project taxa absent from the list)
+    # when the checklist carries project context.
+    @project_checklist = Checklist::ForProject.new(@project) if @project
     Checklist::ForSpeciesList.new(@species_list)
   end
 end

--- a/app/views/controllers/checklists/contents.rb
+++ b/app/views/controllers/checklists/contents.rb
@@ -7,12 +7,14 @@ module Views::Controllers::Checklists
   class Contents < ::Components::Base
     prop :data, ::Checklist
     prop :context, ::Views::Controllers::Checklists::Context
+    prop :project_data, _Nilable(::Checklist), default: nil
 
     def view_template
       div(id: "checklist_contents") do
         render_summary
         render_location_header if @context.location
         render_panels
+        render_missing_taxa_panel if @project_data
         render_footnotes
       end
     end
@@ -100,6 +102,22 @@ module Views::Controllers::Checklists
                data: @data, context: @context,
                taxa: taxa, panel_id: panel_id,
                link_to_name_page: link_to_name_page
+             ))
+    end
+
+    # Project taxa absent from the species-list checklist. Counts and
+    # links match the project checklist: `data:` is the project
+    # checklist, and the project-only context scopes taxon links to
+    # project observations (no admin tools -- `user` is omitted).
+    def render_missing_taxa_panel
+      missing = @project_data.taxa_not_in(@data)
+      return if missing.empty?
+
+      h4 { plain(:checklist_missing_taxa.t) }
+      render(Panel.new(
+               data: @project_data,
+               context: Context.new(project: @context.project),
+               taxa: missing, panel_id: "checklist_missing_panel"
              ))
     end
 

--- a/app/views/controllers/checklists/context.rb
+++ b/app/views/controllers/checklists/context.rb
@@ -13,8 +13,11 @@ module Views::Controllers::Checklists
       [show_user, project, location, species_list]
     end
 
+    # Project admin tools (target-names widget, remove buttons) belong
+    # to the project-scoped checklist only -- a species-list checklist
+    # may carry a project purely as banner context.
     def admin?
-      project&.is_admin?(user)
+      species_list.nil? && project&.is_admin?(user)
     end
   end
 end

--- a/app/views/controllers/checklists/panel.rb
+++ b/app/views/controllers/checklists/panel.rb
@@ -71,11 +71,13 @@ module Views::Controllers::Checklists
                                  "include_subtaxa:false")
     end
 
+    # The list wins over the project -- a species-list checklist may
+    # carry a project as banner context, but its taxa are list-scoped.
     def link_prefix_for(user:, project:, list:)
-      return "user:#{user.id}"       if user
-      return "project:#{project.id}" if project
+      return "user:#{user.id}" if user
+      return "list:#{list.id}" if list
 
-      "list:#{list.id}" if list
+      "project:#{project.id}" if project
     end
 
     def target_name?(name_id)

--- a/app/views/controllers/checklists/show.rb
+++ b/app/views/controllers/checklists/show.rb
@@ -5,13 +5,17 @@ module Views::Controllers::Checklists
   class Show < Views::FullPageBase
     prop :data, ::Checklist
     prop :context, ::Views::Controllers::Checklists::Context
+    # Project checklist backing the "Missing Taxa" panel on a
+    # species-list checklist with project context.
+    prop :project_data, _Nilable(::Checklist), default: nil
 
     def view_template
       render_page_chrome
       render_target_names_widget if @context.admin?
       # Sibling reference in the `Views::Controllers::Checklists`
       # module — resolves to `Checklists::Contents`.
-      render(Contents.new(data: @data, context: @context))
+      render(Contents.new(data: @data, context: @context,
+                          project_data: @project_data))
     end
 
     private

--- a/app/views/controllers/species_lists/show.rb
+++ b/app/views/controllers/species_lists/show.rb
@@ -75,11 +75,16 @@ module Views::Controllers::SpeciesLists
         project_button(:map.ti, add_q_param(map_observations_path, @query))
         project_button(:observations.ti,
                        add_q_param(observations_path, @query))
-        project_button(:names.ti,
-                       checklist_path(species_list_id: @species_list.id))
+        project_button(:names.ti, checklist_names_path)
         render_locations_button
         render_images_button
       end
+    end
+
+    def checklist_names_path
+      checklist_path(
+        { species_list_id: @species_list.id, project: @project&.id }.compact
+      )
     end
 
     def render_locations_button

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2782,7 +2782,7 @@
   checklist_unobserved_targets: Unobserved target names
   checklist_species_level: Species and below
   checklist_higher_level: Higher-level taxa
-  checklist_missing_taxa: Missing Taxa
+  checklist_missing_taxa: Missing taxa
   checklist_taxon: taxon
   checklist_taxa: taxa
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2782,6 +2782,7 @@
   checklist_unobserved_targets: Unobserved target names
   checklist_species_level: Species and below
   checklist_higher_level: Higher-level taxa
+  checklist_missing_taxa: Missing Taxa
   checklist_taxon: taxon
   checklist_taxa: taxa
 

--- a/test/controllers/checklists_controller_test.rb
+++ b/test/controllers/checklists_controller_test.rb
@@ -47,6 +47,30 @@ class ChecklistsControllerTest < FunctionalTestCase
     prove_checklist_content(expect)
   end
 
+  # A `project` param on a species-list checklist shows the project
+  # banner, but the checklist itself stays list-scoped: taxon links go
+  # to list observations and project admin tools stay hidden.
+  def test_checklist_for_species_list_with_project_context
+    login # rolf, an admin of rare_fungi_project
+    list = species_lists(:one_genus_three_species_list)
+    project = projects(:rare_fungi_project)
+
+    get(:show, params: { species_list_id: list.id, project: project.id })
+
+    assert_select("#project_banner",
+                  text: /#{Regexp.escape(project.title)}/)
+    assert_match(/Checklist for #{list.title}/, css_select("title").text,
+                 "Title should still be the species list's")
+    assert_select(".checklist a[href*='list%3A#{list.id}']")
+    assert_select(".checklist a[href*='project%3A']", count: 0)
+    assert_select(
+      "form[action='#{project_target_names_path(project_id: project.id)}']",
+      { count: 0 },
+      "Project target-names admin widget belongs to the project " \
+      "checklist, not a list checklist with project context"
+    )
+  end
+
   # Prove that Project checklist goes to correct page with correct content
   def test_checklist_for_project
     login

--- a/test/controllers/checklists_controller_test.rb
+++ b/test/controllers/checklists_controller_test.rb
@@ -51,14 +51,20 @@ class ChecklistsControllerTest < FunctionalTestCase
   # banner, but the checklist itself stays list-scoped: taxon links go
   # to list observations and project admin tools stay hidden.
   def test_checklist_for_species_list_with_project_context
-    login # rolf, an admin of rare_fungi_project
+    login("dick") # an admin of bolete_project
     list = species_lists(:one_genus_three_species_list)
-    project = projects(:rare_fungi_project)
+    project = projects(:bolete_project)
 
     get(:show, params: { species_list_id: list.id, project: project.id })
 
     assert_select("#project_banner",
                   text: /#{Regexp.escape(project.title)}/)
+    assert_select(
+      "li.nav-item a.nav-link.active[href=?]",
+      species_lists_path(project: project.id),
+      { count: 1 },
+      "Observation Lists should be the active banner tab"
+    )
     assert_match(/Checklist for #{list.title}/, css_select("title").text,
                  "Title should still be the species list's")
     assert_select(".checklist a[href*='list%3A#{list.id}']")

--- a/test/controllers/checklists_controller_test.rb
+++ b/test/controllers/checklists_controller_test.rb
@@ -43,6 +43,8 @@ class ChecklistsControllerTest < FunctionalTestCase
     get(:show, params: { species_list_id: list.id })
     assert_match(/Checklist for #{list.title}/, css_select("title").text,
                  "Wrong page")
+    assert_select("#checklist_missing_panel", { count: 0 },
+                  "No Missing Taxa panel without project context")
 
     prove_checklist_content(expect)
   end
@@ -68,7 +70,22 @@ class ChecklistsControllerTest < FunctionalTestCase
     assert_match(/Checklist for #{list.title}/, css_select("title").text,
                  "Title should still be the species list's")
     assert_select(".checklist a[href*='list%3A#{list.id}']")
-    assert_select(".checklist a[href*='project%3A']", count: 0)
+    assert_select("#checklist_species_panel a[href*='project%3A']",
+                  count: 0)
+    assert_select("#checklist_higher_panel a[href*='project%3A']",
+                  count: 0)
+    # Missing Taxa panel: project taxa absent from the list, with
+    # counts and links matching the project checklist.
+    assert_select("h4", text: :checklist_missing_taxa.l)
+    fungi = names(:fungi)
+    assert_select(
+      "#checklist_missing_panel a[href*='project%3A#{project.id}']" \
+      "[href*='name%3A#{fungi.id}']",
+      { text: /Fungi \(1\)/ },
+      "Missing taxon should show the project count and " \
+      "project-scoped observation link"
+    )
+    assert_select("#checklist_missing_panel a[href*='list%3A']", count: 0)
     assert_select(
       "form[action='#{project_target_names_path(project_id: project.id)}']",
       { count: 0 },

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -271,6 +271,12 @@ class SpeciesListsControllerTest < FunctionalTestCase
                   text: /#{Regexp.escape(project.title)}/)
     assert_select("h1#title", /#{spl.title}/,
                   "H1 title element should exist and contain content")
+    assert_select(
+      "#project_species_list_buttons a[href=?]",
+      checklist_path(species_list_id: spl.id, project: project.id),
+      { count: 1 },
+      "Names button should carry the project context to the checklist"
+    )
   end
 
   # Regression test for bug where params[:q] as a String (saved query ID)


### PR DESCRIPTION
## Summary

The Names button on a project-scoped species list page (`/species_lists/2328?project=388`) previously linked to `/checklist?species_list_id=2328`, dropping the project context. This PR carries the context through and makes the checklist page use it.

- The Names button in `Views::Controllers::SpeciesLists::Show` now includes the `project` param when the page has project context.
- `ChecklistsController#show` calls `set_project_ivar` (the same `ApplicationController` method `SpeciesListsController#show` uses), so `/checklist?species_list_id=2328&project=388` renders the project banner — the view already supported a project in its `Context`; the controller just did not set one for the species-list branch.
- The banner's active tab is now Observation Lists rather than Names: `active_project_tab` maps a `species_list_id`-scoped checklist to `"species_lists"`, the same way the existing `location_id` case maps to `"locations"`.
- New **Missing taxa** panel at the bottom of a project-scoped species-list checklist, listing project-checklist taxa absent from the observation list. Counts and taxon links match the project checklist: the panel's `data:` is a `Checklist::ForProject`, and it renders with a project-only `Context` so links go to `project:<id> name:<id>` observation searches. The diff is the new `Checklist#taxa_not_in(other)`, compared by name id. The panel is omitted when the diff is empty, matching the other panels.

Two guards for the previously-impossible combination of both `project` and `species_list` in a checklist `Context`:

- `Checklists::Panel#link_prefix_for` prefers the list over the project, so taxon links in the list's own panels stay scoped to `list:` observations.
- `Context#admin?` now requires `species_list.nil?`, keeping the project target-names admin widget, per-taxon remove buttons, and footnote confined to the project checklist page.

## Test plan

Setup: a species list attached to a project, where the project has observations of at least one taxon not in the list (e.g. locally, `/species_lists/2328?project=388`).

1. From the project-scoped species list page, click the **Names** button. The URL should be `/checklist?species_list_id=...&project=...`.
2. The checklist page should show the project banner, with **Observation Lists** as the active tab (not Names).
3. A **Missing taxa** panel should appear below the observed panels. Spot-check a taxon against the project checklist (`/checklist?project_id=...`): the parenthesized count should match, and clicking it should run the same project-scoped observation search.
4. Taxon links in the list's own panels (Species and below / Higher-level taxa) should still search `list:` observations, not `project:`.
5. As a project admin, confirm the target-names admin widget and per-taxon remove buttons appear on `/checklist?project_id=...` but not on the list checklist with project context.
6. Plain `/checklist?species_list_id=...` (no project param) should be unchanged — no banner, no Missing taxa panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
