### PR TITLE
Add `script/article_rows.rb`: MO Article rows from PR changelog blocks (#5155)

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -39,18 +39,43 @@ faster than they can notice an omission.
 
 **The sentence** (required when `article: yes`, one line):
 
+- **Short: 60 characters or fewer.** It becomes one table cell in the
+  Article, and longer text wraps the table. Readers who want detail
+  click through to the PR, so the sentence only has to say *what*
+  changed, not every case it covers: "Link field slip scans from
+  observation and image pages," not "Field slip scans are now
+  reachable from the observation page, and a photo's existing scan
+  result is linked from its image page instead of only offering a
+  re-read."
 - Written for mushroom observers, not developers. Describe what
   changed from the user's point of view, not how: "Emoji now work in
   comments and profile notes," not "Convert `comments.comment` to
   utf8mb4."
+- Terse, like the existing Article rows: lead with the verb — "Fix …",
+  "Add …", "Allow …", "Speed up …" — no "now", no "This PR".
 - No code identifiers, no backticks, no class/method/file names.
 - No PR/issue numbers — the generator adds the links.
-- Plain present tense, capitalized, ending punctuation optional.
+- Capitalized, no ending punctuation.
+
+These wording rules are the place feedback from Article reviews
+lands: when a reviewer trims or rewords rows, the pattern behind the
+edit belongs here, so the next block is written that way to begin
+with.
 
 ## Format is machine-parsed — keep it exact
 
-The generator reads everything between `<!-- changelog -->` and
+The generators read everything between `<!-- changelog -->` and
 `<!-- /changelog -->`: the first non-blank line must be
 `article: yes` or `article: no`; the remaining non-blank lines are the
 sentence. A block that does not parse is treated as absent (excluded
-from the Article, flagged at deploy).
+from the Article, flagged for manual review). When a description
+quotes an example block, the *last* block in the body is the one that
+counts.
+
+## Producing the Article rows
+
+`script/article_rows.rb --since YYYY-MM-DD [--until YYYY-MM-DD]`
+prints one Textile row per `article: yes` PR merged in the range,
+newest first, and lists the blockless PRs on stderr for a human
+verdict. Paste the rows into the Article by hand (they go under the
+blank separator row, newest first).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,9 @@
 <!--
 The changelog block below feeds the automated changelogs (issue #5155).
 - `article: yes` + a one-line, plain-English sentence written for site
-  users (no code names) => the change appears in the user-facing MO
-  Article changelog with that sentence.
+  users (no code names; 60 characters or fewer, e.g. "Fix map cluster
+  Show All for shared-location observations") => the change appears in
+  the user-facing MO Article changelog with that sentence.
 - `article: no` (and no sentence) => technical-only change; it still
   appears in CHANGELOG.md automatically.
 Pick one — leaving `yes|no` unedited counts as "no block" and gets

--- a/script/article_rows.rb
+++ b/script/article_rows.rb
@@ -1,0 +1,149 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Prints MO Article changelog rows (Textile) for the PRs merged in a
+# date range, from the changelog block each PR body carries (see
+# .claude/rules/changelog.md): `article: yes` PRs become rows, using
+# the block's sentence; `article: no` PRs are counted; PRs with no
+# parseable block are listed on stderr for a human to judge. Nothing
+# is written anywhere -- paste the rows into the article by hand.
+#
+#   script/article_rows.rb --since 2026-08-22 [--until 2026-08-31]
+#
+# Rows come out newest first, in the article's table format, with the
+# date cell marked nowrap so the link column cannot squeeze it.
+
+require("date")
+require("json")
+require("open3")
+
+# Turns merged PRs' changelog blocks into Textile article rows.
+class ArticleRows
+  USAGE = "Usage: script/article_rows.rb --since YYYY-MM-DD " \
+          "[--until YYYY-MM-DD]"
+  REPO = "MushroomObserver/mushroom-observer"
+  BLOCK = %r{<!--\s*changelog\s*-->(.*?)<!--\s*/changelog\s*-->}m
+  # GitHub search returns at most this many results per query.
+  SEARCH_CAP = 1000
+  # Longer sentences wrap the article's table.
+  MAX_SENTENCE = 60
+
+  def initialize(argv)
+    @since = nil
+    @until = Date.today # rubocop:disable Rails/Date -- plain Ruby, no zone
+    parse_args(argv)
+    abort(USAGE) unless @since
+  end
+
+  def run
+    pulls = merged_pulls.sort_by { |pull| pull["mergedAt"] }.reverse
+    rows, skipped, blockless = classify(pulls)
+    puts(rows)
+    warn("#{rows.size} row(s); #{skipped} PR(s) marked article: no.")
+    report_blockless(blockless)
+  end
+
+  private
+
+  def parse_args(argv)
+    args = argv.dup
+    until args.empty?
+      case (arg = args.shift)
+      when "--since" then @since = parse_date(args.shift)
+      when "--until" then @until = parse_date(args.shift)
+      else abort("Unknown argument: #{arg}\n#{USAGE}")
+      end
+    end
+  end
+
+  def parse_date(value)
+    Date.parse(value.to_s)
+  rescue ArgumentError
+    abort("Not a date: #{value.inspect}\n#{USAGE}")
+  end
+
+  def classify(pulls)
+    rows = []
+    skipped = 0
+    blockless = []
+    pulls.each do |pull|
+      verdict, sentence = parse_block(pull["body"])
+      case verdict
+      when "yes" then rows << row(pull, sentence)
+      when "no" then skipped += 1
+      else blockless << pull
+      end
+    end
+    [rows, skipped, blockless]
+  end
+
+  # [verdict, sentence]; verdict nil when the block is absent or does
+  # not parse, the same rule the rules file states. The last block in
+  # the body counts: a description may quote an example block above it.
+  def parse_block(body)
+    match = body.to_s.scan(BLOCK).last
+    return [nil, nil] unless match
+
+    lines = match[0].lines.map(&:strip).reject(&:empty?)
+    verdict = lines.shift.to_s[/\Aarticle:\s*(yes|no)\z/i, 1]&.downcase
+    return [nil, nil] unless verdict
+
+    [verdict, lines.join(" ")]
+  end
+
+  def row(pull, sentence)
+    sentence = sentence.sub(/[.!]\z/, "")
+    if sentence.length > MAX_SENTENCE
+      warn("PR##{pull["number"]}: sentence is #{sentence.length} chars " \
+           "(over #{MAX_SENTENCE}); trim it.")
+    end
+    %(|{white-space:nowrap}. #{pull["mergedAt"][0, 10]} | #{sentence} | ) +
+      %("PR##{pull["number"]}":#{pull["url"]} |)
+  end
+
+  def report_blockless(pulls)
+    return if pulls.empty?
+
+    warn("\n#{pulls.size} PR(s) with no changelog block -- judge by hand:")
+    pulls.each do |pull|
+      warn("  PR##{pull["number"]} #{pull["mergedAt"][0, 10]} #{pull["title"]}")
+    end
+  end
+
+  # Month by month: GitHub's search caps each query's results.
+  def merged_pulls
+    months.flat_map { |from, to| merged_in(from, to) }
+  end
+
+  def months
+    from = @since
+    windows = []
+    while from <= @until
+      to = [from.next_month - 1, @until].min
+      windows << [from.iso8601, to.iso8601]
+      from = to + 1
+    end
+    windows
+  end
+
+  def merged_in(from, to)
+    pulls = JSON.parse(
+      run_cmd("gh", "pr", "list", "--repo", REPO, "--state", "merged",
+              "--limit", SEARCH_CAP.to_s, "--search", "merged:#{from}..#{to}",
+              "--json", "number,title,url,mergedAt,body")
+    )
+    if pulls.size >= SEARCH_CAP
+      abort("#{pulls.size} PRs merged in #{from}..#{to} hits GitHub's " \
+            "search cap; use a shorter range.")
+    end
+    pulls
+  end
+
+  def run_cmd(*cmd)
+    out, err, status = Open3.capture3(*cmd)
+    abort("`#{cmd.join(" ")}` failed:\n#{err}") unless status.success?
+    out
+  end
+end
+
+ArticleRows.new(ARGV).run


### PR DESCRIPTION
## Summary

Part of #5155 (step 4, the Article half). Adds `script/article_rows.rb`, which turns the changelog blocks in merged PR bodies into rows for the MO Article changelog:

```
script/article_rows.rb --since 2026-08-22 [--until 2026-08-31]
```

- One Textile row per `article: yes` PR merged in the range, newest first, in the article's table format with the date cell marked `{white-space:nowrap}` so the link column cannot squeeze it. Output goes to stdout; the rows are pasted into the Article by hand.
- `article: no` PRs are counted; PRs with no parseable block are listed on stderr for a human verdict — same rule as the deploy-side changelog.
- The **last** block in a body is the one parsed: #5158's description quotes the example block above its own, and a first-match parser turned that example into a row.
- Sentences over 60 characters get a warning naming the PR; PRs are fetched month by month to stay under GitHub's 1,000-result search cap.

Also tightens the block-writing guidance, based on the first use (my own blocks on #5169/#5170 came out at 138 and 161 characters, which wraps the article's table): `.claude/rules/changelog.md` now asks for 60 characters or fewer, verb-first phrasing like the existing rows, no ending punctuation, and says the wording rules are where Article-review feedback lands; the PR template carries the length hint. The two over-long sentences were trimmed in the PR bodies themselves.

No runtime code changes.

## Test plan

- `script/article_rows.rb --since 2026-08-22`: prints two rows (#5170, #5169), reports four `article: no` PRs, lists the six blockless ones from 08-22 on stderr, and does **not** emit a row for #5158's quoted example block.
- `script/article_rows.rb --since 2026-08-01 --until 2026-08-21`: zero rows (no blocks existed yet), every PR listed as blockless.
- `script/article_rows.rb` with no `--since`, or a bad date: usage error.

<!-- changelog -->
article: no
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
