### PR TITLE
Clean up the abandoned `Occurrence` when an observation moves to another

### DIFF
--- a/app/jobs/misc_data_repairs_job.rb
+++ b/app/jobs/misc_data_repairs_job.rb
@@ -47,8 +47,12 @@ class MiscDataRepairsJob < ApplicationJob
 
   private
 
+  # A task that hits rows it can't repair yields each failure message
+  # instead of raising, so the sweep continues; route those to the
+  # #alerts channel for human review. Tasks that don't yield ignore
+  # the block.
   def run_task(klass, method, description, dry_run)
     log("#{description}...")
-    klass.send(method, dry_run: dry_run)
+    klass.send(method, dry_run: dry_run) { |failure| alert(failure) }
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -225,7 +225,6 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       return
     end
 
-    old_occ = occurrence
     occ = slip.occurrence
     occ ||= Occurrence.create!(
       user: user || current_user,
@@ -233,7 +232,6 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       field_slip: slip
     )
     self.occurrence = occ
-    cleanup_old_occurrence(old_occ, occ)
   end
 
   has_many :observation_herbarium_records, dependent: :destroy
@@ -256,6 +254,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # rubocop:enable Rails/ActiveRecordCallbacksOrder
   after_update :notify_users_after_change
   after_update :update_occurrence_specimen_cache
+  after_update :cleanup_abandoned_occurrence
   before_destroy :destroy_orphaned_collection_numbers
   before_destroy :notify_species_lists
   after_destroy :destroy_dependents
@@ -1271,16 +1270,27 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     occ.destroy_if_incomplete!
   end
 
-  # When an observation moves to a new occurrence, clean up the old one.
-  def cleanup_old_occurrence(old_occ, new_occ)
-    return unless old_occ && old_occ.id != new_occ.id
+  # When an observation moves to a different occurrence, clean up the
+  # one it left: repoint the primary if it was this observation, destroy
+  # the occurrence if it emptied or dropped below 2 members, and refresh
+  # its has_specimen cache. Must run after save -- before it, this
+  # observation still counts as a member of the old occurrence, so the
+  # primary could be "reassigned" right back to the departing record.
+  # Detaching (occurrence -> nil) is excluded; those flows (dissolve,
+  # field slip sync, occurrence edit) do their own cleanup.
+  def cleanup_abandoned_occurrence
+    old_id, new_id = saved_change_to_occurrence_id
+    return unless old_id && new_id
 
-    old_occ.reload
+    old_occ = Occurrence.find_by(id: old_id)
+    return unless old_occ
+
     reassign_occurrence_primary(old_occ) if old_occ.primary_observation_id == id
-    return unless Occurrence.exists?(old_occ.id)
+    return if old_occ.destroyed?
 
     old_occ.reload
     old_occ.destroy_if_incomplete!
+    old_occ.recompute_has_specimen! unless old_occ.destroyed?
   end
 
   def reassign_occurrence_primary(occ)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1270,18 +1270,26 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     occ.destroy_if_incomplete!
   end
 
-  # When an observation moves to a different occurrence, clean up the
-  # one it left: repoint the primary if it was this observation, destroy
-  # the occurrence if it emptied or dropped below 2 members, and refresh
-  # its has_specimen cache. Must run after save -- before it, this
-  # observation still counts as a member of the old occurrence, so the
-  # primary could be "reassigned" right back to the departing record.
-  # Detaching (occurrence -> nil) is excluded; those flows (dissolve,
-  # field slip sync, occurrence edit) do their own cleanup.
+  # When an observation moves to a different occurrence, fix up both
+  # sides. Old occurrence: repoint the primary if it was this
+  # observation, destroy the occurrence if it emptied or dropped below
+  # 2 members, and refresh its has_specimen cache. Must run after save
+  # -- before it, this observation still counts as a member of the old
+  # occurrence, so the primary could be "reassigned" right back to the
+  # departing record. New occurrence: refresh its has_specimen cache
+  # too -- update_occurrence_specimen_cache only fires when `specimen`
+  # itself changed, not when the membership did. Detaching
+  # (occurrence -> nil) is excluded; those flows (dissolve, field slip
+  # sync, occurrence edit) do their own cleanup.
   def cleanup_abandoned_occurrence
     old_id, new_id = saved_change_to_occurrence_id
     return unless old_id && new_id
 
+    cleanup_old_occurrence_after_move(old_id)
+    occurrence&.recompute_has_specimen!
+  end
+
+  def cleanup_old_occurrence_after_move(old_id)
     old_occ = Occurrence.find_by(id: old_id)
     return unless old_occ
 

--- a/app/models/occurrence.rb
+++ b/app/models/occurrence.rb
@@ -198,9 +198,10 @@ class Occurrence < AbstractModel
       merged_obs.each do |obs|
         obs.update!(occurrence: keeper)
       end
-      # Observation#cleanup_abandoned_occurrence destroys the emptied
-      # occurrence as its last member moves; finish the job if it
-      # survived (it kept a field slip).
+      # Observation#cleanup_abandoned_occurrence normally destroys the
+      # emptied occurrence as its last member moves; finish the job if
+      # it survived (e.g. its primary was already dangling, so the
+      # member-departure reassign path did not run).
       Occurrence.find_by(id: absorbed.id)&.destroy!
       keeper.recompute_has_specimen!
     end

--- a/app/models/occurrence.rb
+++ b/app/models/occurrence.rb
@@ -19,6 +19,7 @@
 class Occurrence < AbstractModel
   include Occurrence::ProjectGaps
   include Occurrence::Logging
+  include Occurrence::SpecimenCache
 
   MAX_OBSERVATIONS = 10
 
@@ -46,25 +47,6 @@ class Occurrence < AbstractModel
   validates :primary_observation, presence: true
   validate :primary_observation_must_belong_to_occurrence, on: :update
   validate :observation_count_within_limits, on: :update
-
-  # Recompute cached has_specimen from associated observations.
-  def recompute_has_specimen!
-    update!(has_specimen: observations.where(specimen: true).exists?)
-  end
-
-  # Nightly safety net: recompute has_specimen on all occurrences.
-  def self.refresh_has_specimen_cache(dry_run: false)
-    msgs = []
-    find_each do |occ|
-      correct = occ.observations.where(specimen: true).exists?
-      next if occ.has_specimen == correct
-
-      msgs << "Occurrence ##{occ.id}: has_specimen " \
-              "#{occ.has_specimen} -> #{correct}"
-      occ.update!(has_specimen: correct) unless dry_run
-    end
-    msgs
-  end
 
   # Recalculate shared consensus across all observations.
   def recalculate_consensus!(user = nil)
@@ -216,7 +198,10 @@ class Occurrence < AbstractModel
       merged_obs.each do |obs|
         obs.update!(occurrence: keeper)
       end
-      absorbed.reload.destroy!
+      # Observation#cleanup_abandoned_occurrence destroys the emptied
+      # occurrence as its last member moves; finish the job if it
+      # survived (it kept a field slip).
+      Occurrence.find_by(id: absorbed.id)&.destroy!
       keeper.recompute_has_specimen!
     end
     log_observation_added(merged_obs, user)

--- a/app/models/occurrence/specimen_cache.rb
+++ b/app/models/occurrence/specimen_cache.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Maintains the cached has_specimen column: true if any member
+# observation has a specimen.
+module Occurrence::SpecimenCache
+  extend ActiveSupport::Concern
+
+  # Recompute cached has_specimen from associated observations.
+  def recompute_has_specimen!
+    update!(has_specimen: observations.where(specimen: true).exists?)
+  end
+
+  class_methods do
+    # Nightly safety net: recompute has_specimen on all occurrences.
+    # A row that fails validation (e.g. a dangling primary_observation)
+    # doesn't abort the sweep: its failure message is recorded, yielded
+    # to the caller, and the remaining rows are still repaired.
+    def refresh_has_specimen_cache(dry_run: false)
+      msgs = []
+      find_each do |occ|
+        correct = occ.observations.where(specimen: true).exists?
+        next if occ.has_specimen == correct
+
+        msgs << "Occurrence ##{occ.id}: has_specimen " \
+                "#{occ.has_specimen} -> #{correct}"
+        begin
+          occ.update!(has_specimen: correct) unless dry_run
+        rescue ActiveRecord::RecordInvalid => e
+          failure = "Occurrence ##{occ.id}: has_specimen repair " \
+                    "failed - #{e.message}"
+          msgs << failure
+          yield(failure) if block_given?
+        end
+      end
+      msgs
+    end
+  end
+end

--- a/test/jobs/misc_data_repairs_job_test.rb
+++ b/test/jobs/misc_data_repairs_job_test.rb
@@ -25,6 +25,25 @@ class MiscDataRepairsJobTest < ActiveJob::TestCase
     MiscDataRepairsJob.perform_now(dry_run: true)
   end
 
+  # A task that yields row-level failure messages (rows it could not
+  # repair) gets each one routed to ApplicationJob#alert.
+  def test_row_level_failures_are_routed_to_alert
+    alerts = []
+    job = MiscDataRepairsJob.new
+    fake = lambda { |dry_run:, &blk|
+      blk&.call("Occurrence #1: repair failed (dry_run=#{dry_run})")
+      []
+    }
+    job.stub(:alert, ->(msg) { alerts << msg }) do
+      Occurrence.stub(:refresh_has_specimen_cache, fake) do
+        job.perform(dry_run: true)
+      end
+    end
+
+    assert_equal(1, alerts.size)
+    assert_match(/Occurrence #1: repair failed/, alerts.first)
+  end
+
   private
 
   def stub_tasks(calls, tasks = MiscDataRepairsJob::TASKS, &block)

--- a/test/models/occurrence_test.rb
+++ b/test/models/occurrence_test.rb
@@ -134,15 +134,45 @@ class OccurrenceTest < UnitTestCase
     new_occ = @obs2.reload.occurrence
     assert_not_equal(old_occ.id, new_occ.id)
 
-    # Move obs1 to fs2 — triggers cleanup_old_occurrence
+    # Move obs1 to fs2 — the abandoned occurrence empties; even with a
+    # field slip it cannot survive without a valid primary, so it is
+    # destroyed and the slip freed.
     @obs1.update!(field_slip: fs2)
     @obs1.reload
     assert_equal(new_occ.id, @obs1.occurrence_id,
                  "obs1 should now belong to new occurrence")
-    # Old occurrence retains field_slip link, so destroy_if_incomplete!
-    # preserves it; but cleanup_old_occurrence still ran (coverage).
-    assert(Occurrence.exists?(old_occ.id),
-           "Old occurrence with field_slip should survive")
+    assert_not(Occurrence.exists?(old_occ.id),
+               "Emptied occurrence should be destroyed")
+  end
+
+  def test_move_to_other_occurrence_reassigns_abandoned_primary
+    @obs1.update!(specimen: true)
+    [@obs2, @obs3, @obs4].each { |obs| obs.update!(specimen: false) }
+    occ_a = create_occurrence(@obs1, @obs2, @obs3)
+    occ_b = create_occurrence(@obs4)
+    occ_a.recompute_has_specimen!
+    assert(occ_a.reload.has_specimen)
+
+    @obs1.update!(occurrence: occ_b)
+
+    occ_a.reload
+    assert_not_equal(@obs1.id, occ_a.primary_observation_id,
+                     "Primary should be reassigned off the departed obs")
+    assert(occ_a.observations.exists?(id: occ_a.primary_observation_id),
+           "Reassigned primary should be a remaining member")
+    assert_not(occ_a.has_specimen,
+               "has_specimen cache should be refreshed after the move")
+  end
+
+  def test_move_to_other_occurrence_destroys_incomplete_abandoned
+    occ_a = create_occurrence(@obs1, @obs2)
+    occ_b = create_occurrence(@obs3, @obs4)
+
+    @obs1.update!(occurrence: occ_b)
+
+    assert_not(Occurrence.exists?(occ_a.id),
+               "Occurrence reduced below 2 members should be destroyed")
+    assert_nil(@obs2.reload.occurrence_id)
   end
 
   def test_single_obs_occurrence_not_destroyed
@@ -617,6 +647,29 @@ class OccurrenceTest < UnitTestCase
       msgs.any? { |m| m.include?("Occurrence ##{occ.id}") },
       "Should not report when already correct"
     )
+  end
+
+  def test_refresh_has_specimen_cache_continues_past_broken_row
+    [@obs1, @obs2, @obs3, @obs4].each { |obs| obs.update!(specimen: false) }
+    broken = create_occurrence(@obs1, @obs2)
+    stale = create_occurrence(@obs3, @obs4)
+    # Corrupt `broken` the way bad production rows looked: primary
+    # belongs to another occurrence, cache wrong (update_columns
+    # bypasses the validation that normally prevents this).
+    broken.update_columns(primary_observation_id: @obs3.id,
+                          has_specimen: true)
+    stale.update_column(:has_specimen, true)
+
+    failures = []
+    msgs = Occurrence.refresh_has_specimen_cache { |msg| failures << msg }
+
+    assert_equal(1, failures.size)
+    assert_match(/Occurrence ##{broken.id}.*failed/, failures.first)
+    assert(msgs.any? { |m| m.include?("Occurrence ##{stale.id}") })
+    assert_not(stale.reload.has_specimen,
+               "Rows after the broken one should still be repaired")
+    assert(broken.reload.has_specimen,
+           "Broken row should be left unchanged")
   end
 
   # == Coverage: check_multiple_occurrences! ==

--- a/test/models/occurrence_test.rb
+++ b/test/models/occurrence_test.rb
@@ -162,6 +162,9 @@ class OccurrenceTest < UnitTestCase
            "Reassigned primary should be a remaining member")
     assert_not(occ_a.has_specimen,
                "has_specimen cache should be refreshed after the move")
+    assert(occ_b.reload.has_specimen,
+           "Destination occurrence's has_specimen cache should pick up " \
+           "the arriving specimen")
   end
 
   def test_move_to_other_occurrence_destroys_incomplete_abandoned


### PR DESCRIPTION
## Summary

The 2026-08-21 #alerts failure (`ActiveRecord::RecordInvalid: Validation failed: Primary observation must belong to this occurrence` from `MiscDataRepairsJob`) traced back to observations being moved between occurrences without any cleanup of the occurrence they left. Two production occurrences (#5076 and #5414) were left with a `primary_observation_id` pointing at an observation now belonging to a different occurrence, which made every subsequent save of those occurrences fail validation — including the nightly `has_specimen` sweep and attempts to repair them through the edit form (the edit action recomputes `has_specimen` before it repoints the primary, so the save aborts first).

Two causes:

- `Observation#cleanup_old_occurrence` ran during `field_slip=` **assignment**, before save, while the departing observation still counted as a member of the old occurrence — so it could "reassign" the old occurrence's primary right back to the departing observation (the #5414 shape, leaving an emptied occurrence behind in the #5076 shape).
- The bare `obs.update!(occurrence: occ)` move sites (`FieldSlipsController::ObservationHandling`, `Observations::FieldSlips`, `API2::FieldSlipAPI`, `API2::ObservationAPI`, `API2::OccurrenceAPI`) had no old-occurrence cleanup.

## Changes

- Replace `cleanup_old_occurrence` with an `after_update :cleanup_abandoned_occurrence` callback on `Observation` that fires on any occurrence-to-occurrence move (detach-to-nil flows are excluded; they do their own cleanup): reassign the old occurrence's primary if it was the departing observation, destroy the occurrence if it drops below 2 members, and refresh its `has_specimen` cache. Because it runs after save, the departing observation can no longer be re-picked as primary, and every move site is covered without per-caller changes.
- **Behavior change:** an occurrence that *empties* is now destroyed even when it has a field slip — it cannot be valid with no members and no valid primary — freeing the slip for reattachment. The test that pinned the old survive-behavior is updated.
- `Occurrence.merge!` now tolerates the callback having already destroyed the emptied occurrence (`find_by` + `&.destroy!` instead of `reload.destroy!`).
- `Occurrence.refresh_has_specimen_cache` (moved into a new `Occurrence::SpecimenCache` concern to stay under `Metrics/ClassLength`) no longer aborts the sweep when a row fails validation: the failure is recorded in the returned messages and yielded to the caller, and remaining rows are still repaired.
- `MiscDataRepairsJob#run_task` passes a block that routes each yielded row-level failure to `ApplicationJob#alert`, so unrepairable rows land in the #alerts channel for review instead of crashing the whole nightly job.

The production data repair for occurrences #5076/#5414 is a separate one-off runner script (not in the repo), verified against a local production copy.

## Test plan

- Create two occurrences A (3 members, its primary having a specimen) and B via the occurrence UI. From the edit form of an observation that is A's primary, assign it a field slip code belonging to B's occurrence. Then check occurrence A: its primary should be one of its remaining members, and its Has-Specimen state should match the remaining members.
- Repeat with A having only 2 members: A should be gone afterward and its remaining observation detached.
- Repeat with A being a single-observation field-slip occurrence: A should be gone and its field slip free to reattach.
- `bin/rails runner 'pp Occurrence.refresh_has_specimen_cache(dry_run: true)'` on a database with a deliberately corrupted row (`update_columns(primary_observation_id: <foreign obs>)`) should report the row and keep sweeping instead of raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVhpwpNPzcHkkzUuZamCsw
