### PR TITLE
Fix four recurring #alerts noise sources (`UserStats` orphans, `external_id` 500, scanner MIME 500, `define_a_location` deadlock)

### DIFF
--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -57,6 +57,9 @@ class ExternalLink < AbstractModel
   validates :external_site, presence: true
   validates :user, presence: true
   validates :url, length: { maximum: 100 }, allow_blank: true
+  # Matches the column's varchar(64); without this a long paste 500s
+  # with ActiveRecord::ValueTooLong instead of a form error.
+  validates :external_id, length: { maximum: 64 }, allow_blank: true
   validate  :check_url_syntax
   # No general one-link-per-(target, site) rule: an MO obs can legitimately
   # correspond to several iNat obs (iNat-side duplicates of one collection),

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1406,15 +1406,20 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
-  # After defining a location, update any lists using old "where" name.
+  # After defining a location, update any observations using old "where"
+  # name. The bulk update can deadlock against concurrent observation
+  # saves; one retry after MySQL rolls the victim back is enough.
   def self.define_a_location(location, old_name)
-    old_name = connection.quote(old_name)
-    new_name = connection.quote(location.name)
-    connection.update(%(
-      UPDATE observations
-      SET `where` = #{new_name}, location_id = #{location.id}
-      WHERE `where` = #{old_name}
-    ))
+    retried = false
+    begin
+      Observation.where(where: old_name).
+        update_all(where: location.name, location_id: location.id)
+    rescue ActiveRecord::Deadlocked
+      raise if retried
+
+      retried = true
+      retry
+    end
   end
 
   ##############################################################################

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -722,9 +722,11 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
         UserGroup.one_user(id)&.destroy
       end
       UserGroupUser.where(user_id: ids).delete_all
-      # delete_all below bypasses `has_many :api_keys, dependent: :destroy`,
-      # so clean them here too (erase_user handles this via OWN_RECORDS).
+      # delete_all below bypasses `has_many :api_keys, dependent: :destroy`
+      # and `has_one :user_stats, dependent: :destroy`, so clean them here
+      # too (erase_user handles this via OWN_RECORDS).
       APIKey.where(user_id: ids).delete_all
+      UserStats.where(user_id: ids).delete_all
       User.where(id: ids).delete_all
     end
 

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -231,10 +231,15 @@ class UserStats < ApplicationRecord
     # This runs after the migration, to copy columns from users to user_stats
     # It's a batch insert, so it's fast.
     def create_user_stats_for_all_users_without
+      # Verified users only: unverified accounts can't contribute and
+      # are culled after a month (User.cull_unverified_users), so a
+      # stats row would just become nightly churn.
       records = User.where.missing(:user_stats).
+                where.not(verified: nil).
                 pluck(:id).map do |id|
                   { user_id: id }
                 end
+      return if records.empty?
 
       UserStats.insert_all(records)
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,12 @@ module MushroomObserver
     # else a scanner's malformed bytes reach a String op and 500.
     config.middleware.insert_before(0, Rack::UTF8Sanitizer)
 
+    # A hostile/garbage Accept header (vulnerability scanners) is the
+    # client's error, not a 500.
+    config.action_dispatch.rescue_responses[
+      "ActionDispatch::Http::MimeNegotiation::InvalidType"
+    ] = :not_acceptable
+
     # Tells rails not to generate controller-specific css and js stubs.
     config.generators.assets = false
 

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -32,6 +32,7 @@ if enabled
       ActionController::InvalidAuthenticityToken
       ActionController::UnknownFormat
       ActionController::BadRequest
+      ActionDispatch::Http::MimeNegotiation::InvalidType
       Rack::QueryParser::InvalidParameterError
     ],
     # Collapse a burst of the same error into one alert.

--- a/test/models/external_link_test.rb
+++ b/test/models/external_link_test.rb
@@ -210,4 +210,14 @@ class ExternalLinkTest < UnitTestCase
     link.update!(relationship: :import, external_id: "234723")
     assert(link.reload.import?, "Link should upgrade to import in place")
   end
+
+  def test_external_id_length_validation
+    link = external_links(:coprinus_comatus_obs_mycoportal_link)
+    link.external_id = "9" * 65
+    assert_not(link.valid?, "external_id over 64 chars should be invalid")
+    assert(link.errors[:external_id].any?)
+
+    link.external_id = "9" * 64
+    assert(link.valid?, "external_id of 64 chars should be valid")
+  end
 end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -2702,6 +2702,47 @@ class ObservationTest < UnitTestCase
     assert_not(obs.shows_merged_notes?)
   end
 
+  def test_define_a_location_updates_matching_observations
+    obs = observations(:minimal_unknown_obs)
+    obs.update_columns(where: "Deadlock Test Town, USA", location_id: nil)
+    loc = locations(:albion)
+
+    Observation.define_a_location(loc, "Deadlock Test Town, USA")
+
+    obs.reload
+    assert_equal(loc.id, obs.location_id)
+    assert_equal(loc.name, obs.where)
+  end
+
+  def test_define_a_location_retries_once_on_deadlock
+    calls = 0
+    relation = Object.new
+    relation.define_singleton_method(:update_all) do |*_args|
+      calls += 1
+      raise(ActiveRecord::Deadlocked) if calls == 1
+
+      1
+    end
+
+    Observation.stub(:where, relation) do
+      Observation.define_a_location(locations(:albion), "Nowhere, USA")
+    end
+    assert_equal(2, calls, "update should be retried after one deadlock")
+  end
+
+  def test_define_a_location_reraises_repeated_deadlock
+    relation = Object.new
+    relation.define_singleton_method(:update_all) do |*_args|
+      raise(ActiveRecord::Deadlocked)
+    end
+
+    Observation.stub(:where, relation) do
+      assert_raises(ActiveRecord::Deadlocked) do
+        Observation.define_a_location(locations(:albion), "Nowhere, USA")
+      end
+    end
+  end
+
   private
 
   # Build a two-member occurrence from two obs fixtures with the given

--- a/test/models/user_stats_test.rb
+++ b/test/models/user_stats_test.rb
@@ -80,6 +80,15 @@ class UserStatsTest < UnitTestCase
     assert_equal(mary.votes.size, mary_stats.votes)
   end
 
+  def test_refresh_all_user_stats_skips_unverified_users
+    UserStats.refresh_all_user_stats
+    assert_nil(
+      UserStats.find_by(user_id: users(:unverified).id),
+      "Unverified users should not get a stats row (they get culled, " \
+      "orphaning it)"
+    )
+  end
+
   # Regression test for the sign bug where a :del incremented the
   # per-field user_stats counter instead of decrementing it (issue #4638).
   # users.contribution was correctly signed all along; both must move

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -552,14 +552,19 @@ class UserTest < UnitTestCase
   def test_culling_unverified_users
     unverified = users(:unverified)
     key = APIKey.create!(user: unverified, notes: "cull test")
+    stats = UserStats.create!(user_id: unverified.id)
     msgs = User.cull_unverified_users(dry_run: true)
     assert_equal("Deleted 1 unverified user(s).", msgs.first)
     assert(APIKey.exists?(key.id), "dry run should not delete the api_key")
+    assert(UserStats.exists?(stats.id),
+           "dry run should not delete user_stats")
     msgs = User.cull_unverified_users(dry_run: false)
     assert_equal("Deleted 1 unverified user(s).", msgs.first)
     assert_nil(User.find_by(id: unverified.id))
     assert_not(APIKey.exists?(key.id),
                "culling should delete the unverified user's api_key")
+    assert_not(UserStats.exists?(stats.id),
+               "culling should delete the unverified user's user_stats")
   end
 
   def test_lookup_unique_text_name


### PR DESCRIPTION
## Summary

Fixes four independent sources of recurring #alerts noise, diagnosed from the channel backlog.

**1. Nightly UserStats orphan churn (`CheckForBrokenReferencesJob`, ~1,200–1,400 deletions/night).** `RefreshAllUserStatsJob` created a stats row for every user without one — including unverified signups — and `User.cull_unverified_users` deletes those users with `delete_all`, which bypasses `has_one :user_stats, dependent: :destroy`. The reference checker then deleted the orphans and alerted, every night. Now `cull_unverified_users` deletes the UserStats rows alongside the API keys it already handles the same way, and `create_user_stats_for_all_users_without` skips unverified users (they can't contribute, and a user who later verifies gets their row on the next nightly run).

**2. `ExternalLink#external_id` 500 (`ActiveRecord::ValueTooLong`).** The column is `varchar(64)`; `url` had a length validation but `external_id` didn't, so pasting something oversized into the ID field crashed instead of rendering the form's error path. Added the matching length validation.

**3. Vulnerability-scanner Accept headers (`ActionDispatch::Http::MimeNegotiation::InvalidType`).** A scanner sending `Accept: ../../../../etc/services{{` produced a 500 and an alert. The exception is now mapped to `406 Not Acceptable` via `config.action_dispatch.rescue_responses` and excluded from exception notification — it's the client's garbage, not our bug.

**4. Deadlock in `Observation.define_a_location` (`locations#create`).** The bulk `UPDATE observations SET where=...` when defining a location deadlocked once against concurrent observation saves. Rewritten from raw SQL to `update_all` (matching `SpeciesList.define_a_location`, and per the no-raw-SQL rule) with a single retry after MySQL rolls the victim back.

## Test plan

- As an unverified-email account older than a month exists, run `bin/rails runner 'pp User.cull_unverified_users(dry_run: true)'` — then after a live run, confirm `UserStats.where.missing(:user).count` stays 0 on subsequent nights (no more `CheckForBrokenReferencesJob` UserStats alerts).
- On an observation, add an external link with a pasted value longer than 64 characters in the ID field — expect a form validation error, not a 500.
- `curl -H "Accept: ../../etc/services{{" https://mushroomobserver.org/` — expect 406 and no #alerts message.
- Define a new location from a "where" string used by existing observations; confirm they adopt the location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVhpwpNPzcHkkzUuZamCsw
