### PR TITLE
Changelog block convention: `.claude/rules/changelog.md` + PR template (#5155 step 1)

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -1,0 +1,56 @@
+# Changelog block — required in every PR description
+
+Every `gh pr create` body must include a changelog block (put it at the
+end, after the test plan):
+
+```
+<!-- changelog -->
+article: yes
+Maps of name lists now support clustering and zoom.
+<!-- /changelog -->
+```
+
+This is the PR-time half of the automated changelog (issue #5155).
+Two changelogs are generated from merged PRs at deploy time:
+
+- **`CHANGELOG.md`** — technical, lists every merged PR. Nothing to do
+  per-PR; the generator uses the PR title.
+- **The MO Article changelog** (user-facing, curated) — fed by this
+  block: `article:` decides whether the PR appears there, and the
+  sentence is what site users read.
+
+Reviewers edit the block in place like any other part of the PR body.
+A PR with no block is excluded from the Article and flagged in the
+deploy output for manual review — the block is how a deliberate
+decision is told apart from an omission.
+
+## Filling it in
+
+**`article: yes`** for changes a non-technical site user would notice
+or care about: new features, UI changes, user-visible bug fixes,
+performance improvements users would feel.
+
+**`article: no`** for internal work: refactors, tests, CI/tooling,
+code style, RuboCop cops, dependency bumps, dev docs, admin-only
+tooling, data repairs with no visible effect. Omit the sentence line.
+
+When genuinely unsure, prefer `yes` — a reviewer can flip it to `no`
+faster than they can notice an omission.
+
+**The sentence** (required when `article: yes`, one line):
+
+- Written for mushroom observers, not developers. Describe what
+  changed from the user's point of view, not how: "Emoji now work in
+  comments and profile notes," not "Convert `comments.comment` to
+  utf8mb4."
+- No code identifiers, no backticks, no class/method/file names.
+- No PR/issue numbers — the generator adds the links.
+- Plain present tense, capitalized, ending punctuation optional.
+
+## Format is machine-parsed — keep it exact
+
+The generator reads everything between `<!-- changelog -->` and
+`<!-- /changelog -->`: the first non-blank line must be
+`article: yes` or `article: no`; the remaining non-blank lines are the
+sentence. A block that does not parse is treated as absent (excluded
+from the Article, flagged at deploy).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What this PR changes and why. -->
+
+## Test plan
+
+<!-- How a reviewer can verify the change. -->
+
+<!--
+The changelog block below feeds the automated changelogs (issue #5155).
+- `article: yes` + a one-line, plain-English sentence written for site
+  users (no code names) => the change appears in the user-facing MO
+  Article changelog with that sentence.
+- `article: no` (and no sentence) => technical-only change; it still
+  appears in CHANGELOG.md automatically.
+Pick one — leaving `yes|no` unedited counts as "no block" and gets
+flagged at deploy for manual review. Reviewers: feel free to edit the
+verdict or reword the sentence. Details: .claude/rules/changelog.md
+-->
+<!-- changelog -->
+article: yes|no
+
+<!-- /changelog -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,9 @@ scope below what the sweep already declared.
 See `.claude/rules/copilot_review_comments.md` for replying on the PR
 thread when a Copilot review finding is addressed, so later review
 passes don't re-verify it from scratch.
+See `.claude/rules/changelog.md` — every PR body needs a changelog
+block (`article:` verdict + user-facing sentence) for the automated
+changelogs (#5155).
 See `.claude/rules/no_raw_sql.md` — no raw SQL strings anywhere in the
 app; use ActiveRecord/Arel instead.
 See `.claude/rules/params_to_literal_props.md` — guard raw params


### PR DESCRIPTION
## Summary

Step 1 of #5155 (automated changelog): every PR body now carries a machine-parseable changelog block recording, at PR-creation time, whether the change belongs in the user-facing MO Article changelog and what its user-facing sentence is:

```
<!-- changelog -->
article: yes
Maps of name lists now support clustering and zoom.
<!-- /changelog -->
```

- **`.claude/rules/changelog.md`** — auto-loaded into every Claude session working in the repo; instructs sessions creating PRs to author the block (verdict + sentence), with guidance on what counts as article-worthy and how to write the sentence for site users rather than developers.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — new (the repo had none); gives human-authored PRs the same block plus a short how-to comment. An unedited `article: yes|no` placeholder parses as "no block," which the deploy output flags for manual review, so laziness fails visibly rather than silently.
- One pointer line in `CLAUDE.md`'s rules list.

Reviewers edit the block in place like any other part of a PR body. Blockless PRs (dependabot, drive-bys) are excluded from the Article by default and flagged at deploy; they still appear in `CHANGELOG.md`, whose standalone generator is the next PR. Landing this first lets blocks accumulate on new PRs while the generator is iterated.

## Test plan

- Open a new PR in the GitHub UI and confirm the template appears with the block and instructions.
- Confirm the block below in this PR's own body (dogfooding) reads as intended.

<!-- changelog -->
article: no
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVhpwpNPzcHkkzUuZamCsw
