### PR TITLE
Fix false constraint-violation warning from reused field-slip prefix

### DIFF
--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -218,11 +218,16 @@ module ObservationsController::FieldSlips
     # `bar_field_slip` already told the user why; saving the observation
     # without the code is the whole point of that branch.
     return :unchanged if @field_slip_barred
+    return :unchanged if field_code_unchanged?
 
-    code = field_code
-    return :unchanged if code == @observation.field_slip&.code.to_s
+    field_code.blank? ? clear_field_slip : assign_field_slip(field_code)
+  end
 
-    code.blank? ? clear_field_slip : assign_field_slip(code)
+  # True when the submitted code is the same as the observation's own
+  # field slip (or both are absent) -- i.e. the slip link isn't
+  # changing on this submit.
+  def field_code_unchanged?
+    field_code == @observation.field_slip&.code.to_s
   end
 
   def clear_field_slip

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -214,7 +214,7 @@ module ObservationsController::Validators
     @suspect_checked_projects |= [slip_project]
   end
 
-  # The Project named by typed/scanned code names. When the code is
+  # The Project named by typed/scanned code. When the code is
   # unchanged from the Observation's own field slip, that slip's
   # attached (possibly nil) Project is the source of
   # truth. Looked up fresh by id (rather than

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -214,8 +214,18 @@ module ObservationsController::Validators
     @suspect_checked_projects |= [slip_project]
   end
 
-  # The project the typed/scanned code's prefix names.
+  # The Project named by typed/scanned code names. When the code is
+  # unchanged from the Observation's own field slip, that slip's
+  # attached (possibly nil) Project is the source of
+  # truth. Looked up fresh by id (rather than
+  # via the strict-loaded `field_slip.project` association) to match
+  # the other branch's unscoped `Project.find_by`.
   def slip_prefix_project
+    if field_code_unchanged?
+      project_id = @observation.field_slip&.project_id
+      return project_id && Project.find(project_id)
+    end
+
     prefix = FieldSlip.prefix_for_code(field_code)
     prefix && Project.find_by(field_slip_prefix: prefix)
   end

--- a/app/controllers/observations_controller/validators.rb
+++ b/app/controllers/observations_controller/validators.rb
@@ -223,7 +223,7 @@ module ObservationsController::Validators
   def slip_prefix_project
     if field_code_unchanged?
       project_id = @observation.field_slip&.project_id
-      return project_id && Project.find(project_id)
+      return Project.find_by(id: project_id) if project_id
     end
 
     prefix = FieldSlip.prefix_for_code(field_code)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1549,9 +1549,9 @@
   form_observations_projects_use_spare_slip: Use as Spare Slip
   form_observations_projects_use_spare_help: "; or\n- Check [:form_observations_projects_use_spare_slip] to attach the field slip to this observation with no project"
   form_observations_projects_kind_date: Out-of-range date
-  form_observations_projects_kind_bbox: Out-of-bbox location
-  form_observations_projects_kind_target_name: Non-target name
-  form_observations_projects_kind_target_location: Non-target location
+  form_observations_projects_kind_bbox: "[:form_violations_kind_bbox]"
+  form_observations_projects_kind_target_name: "[:form_violations_kind_target_name]"
+  form_observations_projects_kind_target_location: "[:form_violations_kind_target_location]"
   form_observations_projects_kind_prefix_mismatch: Field slip prefix mismatch
 
   form_observations_there_is_a_problem_with_location: There is a problem with the location. "+[:see_message_below]+":#location_messages

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -1035,6 +1035,79 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     assert_field_slip_race_reported(:too_many)
   end
 
+  # A project's field_slip_prefix is unique but reassignable: freeing it
+  # from its original project and giving it to a different
+  # project must not make that new project a target for an observation
+  # whose slip code still belongs to the
+  # original project. See #5150.
+  def test_update_unchanged_field_slip_code_ignores_reassigned_prefix
+    obs = observations(:minimal_unknown_obs)
+    slip = field_slips(:field_slip_one)
+    original_project = projects(:eol_project)
+    reassigned_project = projects(:current_project)
+    assert_equal(original_project, slip.project,
+                 "Test fixture setup: obs's field slip should still " \
+                 "belong to its own project")
+    assert_equal(slip, obs.field_slip,
+                 "Test fixture setup: obs should carry this field slip")
+
+    original_project.update!(field_slip_prefix: nil)
+    reassigned_project.update!(
+      field_slip_prefix: FieldSlip.prefix_for_code(slip.code)
+    )
+
+    login(obs.user.login)
+    put(:update,
+        params: { id: obs.id,
+                  observation: obs_params(obs).merge(
+                    collector: "Ashley Laman"
+                  ),
+                  field_code: slip.code })
+
+    assert_flash_success(
+      on_fail: "Editing an observation without changing its field " \
+               "slip code should not warn about constraint violations " \
+               "of whichever project now happens to own the slip's " \
+               "prefix -- only the slip's own (unchanged) project " \
+               "matters"
+    )
+    assert_redirected_to(permanent_observation_path(obs.id))
+    assert_equal("Ashley Laman", obs.reload.collector,
+                 "Update should still have gone through")
+  end
+
+  # The prefix-reassignment scenario above must not swallow a conflict
+  # the user explicitly opts into by checking the box themselves.
+  def test_update_explicit_project_check_still_flags_constraint_violation
+    obs = observations(:minimal_unknown_obs)
+    slip = field_slips(:field_slip_one)
+    original_project = projects(:eol_project)
+    reassigned_project = projects(:current_project)
+
+    original_project.update!(field_slip_prefix: nil)
+    reassigned_project.update!(
+      field_slip_prefix: FieldSlip.prefix_for_code(slip.code)
+    )
+
+    login(obs.user.login)
+    put(:update,
+        params: { id: obs.id,
+                  observation: obs_params(obs).merge(
+                    project_ids: [reassigned_project.id.to_s]
+                  ),
+                  field_code: slip.code })
+
+    assert_flash_error(
+      on_fail: "Explicitly checking a project that violates its " \
+               "constraints should still be flagged, even though an " \
+               "unchanged field-slip code no longer implicates it " \
+               "automatically"
+    )
+    assert_not_includes(obs.reload.project_ids, reassigned_project.id,
+                        "A non-admin's violating checked project " \
+                        "should not have been added")
+  end
+
   # Unchecking one project box moves every observation of the occurrence,
   # so the flash has to say how many rather than letting the rest go
   # unmentioned. See #4932.


### PR DESCRIPTION
Also rename "Out-of-bbox location" to "Outside project location" to match wording used elsewhere.

Fixes #5150