### PR TITLE
Rule: create every PR as a draft

### DIFF
--- a/.claude/rules/gh_pr_issue_formatting.md
+++ b/.claude/rules/gh_pr_issue_formatting.md
@@ -14,6 +14,12 @@ Fix Image::Processor#ssh_sizes logging false failures
 
 This lives in this file (not just something said in conversation) because every file under `.claude/rules/` is auto-loaded into context every session regardless of whether `CLAUDE.md` links to it — that's the mechanism that makes a rule actually stick across sessions. Something only ever stated in conversation does not persist once that conversation ends; a rule file does.
 
+## Create every PR as a draft
+
+`gh pr create --draft …`, always. Marking it ready (`gh pr ready <n>`) is Nathan's call unless he asks the session to do it; when asked, wait until the PR is at least two minutes old and the session's own checks (tests, RuboCop) have passed.
+
+Two reasons. Nathan wants session-created PRs to arrive as drafts so a PR is visibly "Claude's proposal" until a human has looked at it. And it sidesteps a Copilot review failure: the repo ruleset requests a Copilot review the moment a non-draft PR opens, and that request sometimes aborts after ~45 s ("Copilot encountered an error") — a fast pre-review failure that then sticks to the PR number, so re-requesting keeps failing and only a fresh PR recovers (#5162→#5169, #5173→#5176, #5177→#5178). Drafts get no automatic request (`review_draft_pull_requests` is off); the request fires on "ready for review," once the PR's merge ref has had time to exist. See `copilot_review_comments.md` for the stuck-PR remedy.
+
 ## Bodies: write to a file, never HEREDOC
 
 When using `gh pr create` or `gh pr edit`, **always** write the body to a file first and pass it via `--body-file`. Never use a HEREDOC (`$(cat <<'EOF' ... EOF)`) for a PR body that contains backticks for code formatting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,8 @@ test.
   - **Setup**: Create `.claude/developer.json` with
     `{"branchPrefix": "your-initials"}` (git-ignored)
 - Commit messages include Claude Code attribution
-- Create PRs via `gh pr create` with detailed descriptions
+- Create PRs via `gh pr create --draft` with detailed descriptions —
+  always a draft; see `.claude/rules/gh_pr_issue_formatting.md`
 - Link PRs to issues with `Fixes #issue_number`
 
 ## Architecture


### PR DESCRIPTION
## Summary

Rule: every PR created in a Claude session is opened as a draft (`gh pr create --draft`); marking it ready is Nathan's call unless he asks the session to do it (then: at least two minutes after creation, with tests and RuboCop green). Recorded in `.claude/rules/gh_pr_issue_formatting.md` and `CLAUDE.md`'s Git Workflow.

Two reasons, both in the rule text:

- Session-created PRs should visibly be proposals until a human has looked.
- It sidesteps a Copilot review failure. Timing every Copilot attempt since #5167: each successful review took 2–5 minutes; each "Copilot encountered an error" arrived 46–50 seconds after the request — a fast pre-review abort — and once a PR has hit it, every later request on that PR fails the same way (#5162→#5169, #5173→#5176, #5177→#5178 all recovered only as fresh PRs). The aborts all came from the ruleset's automatic request fired 0–1 s after PR creation; no manual request on a fresh PR has failed. Drafts get no automatic request (`review_draft_pull_requests` is off in the ruleset), and the request fires on "ready for review", after the PR's merge ref has had time to exist.

This PR is itself a draft.

## Test plan

- Read the new section of `.claude/rules/gh_pr_issue_formatting.md`.
- Over the next few session-created PRs: mark each ready a couple of minutes after creation and note whether Copilot's review runs (2–5 min) or aborts (~50 s). If aborts persist on ready-from-draft PRs, the timing theory is wrong and the rule keeps only its first justification.

<!-- changelog -->
article: no
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
