### PR TITLE
Block deleting a read-only reflection (#5180)

### DIFF
--- a/app/controllers/observations_controller/destroy.rb
+++ b/app/controllers/observations_controller/destroy.rb
@@ -12,6 +12,10 @@ module ObservationsController::Destroy
 
     @observation.current_user = @user
     obs_id = @observation.id
+    # Permission first, THEN the reflection guard -- so a user who can't
+    # delete the observation gets the standard denial without being told
+    # it is a reflection (matches EditAndUpdate#editable_or_redirect?).
+    return if destroy_denied?(obs_id)
     return if destroy_blocked_for_reflection?(obs_id)
 
     # decide where to redirect after deleting observation, using Query.next_id
@@ -20,21 +24,29 @@ module ObservationsController::Destroy
       next_id = this_query.next_id
     end
 
-    if !permission!(@observation)
-      flash_error(:runtime_destroy_observation_denied.t(id: obs_id))
-      redirect_to({ action: :show, id: obs_id })
     # Refetch fresh (non-strict_loading) for the destroy cascade. current_user
     # doesn't carry over from @observation above - it's a different instance.
-    elsif !refetch_for_destroy(@observation.id).destroy
-      flash_error(:runtime_destroy_observation_failed.t(id: obs_id))
-      redirect_to({ action: :show, id: obs_id })
-    else
+    if refetch_for_destroy(@observation.id).destroy
       flash_notice(:runtime_destroy_observation_success.t(id: param_id))
       redirect_after_destroy(this_query, next_id)
+    else
+      flash_error(:runtime_destroy_observation_failed.t(id: obs_id))
+      redirect_to({ action: :show, id: obs_id })
     end
   end
 
   private
+
+  # Standard permission-denied path. Checked before the reflection guard,
+  # so a non-owner gets the usual denial rather than the reflection
+  # warning (which would leak that the observation is a reflection).
+  def destroy_denied?(obs_id)
+    return false if permission!(@observation)
+
+    flash_error(:runtime_destroy_observation_denied.t(id: obs_id))
+    redirect_to(action: :show, id: obs_id)
+    true
+  end
 
   # A read-only reflection mirrors its imported source and is changed
   # only by resync; deleting it on MO would drop the mirror (and its

--- a/app/controllers/observations_controller/destroy.rb
+++ b/app/controllers/observations_controller/destroy.rb
@@ -12,6 +12,8 @@ module ObservationsController::Destroy
 
     @observation.current_user = @user
     obs_id = @observation.id
+    return if destroy_blocked_for_reflection?(obs_id)
+
     # decide where to redirect after deleting observation, using Query.next_id
     if (this_query = find_query(:Observation))
       this_query.current_id = @observation.id
@@ -33,6 +35,17 @@ module ObservationsController::Destroy
   end
 
   private
+
+  # A read-only reflection mirrors its imported source and is changed
+  # only by resync; deleting it on MO would drop the mirror (and its
+  # import link) while the source lives on. Block it like the edit lock.
+  def destroy_blocked_for_reflection?(obs_id)
+    return false unless @observation.reflection?
+
+    flash_warning(:destroy_observation_is_reflection.t)
+    redirect_to(action: :show, id: obs_id)
+    true
+  end
 
   def refetch_for_destroy(id)
     obs = Observation.find(id)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1491,6 +1491,7 @@
   observation_field_slip_project_closed: 'Field slip "[code]" belongs to the [title] project, which you are not a member of and cannot join on your own. The observation was saved without the field slip code. You can "ask a project admin to add you":[url] and enter the code again once they do.'
   observation_field_slip_spare_used: Field slip [code] was attached as a spare, with no project.
   edit_observation_is_reflection: This observation is a read-only reflection of its imported source. To change it, edit it at the source and resync.
+  destroy_observation_is_reflection: This observation is a read-only reflection of its imported source and can't be deleted here. To remove it, delete it at the source and resync.
   edit_observation_companion_created: That observation is a read-only reflection of its imported source, so Mushroom Observer created this companion observation for your changes and linked the two as one occurrence. Edit the companion here; the reflection keeps the imported data.
   edit_observation_companion_existing: That observation is a read-only reflection of its imported source. You are editing its linked companion observation instead.
   create_observation_field_slip_invalid: 'Observation created, but the field slip code "[code]" was invalid and was not attached.'

--- a/test/controllers/observations_controller_destroy_test.rb
+++ b/test/controllers/observations_controller_destroy_test.rb
@@ -43,8 +43,9 @@ class ObservationsControllerDestroyTest < FunctionalTestCase
     end
   end
 
-  # A read-only reflection (#4214) can't be deleted on MO -- the guard
-  # blocks it before the permission check, even for the owner.
+  # A read-only reflection (#4214) can't be deleted on MO -- the owner,
+  # who passes the permission check, is stopped by the reflection guard
+  # with a warning.
   def test_destroy_reflection_blocked
     obs = observations(:imported_inat_obs)
     obs.update_column(:reflected_at, Time.zone.now)
@@ -56,6 +57,24 @@ class ObservationsControllerDestroyTest < FunctionalTestCase
     end
     assert_redirected_to(action: :show, id: id)
     assert_flash_warning
+    assert(Observation.find(id).reflection?)
+  end
+
+  # A non-owner gets the standard permission-denied path (an error flash),
+  # not the reflection warning -- the permission check runs before the
+  # reflection guard, so reflection status isn't leaked (Copilot #5193).
+  def test_destroy_reflection_by_non_owner_is_permission_denied
+    obs = observations(:imported_inat_obs)
+    obs.update_column(:reflected_at, Time.zone.now)
+    id = obs.id
+    assert_not_equal("mary", obs.user.login, "mary must not own the obs")
+    login("mary")
+
+    assert_no_difference("Observation.count") do
+      delete(:destroy, params: { id: id })
+    end
+    assert_flash_error
+    assert_redirected_to(action: :show, id: id)
     assert(Observation.find(id).reflection?)
   end
 

--- a/test/controllers/observations_controller_destroy_test.rb
+++ b/test/controllers/observations_controller_destroy_test.rb
@@ -43,6 +43,22 @@ class ObservationsControllerDestroyTest < FunctionalTestCase
     end
   end
 
+  # A read-only reflection (#4214) can't be deleted on MO -- the guard
+  # blocks it before the permission check, even for the owner.
+  def test_destroy_reflection_blocked
+    obs = observations(:imported_inat_obs)
+    obs.update_column(:reflected_at, Time.zone.now)
+    id = obs.id
+    login(obs.user.login)
+
+    assert_no_difference("Observation.count") do
+      delete(:destroy, params: { id: id })
+    end
+    assert_redirected_to(action: :show, id: id)
+    assert_flash_warning
+    assert(Observation.find(id).reflection?)
+  end
+
   def test_original_filename_visibility
     login("mary")
     obs_id = observations(:agaricus_campestris_obs).id


### PR DESCRIPTION
## Summary

Closes the deletion gap in the read-only reflection lock (#4214, part of #4208). Editing an imported reflection was blocked, but `ObservationsController::Destroy#destroy` had only a permission check — so a user could delete their own reflection on MO, dropping the mirror and its import `ExternalLink` (via `dependent: :destroy`) while the iNaturalist source lived on. A later resync of the occurrence would then have nothing to refresh, and the correspondence would be silently lost.

Adds a `reflection?` guard to `#destroy`, mirroring the edit lock's `redirect_if_reflection!`. It runs before the permission check, so even the owner is redirected to the show page with a warning that points at the source. Confirmed there is no API2 delete path for observations (`API2::ObservationAPI` has no `delete`), so the web `destroy` is the only path to guard.

Per the discussion on #5180, **blocking is the conservative default** — if a case for user-initiated deletion of an imported reflection comes up, we revise then rather than guessing at a confirm/soft-delete flow now.

## Test plan

- `bin/rails test test/controllers/observations_controller_destroy_test.rb` — `test_destroy_reflection_blocked` sets `reflected_at` on an owned observation, attempts delete as the owner, and asserts no deletion, a redirect to show, a warning flash, and that the observation is still a reflection.

<!-- changelog -->
article: no
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
