### PR TITLE
Edit on a read-only reflection opens a companion observation (#4214)

### DIFF
--- a/app/classes/field_slip/attacher.rb
+++ b/app/classes/field_slip/attacher.rb
@@ -33,9 +33,8 @@ class FieldSlip
 
     # Returns what happened, for the caller's log line.
     def attach
-      return :already_linked if @observation.occurrence_id
-
       existing = FieldSlip.find_by(code: @code)
+      return merge_or_refuse(existing) if @observation.occurrence_id
       return join_or_refuse(existing) if existing&.occurrence
       return :closed_project if barred?(existing)
 
@@ -73,6 +72,54 @@ class FieldSlip
 
     def occurrence_full?(slip)
       slip.occurrence.observations.count >= Occurrence::MAX_OBSERVATIONS
+    end
+
+    # The observation already belongs to an occurrence, and the slip's
+    # code names a slip on a different one -- both hold observations of
+    # the same collection, so merge them (only on the human-confirmed
+    # review path; the background job leaves it alone). Merge INTO the
+    # slip's occurrence so its field slip and primary survive (see
+    # Occurrence.merge!, which keeps the keeper's).
+    def merge_or_refuse(slip)
+      occ = @observation.occurrence
+      return :already_linked unless @join_in_use && slip&.occurrence
+      return :already_linked if slip.occurrence.id == occ.id
+
+      refusal = merge_refusal(slip, occ)
+      return refusal if refusal
+
+      Occurrence.merge!(slip.occurrence, occ, @user)
+      ensure_native_primary(slip.occurrence)
+      @observation.reload
+      apply_project(slip)
+      :merged
+    end
+
+    # The reason this merge can't happen, or nil.
+    def merge_refusal(slip, occ)
+      if occ.field_slip && occ.field_slip_id != slip.id
+        :occurrence_conflict
+      elsif merge_overflows?(slip, occ)
+        :occurrence_full
+      elsif barred?(slip)
+        :closed_project
+      end
+    end
+
+    def merge_overflows?(slip, occ)
+      combined = (slip.occurrence.observation_ids | occ.observation_ids)
+      combined.size > Occurrence::MAX_OBSERVATIONS
+    end
+
+    # A reflection may not be an occurrence's primary; if the merge
+    # left one there, repoint to the oldest native member.
+    def ensure_native_primary(occurrence)
+      occurrence.reload
+      primary = occurrence.primary_observation
+      return unless primary&.reflection?
+
+      native = occurrence.observations.reject(&:reflection?).min_by(&:id)
+      occurrence.update!(primary_observation: native) if native
     end
 
     def link(slip)

--- a/app/classes/field_slip/extractor/name_proposer.rb
+++ b/app/classes/field_slip/extractor/name_proposer.rb
@@ -72,13 +72,23 @@ class FieldSlip
                     feedback: resolver.results.except(:success))
       end
 
+      # Reuse this user's existing naming for the name if there is one:
+      # a reviewer who saves the same review twice (a re-review, a
+      # rescan) is restating one reading, not proposing it again, so
+      # this must not stack duplicate namings on the observation.
       def propose_naming(name)
+        naming = @observation.namings.find_by(user: @user, name: name) ||
+                 build_naming(name)
+        cast_vote(naming)
+        Outcome.new(status: :proposed, naming: naming, feedback: {})
+      end
+
+      def build_naming(name)
         naming = Naming.construct({}, @observation)
         naming.name = name
         naming.user = @user
         naming.save!
-        cast_vote(naming)
-        Outcome.new(status: :proposed, naming: naming, feedback: {})
+        naming
       end
 
       # Attributed to the reviewer, not the observation's owner: an

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -82,13 +82,20 @@ class FormObject::FieldSlipReview < FormObject::Base
     end
   end
 
-  # The read code can be applied -- ticking it attaches the slip --
-  # exactly when the observation has none. The background job usually
-  # already did this (see ExtractFieldSlipJob#attach_read_code), so
-  # this is the manual path for what it couldn't decide on its own.
+  # Ticking the read code applies it. That does something in two cases:
+  # the observation has no occurrence (attach the slip), or the code
+  # names a slip on a DIFFERENT occurrence (merge the two -- e.g. a
+  # reflection whose Edit-companion gave it an occurrence, reviewed
+  # against a recorder's slip). It does nothing when the observation's
+  # own occurrence already holds the slip, so no tick is offered then.
   def self.code_attachable?(extract, template, observation)
-    observation.occurrence_id.nil? &&
-      extract.value_for(template.code_field).present?
+    code = extract.value_for(template.code_field).to_s.strip
+    return false if code.blank?
+    return true if observation.occurrence_id.nil?
+
+    slip = FieldSlip.find_by(code: code.upcase)
+    slip&.occurrence.present? &&
+      slip.occurrence.id != observation.occurrence_id
   end
 
   def self.role_for(template, field)

--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -261,10 +261,11 @@ module Images
     def attach_ticked_code
       code_field = @extract.template.code_field
       return unless params.dig(:use, code_field) == "1"
-      return unless @observation.occurrence_id.nil?
 
       # Normalized once, so lookups, the attach, and the flash all
-      # speak the same canonical code.
+      # speak the same code. An observation that is already in an
+      # occurrence is handled too -- Attacher merges the occurrences
+      # when the slip is on a different one.
       code = params.dig(:value, code_field).to_s.strip.upcase
       return if code.blank?
 
@@ -286,6 +287,9 @@ module Images
         @observation.reload
       when :joined
         flash_notice(:field_slip_extract_joined.t(code: code))
+        @observation.reload
+      when :merged
+        flash_notice(:field_slip_extract_merged.t(code: code))
         @observation.reload
       else
         flash_warning(:field_slip_extract_attach_failed.t(

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -25,7 +25,7 @@ module ObservationsController::EditAndUpdate
   #   @good_images                      list of images already attached
   #
   def edit
-    return unless editable_or_redirect?
+    return unless editable_or_redirect?(companion: true)
 
     init_license_var
     init_new_image_var(@observation.when)
@@ -55,14 +55,14 @@ module ObservationsController::EditAndUpdate
   # edit see the reflection warning. Returns true only when the request
   # may proceed; each guard performs its own redirect when it stops the
   # request.
-  def editable_or_redirect?
+  def editable_or_redirect?(companion: false)
     return false unless find_observation!
 
     unless permission!(@observation)
       redirect_to(action: :show, id: @observation.id)
       return false
     end
-    return false if redirect_if_reflection!
+    return false if companion ? redirect_to_companion! : redirect_if_reflection!
 
     true
   end
@@ -76,6 +76,30 @@ module ObservationsController::EditAndUpdate
 
     flash_warning(:edit_observation_is_reflection.t)
     redirect_to(action: :show, id: @observation.id)
+  end
+
+  # Edit on a reflection opens its companion instead (#4214): the
+  # occurrence's existing editable member, or a new one copying the
+  # snapshot. Returns the redirect when it stops the request.
+  def redirect_to_companion!
+    return unless @observation.reflection?
+
+    companion, notice = find_or_create_companion
+    flash_notice(notice.t)
+    redirect_to(edit_observation_path(companion.id))
+  rescue ActiveRecord::RecordInvalid => e
+    flash_error(e.record.errors.full_messages.join("; "))
+    redirect_to(action: :show, id: @observation.id)
+  end
+
+  # [companion, flash tag]
+  def find_or_create_companion
+    builder = Observation::Companion.new(@observation, @user)
+    if (companion = builder.existing)
+      [companion, :edit_observation_companion_existing]
+    else
+      [builder.create, :edit_observation_companion_created]
+    end
   end
 
   # Edit-mode: just build the union of projects to display. The

--- a/app/models/observation/companion.rb
+++ b/app/models/observation/companion.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# The editable twin of a read-only reflection (#4214). A reflection's
+# snapshot (date, location, GPS, notes, images) mirrors its source and
+# cannot be edited on MO, so Edit hands the user a companion
+# observation in the same occurrence: one that already exists, or a
+# new one copying the snapshot and sharing the images. The reflection
+# stays the occurrence's primary, and -- members of an occurrence share
+# project membership -- the companion joins the reflection's projects.
+class Observation::Companion
+  # `collector_user_id` is left to the model, which re-derives it from
+  # `collector` on save.
+  SNAPSHOT = [:when, :where, :location_id, :lat, :lng, :alt, :gps_hidden,
+              :is_collection_location, :specimen, :notes,
+              :collector].freeze
+
+  def initialize(reflection, user)
+    @reflection = reflection
+    @user = user
+  end
+
+  # A non-reflection member of the occurrence the user may edit. Read
+  # from the database, not the reflection's loaded association, which
+  # can predate a companion created moments ago.
+  def existing
+    return unless @reflection.occurrence_id
+
+    Observation.where(occurrence_id: @reflection.occurrence_id).
+      where.not(id: @reflection.id).order(:id).
+      find { |obs| !obs.reflection? && obs.can_edit?(@user) }
+  end
+
+  # Raises ActiveRecord::RecordInvalid when the occurrence is full.
+  def create
+    Observation.transaction do
+      companion = build
+      companion.save!
+      propose_name(companion)
+      join_occurrence(companion)
+      # After the occurrence link: a photo attached to an observation
+      # with no occurrence gets scanned for a field slip QR code.
+      share_images(companion)
+      join_projects(companion)
+      companion.log(:log_observation_created, user: @user)
+      companion
+    end
+  end
+
+  private
+
+  def build
+    attrs = @reflection.attributes.symbolize_keys.slice(*SNAPSHOT)
+    obs = Observation.new(attrs.merge(user: @user, name: name,
+                                      source: "mo_website"))
+    obs.current_user = @user
+    obs
+  end
+
+  # Fetched afresh: the reflection may come from a strict-loading
+  # query, and proposing a name walks the Name's interests.
+  def name
+    @name ||= Name.find(@reflection.name_id)
+  end
+
+  def propose_name(companion)
+    naming = companion.namings.create!(name: name, user: @user)
+    Observation::NamingConsensus.new(companion).
+      change_vote(naming, Vote.maximum_vote, @user)
+  end
+
+  def join_occurrence(companion)
+    occurrence = @reflection.occurrence
+    if occurrence
+      Occurrence.check_max_observations!(occurrence.observations.to_a +
+                                         [companion])
+      companion.update!(occurrence: occurrence)
+      Occurrence.log_observation_added([companion], @user)
+      occurrence.recompute_has_specimen!
+    else
+      Occurrence.create_manual(@reflection, [@reflection, companion], @user)
+    end
+  end
+
+  def share_images(companion)
+    @reflection.images.each do |image|
+      companion.add_image(image)
+      image.current_user = @user
+      image.log_reuse_for(companion)
+    end
+    return unless @reflection.thumb_image_id
+
+    companion.update!(thumb_image_id: @reflection.thumb_image_id)
+  end
+
+  def join_projects(companion)
+    @reflection.projects.each { |project| project.add_observation(companion) }
+  end
+end

--- a/app/models/observation/companion.rb
+++ b/app/models/observation/companion.rb
@@ -4,9 +4,12 @@
 # snapshot (date, location, GPS, notes, images) mirrors its source and
 # cannot be edited on MO, so Edit hands the user a companion
 # observation in the same occurrence: one that already exists, or a
-# new one copying the snapshot and sharing the images. The reflection
-# stays the occurrence's primary, and -- members of an occurrence share
-# project membership -- the companion joins the reflection's projects.
+# new one copying the snapshot. The native companion is the
+# occurrence's primary (a reflection is not), and -- members of an
+# occurrence share project membership -- it joins the reflection's
+# projects. Images stay on the reflection: the occurrence pools its
+# members' images for display, so the companion only points its
+# thumbnail at the reflection's.
 class Observation::Companion
   # `collector_user_id` is left to the model, which re-derives it from
   # `collector` on save.
@@ -19,15 +22,18 @@ class Observation::Companion
     @user = user
   end
 
-  # A non-reflection member of the occurrence the user may edit. Read
-  # from the database, not the reflection's loaded association, which
-  # can predate a companion created moments ago.
+  # A non-reflection member of the occurrence the user may edit, made
+  # the primary if a reflection still holds that spot. Read from the
+  # database, not the reflection's loaded association, which can
+  # predate a companion created moments ago.
   def existing
     return unless @reflection.occurrence_id
 
-    Observation.where(occurrence_id: @reflection.occurrence_id).
-      where.not(id: @reflection.id).order(:id).
-      find { |obs| !obs.reflection? && obs.can_edit?(@user) }
+    companion = Observation.where(occurrence_id: @reflection.occurrence_id).
+                where.not(id: @reflection.id).order(:id).
+                find { |obs| !obs.reflection? && obs.can_edit?(@user) }
+    make_primary(companion) if companion
+    companion
   end
 
   # Raises ActiveRecord::RecordInvalid when the occurrence is full.
@@ -37,9 +43,7 @@ class Observation::Companion
       companion.save!
       propose_name(companion)
       join_occurrence(companion)
-      # After the occurrence link: a photo attached to an observation
-      # with no occurrence gets scanned for a field slip QR code.
-      share_images(companion)
+      point_thumbnail(companion)
       join_projects(companion)
       companion.log(:log_observation_created, user: @user)
       companion
@@ -76,17 +80,21 @@ class Observation::Companion
       companion.update!(occurrence: occurrence)
       Occurrence.log_observation_added([companion], @user)
       occurrence.recompute_has_specimen!
+      make_primary(companion)
     else
-      Occurrence.create_manual(@reflection, [@reflection, companion], @user)
+      Occurrence.create_manual(companion, [@reflection, companion], @user)
     end
   end
 
-  def share_images(companion)
-    @reflection.images.each do |image|
-      companion.add_image(image)
-      image.current_user = @user
-      image.log_reuse_for(companion)
-    end
+  def make_primary(companion)
+    occurrence = Occurrence.find(companion.occurrence_id)
+    return if occurrence.primary_observation_id == companion.id
+
+    occurrence.update!(primary_observation: companion)
+  end
+
+  # Any occurrence member's image may be an observation's thumbnail.
+  def point_thumbnail(companion)
     return unless @reflection.thumb_image_id
 
     companion.update!(thumb_image_id: @reflection.thumb_image_id)

--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -30,8 +30,10 @@ module Views::Layouts
 
     private
 
+    # A read-only reflection keeps its edit icon: Edit opens a linked
+    # companion observation for the changes.
     def edit_item
-      return nil unless can_edit_object? && !read_only_reflection?
+      return nil unless can_edit_object?
 
       ::Components::Button::Edit.new(
         target: @object, variant: :strip,
@@ -50,13 +52,6 @@ module Views::Layouts
 
     def can_edit_object?
       in_admin_mode? || @object.can_edit?(@user)
-    end
-
-    # A read-only reflection (#4214) can't have its scalar core edited on
-    # MO, so no edit icon -- change it at the source and resync. Delete is
-    # a separate lifecycle concern and stays available.
-    def read_only_reflection?
-      @object.respond_to?(:reflection?) && @object.reflection?
     end
 
     def can_destroy_object?

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1138,7 +1138,7 @@
   source_credit_external_text: Imported from [name]
   source_credit_help_link: About imported observations
   via: via
-  observation_reflection_read_only_note: Read-only reflection of its imported source. To change it, edit it at the source and resync.
+  observation_reflection_read_only_note: Read-only reflection of its imported source. Edit opens a linked companion observation for your changes; the reflection itself changes only by resync.
   observation_resync_confirm: If you recently edited at the source, those changes may take up to 10 seconds to appear there. Ready to sync now, or would you rather wait?
   observation_resync_started: Syncing imported data from the source. This may take a moment.
   observation_resync_pending: A sync is already underway. Results will appear shortly.
@@ -1491,6 +1491,8 @@
   observation_field_slip_project_closed: 'Field slip "[code]" belongs to the [title] project, which you are not a member of and cannot join on your own. The observation was saved without the field slip code. You can "ask a project admin to add you":[url] and enter the code again once they do.'
   observation_field_slip_spare_used: Field slip [code] was attached as a spare, with no project.
   edit_observation_is_reflection: This observation is a read-only reflection of its imported source. To change it, edit it at the source and resync.
+  edit_observation_companion_created: That observation is a read-only reflection of its imported source, so Mushroom Observer created this companion observation for your changes and linked the two as one occurrence. Edit the companion here; the reflection keeps the imported data.
+  edit_observation_companion_existing: That observation is a read-only reflection of its imported source. You are editing its linked companion observation instead.
   create_observation_field_slip_invalid: 'Observation created, but the field slip code "[code]" was invalid and was not attached.'
   create_observation_field_slip_full: 'Observation created, but field slip "[code]" already has [max] observations, the maximum allowed, so it was not attached.'
   form_observations_specimen_available: Specimen Available

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2644,6 +2644,8 @@
   field_slip_attach_reason_invalid: the code is not valid
   field_slip_attach_reason_already_linked: this observation already has a field slip
   field_slip_extract_joined: Field slip [code] was already in use, so this observation was linked to it as another observation of the same collection.
+  field_slip_extract_merged: Field slip [code] was already in use, so this observation's matching observations were merged with the collection already linked to it.
+  field_slip_attach_reason_occurrence_conflict: this observation's matching observations already carry a different field slip
   observation_field_slip_in_use: 'Field slip [code] was detected in a photo, but it is already attached to "another observation":[url], so it was not attached automatically. Use Read Field Slip to review the photo — saving the review will link this observation to the same field slip.'
   field_slip_extract_project_joined: Added the observation to [title], whose constraints it now satisfies.
   field_slip_extract_conflict: The saved values violate the constraints of [title], but field slip [code] already belongs to another observation there — a conflict only a person can sort out. The values were kept, and this observation was removed from the field slip and the project.

--- a/test/classes/field_slip/attacher_test.rb
+++ b/test/classes/field_slip/attacher_test.rb
@@ -82,6 +82,78 @@ class FieldSlip::AttacherTest < UnitTestCase
     assert_includes(@obs.occurrence.observations, other.reload)
   end
 
+  # When the reviewed observation already belongs to an occurrence and
+  # the slip is on a different one, join_in_use merges them into the
+  # slip's occurrence -- keeping the slip and a native primary (#4214).
+  def test_join_in_use_merges_when_the_observation_has_an_occurrence
+    reflection = observations(:minimal_unknown_obs)
+    reflection.update!(occurrence: nil, reflected_at: Time.zone.now)
+    companion = observations(:detailed_unknown_obs)
+    companion.update!(occurrence: nil)
+    own_occ = Occurrence.create!(user: @obs.user,
+                                 primary_observation: companion)
+    [reflection, companion].each { |o| o.update!(occurrence: own_occ) }
+
+    slip_obs = observations(:coprinus_comatus_obs)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0520", slip_obs.user)
+    slip_obs.update!(occurrence: nil)
+    slip_obs.field_slip = slip
+    slip_obs.save!
+    slip_occ = slip.reload.occurrence
+
+    result = FieldSlip::Attacher.attach(observation: reflection.reload,
+                                        code: "OPEN-0520",
+                                        user: @obs.user, join_in_use: true)
+
+    assert_equal(:merged, result)
+    assert_equal(slip_occ.id, reflection.reload.occurrence_id)
+    assert_not(Occurrence.exists?(own_occ.id), "the emptied occ is gone")
+    merged = slip_occ.reload.observations
+    assert_includes(merged, reflection)
+    assert_includes(merged, companion)
+    assert_includes(merged, slip_obs.reload)
+    assert_equal(slip, slip_occ.field_slip, "the slip survives the merge")
+    assert_not(slip_occ.primary_observation.reflection?,
+               "the primary is a native observation")
+  end
+
+  # The background (non-join_in_use) path leaves an occurrence-holding
+  # observation alone -- no merge.
+  def test_occurrence_holding_observation_is_left_alone_without_join_in_use
+    @obs.update!(occurrence: nil)
+    own = Occurrence.create!(user: @obs.user, primary_observation: @obs)
+    @obs.update!(occurrence: own)
+    slip_obs = observations(:coprinus_comatus_obs)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0521", slip_obs.user)
+    slip_obs.update!(occurrence: nil)
+    slip_obs.field_slip = slip
+    slip_obs.save!
+
+    assert_equal(:already_linked, attach(code: "OPEN-0521"))
+    assert_equal(own.id, @obs.reload.occurrence_id)
+  end
+
+  # Two occurrences that each already carry a different field slip can't
+  # be merged by a slip review.
+  def test_merge_refuses_when_the_observation_occurrence_has_another_slip
+    own_slip = FieldSlip.find_or_create_by_code("OPEN-0530", @obs.user)
+    @obs.field_slip = own_slip
+    @obs.save!
+
+    slip_obs = observations(:coprinus_comatus_obs)
+    other_slip = FieldSlip.find_or_create_by_code("OPEN-0531", slip_obs.user)
+    slip_obs.update!(occurrence: nil)
+    slip_obs.field_slip = other_slip
+    slip_obs.save!
+
+    result = FieldSlip::Attacher.attach(observation: @obs.reload,
+                                        code: "OPEN-0531",
+                                        user: @obs.user, join_in_use: true)
+
+    assert_equal(:occurrence_conflict, result)
+    assert_equal("OPEN-0530", @obs.reload.field_slip.code)
+  end
+
   def test_join_in_use_refuses_a_full_occurrence
     other = observations(:coprinus_comatus_obs)
     slip = FieldSlip.find_or_create_by_code("OPEN-0511", other.user)

--- a/test/classes/field_slip/attacher_test.rb
+++ b/test/classes/field_slip/attacher_test.rb
@@ -117,6 +117,79 @@ class FieldSlip::AttacherTest < UnitTestCase
                "the primary is a native observation")
   end
 
+  # If the slip's occurrence had a reflection as primary, the merge
+  # repoints it to a native member (a reflection is not a primary).
+  def test_merge_repoints_a_reflection_primary_to_a_native
+    own = Occurrence.create!(user: @obs.user, primary_observation: @obs)
+    @obs.update!(occurrence: own)
+
+    slip_reflection = observations(:detailed_unknown_obs)
+    slip_reflection.update!(occurrence: nil, reflected_at: Time.zone.now)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0550", slip_reflection.user)
+    slip_reflection.field_slip = slip
+    slip_reflection.save!
+    slip_occ = slip.reload.occurrence
+    assert(slip_occ.primary_observation.reflection?,
+           "premise: reflection is primary")
+
+    result = FieldSlip::Attacher.attach(observation: @obs.reload,
+                                        code: "OPEN-0550",
+                                        user: @obs.user, join_in_use: true)
+
+    assert_equal(:merged, result)
+    assert_equal(@obs.id, slip_occ.reload.primary_observation_id,
+                 "the native member becomes primary")
+    assert_not(slip_occ.primary_observation.reflection?)
+  end
+
+  def test_merge_refuses_a_full_occurrence
+    own = Occurrence.create!(user: @obs.user, primary_observation: @obs)
+    @obs.update!(occurrence: own)
+    slip_obs = observations(:coprinus_comatus_obs)
+    slip = FieldSlip.find_or_create_by_code("OPEN-0560", slip_obs.user)
+    slip_obs.update!(occurrence: nil)
+    slip_obs.field_slip = slip
+    slip_obs.save!
+
+    original = Occurrence::MAX_OBSERVATIONS
+    Occurrence.send(:remove_const, :MAX_OBSERVATIONS)
+    Occurrence.const_set(:MAX_OBSERVATIONS, 1)
+    result = FieldSlip::Attacher.attach(observation: @obs.reload,
+                                        code: "OPEN-0560",
+                                        user: @obs.user, join_in_use: true)
+
+    assert_equal(:occurrence_full, result)
+    assert_equal(own.id, @obs.reload.occurrence_id)
+  ensure
+    Occurrence.send(:remove_const, :MAX_OBSERVATIONS)
+    Occurrence.const_set(:MAX_OBSERVATIONS, original)
+  end
+
+  def test_merge_refuses_a_closed_project_slip
+    closed = projects(:bolete_project)
+    assert_not(closed.open_membership, "premise: closed to self-joining")
+    stranger = users(:zero_user)
+    assert_not(closed.member?(stranger), "premise: not a member")
+
+    @obs.update!(user: stranger)
+    own = Occurrence.create!(user: stranger, primary_observation: @obs)
+    @obs.update!(occurrence: own)
+
+    owner = closed.user_group.users.first
+    slip = FieldSlip.find_or_create_by_code("BLT-0570", owner)
+    slip_obs = observations(:coprinus_comatus_obs)
+    slip_obs.update!(occurrence: nil)
+    slip_obs.field_slip = slip
+    slip_obs.save!
+
+    result = FieldSlip::Attacher.attach(observation: @obs.reload,
+                                        code: "BLT-0570",
+                                        user: stranger, join_in_use: true)
+
+    assert_equal(:closed_project, result)
+    assert_equal(own.id, @obs.reload.occurrence_id)
+  end
+
   # The background (non-join_in_use) path leaves an occurrence-holding
   # observation alone -- no merge.
   def test_occurrence_holding_observation_is_left_alone_without_join_in_use

--- a/test/classes/field_slip/extractor/name_proposer_test.rb
+++ b/test/classes/field_slip/extractor/name_proposer_test.rb
@@ -38,6 +38,20 @@ class FieldSlip::Extractor::NameProposerTest < UnitTestCase
     assert_equal("Coprinus comatus", outcome.naming.name.text_name)
   end
 
+  # Saving the same review twice (a re-review, a rescan) restates one
+  # reading, not two -- it reuses the reviewer's existing naming rather
+  # than stacking duplicates on the observation.
+  def test_proposing_the_same_name_twice_reuses_the_naming
+    first = propose("Coprinus comatus")
+    before = @obs.reload.namings.count
+
+    second = propose("Coprinus comatus")
+
+    assert_predicate(second, :proposed?)
+    assert_equal(first.naming, second.naming)
+    assert_equal(before, @obs.reload.namings.count)
+  end
+
   # An admin reading someone else's slip is stating their own reading of
   # it, so the naming and the vote are theirs, not the owner's.
   def test_naming_is_attributed_to_the_reviewer

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -93,6 +93,40 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
     assert_not(row_for(review, "Field Slip Code").savable)
   end
 
+  # The observation has its own occurrence (e.g. a reflection paired
+  # with its Edit-companion), and the read code names a slip on a
+  # different one: the code row is savable so the reviewer can merge
+  # the two (#4214).
+  def test_code_row_savable_to_merge_a_different_slip_occurrence
+    @obs.update!(occurrence: nil)
+    own = Occurrence.create!(user: @obs.user, primary_observation: @obs)
+    @obs.update!(occurrence: own)
+    slip_obs = observations(:coprinus_comatus_obs)
+    slip = FieldSlip.find_or_create_by_code("NEMF-10333", slip_obs.user)
+    slip_obs.update!(occurrence: nil)
+    slip_obs.field_slip = slip
+    slip_obs.save!
+
+    review = build(fields: { "Field Slip Code" => "NEMF-10333" })
+    row = row_for(review, "Field Slip Code")
+
+    assert(row.savable)
+    assert(row.default_use?)
+  end
+
+  # The read code names the slip already on the observation's own
+  # occurrence -- applying it would do nothing, so no tick is offered.
+  def test_code_row_review_only_when_its_own_occurrence_holds_the_slip
+    @obs.update!(occurrence: nil)
+    slip = FieldSlip.find_or_create_by_code("NEMF-10444", @obs.user)
+    @obs.field_slip = slip
+    @obs.save!
+
+    review = build(fields: { "Field Slip Code" => "NEMF-10444" })
+
+    assert_not(row_for(review, "Field Slip Code").savable)
+  end
+
   # ---------- current values ----------
 
   def test_current_value_reads_a_column

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -484,6 +484,32 @@ module Images
       assert_equal(@obs.id, @obs.occurrence.primary_observation_id)
     end
 
+    # The reviewed observation already belongs to an occurrence (e.g. a
+    # reflection paired with its companion), and the slip is on another
+    # one: saving the ticked code merges the two (#4214), rather than
+    # doing nothing silently as it did before.
+    def test_update_merges_when_the_observation_already_has_an_occurrence
+      own = Occurrence.create!(user: @obs.user, primary_observation: @obs)
+      @obs.update!(occurrence: own)
+      other = observations(:coprinus_comatus_obs)
+      other.update!(occurrence: nil)
+      slip = FieldSlip.find_or_create_by_code("OPEN-0540", other.user)
+      other.field_slip = slip
+      other.save!
+      slip_occ = slip.reload.occurrence
+      record_extract(fields: { "Field Slip Code" => "OPEN-0540" })
+      login_as_site_admin
+
+      put(:update, params: { image_id: @image.id,
+                             use: { "Field Slip Code" => "1" },
+                             value: { "Field Slip Code" => "OPEN-0540" } })
+
+      assert_flash_success
+      assert_equal(slip_occ.id, @obs.reload.occurrence_id)
+      assert_not(Occurrence.exists?(own.id))
+      assert_includes(slip_occ.reload.observations, other.reload)
+    end
+
     def test_update_warns_when_the_ticked_code_cannot_attach
       @obs.update!(occurrence: nil)
       other = observations(:coprinus_comatus_obs)

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -259,6 +259,7 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     obs = observations(:imported_inat_obs)
     obs.update_column(:reflected_at, Time.zone.now)
     obs.images << images(:in_situ_image)
+    obs.update_column(:thumb_image_id, images(:in_situ_image).id)
     project = projects(:eol_project)
     project.add_observation(obs)
     login(obs.user.login)
@@ -277,12 +278,14 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     assert_equal(obs.when, companion.when)
     assert_equal(obs.where, companion.where)
     assert_equal(obs.notes, companion.notes)
-    assert_equal(obs.image_ids.sort, companion.image_ids.sort)
+    assert_empty(companion.image_ids, "images stay on the reflection")
+    assert_equal(obs.thumb_image_id, companion.thumb_image_id)
     assert_equal(obs.project_ids.sort, companion.project_ids.sort)
     occurrence = companion.occurrence
     assert_not_nil(occurrence)
     assert_equal(obs.reload.occurrence_id, occurrence.id)
-    assert_equal(obs.id, occurrence.primary_observation_id)
+    assert_equal(companion.id, occurrence.primary_observation_id,
+                 "the native companion is the primary")
     assert(obs.reflection?, "the reflection must stay a reflection")
   end
 

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -251,19 +251,56 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     assert_response(:redirect)
   end
 
-  # A read-only reflection (#4214) can't be edited on MO even by its
-  # owner — the edit form redirects with a warning. The permission check
-  # runs first, so only the owner (who would otherwise pass) sees the
-  # reflection warning.
-  def test_edit_reflection_redirects_with_warning
+  # Edit on a read-only reflection (#4214) creates a companion
+  # observation in a shared occurrence -- copying the snapshot, sharing
+  # the images, joining the reflection's projects -- and lands on the
+  # companion's edit form. The reflection itself is untouched.
+  def test_edit_reflection_creates_companion
+    obs = observations(:imported_inat_obs)
+    obs.update_column(:reflected_at, Time.zone.now)
+    obs.images << images(:in_situ_image)
+    project = projects(:eol_project)
+    project.add_observation(obs)
+    login(obs.user.login)
+
+    assert_difference("Observation.count", 1) do
+      get(:edit, params: { id: obs.id })
+    end
+
+    companion = obs.reload.occurrence.observations.where.not(id: obs.id).first
+    assert_not_nil(companion, "Cannot find the companion observation")
+    assert_redirected_to(edit_observation_path(companion.id))
+    assert_flash_success
+    assert_not(companion.reflection?)
+    assert_equal(obs.user_id, companion.user_id)
+    assert_equal(obs.name_id, companion.name_id)
+    assert_equal(obs.when, companion.when)
+    assert_equal(obs.where, companion.where)
+    assert_equal(obs.notes, companion.notes)
+    assert_equal(obs.image_ids.sort, companion.image_ids.sort)
+    assert_equal(obs.project_ids.sort, companion.project_ids.sort)
+    occurrence = companion.occurrence
+    assert_not_nil(occurrence)
+    assert_equal(obs.reload.occurrence_id, occurrence.id)
+    assert_equal(obs.id, occurrence.primary_observation_id)
+    assert(obs.reflection?, "the reflection must stay a reflection")
+  end
+
+  # A second Edit goes to the companion that already exists.
+  def test_edit_reflection_reuses_existing_companion
     obs = observations(:imported_inat_obs)
     obs.update_column(:reflected_at, Time.zone.now)
     login(obs.user.login)
-
     get(:edit, params: { id: obs.id })
+    companion = obs.reload.occurrence.observations.where.not(id: obs.id).first
+    assert_not_nil(companion, "Cannot find the companion observation")
 
-    assert_redirected_to(action: :show, id: obs.id)
-    assert_flash_warning
+    assert_no_difference("Observation.count") do
+      get(:edit, params: { id: obs.id })
+    end
+
+    assert_redirected_to(edit_observation_path(companion.id))
+    assert_flash_success
   end
 
   # A non-owner hitting edit on a reflection gets the same

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -306,6 +306,30 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     assert_flash_success
   end
 
+  # When the companion can't be made -- the reflection's occurrence is
+  # already full -- Edit flashes the error and returns to Show rather
+  # than 500ing.
+  def test_edit_reflection_flashes_when_the_companion_cannot_be_created
+    obs = observations(:imported_inat_obs)
+    obs.update_column(:reflected_at, Time.zone.now)
+    occ = Occurrence.create!(user: obs.user, primary_observation: obs)
+    obs.update!(occurrence: occ)
+    login(obs.user.login)
+
+    original = Occurrence::MAX_OBSERVATIONS
+    Occurrence.send(:remove_const, :MAX_OBSERVATIONS)
+    Occurrence.const_set(:MAX_OBSERVATIONS, 1)
+    assert_no_difference("Observation.count") do
+      get(:edit, params: { id: obs.id })
+    end
+
+    assert_redirected_to(action: :show, id: obs.id)
+    assert_flash_error
+  ensure
+    Occurrence.send(:remove_const, :MAX_OBSERVATIONS)
+    Occurrence.const_set(:MAX_OBSERVATIONS, original)
+  end
+
   # A non-owner hitting edit on a reflection gets the same
   # permission-denied error as on any observation they can't edit —
   # not the reflection warning (Copilot review on #4852).

--- a/test/models/observation/companion_test.rb
+++ b/test/models/observation/companion_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Observation::Companion -- the editable twin Edit opens for a
+# read-only reflection (#4214).
+class Observation::CompanionTest < UnitTestCase
+  def setup
+    super
+    @reflection = observations(:imported_inat_obs)
+    @reflection.update_column(:reflected_at, Time.zone.now)
+    @user = @reflection.user
+  end
+
+  def test_create_copies_snapshot_shares_images_and_joins_projects
+    @reflection.update!(lat: 41.5, lng: -70.5, alt: 12, gps_hidden: true,
+                        notes: { Other: "imported notes" },
+                        collector: "Someone Else", collector_user_id: nil)
+    @reflection.images << images(:in_situ_image)
+    @reflection.update!(thumb_image: images(:in_situ_image))
+    project = projects(:eol_project)
+    project.add_observation(@reflection)
+
+    companion = Observation::Companion.new(@reflection, @user).create
+
+    assert_not(companion.reflection?)
+    assert_equal(@user.id, companion.user_id)
+    assert_equal("mo_website", companion.source)
+    Observation::Companion::SNAPSHOT.each do |field|
+      assert_equal(@reflection.send(field), companion.send(field),
+                   "#{field} should be copied")
+    end
+    assert_equal(@reflection.name_id, companion.name_id)
+    assert_equal(@reflection.name_id,
+                 companion.namings.first.name_id)
+    assert_equal([images(:in_situ_image).id], companion.image_ids)
+    assert_equal(images(:in_situ_image).id, companion.thumb_image_id)
+    assert_equal([project.id], companion.project_ids)
+    assert_equal(@reflection.reload.occurrence_id, companion.occurrence_id)
+    assert_equal(@reflection.id,
+                 companion.occurrence.primary_observation_id)
+  end
+
+  def test_create_joins_the_reflections_existing_occurrence
+    sibling = observations(:minimal_unknown_obs)
+    occurrence = Occurrence.create!(user: @user,
+                                    primary_observation: @reflection)
+    @reflection.update!(occurrence: occurrence)
+    sibling.update!(occurrence: occurrence, reflected_at: Time.zone.now)
+
+    companion = Observation::Companion.new(@reflection, @user).create
+
+    assert_equal(occurrence.id, companion.occurrence_id)
+    assert_equal(@reflection.id, occurrence.reload.primary_observation_id)
+    assert_equal(3, occurrence.observations.count)
+  end
+
+  def test_existing_finds_an_editable_non_reflection_member
+    builder = Observation::Companion.new(@reflection, @user)
+    assert_nil(builder.existing)
+
+    companion = builder.create
+
+    assert_equal(companion, builder.existing)
+    # A reflection sibling is not a companion.
+    companion.update_column(:reflected_at, Time.zone.now)
+    assert_nil(Observation::Companion.new(@reflection, @user).existing)
+  end
+
+  def test_create_refuses_a_full_occurrence
+    occurrence = Occurrence.create!(user: @user,
+                                    primary_observation: @reflection)
+    @reflection.update!(occurrence: occurrence)
+    members = Observation.where.not(id: @reflection.id).
+              limit(Occurrence::MAX_OBSERVATIONS - 1)
+    members.each { |obs| obs.update_columns(occurrence_id: occurrence.id) }
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      Observation::Companion.new(@reflection, @user).create
+    end
+  end
+end

--- a/test/models/observation/companion_test.rb
+++ b/test/models/observation/companion_test.rb
@@ -33,15 +33,15 @@ class Observation::CompanionTest < UnitTestCase
     assert_equal(@reflection.name_id, companion.name_id)
     assert_equal(@reflection.name_id,
                  companion.namings.first.name_id)
-    assert_equal([images(:in_situ_image).id], companion.image_ids)
+    # Images stay on the reflection; only the thumbnail pointer is shared.
+    assert_empty(companion.image_ids)
     assert_equal(images(:in_situ_image).id, companion.thumb_image_id)
     assert_equal([project.id], companion.project_ids)
     assert_equal(@reflection.reload.occurrence_id, companion.occurrence_id)
-    assert_equal(@reflection.id,
-                 companion.occurrence.primary_observation_id)
+    assert_equal(companion.id, companion.occurrence.primary_observation_id)
   end
 
-  def test_create_joins_the_reflections_existing_occurrence
+  def test_create_joins_the_reflections_existing_occurrence_as_primary
     sibling = observations(:minimal_unknown_obs)
     occurrence = Occurrence.create!(user: @user,
                                     primary_observation: @reflection)
@@ -51,7 +51,7 @@ class Observation::CompanionTest < UnitTestCase
     companion = Observation::Companion.new(@reflection, @user).create
 
     assert_equal(occurrence.id, companion.occurrence_id)
-    assert_equal(@reflection.id, occurrence.reload.primary_observation_id)
+    assert_equal(companion.id, occurrence.reload.primary_observation_id)
     assert_equal(3, occurrence.observations.count)
   end
 
@@ -65,6 +65,22 @@ class Observation::CompanionTest < UnitTestCase
     # A reflection sibling is not a companion.
     companion.update_column(:reflected_at, Time.zone.now)
     assert_nil(Observation::Companion.new(@reflection, @user).existing)
+  end
+
+  # An occurrence whose primary is still the reflection gets repaired
+  # when Edit lands on its native member.
+  def test_existing_promotes_the_native_member_to_primary
+    native = observations(:minimal_unknown_obs)
+    occurrence = Occurrence.create!(user: @user,
+                                    primary_observation: @reflection)
+    @reflection.update!(occurrence: occurrence)
+    native.update!(occurrence: occurrence, user: @user)
+    assert(native.can_edit?(@user), "premise: the native is editable")
+
+    found = Observation::Companion.new(@reflection, @user).existing
+
+    assert_equal(native, found)
+    assert_equal(native.id, occurrence.reload.primary_observation_id)
   end
 
   def test_create_refuses_a_full_occurrence

--- a/test/views/layouts/header/edit_delete_icons_test.rb
+++ b/test/views/layouts/header/edit_delete_icons_test.rb
@@ -42,17 +42,16 @@ module Views::Layouts
       assert_html(html, "div.object_edit form[action='#{destroy_action}']")
     end
 
-    # A read-only reflection (#4214) drops the edit icon (its scalar core
-    # can't be edited on MO) but keeps delete — a separate lifecycle.
-    def test_reflection_suppresses_edit_icon_but_keeps_delete
+    # A read-only reflection (#4214) keeps both icons: Edit opens a
+    # linked companion observation for the changes.
+    def test_reflection_keeps_edit_and_delete_icons
       @obs.update_column(:reflected_at, Time.zone.now)
       html = render_icons(user: @owner)
       edit_href = routes.edit_observation_path(@obs.id)
       destroy_action = routes.observation_path(@obs.id)
 
-      assert_html(html, "div.object_edit .inline-icon-link", count: 1)
-      assert_no_html(html, "a[href='#{edit_href}']",
-                     "a reflection should have no edit-form link")
+      assert_html(html, "div.object_edit .inline-icon-link", count: 2)
+      assert_html(html, "div.object_edit a[href='#{edit_href}']")
       assert_html(html, "div.object_edit form[action='#{destroy_action}']")
     end
 


### PR DESCRIPTION
## Summary

Part of #4214 / #4208: the "Edit creates a companion" half of read-only reflections, which #4852 left as a flash-and-bounce.

Edit on a read-only reflection now opens a **companion observation** in the same occurrence:

- If the occurrence already has a member that is not a reflection and the user may edit, Edit goes to that member's edit form — and makes it the occurrence's primary if a reflection still holds that spot (a dozen NEMF occurrences are in that state today).
- Otherwise `Observation::Companion` creates one: copies the snapshot (date, `where`/location, GPS, altitude, hidden flag, collection-location flag, specimen flag, notes, collector text — `collector_user_id` is re-derived by the model's own callback), gives it the user's naming of the reflection's consensus name, links the two in an occurrence with the **companion as primary** (a native observation is always the primary; a reflection is not), and adds it to the reflection's projects — members of an occurrence share project membership (#4932). Created by the editing user with source `mo_website`, so it is an ordinary editable observation; resync keeps ignoring it.
- **Images stay on the reflection.** The observation page already pools an occurrence's images across its members, so the companion only points its thumbnail at the reflection's thumbnail (any occurrence member's image may be a thumbnail), which keeps matrix boxes showing a photo.
- The edit form opens with a flash explaining what happened (two variants: companion created / existing companion). A full occurrence surfaces its validation error and bounces to Show.
- The Show page's Edit icon is back on reflections (it was suppressed since #4852); the read-only note now says Edit opens a linked companion.

Update on a reflection is unchanged (still blocked with the existing warning), so a stray PUT cannot spawn companions.

## Test plan

Setup: an observation imported from iNat (a reflection — `reflected_at` set) that you can edit: your own, or one in a project where you have editing trust.

1. Click Edit on a reflection that is not in an occurrence. You land on the edit form of a *new* observation with the same date, location, GPS and notes, no photos of its own but the same thumbnail, and a flash saying a companion was created and linked. Judge the flash wording here.
2. The reflection's Show page shows a matching-observations panel with the companion; the companion is primary; both are in the same projects; the carousel shows the reflection's photos on both pages.
3. Click Edit on the reflection again: you land on the same companion (no new observation), with the "existing companion" flash.
4. Click Edit on a reflection that is already the primary of an occurrence with a native sibling: you land on the sibling's edit form, and the sibling is now the primary.
5. Save a change on the companion (e.g. GPS): the reflection is unchanged.
6. Sync now on either member still works and leaves the companion alone.


## Field-slip review on a companion occurrence

Companion-on-Edit gives a slip-bearing reflection an occurrence, which exposed a silent no-op: "Save to Observation" for a field slip did nothing (and said nothing) once the observation had an occurrence — `attach_ticked_code` returned early, and `Attacher#attach` bailed with `:already_linked`. Now, on the human-confirmed review path, when the reviewed observation is in occurrence A and the ticked slip is on a different occurrence B, `Attacher` merges A into B — keeper is the slip's occurrence, so its field slip and a native primary survive (verified: `Occurrence.merge!` keeps the keeper's slip and primary; routing through `create_manual` instead orphaned the slip). The save flashes the result. The background attach job does not merge. It refuses, with a message, when both occurrences carry different slips or the merge would exceed the occurrence size cap.

<!-- changelog -->
article: yes
Edit an imported observation through a linked companion
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
