### PR TITLE
Convert `comments.comment` and `users.notes` to utf8mb4 (emoji 500s)

### DIFF
--- a/db/migrate/20260821200358_convert_comment_and_user_notes_to_utf8mb4.rb
+++ b/db/migrate/20260821200358_convert_comment_and_user_notes_to_utf8mb4.rb
@@ -6,11 +6,14 @@
 # index-key-length concerns that defer #4625 don't apply here. The
 # connection already runs utf8mb4, so these columns are the only barrier.
 class ConvertCommentAndUserNotesToUtf8mb4 < ActiveRecord::Migration[7.2]
+  # utf8mb4_0900_ai_ci matches every existing utf8mb4 table in the
+  # schema (the MySQL 8+ default), so the eventual #4625 conversion
+  # normalizes on a single collation.
   def up
     change_column(:comments, :comment, :text,
-                  collation: "utf8mb4_general_ci")
+                  collation: "utf8mb4_0900_ai_ci")
     change_column(:users, :notes, :text,
-                  collation: "utf8mb4_general_ci")
+                  collation: "utf8mb4_0900_ai_ci")
   end
 
   def down

--- a/db/migrate/20260821200358_convert_comment_and_user_notes_to_utf8mb4.rb
+++ b/db/migrate/20260821200358_convert_comment_and_user_notes_to_utf8mb4.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# First incremental step toward issue #4625 (full utf8mb4 conversion):
+# the two free-text columns users have hit with 4-byte characters
+# (emoji), each a production 500. TEXT columns sit in no index, so the
+# index-key-length concerns that defer #4625 don't apply here. The
+# connection already runs utf8mb4, so these columns are the only barrier.
+class ConvertCommentAndUserNotesToUtf8mb4 < ActiveRecord::Migration[7.2]
+  def up
+    change_column(:comments, :comment, :text,
+                  collation: "utf8mb4_general_ci")
+    change_column(:users, :notes, :text,
+                  collation: "utf8mb4_general_ci")
+  end
+
+  def down
+    change_column(:comments, :comment, :text,
+                  collation: "utf8mb3_general_ci")
+    change_column(:users, :notes, :text,
+                  collation: "utf8mb3_general_ci")
+  end
+end

--- a/db/migrate/20260821200358_convert_comment_and_user_notes_to_utf8mb4.rb
+++ b/db/migrate/20260821200358_convert_comment_and_user_notes_to_utf8mb4.rb
@@ -8,27 +8,29 @@
 # bytes as utf8mb4) is far under InnoDB's key limit. The connection
 # already runs utf8mb4, so the columns are the only barrier.
 #
-# All of comments' string columns convert together: Comment.pattern
-# CONCATs summary with comment, and on MySQL 8 a CONCAT mixing utf8mb3
-# and utf8mb4 columns resolves to utf8mb4_bin with no derivation, so
-# the pattern-search LIKE fails with "Illegal mix of collations"
-# (caught by CI; MySQL 9's coercion rules tolerate the mix, so it did
-# not reproduce locally). users.notes has no such partner -- the user
-# pattern search reads login + name only.
-#
-# utf8mb4_0900_ai_ci matches every existing utf8mb4 table in the
-# schema (the MySQL 8+ default), so the eventual #4625 conversion
-# normalizes on a single collation.
+# utf8mb4_general_ci, NOT the newer utf8mb4_0900_ai_ci the schema's
+# other (standalone) utf8mb4 tables use: the connection collation is
+# utf8mb4_general_ci, and Arel's `+` string concat (the search_columns
+# pattern scopes, e.g. Comment.pattern) wraps its left operand in a
+# bare CAST(... AS CHAR), which takes the CONNECTION collation no
+# matter what the column's is. CONCAT(general_ci, 0900_ai_ci) then
+# aggregates to utf8mb4_bin with no derivation, and MySQL 8 rejects
+# the pattern-search LIKE on it ("Illegal mix of collations" -- caught
+# by CI; MySQL 9 tolerates it, so it did not reproduce locally).
+# 0900_ai_ci has to wait until #4625 flips the connection collation
+# and every table together. All of comments' string columns convert
+# in one pass so the table stays single-collation; users.notes has no
+# concat partner (the user pattern search reads login + name only).
 class ConvertCommentAndUserNotesToUtf8mb4 < ActiveRecord::Migration[7.2]
   def up
     change_column(:comments, :comment, :text,
-                  collation: "utf8mb4_0900_ai_ci")
+                  collation: "utf8mb4_general_ci")
     change_column(:comments, :summary, :string,
-                  limit: 100, collation: "utf8mb4_0900_ai_ci")
+                  limit: 100, collation: "utf8mb4_general_ci")
     change_column(:comments, :target_type, :string,
-                  limit: 30, collation: "utf8mb4_0900_ai_ci")
+                  limit: 30, collation: "utf8mb4_general_ci")
     change_column(:users, :notes, :text,
-                  collation: "utf8mb4_0900_ai_ci")
+                  collation: "utf8mb4_general_ci")
   end
 
   def down

--- a/db/migrate/20260821200358_convert_comment_and_user_notes_to_utf8mb4.rb
+++ b/db/migrate/20260821200358_convert_comment_and_user_notes_to_utf8mb4.rb
@@ -1,17 +1,32 @@
 # frozen_string_literal: true
 
 # First incremental step toward issue #4625 (full utf8mb4 conversion):
-# the two free-text columns users have hit with 4-byte characters
-# (emoji), each a production 500. TEXT columns sit in no index, so the
-# index-key-length concerns that defer #4625 don't apply here. The
-# connection already runs utf8mb4, so these columns are the only barrier.
+# the free-text columns users have hit with 4-byte characters (emoji),
+# each a production 500. TEXT columns sit in no index, so the
+# index-key-length concerns that defer #4625 don't apply; the one
+# converted indexed column (comments.target_type, varchar(30) = 120
+# bytes as utf8mb4) is far under InnoDB's key limit. The connection
+# already runs utf8mb4, so the columns are the only barrier.
+#
+# All of comments' string columns convert together: Comment.pattern
+# CONCATs summary with comment, and on MySQL 8 a CONCAT mixing utf8mb3
+# and utf8mb4 columns resolves to utf8mb4_bin with no derivation, so
+# the pattern-search LIKE fails with "Illegal mix of collations"
+# (caught by CI; MySQL 9's coercion rules tolerate the mix, so it did
+# not reproduce locally). users.notes has no such partner -- the user
+# pattern search reads login + name only.
+#
+# utf8mb4_0900_ai_ci matches every existing utf8mb4 table in the
+# schema (the MySQL 8+ default), so the eventual #4625 conversion
+# normalizes on a single collation.
 class ConvertCommentAndUserNotesToUtf8mb4 < ActiveRecord::Migration[7.2]
-  # utf8mb4_0900_ai_ci matches every existing utf8mb4 table in the
-  # schema (the MySQL 8+ default), so the eventual #4625 conversion
-  # normalizes on a single collation.
   def up
     change_column(:comments, :comment, :text,
                   collation: "utf8mb4_0900_ai_ci")
+    change_column(:comments, :summary, :string,
+                  limit: 100, collation: "utf8mb4_0900_ai_ci")
+    change_column(:comments, :target_type, :string,
+                  limit: 30, collation: "utf8mb4_0900_ai_ci")
     change_column(:users, :notes, :text,
                   collation: "utf8mb4_0900_ai_ci")
   end
@@ -19,6 +34,10 @@ class ConvertCommentAndUserNotesToUtf8mb4 < ActiveRecord::Migration[7.2]
   def down
     change_column(:comments, :comment, :text,
                   collation: "utf8mb3_general_ci")
+    change_column(:comments, :summary, :string,
+                  limit: 100, collation: "utf8mb3_general_ci")
+    change_column(:comments, :target_type, :string,
+                  limit: 30, collation: "utf8mb3_general_ci")
     change_column(:users, :notes, :text,
                   collation: "utf8mb3_general_ci")
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_21_010000) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -49,7 +49,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_21_010000) do
     t.datetime "created_at", precision: nil
     t.integer "user_id"
     t.string "summary", limit: 100
-    t.text "comment"
+    t.text "comment", collation: "utf8mb4_general_ci"
     t.string "target_type", limit: 30
     t.integer "target_id"
     t.datetime "updated_at", precision: nil
@@ -1051,7 +1051,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_21_010000) do
     t.boolean "thumbnail_maps", default: true, null: false
     t.string "auth_code", limit: 40
     t.integer "keep_filenames", default: 1, null: false
-    t.text "notes"
+    t.text "notes", collation: "utf8mb4_general_ci"
     t.text "mailing_address"
     t.integer "layout_count"
     t.boolean "view_owner_id", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,9 +48,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
   create_table "comments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.integer "user_id"
-    t.string "summary", limit: 100
+    t.string "summary", limit: 100, collation: "utf8mb4_0900_ai_ci"
     t.text "comment", collation: "utf8mb4_0900_ai_ci"
-    t.string "target_type", limit: 30
+    t.string "target_type", limit: 30, collation: "utf8mb4_0900_ai_ci"
     t.integer "target_id"
     t.datetime "updated_at", precision: nil
     t.index ["target_id", "target_type"], name: "target_index"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,9 +48,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
   create_table "comments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.integer "user_id"
-    t.string "summary", limit: 100, collation: "utf8mb4_0900_ai_ci"
-    t.text "comment", collation: "utf8mb4_0900_ai_ci"
-    t.string "target_type", limit: 30, collation: "utf8mb4_0900_ai_ci"
+    t.string "summary", limit: 100, collation: "utf8mb4_general_ci"
+    t.text "comment", collation: "utf8mb4_general_ci"
+    t.string "target_type", limit: 30, collation: "utf8mb4_general_ci"
     t.integer "target_id"
     t.datetime "updated_at", precision: nil
     t.index ["target_id", "target_type"], name: "target_index"
@@ -1051,7 +1051,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
     t.boolean "thumbnail_maps", default: true, null: false
     t.string "auth_code", limit: 40
     t.integer "keep_filenames", default: 1, null: false
-    t.text "notes", collation: "utf8mb4_0900_ai_ci"
+    t.text "notes", collation: "utf8mb4_general_ci"
     t.text "mailing_address"
     t.integer "layout_count"
     t.boolean "view_owner_id", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,7 +49,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
     t.datetime "created_at", precision: nil
     t.integer "user_id"
     t.string "summary", limit: 100
-    t.text "comment", collation: "utf8mb4_general_ci"
+    t.text "comment", collation: "utf8mb4_0900_ai_ci"
     t.string "target_type", limit: 30
     t.integer "target_id"
     t.datetime "updated_at", precision: nil
@@ -1051,7 +1051,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
     t.boolean "thumbnail_maps", default: true, null: false
     t.string "auth_code", limit: 40
     t.integer "keep_filenames", default: 1, null: false
-    t.text "notes", collation: "utf8mb4_general_ci"
+    t.text "notes", collation: "utf8mb4_0900_ai_ci"
     t.text "mailing_address"
     t.integer "layout_count"
     t.boolean "view_owner_id", default: false, null: false


### PR DESCRIPTION
## Summary

Two #alerts production 500s came from users submitting emoji: a 🤣 in a comment (`comments#create`) and repeated attempts by user 210596 to put 🍄 in their profile notes (`profile#update`). Both are the same root cause: the columns are `utf8mb3`, which cannot store 4-byte UTF-8, while the Trilogy connection already runs `utf8mb4` — so the characters reach the column and die there with `Incorrect string value`.

This converts the `comments` table's string columns (`comment`, `summary`, `target_type`) and `users.notes` to `utf8mb4_general_ci`, as a first incremental step toward the full conversion tracked in #4625. The index-key-length audit that defers #4625 barely applies here: `comment` and `notes` are unindexed TEXT, and the one converted indexed column (`target_type`, varchar(30) = 120 bytes as utf8mb4) is far under InnoDB's key limit. Both tables are small (194k comments, 92k users); the ALTERs ran in about a second locally against a production-size copy.

**Collation choice — `utf8mb4_general_ci`, not `utf8mb4_0900_ai_ci`** (tried per Copilot's consistency suggestion; reverted after CI failures): the connection collation is `utf8mb4_general_ci`, and Arel's `+` string concat — used by the `search_columns` pattern scopes, e.g. `Comment.pattern` — wraps its left operand in a bare `CAST(... AS CHAR)`, which takes the *connection* collation regardless of the column's. `CONCAT(general_ci, 0900_ai_ci)` aggregates to `utf8mb4_bin` with no derivation, and MySQL 8 (CI, production) rejects the pattern-search LIKE on it with `Illegal mix of collations (utf8mb4_bin,NONE)...`; MySQL 9 (local dev) tolerates it, which is why the failures only surfaced in CI. With `general_ci` columns the CONCAT resolves cleanly (verified via `COLLATION()`/`COERCIBILITY()` on the generated SQL). `0900_ai_ci` has to arrive with #4625's connection-collation flip, all tables at once — the rationale is also recorded in the migration comment for the next #4625 increment.

All of `comments`' string columns convert in one pass so the table stays single-collation. `users.notes` has no concat partner — the user pattern search reads `login + name` only.

After this, emoji save, render, and are even searchable in comments and profile notes (verified locally with 🤣🍄 round-trips and a `Comment.pattern("🍄")` hit). Other free-text columns (`observations.notes` is the likely next one a user hits) remain `utf8mb3` until #4625 or a follow-up increment.

## Test plan

- CI green is the load-bearing check here — CI runs MySQL 8, which is strict about mixed-collation expressions and matches production; local MySQL 9 is lenient. (The original `general_ci` revision `74644cca5a` passed CI; the `0900_ai_ci` revisions failed it.)
- Deploy, then post a comment containing an emoji and save profile notes containing an emoji — both should save and display correctly; a pattern search matching a comment's text should still work.
- User 210596 can be told their 🍄 works now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVhpwpNPzcHkkzUuZamCsw
