### PR TITLE
Lead with the thumbnail even when it is a sibling's image (#5160)

### DIFF
--- a/app/classes/api2/observation_api.rb
+++ b/app/classes/api2/observation_api.rb
@@ -20,6 +20,7 @@ class API2
         :name,
         { namings: [:name, :user] },
         :sequences,
+        { thumb_image: [:license, :user] },
         :user,
         { votes: :user }
       ]

--- a/app/controllers/observations_controller/show.rb
+++ b/app/controllers/observations_controller/show.rb
@@ -83,6 +83,8 @@ module ObservationsController::Show
                             ).to_a
   end
 
+  # The thumbnail may be a sibling's image (any image in the occurrence
+  # can be chosen), so it leads the combined list, not just its owner's.
   def occurrence_images
     return @observation.images_sorted unless @occurrence
 
@@ -90,7 +92,14 @@ module ObservationsController::Show
     sibling_images = @sibling_observations.
                      flat_map(&:images).uniq -
                      primary_images
-    primary_images + sibling_images
+    thumb_first(primary_images + sibling_images)
+  end
+
+  def thumb_first(images)
+    thumb = images.find { |img| img.id == @observation.thumb_image_id }
+    return images unless thumb
+
+    [thumb] + (images - [thumb])
   end
 
   def load_observation_for_show_observation_page

--- a/app/views/controllers/api2/_observation.json.jbuilder
+++ b/app/views/controllers/api2/_observation.json.jbuilder
@@ -47,6 +47,12 @@ if detail
       other_images << image
     end
   end
+  # The thumbnail may be an occurrence sibling's image, not one of
+  # this observation's own.
+  if object.thumb_image_id && other_images.length == object.images.length &&
+     object.thumb_image
+    json.primary_image(json_image(object.thumb_image))
+  end
   json.images(other_images.map { |x| json_image(x) }) \
     if other_images.any?
   json.comments(object.comments.map { |x| json_comment(x) }) \

--- a/app/views/controllers/api2/_observation.xml.builder
+++ b/app/views/controllers/api2/_observation.xml.builder
@@ -54,24 +54,19 @@ xml.tag!(
       end
     end
     xml_detailed_location(xml, :location, object.location, object.where)
-    object.images.each do |image|
-      # Do it this way, else will not use eager-loaded image instance.
-      xml_detailed_object(xml, :primary_image, image) \
-        if image.id == object.thumb_image_id
+    # Iterate the eager-loaded images rather than reading the
+    # association, and fall back to `thumb_image` only when the
+    # thumbnail is an occurrence sibling's image, not one of this
+    # observation's own.
+    other_images = object.images.reject do |image|
+      image.id == object.thumb_image_id
     end
-    # The thumbnail may be an occurrence sibling's image, not one of
-    # this observation's own.
-    if object.thumb_image_id &&
-       object.images.none? { |image| image.id == object.thumb_image_id } &&
-       object.thumb_image
-      xml_detailed_object(xml, :primary_image, object.thumb_image)
-    end
-    if object.images.length > 1
-      xml.images(number: object.images.length - 1) do
-        object.images.each do |image|
-          xml_detailed_object(xml, :image, image) \
-            if image.id != object.thumb_image_id
-        end
+    primary = (object.images - other_images).first ||
+              (object.thumb_image if object.thumb_image_id)
+    xml_detailed_object(xml, :primary_image, primary) if primary
+    if other_images.any?
+      xml.images(number: other_images.length) do
+        other_images.each { |image| xml_detailed_object(xml, :image, image) }
       end
     end
     if object.comments.any?

--- a/app/views/controllers/api2/_observation.xml.builder
+++ b/app/views/controllers/api2/_observation.xml.builder
@@ -59,6 +59,13 @@ xml.tag!(
       xml_detailed_object(xml, :primary_image, image) \
         if image.id == object.thumb_image_id
     end
+    # The thumbnail may be an occurrence sibling's image, not one of
+    # this observation's own.
+    if object.thumb_image_id &&
+       object.images.none? { |image| image.id == object.thumb_image_id } &&
+       object.thumb_image
+      xml_detailed_object(xml, :primary_image, object.thumb_image)
+    end
     if object.images.length > 1
       xml.images(number: object.images.length - 1) do
         object.images.each do |image|

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -361,6 +361,12 @@ class API2ControllerTest < FunctionalTestCase
 
     assert_no_api_errors
     assert_select("primary_image[id=?]", thumb.id.to_s)
+    assert_select("images[number=?]", primary.images.count.to_s)
+    assert_select("images > image", count: primary.images.count)
+    primary.image_ids.each do |id|
+      assert_select("images > image[id=?]", id.to_s)
+    end
+    assert_select("images > image[id=?]", thumb.id.to_s, count: 0)
   end
 
   # A link identified by `external_id` stores no `url` -- the model's

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -336,6 +336,33 @@ class API2ControllerTest < FunctionalTestCase
     assert_equal(expected, files)
   end
 
+  # The thumbnail can be an occurrence sibling's image (#5160); it is
+  # still the primary_image, and the observation's own images are
+  # still listed.
+  def test_get_observation_primary_image_from_sibling
+    primary = observations(:two_img_obs)
+    sibling = observations(:fungi_obs)
+    thumb = images(:plane_image_example)
+    occ = Occurrence.create!(user: rolf, primary_observation: primary)
+    primary.update!(occurrence: occ, thumb_image: thumb)
+    sibling.update!(occurrence: occ)
+
+    get(:observations, params: { id: primary.id, detail: :high,
+                                 format: :json })
+
+    assert_no_api_errors
+    result = response.parsed_body["results"][0]
+    assert_equal(thumb.id, result.dig("primary_image", "id"))
+    assert_equal(primary.image_ids.sort,
+                 result["images"].pluck("id").sort)
+
+    get(:observations, params: { id: primary.id, detail: :high,
+                                 format: :xml })
+
+    assert_no_api_errors
+    assert_select("primary_image[id=?]", thumb.id.to_s)
+  end
+
   # A link identified by `external_id` stores no `url` -- the model's
   # `normalize_external_id_and_url` deliberately drops it, and
   # `ExternalSite#observation_url` is "the single source of truth for an

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -60,6 +60,28 @@ class ObservationsControllerShowTest < FunctionalTestCase
     assert_select("a[href*='occurrences/#{occ.id}']")
   end
 
+  # Any image in the occurrence can be the thumbnail; when it belongs
+  # to a sibling it still leads the carousel (issue #5160).
+  def test_show_observation_sibling_image_as_thumbnail
+    login("rolf")
+    primary = observations(:two_img_obs)
+    sibling = observations(:fungi_obs)
+    thumb = images(:plane_image_example)
+    assert_includes(sibling.images, thumb)
+    assert_not_includes(primary.images, thumb)
+    occ = Occurrence.create!(user: rolf, primary_observation: primary)
+    primary.update!(occurrence: occ, thumb_image: thumb)
+    sibling.update!(occurrence: occ)
+
+    get(:show, params: { id: primary.id })
+
+    assert_response(:success)
+    assert_select("#observation_images .carousel-inner " \
+                  ".carousel-item:first-child#carousel_item_#{thumb.id}")
+    assert_select("#observation_images .carousel-item",
+                  count: primary.images.count + sibling.images.count)
+  end
+
   def test_show_observation_noteless_image
     obs = observations(:peltigera_mary_obs)
     img = images(:rolf_profile_image)


### PR DESCRIPTION
## Summary

Fixes #5160.

Any image in an observation's occurrence can be chosen as its thumbnail — the edit form offers sibling images and `valid_thumb_image_ids` accepts them — and the choice persists (obs 588908 has `thumb_image_id` pointing at a sibling's image). But two places only looked for the thumbnail among the observation's *own* images:

- **Observation show page**: `occurrence_images` built the carousel as own images (thumbnail first) + sibling images, so a sibling-owned thumbnail sat in the sibling part of the list and the first own image led the carousel. Now the combined list is reordered so the thumbnail leads wherever it came from (`thumb_first`).
- **API2**: `primary_image` (JSON and XML, `detail=high`) was derived by scanning `object.images` for `thumb_image_id`, so a sibling-owned thumbnail yielded no `primary_image` (visible on 588908 today). Both builders now fall back to `object.thumb_image` when the thumbnail is not among the observation's own images; the `images` list is unchanged.

Nothing changes for observations whose thumbnail is one of their own images.

## Test plan

Setup: an occurrence with two observations that each have photos; on the primary, edit and pick one of the *sibling's* photos as the thumbnail.

1. Open the primary observation: the carousel opens on the chosen sibling photo, and the thumbnail strip marks it as current. The observation's own photos still appear in the carousel.
2. Open a sibling observation: its own thumbnail still leads (unchanged).
3. `https://mushroomobserver.org/api2/observations?id=<primary>&detail=high&format=json`: `primary_image.id` is the sibling photo's id; `images` lists the primary's own photos. Same for `format=xml`.
4. Regression check on an ordinary observation (thumbnail among its own photos): page and API output unchanged.

<!-- changelog -->
article: yes
Show the chosen thumbnail even when it is a sibling's photo
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu

