### PR TITLE
Retry after flaky iNat response to writing Observation Field

### DIFF
--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -7,6 +7,18 @@ class Inat
   class ObservationImporter
     include Inat::Constants
 
+    # Transient iNat/AWS failures worth retrying with backoff before
+    # giving up on the writeback (and, ultimately, on the just-created
+    # MO Observation). See #4589.
+    RETRYABLE_WRITEBACK_ERRORS = [
+      RestClient::ServiceUnavailable, RestClient::TooManyRequests,
+      RestClient::BadGateway, RestClient::GatewayTimeout,
+      RestClient::RequestTimeout, RestClient::ServerBrokeConnection
+    ].freeze
+    MAX_WRITEBACK_RETRIES = 3       # on a retryable writeback failure
+    WRITEBACK_RETRY_BASE_SLEEP = 2  # seconds; doubles each retry (2, 4, 8)
+    MAX_RETRY_AFTER_WAIT = 8        # iNat's Retry-After honored up to this
+
     attr_reader :inat_import, :user, :job,
                 :unlicensed_obs_count, :skipped_images_count, :image_ids
 
@@ -223,7 +235,8 @@ class Inat
       )
     end
 
-    def update_inat_observation_field(observation_id:, field_id:, value:)
+    def update_inat_observation_field(observation_id:, field_id:, value:,
+                                      attempt: 1)
       payload = { observation_field_value: { observation_id: observation_id,
                                              observation_field_id: field_id,
                                              value: value } }
@@ -231,10 +244,68 @@ class Inat
         request(method: :post,
                 path: "observation_field_values",
                 payload: payload)
+    rescue *RETRYABLE_WRITEBACK_ERRORS => e
+      retry_or_raise_writeback(e, payload, attempt)
     rescue ::RestClient::ExceptionWithResponse => e
-      error = { error: e.http_code, payload: payload }.to_json
-      log_with_response_error(error)
-      raise(e)
+      log_and_raise_writeback_error(e, payload)
+    end
+
+    # iNat can return a transient error (503, etc.) after the field value
+    # was persisted. Confirm before retrying or giving up, so a false
+    # error doesn't needlessly retry or back out the just-created MO
+    # Observation.
+    def retry_or_raise_writeback(error, payload, attempt)
+      ofv = payload[:observation_field_value]
+      return if field_actually_written?(ofv[:observation_id], ofv[:value])
+
+      if attempt <= MAX_WRITEBACK_RETRIES
+        backoff_for_writeback_retry(error, attempt)
+        return update_inat_observation_field(
+          observation_id: ofv[:observation_id],
+          field_id: ofv[:observation_field_id],
+          value: ofv[:value], attempt: attempt + 1
+        )
+      end
+
+      log_and_raise_writeback_error(error, payload)
+    end
+
+    def field_actually_written?(observation_id, value)
+      raw_obs = fetch_inat_observation(observation_id)
+      Inat::Obs.new(JSON.generate(raw_obs)).mo_url_field_value == value
+    rescue StandardError
+      false
+    end
+
+    def fetch_inat_observation(observation_id)
+      response = Inat::APIRequest.new(@inat_import.token).
+                 request(path: "observations/#{observation_id}")
+      JSON.parse(response.body, symbolize_names: true)[:results]&.first || {}
+    end
+
+    def backoff_for_writeback_retry(error, attempt)
+      backoff = retry_after_seconds(error) ||
+                WRITEBACK_RETRY_BASE_SLEEP * (2**(attempt - 1))
+      warn("  iNat writeback #{error.class} on observation field; " \
+           "retry #{attempt}/#{MAX_WRITEBACK_RETRIES} in #{backoff}s")
+      sleep(backoff)
+    end
+
+    # Honor iNat's Retry-After when it's within our own retry budget;
+    # otherwise fall back to our own doubling backoff so a large
+    # server-suggested wait can't stall the whole import.
+    def retry_after_seconds(error)
+      headers = error.response&.headers
+      seconds = headers && headers[:retry_after]&.to_i
+      return nil unless seconds&.positive? && seconds <= MAX_RETRY_AFTER_WAIT
+
+      seconds
+    end
+
+    def log_and_raise_writeback_error(error, payload)
+      error_json = { error: error.http_code, payload: payload }.to_json
+      log_with_response_error(error_json)
+      raise(error)
     end
 
     def increment_imported_counts

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -256,7 +256,9 @@ class Inat
     # Observation.
     def retry_or_raise_writeback(error, payload, attempt)
       ofv = payload[:observation_field_value]
-      return if field_actually_written?(ofv[:observation_id], ofv[:value])
+      return if field_actually_written?(ofv[:observation_id],
+                                        ofv[:observation_field_id],
+                                        ofv[:value])
 
       if attempt <= MAX_WRITEBACK_RETRIES
         backoff_for_writeback_retry(error, attempt)
@@ -270,9 +272,14 @@ class Inat
       log_and_raise_writeback_error(error, payload)
     end
 
-    def field_actually_written?(observation_id, value)
+    # Verify by the field_id passed in, not a field hard-coded to the MO
+    # URL field -- update_inat_observation_field's signature is generic,
+    # so this stays correct if it's called for another observation field.
+    def field_actually_written?(observation_id, field_id, value)
       raw_obs = fetch_inat_observation(observation_id)
-      Inat::Obs.new(JSON.generate(raw_obs)).mo_url_field_value == value
+      fields = Inat::Obs.new(JSON.generate(raw_obs)).inat_obs_fields
+      fields&.find { |field| field[:field_id] == field_id }&.dig(:value) ==
+        value
     rescue StandardError
       false
     end

--- a/test/classes/inat_observation_importer_test.rb
+++ b/test/classes/inat_observation_importer_test.rb
@@ -3,6 +3,8 @@
 require("test_helper")
 
 class InatObservationImporterTest < UnitTestCase
+  include Inat::Constants
+
   # update_timings keeps a cumulative moving average (CMA) of per-observation
   # import time for the current job. After obs #1 with elapsed T: avg = T.
   # After obs #2 with elapsed S: avg = (T + S) / 2.
@@ -76,5 +78,153 @@ class InatObservationImporterTest < UnitTestCase
     ) do
       importer.import_page(page)
     end
+  end
+
+  # ---------- update_inat_observation_field: 503 writeback retry (#4589) ----
+
+  def test_writeback_ignores_503_when_field_already_written
+    importer, args = writeback_call_args
+    stub_writeback_post(status: 503)
+    stub_writeback_verification_get(args, written: true)
+
+    importer.send(:update_inat_observation_field, **args)
+
+    assert_requested(:post, writeback_post_url, times: 1)
+    assert_requested(:get, writeback_get_url(args[:observation_id]),
+                     times: 1)
+  end
+
+  def test_writeback_retries_503_with_default_backoff_then_succeeds
+    importer, args = writeback_call_args
+    sleeps = stub_sleep_spy(importer)
+    stub_request(:post, writeback_post_url).
+      to_return({ status: 503 }, { status: 200 })
+    stub_writeback_verification_get(args, written: false)
+
+    importer.send(:update_inat_observation_field, **args)
+
+    assert_requested(:post, writeback_post_url, times: 2)
+    assert_equal([2], sleeps,
+                 "First retry should use the default doubling backoff " \
+                 "when iNat sends no Retry-After header")
+  end
+
+  def test_writeback_honors_retry_after_within_budget
+    importer, args = writeback_call_args
+    sleeps = stub_sleep_spy(importer)
+    stub_request(:post, writeback_post_url).
+      to_return({ status: 503, headers: { "Retry-After" => "3" } },
+                { status: 200 })
+    stub_writeback_verification_get(args, written: false)
+
+    importer.send(:update_inat_observation_field, **args)
+
+    assert_equal([3], sleeps,
+                 "Should sleep iNat's Retry-After value when it's " \
+                 "within the retry budget, instead of the doubling default")
+  end
+
+  def test_writeback_ignores_retry_after_over_budget
+    importer, args = writeback_call_args
+    sleeps = stub_sleep_spy(importer)
+    stub_request(:post, writeback_post_url).
+      to_return({ status: 503, headers: { "Retry-After" => "30" } },
+                { status: 200 })
+    stub_writeback_verification_get(args, written: false)
+
+    importer.send(:update_inat_observation_field, **args)
+
+    assert_equal([2], sleeps,
+                 "A Retry-After above the retry budget should be " \
+                 "ignored in favor of the doubling default")
+  end
+
+  def test_writeback_raises_after_exhausting_retries
+    importer, args = writeback_call_args
+    sleeps = stub_sleep_spy(importer)
+    stub_writeback_post(status: 503)
+    stub_writeback_verification_get(args, written: false)
+
+    assert_raises(RestClient::ServiceUnavailable,
+                  "Should give up and raise once retries are exhausted " \
+                  "and the field is still unconfirmed") do
+      importer.send(:update_inat_observation_field, **args)
+    end
+
+    assert_requested(
+      :post, writeback_post_url,
+      times: ::Inat::ObservationImporter::MAX_WRITEBACK_RETRIES + 1
+    )
+    assert_equal([2, 4, 8], sleeps,
+                 "Should back off 2s/4s/8s across the 3 retries")
+  end
+
+  def test_writeback_treats_failed_verification_as_unconfirmed
+    importer, args = writeback_call_args
+    sleeps = stub_sleep_spy(importer)
+    stub_request(:post, writeback_post_url).
+      to_return({ status: 503 }, { status: 200 })
+    stub_request(:get, writeback_get_url(args[:observation_id])).
+      to_return(status: 500)
+
+    importer.send(:update_inat_observation_field, **args)
+
+    assert_requested(:post, writeback_post_url, times: 2)
+    assert_equal([2], sleeps,
+                 "A failed verification GET should be treated as " \
+                 "unconfirmed and fall through to a normal retry")
+  end
+
+  def test_writeback_raises_immediately_on_non_retryable_error
+    importer, args = writeback_call_args
+    stub_writeback_post(status: 401)
+
+    assert_raises(RestClient::Unauthorized,
+                  "Non-retryable errors should raise without retrying " \
+                  "or checking iNat for the written field") do
+      importer.send(:update_inat_observation_field, **args)
+    end
+
+    assert_requested(:post, writeback_post_url, times: 1)
+    assert_not_requested(:get, writeback_get_url(args[:observation_id]))
+  end
+
+  private
+
+  def writeback_call_args
+    import = inat_imports(:rolf_inat_import)
+    importer = ::Inat::ObservationImporter.new(import, import.user)
+    args = { observation_id: 123, field_id: MO_URL_OBSERVATION_FIELD_ID,
+             value: "#{MO.http_domain}/456" }
+    [importer, args]
+  end
+
+  # Replace `sleep` on the importer instance with a spy that records the
+  # requested durations instead of sleeping the test thread.
+  def stub_sleep_spy(importer)
+    sleeps = []
+    importer.define_singleton_method(:sleep) { |secs| sleeps << secs }
+    importer.define_singleton_method(:warn) { |*| } # quiet retry logging
+    sleeps
+  end
+
+  def writeback_post_url
+    "#{API_BASE}/observation_field_values"
+  end
+
+  def writeback_get_url(observation_id)
+    "#{API_BASE}/observations/#{observation_id}"
+  end
+
+  def stub_writeback_post(status:)
+    stub_request(:post, writeback_post_url).to_return(status: status)
+  end
+
+  def stub_writeback_verification_get(args, written:)
+    ofvs = written ? [{ field_id: args[:field_id], value: args[:value] }] : []
+    body = { results: [{ id: args[:observation_id], ofvs: ofvs }] }.to_json
+
+    stub_request(:get, writeback_get_url(args[:observation_id])).
+      to_return(status: 200, body: body)
   end
 end


### PR DESCRIPTION
See [Copilot PR Overview](https://github.com/MushroomObserver/mushroom-observer/pull/5185#pullrequestreview-5003274074)
<!-- changelog -->
article: yes
Retry writing Observation Field after flaky iNat response
<!-- /changelog -->