### PR TITLE
Nightly retry sweep for failed GPS strips (`Image.retry_failed_gps_strips`)

### DIFF
--- a/app/jobs/misc_data_repairs_job.rb
+++ b/app/jobs/misc_data_repairs_job.rb
@@ -35,6 +35,7 @@ class MiscDataRepairsJob < ApplicationJob
      "occurrence has_specimen cache"],
     [Observation, :refresh_needs_naming_column,
      "observations needing naming"],
+    [Image, :retry_failed_gps_strips, "failed GPS strips"],
     [User, :cull_unverified_users, "cull unverified users"]
   ].freeze
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -979,16 +979,17 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
   def self.retry_failed_gps_strips(dry_run: false,
                                    min_id: GPS_STRIP_RETRY_MIN_ID,
                                    limit: 200)
-    images = joins(observation_images: :observation).
-             where(observations: { gps_hidden: true }).
-             where(gps_stripped: false).
-             where(id: min_id..).
-             distinct.order(:id).to_a
-    msgs = images.first(limit).map do |img|
+    scope = joins(observation_images: :observation).
+            where(observations: { gps_hidden: true }).
+            where(gps_stripped: false).
+            where(id: min_id..).
+            distinct
+    total = scope.count
+    msgs = scope.order(:id).limit(limit).map do |img|
       retry_gps_strip(img, dry_run) { |failure| yield(failure) if block_given? }
     end
-    if images.size > limit
-      msgs << "GPS strip retries capped at #{limit}/#{images.size}; " \
+    if total > limit
+      msgs << "GPS strip retries capped at #{limit}/#{total}; " \
               "the rest run on later nights"
     end
     msgs

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -965,6 +965,47 @@ class Image < AbstractModel # rubocop:disable Metrics/ClassLength
       find { |path| File.exist?(path) }
   end
 
+  # Ids below this have their originals only in the GCS archive bucket,
+  # not on the images server, so script/strip_exif cannot reach them.
+  GPS_STRIP_RETRY_MIN_ID = 1_600_000
+
+  # Nightly retry of GPS strips still pending on images attached to a
+  # gps_hidden observation. A failed strip only flashes an error at the
+  # submitting user (see strip_gps! callers), so without this sweep it
+  # is not retried and the original keeps its GPS. Yields a message per
+  # still-failing image so the caller can alert. The per-run cap keeps
+  # a pathological backlog from turning the nightly job into thousands
+  # of ssh execs; the remainder is reported, not silently dropped.
+  def self.retry_failed_gps_strips(dry_run: false,
+                                   min_id: GPS_STRIP_RETRY_MIN_ID,
+                                   limit: 200)
+    images = joins(observation_images: :observation).
+             where(observations: { gps_hidden: true }).
+             where(gps_stripped: false).
+             where(id: min_id..).
+             distinct.order(:id).to_a
+    msgs = images.first(limit).map do |img|
+      retry_gps_strip(img, dry_run) { |failure| yield(failure) if block_given? }
+    end
+    if images.size > limit
+      msgs << "GPS strip retries capped at #{limit}/#{images.size}; " \
+              "the rest run on later nights"
+    end
+    msgs
+  end
+
+  def self.retry_gps_strip(img, dry_run)
+    return "Image ##{img.id}: would retry GPS strip" if dry_run
+
+    error = img.strip_gps!
+    return "Image ##{img.id}: GPS strip retried" unless error
+
+    failure = "Image ##{img.id}: GPS strip retry failed - #{error}"
+    yield(failure)
+    failure
+  end
+  private_class_method :retry_gps_strip
+
   # Attempt to strip GPS data from original image. Returns error message as
   # string if it fails.
   #

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -318,10 +318,83 @@ class ImageTest < UnitTestCase
     end
   end
 
+  # -- retry_failed_gps_strips --
+
+  def test_retry_failed_gps_strips_dry_run_reports_without_stripping
+    img = unstripped_hidden_image
+
+    Open3.stub(:capture2e, ->(*) { raise("must not shell out") }) do
+      msgs = Image.retry_failed_gps_strips(dry_run: true, min_id: img.id)
+      assert_includes(msgs, "Image ##{img.id}: would retry GPS strip")
+    end
+    assert_false(img.reload.gps_stripped)
+  end
+
+  def test_retry_failed_gps_strips_strips_and_flags
+    img = unstripped_hidden_image
+    failures = []
+
+    Open3.stub(:capture2e, ["", stub_status(true)]) do
+      msgs = Image.retry_failed_gps_strips(min_id: img.id) do |failure|
+        failures << failure
+      end
+      assert_includes(msgs, "Image ##{img.id}: GPS strip retried")
+    end
+
+    assert_empty(failures)
+    assert_true(img.reload.gps_stripped)
+  end
+
+  def test_retry_failed_gps_strips_yields_failures_and_continues
+    img = unstripped_hidden_image
+    failures = []
+
+    Open3.stub(:capture2e, ["boom", stub_status(false)]) do
+      msgs = Image.retry_failed_gps_strips(min_id: img.id) do |failure|
+        failures << failure
+      end
+      assert_includes(msgs,
+                      "Image ##{img.id}: GPS strip retry failed - boom")
+    end
+
+    assert_includes(failures,
+                    "Image ##{img.id}: GPS strip retry failed - boom")
+    assert_false(img.reload.gps_stripped)
+  end
+
+  def test_retry_failed_gps_strips_skips_ids_below_min_id
+    img = unstripped_hidden_image
+
+    msgs = Image.retry_failed_gps_strips(dry_run: true, min_id: img.id + 1)
+
+    assert_not(msgs.any? { |m| m.include?("##{img.id}:") },
+               "Images below min_id should be out of scope")
+  end
+
+  def test_retry_failed_gps_strips_caps_per_run_and_reports_remainder
+    img = unstripped_hidden_image
+
+    msgs = Image.retry_failed_gps_strips(dry_run: true, min_id: img.id,
+                                         limit: 0)
+
+    assert_equal(1, msgs.size)
+    assert_match(%r{capped at 0/\d+; the rest run on later nights},
+                 msgs.first)
+  end
+
   def stub_status(success)
     status = Object.new
     status.define_singleton_method(:success?) { success }
     status
+  end
+
+  # A transferred, unstripped image attached to a gps_hidden observation
+  # -- the shape retry_failed_gps_strips sweeps for.
+  def unstripped_hidden_image
+    img = images(:in_situ_image)
+    img.observations.first.update_columns(gps_hidden: true)
+    img.update_columns(gps_stripped: false, transferred: true)
+    img
   end
 
   # dHash is computed from the small local rendition — never the full-size


### PR DESCRIPTION
## Summary

Closes the loop on the live GPS-leak mechanism found while triaging the August `GpsLeakDetectorJob` tripwire hits: 4 of the 5 flagged images had `gps_stripped=false` — they were added to an already-`gps_hidden` observation after the image had transferred, the remote strip (`script/strip_exif <id> 1` over ssh) failed, and the only consequence was a flash error at the submitting user. Nothing retried the strip, so the original kept its GPS until the weekly tripwire noticed.

`Image.retry_failed_gps_strips` runs nightly as a `MiscDataRepairsJob` task: it finds images attached to a `gps_hidden` observation with `gps_stripped=false` and calls the idempotent `strip_gps!` on each. Per-image failures are yielded to the caller — once #5151's yield-to-alert mechanism in `MiscDataRepairsJob#run_task` lands, a strip that keeps failing shows up in #alerts nightly instead of silently waiting for the tripwire.

Two scoping decisions:

- **`id >= 1_600_000` floor** (`GPS_STRIP_RETRY_MIN_ID`): older originals exist only in the GCS archive bucket, which `script/strip_exif` documents it cannot reach — retrying those ~1,080 rows would fail on each nightly run, indefinitely. Their archive copies were already cleaned in the July #4859 remediation; their stale flags are harmless and stay out of scope.
- **Per-run cap of 200, remainder reported** (not silently dropped): production currently has ~950 matching rows at or above the floor. All of their files were verified clean by the July images-server audit, so for them the "retry" is a no-op exiftool pass that finally sets the stale flag — but ~950 sequential ssh execs in one nightly run is not a "cheap task." The cap drains the backlog over ~5 nights, after which the steady state is zero-to-a-few rows. (To drain it in one manual pass instead: `bin/rails runner 'puts Image.retry_failed_gps_strips(limit: 2000) { |f| warn(f) }'` on the web server.)

Merge-order note: independent of #5151 — on current `main` the yielded failures land in the job log only; with #5151 they also alert. No textual conflict (this touches `TASKS`, #5151 touches `run_task`).

## Test plan

- After deploy, `log/job.log` should show "failed GPS strips..." each night, with up to 200 `Image #N: GPS strip retried` lines per night until the ~950-row backlog drains (verify with `Image.joins(observation_images: :observation).where(observations: { gps_hidden: true }, gps_stripped: false).where(id: 1_600_000..).count` trending to 0).
- Reproduce the original bug shape: add a photo to an existing observation that has "hide GPS" set, with the images server unreachable (or observe a naturally failing strip) — the next nightly run should retry it, and the following Monday's tripwire should stay quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVhpwpNPzcHkkzUuZamCsw
