### PR TITLE
Retry iNat photo downloads if Amazon Web Services flakes out

### DIFF
--- a/app/classes/inat/mo_observation_builder/image_handling.rb
+++ b/app/classes/inat/mo_observation_builder/image_handling.rb
@@ -8,6 +8,9 @@ class Inat
     # provenance — source + iNat photo id — directly on the created image.
     # Mixed into MoObservationBuilder.
     module ImageHandling
+      MAX_UPLOAD_RETRIES = 3       # per image, on transient download failure
+      UPLOAD_RETRY_BASE_SLEEP = 2  # seconds; doubles each retry (2, 4, 8)
+
       private
 
       def add_inat_images(inat_obs_photos)
@@ -45,16 +48,41 @@ class Inat
       # (read by ObservationImporter, then InatImportJob) so a
       # TransferImagesJob can be enqueued for the whole import batch at
       # once, rather than image-by-image.
-      def upload_inat_image(params, external_id)
+      def upload_inat_image(params, external_id, attempt: 1)
         api = API2.execute(params)
-        if api.errors.any?
-          raise("Failed to import image #{external_id}: " \
-                "#{api.errors.join(", ")}")
-        end
+        return finish_upload(api) if api.errors.empty?
 
+        retry_or_raise_upload(api, params, external_id, attempt)
+      end
+
+      def finish_upload(api)
         image = api.results.first
         @created_image_ids << image.id
         image
+      end
+
+      # AWS/S3 is occasionally unavailable for a moment (#5183); retry a
+      # download failure before giving up on the whole observation.
+      def retry_or_raise_upload(api, params, external_id, attempt)
+        if retryable_upload_failure?(api.errors) &&
+           attempt <= MAX_UPLOAD_RETRIES
+          backoff_for_upload_retry(external_id, attempt)
+          return upload_inat_image(params, external_id, attempt: attempt + 1)
+        end
+
+        raise("Failed to import image #{external_id}: " \
+              "#{api.errors.join(", ")}")
+      end
+
+      def retryable_upload_failure?(errors)
+        errors.any?(API2::CouldntDownloadURL)
+      end
+
+      def backoff_for_upload_retry(external_id, attempt)
+        backoff = UPLOAD_RETRY_BASE_SLEEP * (2**(attempt - 1))
+        warn("  iNat image #{external_id} download failed; " \
+             "retry #{attempt}/#{MAX_UPLOAD_RETRIES} in #{backoff}s")
+        sleep(backoff)
       end
 
       # Recorded directly on the image so it survives regardless of the

--- a/test/classes/inat_mo_observation_builder_test.rb
+++ b/test/classes/inat_mo_observation_builder_test.rb
@@ -288,6 +288,75 @@ class InatMoObservationBuilderTest < UnitTestCase
     end
   end
 
+  # AWS/S3 is occasionally unavailable for a moment (#5183); a download
+  # failure should be retried, not fail the whole observation.
+  def test_upload_inat_image_retries_transient_download_failure
+    image = images(:in_situ_image)
+    responses = [
+      FakeAPI2Response.new([download_error], nil),
+      FakeAPI2Response.new([download_error], nil),
+      FakeAPI2Response.new([], [image])
+    ]
+    call_count = 0
+    builder = builder_for
+    builder.define_singleton_method(:sleep) { |*| } # skip backoff waits
+
+    API2.stub(:execute, lambda { |_params|
+      call_count += 1
+      responses[call_count - 1]
+    }) do
+      result = builder.send(:upload_inat_image, {}, "377332865")
+      assert_equal(image, result,
+                   "Should return the image once a retry succeeds")
+    end
+
+    assert_equal(3, call_count,
+                 "Should retry an image download failure, succeed on the " \
+                 "third attempt")
+  end
+
+  def test_upload_inat_image_raises_after_exhausting_retries
+    fake_api = FakeAPI2Response.new([download_error], nil)
+    call_count = 0
+    builder = builder_for
+    builder.define_singleton_method(:sleep) { |*| } # skip backoff waits
+
+    API2.stub(:execute, lambda { |_params|
+      call_count += 1
+      fake_api
+    }) do
+      err = assert_raises(RuntimeError) do
+        builder.send(:upload_inat_image, {}, "377332865")
+      end
+      assert_match(/Failed to import image 377332865/, err.message,
+                   "Error should identify the failing iNat photo")
+    end
+
+    assert_equal(Inat::MoObservationBuilder::ImageHandling::
+                 MAX_UPLOAD_RETRIES + 1, call_count,
+                 "Should try once, retry until the cap is reached, " \
+                 "before giving up")
+  end
+
+  def test_upload_inat_image_does_not_retry_non_download_errors
+    error = API2::MissingParameter.new(:upload_url)
+    fake_api = FakeAPI2Response.new([error], nil)
+    call_count = 0
+    builder = builder_for
+
+    API2.stub(:execute, lambda { |_params|
+      call_count += 1
+      fake_api
+    }) do
+      assert_raises(RuntimeError) do
+        builder.send(:upload_inat_image, {}, "377332865")
+      end
+    end
+
+    assert_equal(1, call_count,
+                 "A non-retryable API2 error should not be retried")
+  end
+
   # created_image_ids is what ObservationImporter (then InatImportJob)
   # reads to enqueue one TransferImagesJob per import batch (#4791).
   def test_upload_inat_image_accumulates_created_image_ids
@@ -304,6 +373,14 @@ class InatMoObservationBuilderTest < UnitTestCase
   end
 
   private
+
+  def download_error
+    API2::CouldntDownloadURL.new(
+      "https://inaturalist-open-data.s3.amazonaws.com/photos/" \
+      "377332865/original.jpeg",
+      StandardError.new("simulated S3 outage")
+    )
+  end
 
   def builder_for(provisional_name: nil, name_override: nil,
                   obs_taxon_name: nil)


### PR DESCRIPTION
### Summary ###

See https://github.com/MushroomObserver/mushroom-observer/pull/5184#pullrequestreview-5003122128 below

<!-- changelog -->
article: yes
Retry iNat photo download after flaky AWS response
<!-- /changelog -->