### PR TITLE
Changelog blocks: no UI jargon, capitalize MO object names

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -53,7 +53,8 @@ faster than they can notice an omission.
   utf8mb4."
 - Terse, like the existing Article rows: lead with the verb — "Fix …",
   "Add …", "Allow …", "Speed up …" — no "now", no "This PR".
-- No code identifiers, no backticks, no class/method/file names.
+- No code identifiers, no backticks, no class/method/file names in
+  the sentence text itself.
 - **No developer or UI-implementation jargon** (Joe, 2026-08-24
   Article review). Replace it with what the user sees:
   - "lightbox" → "the enlarged image" / "the enlarged image view"

--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -54,6 +54,21 @@ faster than they can notice an omission.
 - Terse, like the existing Article rows: lead with the verb — "Fix …",
   "Add …", "Allow …", "Speed up …" — no "now", no "This PR".
 - No code identifiers, no backticks, no class/method/file names.
+- **No developer or UI-implementation jargon** (Joe, 2026-08-24
+  Article review). Replace it with what the user sees:
+  - "lightbox" → "the enlarged image" / "the enlarged image view"
+  - "modal" → "pop-up" / "dialog", or rewrite without it
+  - "500", "crash", "race" → "error" / "bug"
+  - "parameter" / "param" — this word almost always means the entry
+    is describing an internal detail, not a user-facing change. Take
+    it as a signal to either rewrite the sentence for the user or set
+    `article: no`.
+- **Capitalize MO object names, singular and plural** (Joe, same
+  review): Observation(s), Name(s), Location(s), Project(s), Image(s),
+  Occurrence(s), Field Slip(s), Species List(s), Herbarium/Herbaria,
+  Naming(s), Sequence(s), Comment(s), Description(s), Publication(s),
+  User(s), Checklist(s), External Link(s). Leave everyday words
+  lowercase (photo, thumbnail, collector, admin as a role).
 - No PR/issue numbers — the generator adds the links.
 - Capitalized, no ending punctuation.
 


### PR DESCRIPTION
## Summary

Folds Joe's 2026-08-24 review of the 2026 MO Improvements Article into the changelog-block wording rules (`.claude/rules/changelog.md`), so future `article: yes` sentences follow them from the start:

- **No developer / UI-implementation jargon.** Replace it with what the user sees: "lightbox" → "the enlarged image", "modal" → "pop-up" / "dialog", "500" / "crash" / "race" → "error" / "bug". "parameter" / "param" is called out as a signal that the entry is describing an internal detail — rewrite it for the user or set `article: no`.
- **Capitalize MO object names, singular and plural** — Observation(s), Name(s), Location(s), Project(s), Image(s), Occurrence(s), Field Slip(s), Species List(s), Herbarium/Herbaria, Naming(s), Sequence(s), Comment(s), Description(s), Publication(s), User(s), Checklist(s), External Link(s) — while leaving everyday words lowercase (photo, thumbnail, collector, admin as a role).

The Article draft itself (in the gitignored `projects/` working area, applied to the local database for Nathan's re-review) was revised to match; that's not part of this diff.

## Test plan

- Read the revised "The sentence" bullets in `.claude/rules/changelog.md`.

<!-- changelog -->
article: no
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
