### PR TITLE
Edit on a read-only reflection opens a companion observation (#4214)

### DIFF
--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -25,7 +25,7 @@ module ObservationsController::EditAndUpdate
   #   @good_images                      list of images already attached
   #
   def edit
-    return unless editable_or_redirect?
+    return unless editable_or_redirect?(companion: true)
 
     init_license_var
     init_new_image_var(@observation.when)
@@ -55,14 +55,14 @@ module ObservationsController::EditAndUpdate
   # edit see the reflection warning. Returns true only when the request
   # may proceed; each guard performs its own redirect when it stops the
   # request.
-  def editable_or_redirect?
+  def editable_or_redirect?(companion: false)
     return false unless find_observation!
 
     unless permission!(@observation)
       redirect_to(action: :show, id: @observation.id)
       return false
     end
-    return false if redirect_if_reflection!
+    return false if companion ? redirect_to_companion! : redirect_if_reflection!
 
     true
   end
@@ -76,6 +76,30 @@ module ObservationsController::EditAndUpdate
 
     flash_warning(:edit_observation_is_reflection.t)
     redirect_to(action: :show, id: @observation.id)
+  end
+
+  # Edit on a reflection opens its companion instead (#4214): the
+  # occurrence's existing editable member, or a new one copying the
+  # snapshot. Returns the redirect when it stops the request.
+  def redirect_to_companion!
+    return unless @observation.reflection?
+
+    companion, notice = find_or_create_companion
+    flash_notice(notice.t)
+    redirect_to(edit_observation_path(companion.id))
+  rescue ActiveRecord::RecordInvalid => e
+    flash_error(e.record.errors.full_messages.join("; "))
+    redirect_to(action: :show, id: @observation.id)
+  end
+
+  # [companion, flash tag]
+  def find_or_create_companion
+    builder = Observation::Companion.new(@observation, @user)
+    if (companion = builder.existing)
+      [companion, :edit_observation_companion_existing]
+    else
+      [builder.create, :edit_observation_companion_created]
+    end
   end
 
   # Edit-mode: just build the union of projects to display. The

--- a/app/models/observation/companion.rb
+++ b/app/models/observation/companion.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# The editable twin of a read-only reflection (#4214). A reflection's
+# snapshot (date, location, GPS, notes, images) mirrors its source and
+# cannot be edited on MO, so Edit hands the user a companion
+# observation in the same occurrence: one that already exists, or a
+# new one copying the snapshot and sharing the images. The reflection
+# stays the occurrence's primary, and -- members of an occurrence share
+# project membership -- the companion joins the reflection's projects.
+class Observation::Companion
+  # `collector_user_id` is left to the model, which re-derives it from
+  # `collector` on save.
+  SNAPSHOT = [:when, :where, :location_id, :lat, :lng, :alt, :gps_hidden,
+              :is_collection_location, :specimen, :notes,
+              :collector].freeze
+
+  def initialize(reflection, user)
+    @reflection = reflection
+    @user = user
+  end
+
+  # A non-reflection member of the occurrence the user may edit. Read
+  # from the database, not the reflection's loaded association, which
+  # can predate a companion created moments ago.
+  def existing
+    return unless @reflection.occurrence_id
+
+    Observation.where(occurrence_id: @reflection.occurrence_id).
+      where.not(id: @reflection.id).order(:id).
+      find { |obs| !obs.reflection? && obs.can_edit?(@user) }
+  end
+
+  # Raises ActiveRecord::RecordInvalid when the occurrence is full.
+  def create
+    Observation.transaction do
+      companion = build
+      companion.save!
+      propose_name(companion)
+      join_occurrence(companion)
+      # After the occurrence link: a photo attached to an observation
+      # with no occurrence gets scanned for a field slip QR code.
+      share_images(companion)
+      join_projects(companion)
+      companion.log(:log_observation_created, user: @user)
+      companion
+    end
+  end
+
+  private
+
+  def build
+    attrs = @reflection.attributes.symbolize_keys.slice(*SNAPSHOT)
+    obs = Observation.new(attrs.merge(user: @user, name: name,
+                                      source: "mo_website"))
+    obs.current_user = @user
+    obs
+  end
+
+  # Fetched afresh: the reflection may come from a strict-loading
+  # query, and proposing a name walks the Name's interests.
+  def name
+    @name ||= Name.find(@reflection.name_id)
+  end
+
+  def propose_name(companion)
+    naming = companion.namings.create!(name: name, user: @user)
+    Observation::NamingConsensus.new(companion).
+      change_vote(naming, Vote.maximum_vote, @user)
+  end
+
+  def join_occurrence(companion)
+    occurrence = @reflection.occurrence
+    if occurrence
+      Occurrence.check_max_observations!(occurrence.observations.to_a +
+                                         [companion])
+      companion.update!(occurrence: occurrence)
+      Occurrence.log_observation_added([companion], @user)
+      occurrence.recompute_has_specimen!
+    else
+      Occurrence.create_manual(@reflection, [@reflection, companion], @user)
+    end
+  end
+
+  def share_images(companion)
+    @reflection.images.each do |image|
+      companion.add_image(image)
+      image.current_user = @user
+      image.log_reuse_for(companion)
+    end
+    return unless @reflection.thumb_image_id
+
+    companion.update!(thumb_image_id: @reflection.thumb_image_id)
+  end
+
+  def join_projects(companion)
+    @reflection.projects.each { |project| project.add_observation(companion) }
+  end
+end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1138,7 +1138,7 @@
   source_credit_external_text: Imported from [name]
   source_credit_help_link: About imported observations
   via: via
-  observation_reflection_read_only_note: Read-only reflection of its imported source. To change it, edit it at the source and resync.
+  observation_reflection_read_only_note: Read-only reflection of its imported source. Edit opens a linked companion observation for your changes; the reflection itself changes only by resync.
   observation_resync_confirm: If you recently edited at the source, those changes may take up to 10 seconds to appear there. Ready to sync now, or would you rather wait?
   observation_resync_started: Syncing imported data from the source. This may take a moment.
   observation_resync_pending: A sync is already underway. Results will appear shortly.
@@ -1491,6 +1491,8 @@
   observation_field_slip_project_closed: 'Field slip "[code]" belongs to the [title] project, which you are not a member of and cannot join on your own. The observation was saved without the field slip code. You can "ask a project admin to add you":[url] and enter the code again once they do.'
   observation_field_slip_spare_used: Field slip [code] was attached as a spare, with no project.
   edit_observation_is_reflection: This observation is a read-only reflection of its imported source. To change it, edit it at the source and resync.
+  edit_observation_companion_created: That observation is a read-only reflection of its imported source, so Mushroom Observer created this companion observation for your changes and linked the two as one occurrence. Edit the companion here; the reflection keeps the imported data.
+  edit_observation_companion_existing: That observation is a read-only reflection of its imported source. You are editing its linked companion observation instead.
   create_observation_field_slip_invalid: 'Observation created, but the field slip code "[code]" was invalid and was not attached.'
   create_observation_field_slip_full: 'Observation created, but field slip "[code]" already has [max] observations, the maximum allowed, so it was not attached.'
   form_observations_specimen_available: Specimen Available

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -251,19 +251,56 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     assert_response(:redirect)
   end
 
-  # A read-only reflection (#4214) can't be edited on MO even by its
-  # owner — the edit form redirects with a warning. The permission check
-  # runs first, so only the owner (who would otherwise pass) sees the
-  # reflection warning.
-  def test_edit_reflection_redirects_with_warning
+  # Edit on a read-only reflection (#4214) creates a companion
+  # observation in a shared occurrence -- copying the snapshot, sharing
+  # the images, joining the reflection's projects -- and lands on the
+  # companion's edit form. The reflection itself is untouched.
+  def test_edit_reflection_creates_companion
+    obs = observations(:imported_inat_obs)
+    obs.update_column(:reflected_at, Time.zone.now)
+    obs.images << images(:in_situ_image)
+    project = projects(:eol_project)
+    project.add_observation(obs)
+    login(obs.user.login)
+
+    assert_difference("Observation.count", 1) do
+      get(:edit, params: { id: obs.id })
+    end
+
+    companion = obs.reload.occurrence.observations.where.not(id: obs.id).first
+    assert_not_nil(companion, "Cannot find the companion observation")
+    assert_redirected_to(edit_observation_path(companion.id))
+    assert_flash_success
+    assert_not(companion.reflection?)
+    assert_equal(obs.user_id, companion.user_id)
+    assert_equal(obs.name_id, companion.name_id)
+    assert_equal(obs.when, companion.when)
+    assert_equal(obs.where, companion.where)
+    assert_equal(obs.notes, companion.notes)
+    assert_equal(obs.image_ids.sort, companion.image_ids.sort)
+    assert_equal(obs.project_ids.sort, companion.project_ids.sort)
+    occurrence = companion.occurrence
+    assert_not_nil(occurrence)
+    assert_equal(obs.reload.occurrence_id, occurrence.id)
+    assert_equal(obs.id, occurrence.primary_observation_id)
+    assert(obs.reflection?, "the reflection must stay a reflection")
+  end
+
+  # A second Edit goes to the companion that already exists.
+  def test_edit_reflection_reuses_existing_companion
     obs = observations(:imported_inat_obs)
     obs.update_column(:reflected_at, Time.zone.now)
     login(obs.user.login)
-
     get(:edit, params: { id: obs.id })
+    companion = obs.reload.occurrence.observations.where.not(id: obs.id).first
+    assert_not_nil(companion, "Cannot find the companion observation")
 
-    assert_redirected_to(action: :show, id: obs.id)
-    assert_flash_warning
+    assert_no_difference("Observation.count") do
+      get(:edit, params: { id: obs.id })
+    end
+
+    assert_redirected_to(edit_observation_path(companion.id))
+    assert_flash_success
   end
 
   # A non-owner hitting edit on a reflection gets the same

--- a/test/models/observation/companion_test.rb
+++ b/test/models/observation/companion_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Observation::Companion -- the editable twin Edit opens for a
+# read-only reflection (#4214).
+class Observation::CompanionTest < UnitTestCase
+  def setup
+    super
+    @reflection = observations(:imported_inat_obs)
+    @reflection.update_column(:reflected_at, Time.zone.now)
+    @user = @reflection.user
+  end
+
+  def test_create_copies_snapshot_shares_images_and_joins_projects
+    @reflection.update!(lat: 41.5, lng: -70.5, alt: 12, gps_hidden: true,
+                        notes: { Other: "imported notes" },
+                        collector: "Someone Else", collector_user_id: nil)
+    @reflection.images << images(:in_situ_image)
+    @reflection.update!(thumb_image: images(:in_situ_image))
+    project = projects(:eol_project)
+    project.add_observation(@reflection)
+
+    companion = Observation::Companion.new(@reflection, @user).create
+
+    assert_not(companion.reflection?)
+    assert_equal(@user.id, companion.user_id)
+    assert_equal("mo_website", companion.source)
+    Observation::Companion::SNAPSHOT.each do |field|
+      assert_equal(@reflection.send(field), companion.send(field),
+                   "#{field} should be copied")
+    end
+    assert_equal(@reflection.name_id, companion.name_id)
+    assert_equal(@reflection.name_id,
+                 companion.namings.first.name_id)
+    assert_equal([images(:in_situ_image).id], companion.image_ids)
+    assert_equal(images(:in_situ_image).id, companion.thumb_image_id)
+    assert_equal([project.id], companion.project_ids)
+    assert_equal(@reflection.reload.occurrence_id, companion.occurrence_id)
+    assert_equal(@reflection.id,
+                 companion.occurrence.primary_observation_id)
+  end
+
+  def test_create_joins_the_reflections_existing_occurrence
+    sibling = observations(:minimal_unknown_obs)
+    occurrence = Occurrence.create!(user: @user,
+                                    primary_observation: @reflection)
+    @reflection.update!(occurrence: occurrence)
+    sibling.update!(occurrence: occurrence, reflected_at: Time.zone.now)
+
+    companion = Observation::Companion.new(@reflection, @user).create
+
+    assert_equal(occurrence.id, companion.occurrence_id)
+    assert_equal(@reflection.id, occurrence.reload.primary_observation_id)
+    assert_equal(3, occurrence.observations.count)
+  end
+
+  def test_existing_finds_an_editable_non_reflection_member
+    builder = Observation::Companion.new(@reflection, @user)
+    assert_nil(builder.existing)
+
+    companion = builder.create
+
+    assert_equal(companion, builder.existing)
+    # A reflection sibling is not a companion.
+    companion.update_column(:reflected_at, Time.zone.now)
+    assert_nil(Observation::Companion.new(@reflection, @user).existing)
+  end
+
+  def test_create_refuses_a_full_occurrence
+    occurrence = Occurrence.create!(user: @user,
+                                    primary_observation: @reflection)
+    @reflection.update!(occurrence: occurrence)
+    members = Observation.where.not(id: @reflection.id).
+              limit(Occurrence::MAX_OBSERVATIONS - 1)
+    members.each { |obs| obs.update_columns(occurrence_id: occurrence.id) }
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      Observation::Companion.new(@reflection, @user).create
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Part of #4214 / #4208: the "Edit creates a companion" half of read-only reflections, which #4852 left as a flash-and-bounce.

Edit on a read-only reflection now opens a **companion observation** in the same occurrence:

- If the occurrence already has a member that is not a reflection and the user may edit, Edit goes to that member's edit form.
- Otherwise `Observation::Companion` creates one: copies the snapshot (date, `where`/location, GPS, altitude, hidden flag, collection-location flag, specimen flag, notes, collector text — `collector_user_id` is re-derived by the model's own callback), gives it the user's naming of the reflection's consensus name, shares the reflection's images and thumbnail (logged as reuse), links the two in an occurrence with the reflection as primary (or joins the reflection's existing occurrence), and adds it to the reflection's projects — members of an occurrence share project membership (#4932). Created by the editing user with source `mo_website`, so it is an ordinary editable observation; resync keeps ignoring it.
- The edit form opens with a flash explaining what happened (two variants: companion created / existing companion). A full occurrence surfaces its validation error and bounces to Show.

Update on a reflection is unchanged (still blocked with the existing warning), so a stray PUT cannot spawn companions. The Show page's read-only note now says Edit opens a linked companion.

## Test plan

Setup: an observation imported from iNat on your account (a reflection — `reflected_at` set), ideally with photos and in a project.

1. Click Edit on it. You land on the edit form of a *new* observation with the same date, location, GPS, notes and photos, and a flash saying a companion was created and linked. Judge the flash wording here.
2. The original's Show page now shows a matching-observations panel with the companion; the original is primary; both are in the same projects.
3. Click Edit on the original again: you land on the same companion (no new observation), with the "existing companion" flash.
4. Save a change on the companion (e.g. GPS): the reflection is unchanged.
5. Sync now on either member still works and leaves the companion alone.

<!-- changelog -->
article: yes
Edit an imported observation through a linked companion
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
