### PR TITLE
Prefix only bare-number field slip codes in `AddDispatchController`

### DIFF
--- a/app/controllers/add_dispatch_controller.rb
+++ b/app/controllers/add_dispatch_controller.rb
@@ -14,7 +14,7 @@ class AddDispatchController < ApplicationController
     # of the field slip if it's different.
     # This is how the Project context gets passed if it is relevant.
     @project = find_project
-    @field_slip_code = find_code(@project, params[:field_slip])&.strip
+    @field_slip_code = find_code(@project, params[:field_slip])
     url = if @field_slip_code
             "#{MO.http_domain}/qr/#{@field_slip_code}"
           else
@@ -38,10 +38,17 @@ class AddDispatchController < ApplicationController
     projects.where.not(field_slip_prefix: nil).first
   end
 
+  # Only a bare number gets the project prefix ("2345" ->
+  # "PREFIX-2345"); anything else is taken as a complete code and
+  # passed through unchanged. Prefixes can start with digits
+  # ("2026-NAMATEST"), so a complete code is recognizable only by
+  # matching the whole entry, not its first character.
   def find_code(project, code)
+    code = code.to_s.strip
     return nil if code.blank?
-    return code unless code[0].match?(/\d/)
-    return "#{project.field_slip_prefix}-#{code}" if project
+    return code unless code.match?(/\A\d+\z/)
+    return "#{project.field_slip_prefix}-#{code}" if
+      project&.field_slip_prefix.present?
 
     flash_warning(:bad_dispatch_code.t(code:))
     nil

--- a/test/controllers/add_dispatch_controller_test.rb
+++ b/test/controllers/add_dispatch_controller_test.rb
@@ -78,6 +78,51 @@ class AddDispatchControllerTest < FunctionalTestCase
     assert_redirected_to(expected_full_url)
   end
 
+  # A complete code under a digit-leading prefix must pass through
+  # unchanged -- issue #5146: it used to get the prefix prepended
+  # again ("2026-NAMATEST-2026-NAMATEST-1235").
+  def test_new_full_code_with_digit_leading_prefix_passes_through
+    @project.update!(field_slip_prefix: "2026-NAMATEST")
+    field_slip_code = "2026-NAMATEST-1235"
+
+    get(:new, params: {
+          project: @project.id,
+          field_slip: field_slip_code
+        })
+
+    expected_url = "#{MO.http_domain}/qr/#{field_slip_code}"
+    assert_redirected_to("#{expected_url}?project=#{@project.id}")
+  end
+
+  # A digit-leading code entered against a project with no prefix must
+  # not gain a bare leading dash -- issue #5146 ("-2026-NAMA-2345").
+  def test_new_digit_leading_code_without_prefix_passes_through
+    @project.update!(field_slip_prefix: nil)
+    field_slip_code = "2026-NAMA-2345"
+
+    get(:new, params: {
+          project: @project.id,
+          field_slip: field_slip_code
+        })
+
+    expected_url = "#{MO.http_domain}/qr/#{field_slip_code}"
+    assert_redirected_to("#{expected_url}?project=#{@project.id}")
+  end
+
+  # A bare number can't be resolved without a prefix to attach it to.
+  def test_new_numeric_code_with_blank_prefix_warns_and_falls_through
+    @project.update!(field_slip_prefix: nil)
+    field_slip_code = "2345"
+
+    get(:new, params: {
+          project: @project.id,
+          field_slip: field_slip_code
+        })
+
+    assert_redirected_to("#{new_observation_path}?project=#{@project.id}")
+    assert_flash_warning(:bad_dispatch_code, code: field_slip_code)
+  end
+
   # Test with species list
   def test_new_with_species_list_includes_species_list_in_params
     get(:new, params: {


### PR DESCRIPTION
## Summary

Fixes #5146.

`AddDispatchController#find_code` decided "this entry needs the project prefix" by testing whether the **first character** was a digit. That heuristic breaks as soon as a project's `field_slip_prefix` itself starts with a digit, which produced both reported symptoms:

- Project 408 (`2026-NAMATEST`): entering the complete code `2026-NAMATEST-1235` starts with `2`, so the prefix was prepended again → `2026-NAMATEST-2026-NAMATEST-1235`.
- Project 407 (blank prefix on the record): entering `2026-NAMA-2345` also starts with a digit, so `"#{prefix}-#{code}"` interpolated a blank prefix → `-2026-NAMA-2345`.
- `CCMS-9999` worked only because it starts with a letter.

Mixed case in the prefix was not involved.

## Fix

Per the issue's stated desired behavior: only an **all-digits** entry gets the prefix (`2345` → `2026-NAMATEST-2345`); anything else is taken as a complete code and passed through unchanged. Two supporting tightenings: the prefix is only attached when the project has one (`field_slip_prefix.present?`) — a bare number with no prefix available warns with `bad_dispatch_code` and falls through to the plain new-observation form, instead of minting `-2345` — and the entry is stripped before classification, so a padded `" 2345 "` classifies as numeric.

## Test plan

Setup: a project whose `field_slip_prefix` starts with a digit (e.g. 2026 NAMA Yoop Testing, prefix `2026-NAMATEST`), viewed at `/projects/<id>`.

1. In the Field Slip box, enter a bare number (`2345`) and click Add — should land on `/qr/2026-NAMATEST-2345`.
2. Enter the complete code `2026-NAMATEST-1235` — should land on `/qr/2026-NAMATEST-1235`, no duplicated prefix.
3. On a project with no field-slip prefix, enter `2026-NAMA-2345` — should pass through unchanged (no leading dash); enter a bare `2345` — should land on the new-observation form with a "bad dispatch code" warning.
4. `CCMS-9999`-style letter-leading codes behave as before.
