### PR TITLE
Changelog for `deploy-2026-08-24-12-01`; fix pool timezone skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-08-24 (deploy-2026-08-24-12-01)
+
+- Changelog block convention: `.claude/rules/changelog.md` + PR template (#5155 step 1) ([PR5158](https://github.com/MushroomObserver/mushroom-observer/pull/5158), @mo-nathan)
+- Standalone `CHANGELOG.md` generator: `script/generate_changelog.rb` (#5155 step 2) ([PR5159](https://github.com/MushroomObserver/mushroom-observer/pull/5159), @mo-nathan)
+- Changelog: bare `#NNNN` PR references instead of markdown links (#5155) ([PR5167](https://github.com/MushroomObserver/mushroom-observer/pull/5167), @mo-nathan)
+- Link field slip scans from the observation and image pages (#5161) ([PR5169](https://github.com/MushroomObserver/mushroom-observer/pull/5169), @mo-nathan)
+- Lead with the thumbnail even when it is a sibling's image (#5160) ([PR5170](https://github.com/MushroomObserver/mushroom-observer/pull/5170), @mo-nathan)
+- Changelog: find PRs by merge-commit reachability; regenerate 2026 (#5155) ([PR5171](https://github.com/MushroomObserver/mushroom-observer/pull/5171), @mo-nathan)
+- Add `script/article_rows.rb`: MO Article rows from PR changelog blocks (#5155) ([PR5176](https://github.com/MushroomObserver/mushroom-observer/pull/5176), @mo-nathan)
+- Edit on a read-only reflection opens a companion observation (#4214) ([PR5178](https://github.com/MushroomObserver/mushroom-observer/pull/5178), @mo-nathan)
+- Rule: create every PR as a draft ([PR5179](https://github.com/MushroomObserver/mushroom-observer/pull/5179), @mo-nathan)
+
 ## 2026-08-22 (deploy-2026-08-22-01-42)
 
 - Prefix only bare-number field slip codes in `AddDispatchController` ([PR5147](https://github.com/MushroomObserver/mushroom-observer/pull/5147), @mo-nathan)

--- a/script/generate_changelog.rb
+++ b/script/generate_changelog.rb
@@ -44,6 +44,12 @@ class ChangelogGenerator
   # parent reaches main; the PR pool reaches back this far before the
   # earliest deploy tag a run looks at.
   POOL_LOOKBACK_DAYS = 365
+  # The gh search bounds are calendar days, but a deploy tag's local
+  # date can trail the UTC merge date of a PR deployed seconds before
+  # it (a PR merged 00:03 UTC, tagged 20:04 the prior day local). Pad
+  # the pool's upper bound so those PRs still fall inside a window; the
+  # rev-list intersection drops anything not in the range.
+  POOL_LOOKAHEAD_DAYS = 2
   # GitHub search returns at most this many results per query.
   SEARCH_CAP = 1000
 
@@ -165,7 +171,7 @@ class ChangelogGenerator
   # its newest tag's date (nothing merged later can be in range).
   def pool_months
     from = tag_date(@pool_from) - POOL_LOOKBACK_DAYS
-    last = tag_date(@pool_to)
+    last = tag_date(@pool_to) + POOL_LOOKAHEAD_DAYS
     months = []
     while from <= last
       to = [from.next_month - 1, last].min


### PR DESCRIPTION
## Summary

`CHANGELOG.md` section for the 2026-08-24 deploy (`deploy-2026-08-24-12-01`), plus a generator fix that the deploy exposed.

**Generator fix.** The section was at first missing #5178 and #5179 even though their merge commits are in the deploy's range. Cause: `pool_months` bounds the `gh pr list` search by the deploy tag's *local* calendar date (2026-08-23), but GitHub records those two PRs as merged 2026-08-24 UTC — they merged 00:03 UTC, seconds before the tag was cut at 20:04 local the prior day. So the search window excluded them while the git range included them, and the intersection dropped them. `POOL_LOOKAHEAD_DAYS = 2` pads the pool's upper bound past that timezone skew; the `git rev-list` intersection still bounds the section to PRs in the range. Any PR merged in the UTC day after a deploy tag's local day would otherwise be lost at every deploy.

**Section.** Regenerated with the fix — 9 PRs, all merge-commit PRs in the range accounted for.

## Test plan

- `script/generate_changelog.rb --tag deploy-2026-08-24-12-01` prints the same 9-PR section as the committed file's top section, including #5178 and #5179.
- Diff shows only the new `## 2026-08-24` section prepended; nothing else changed.

<!-- changelog -->
article: no
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
