### PR TITLE
Add daily batch resync of read-only iNat reflections (#4215)

### DIFF
--- a/app/classes/inat/obs_fetcher.rb
+++ b/app/classes/inat/obs_fetcher.rb
@@ -36,11 +36,15 @@ class Inat
     # nil, the batch returns every id -- and only then does an id missing
     # from the results mean "deleted on iNat" rather than "unchanged".
     def fetch_batch(external_ids, updated_since: nil)
+      ids = external_ids.compact.uniq
+      # An empty id list would query iNat with no `id` filter (i.e. every
+      # observation), so short-circuit to an empty (non-failed) result.
+      return [{}, false] if ids.empty?
+
       by_id = {}
-      fetch_page(external_ids.compact.uniq, updated_since: updated_since).
-        each do |raw|
-          by_id[raw[:id].to_s] = raw
-        end
+      fetch_page(ids, updated_since: updated_since).each do |raw|
+        by_id[raw[:id].to_s] = raw
+      end
       [by_id, false]
     rescue FetchError
       [{}, true]

--- a/app/classes/inat/obs_fetcher.rb
+++ b/app/classes/inat/obs_fetcher.rb
@@ -31,11 +31,16 @@ class Inat
     # Fetch one batch of up to PAGE_SIZE external ids. Returns
     # [results_by_id, failed?] - failed? is true when the batch exhausted its
     # retries, so the caller can mark those obs "fetch_error" vs "not_found".
-    def fetch_batch(external_ids)
+    # `updated_since` (a Time) narrows the batch to ids changed on iNat
+    # since then, so an incremental sync fetches only what moved. Left
+    # nil, the batch returns every id -- and only then does an id missing
+    # from the results mean "deleted on iNat" rather than "unchanged".
+    def fetch_batch(external_ids, updated_since: nil)
       by_id = {}
-      fetch_page(external_ids.compact.uniq).each do |raw|
-        by_id[raw[:id].to_s] = raw
-      end
+      fetch_page(external_ids.compact.uniq, updated_since: updated_since).
+        each do |raw|
+          by_id[raw[:id].to_s] = raw
+        end
       [by_id, false]
     rescue FetchError
       [{}, true]
@@ -43,14 +48,14 @@ class Inat
 
     private
 
-    def fetch_page(ids, attempt: 1)
-      response = get("observations?#{page_query(ids)}")
+    def fetch_page(ids, updated_since: nil, attempt: 1)
+      response = get("observations?#{page_query(ids, updated_since)}")
       JSON.parse(response.body, symbolize_names: true)[:results] || []
     rescue *RETRYABLE_ERRORS, JSON::ParserError => e
       raise(FetchError.new(e.message)) if attempt > MAX_RETRIES
 
       backoff_for_retry(e, ids, attempt)
-      fetch_page(ids, attempt: attempt + 1)
+      fetch_page(ids, updated_since: updated_since, attempt: attempt + 1)
     end
 
     def backoff_for_retry(error, ids, attempt)
@@ -60,9 +65,11 @@ class Inat
       sleep(backoff)
     end
 
-    def page_query(ids)
-      { id: ids.join(","), per_page: PAGE_SIZE,
-        order_by: "id", order: "asc" }.to_query
+    def page_query(ids, updated_since = nil)
+      query = { id: ids.join(","), per_page: PAGE_SIZE,
+                order_by: "id", order: "asc" }
+      query[:updated_since] = updated_since.utc.iso8601 if updated_since
+      query.to_query
     end
 
     def get(path)

--- a/app/classes/inat/observation_resyncer.rb
+++ b/app/classes/inat/observation_resyncer.rb
@@ -14,6 +14,11 @@ class Inat
   # namings, votes, comments, images and sequences are handled by later
   # slices.
   #
+  # The per-reflection refresh itself lives in Inat::ReflectionResync,
+  # shared with the scheduled daily batch (Inat::ReflectionBatchResyncer);
+  # this class adds the occurrence-wide framing and the Turbo broadcast
+  # that updates the page live.
+  #
   # Runs BELOW the read-only edit guard: that guard blocks the web/API
   # edit actions, while this service writes the records directly, so it
   # can refresh reflections nobody is allowed to hand-edit.
@@ -23,13 +28,15 @@ class Inat
   #   - id absent from results    -> :source_deleted, MO data kept, logged;
   #   - id present                -> :synced / :unchanged.
   class ObservationResyncer
-    # Per-reflection outcome; status is one of :synced, :unchanged,
-    # :source_deleted, :fetch_failed.
-    Result = Data.define(:status, :observation)
+    # Per-reflection outcomes come from Inat::ReflectionResync; re-exported
+    # here for callers and tests that reference the occurrence path.
+    Result = ReflectionResync::Result
 
-    def initialize(observation, fetcher: ObsFetcher.new)
+    def initialize(observation, fetcher: ObsFetcher.new,
+                   applier: ReflectionResync.new)
       @observation = observation
       @fetcher = fetcher
+      @applier = applier
     end
 
     # Returns the Array of per-reflection Results (empty when the
@@ -37,20 +44,15 @@ class Inat
     def resync
       return [] if targets.empty?
 
-      by_id, failed = @fetcher.fetch_batch(targets.map { |t| inat_id(t) })
-      results = targets.map { |target| target_result(target, by_id, failed) }
+      by_id, failed = @fetcher.fetch_batch(
+        targets.map { |t| ReflectionResync.inat_id(t) }
+      )
+      results = targets.map { |target| @applier.call(target, by_id, failed) }
       broadcast(results)
       results
     end
 
     private
-
-    def target_result(target, by_id, failed)
-      return Result.new(status: :fetch_failed, observation: target) if failed
-
-      raw = by_id[inat_id(target).to_s]
-      raw ? apply(target, Inat::Obs.new(JSON.generate(raw))) : deleted(target)
-    end
 
     # The occurrence's reflections that have an iNat import link. Only
     # read-only reflections are refreshable: the backlog of still-editable
@@ -58,65 +60,7 @@ class Inat
     # MO-side edits.
     def targets
       @targets ||= @observation.sync_reflections.
-                   select { |obs| inat_link(obs) }
-    end
-
-    def inat_link(obs)
-      link = obs.import_link
-      return nil unless link&.external_site&.name ==
-                        ExternalSite::INATURALIST_NAME
-
-      link
-    end
-
-    def inat_id(obs)
-      inat_link(obs).external_id
-    end
-
-    # Detect a REAL change from what persists, not from the assigned
-    # values: setting `location` triggers a callback that rewrites `where`
-    # to the location's name, so an in-memory `changed?` never converges.
-    # `saved_changes` (sans the timestamp) reflects what actually moved.
-    def apply(obs, inat_obs)
-      obs.assign_attributes(scalar_attributes(obs, inat_obs))
-      obs.save! if obs.changed?
-      changed = obs.saved_changes.except("updated_at").present?
-      mark_synced(obs)
-      log_resync(obs) if changed
-      Result.new(status: changed ? :synced : :unchanged, observation: obs)
-    end
-
-    # The source-owned scalar fields, straight off the fresh iNat data.
-    # `where` is only set when no Location resolves: a present Location
-    # drives `where` from its own name via a callback, so assigning
-    # `where` too would flip it back and forth and never converge.
-    def scalar_attributes(_obs, inat_obs)
-      location = inat_obs.location
-      attrs = { when: inat_obs.when, location: location, lat: inat_obs.lat,
-                lng: inat_obs.lng, gps_hidden: inat_obs.gps_hidden,
-                specimen: inat_obs.specimen?, notes: inat_obs.notes }
-      attrs[:where] = inat_obs.where if location.nil?
-      attrs
-    end
-
-    # The iNat obs is gone: keep every MO record intact, record the loss on
-    # the activity log, and still stamp last_synced_at so the check ran.
-    def deleted(obs)
-      mark_synced(obs)
-      obs.log(:log_observation_source_deleted, user: User.admin)
-      Result.new(status: :source_deleted, observation: obs)
-    end
-
-    def mark_synced(obs)
-      inat_link(obs).update!(last_synced_at: Time.zone.now)
-    end
-
-    # Sync is owned by the admin account: anyone logged in may trigger
-    # it, and the scheduled batch has no triggering user at all, so the
-    # log attributes every resync to the system actor rather than to
-    # whoever happened to press the button.
-    def log_resync(obs)
-      obs.log(:log_observation_resynced, user: User.admin)
+                   select { |obs| ReflectionResync.inat_link(obs) }
     end
 
     # Turbo Stream broadcast so "Sync now" updates pages live, no reload

--- a/app/classes/inat/reflection_batch_resyncer.rb
+++ b/app/classes/inat/reflection_batch_resyncer.rb
@@ -1,21 +1,27 @@
 # frozen_string_literal: true
 
 class Inat
-  # Scheduled daily refresh of the read-only reflections due for sync
-  # (#4215): the same per-reflection resync as the "Sync now" button
-  # (Inat::ReflectionResync), driven over the whole reflection population
-  # instead of one occurrence, and with no Turbo broadcast -- nobody is
-  # watching a scheduled run. iNat ids are chunked to the fetcher's
-  # per-call maximum, so a run is a handful of API calls rather than one
-  # per reflection.
+  # Scheduled daily refresh of the read-only reflections (#4215): the
+  # same per-reflection resync as the "Sync now" button
+  # (Inat::ReflectionResync), driven over the whole reflection population.
   #
-  # "Due" is a reflection whose iNat link was last synced longer ago than
-  # RESYNC_INTERVAL (or never). The interval sits just under a day so a
-  # daily run always re-qualifies a reflection while skipping one a user
-  # just refreshed by hand. Oldest-synced first, so a run cut short still
-  # makes progress on the stalest.
+  # Incremental by iNaturalist's `updated_since`: each run fetches only the
+  # reflections whose source changed since the last clean run (the source
+  # watermark, external_sites.last_successful_sync_at), so the work scales
+  # with how much changed rather than the population size. The first run
+  # (no watermark) is a full reconciliation.
+  #
+  # Because an incremental fetch returns only changed ids, a missing id
+  # means "unchanged", not "deleted" -- so this job does not detect a
+  # source deleted on iNat. That stays the "Sync now" button's job (it
+  # does a full fetch), which is enough while a vanished source only logs
+  # the loss; a scheduled deletion sweep can be added when it needs to do
+  # more.
+  #
+  # iNat ids are chunked to the fetcher's per-call maximum and paced, so a
+  # run is a handful of API calls rather than one per reflection. No Turbo
+  # broadcast -- a scheduled run has no viewer.
   class ReflectionBatchResyncer
-    RESYNC_INTERVAL = 20.hours
     # iNat returns at most PAGE_SIZE results for one id-list query, so a
     # larger chunk would silently drop the overflow.
     CHUNK_SIZE = ObsFetcher::PAGE_SIZE
@@ -26,50 +32,63 @@ class Inat
     end
 
     # Runs the batch and returns a status => count Hash across every
-    # reflection processed (empty when iNaturalist isn't configured or
-    # nothing is due).
+    # reflection processed (empty when iNaturalist isn't configured).
     def resync_all
       site = ExternalSite.find_by(name: ExternalSite::INATURALIST_NAME)
       return {} unless site
 
-      counts = Hash.new(0)
-      due_reflections(site).each_slice(CHUNK_SIZE).with_index do |chunk, i|
-        # Pace chunks to iNat's ~1 req/sec guidance -- the fetcher paces
-        # only its own paginating callers, not one call per chunk here.
-        # No wait before the first chunk.
-        sleep(ObsFetcher::INTER_PAGE_SLEEP) if i.positive?
-        tally_chunk(chunk, counts)
-      end
-      # Only advance the source watermark on a clean run: a transient
-      # fetch failure leaves its reflections still due (their per-link
-      # last_synced_at is untouched), so the source isn't fully synced.
-      site.update!(last_successful_sync_at: Time.zone.now) unless
-        counts[:fetch_failed].positive?
+      since = site.last_successful_sync_at
+      # Stamp the watermark from BEFORE the fetch, so anything changed
+      # while this run was in flight is re-caught next time (re-applying
+      # unchanged data is a no-op).
+      started_at = Time.zone.now
+      counts = tally_all(reflections(site), since)
+      advance_watermark(site, started_at, counts)
       counts
     end
 
     private
 
-    def tally_chunk(chunk, counts)
+    def tally_all(reflections, since)
+      counts = Hash.new(0)
+      reflections.each_slice(CHUNK_SIZE).with_index do |chunk, i|
+        # Pace chunks to iNat's ~1 req/sec guidance -- the fetcher paces
+        # only its own paginating callers, not one call per chunk here.
+        # No wait before the first chunk.
+        sleep(ObsFetcher::INTER_PAGE_SLEEP) if i.positive?
+        tally_chunk(chunk, counts, since)
+      end
+      counts
+    end
+
+    def tally_chunk(chunk, counts, since)
       by_id, failed = @fetcher.fetch_batch(
-        chunk.map { |reflection| ReflectionResync.inat_id(reflection) }
+        chunk.map { |reflection| ReflectionResync.inat_id(reflection) },
+        updated_since: since
       )
       chunk.each do |reflection|
-        result = @applier.call(reflection, by_id, failed)
+        result = @applier.call(reflection, by_id, failed, absent: :unchanged)
         counts[result.status] += 1
       end
     end
 
-    # Read-only reflections whose iNat import link is due for a refresh.
+    # Advance the source watermark only on a clean run: a transient fetch
+    # failure leaves its window unsynced, so the next run must re-cover it.
+    def advance_watermark(site, started_at, counts)
+      return if counts[:fetch_failed].positive?
+
+      site.update!(last_successful_sync_at: started_at)
+    end
+
+    # Every read-only iNat reflection. `updated_since` narrows the fetch
+    # server-side, so there's no per-reflection due filter here.
     # external_links is preloaded so the per-reflection import_link /
     # external_site reads the applier makes don't each hit the database.
-    def due_reflections(site)
-      last_synced = ExternalLink[:last_synced_at]
+    def reflections(site)
       Observation.where.not(reflected_at: nil).
         joins(:external_links).merge(ExternalLink.import).
         where(external_links: { external_site_id: site.id }).
-        where(last_synced.eq(nil).or(last_synced.lt(RESYNC_INTERVAL.ago))).
-        order(last_synced.asc).
+        order(:id).
         preload(external_links: :external_site)
     end
   end

--- a/app/classes/inat/reflection_batch_resyncer.rb
+++ b/app/classes/inat/reflection_batch_resyncer.rb
@@ -74,10 +74,13 @@ class Inat
 
     # Advance the source watermark only on a clean run: a transient fetch
     # failure leaves its window unsynced, so the next run must re-cover it.
+    # update_column, not update!, so stamping this bookkeeping timestamp
+    # isn't blocked by validating unrelated (possibly pre-existing invalid)
+    # fields on the site, and doesn't bump its updated_at.
     def advance_watermark(site, started_at, counts)
       return if counts[:fetch_failed].positive?
 
-      site.update!(last_successful_sync_at: started_at)
+      site.update_column(:last_successful_sync_at, started_at)
     end
 
     # Every read-only iNat reflection. `updated_since` narrows the fetch

--- a/app/classes/inat/reflection_batch_resyncer.rb
+++ b/app/classes/inat/reflection_batch_resyncer.rb
@@ -51,11 +51,14 @@ class Inat
 
     def tally_all(reflections, since)
       counts = Hash.new(0)
-      reflections.each_slice(CHUNK_SIZE).with_index do |chunk, i|
+      # Stream in DB-sized batches rather than loading every reflection into
+      # memory at once -- the population can reach hundreds of thousands.
+      reflections.in_batches(of: CHUNK_SIZE).each_with_index do |batch, i|
         # Pace chunks to iNat's ~1 req/sec guidance -- the fetcher paces
         # only its own paginating callers, not one call per chunk here.
         # No wait before the first chunk.
         sleep(ObsFetcher::INTER_PAGE_SLEEP) if i.positive?
+        chunk = batch.preload(external_links: :external_site).to_a
         tally_chunk(chunk, counts, since)
       end
       counts
@@ -84,15 +87,14 @@ class Inat
     end
 
     # Every read-only iNat reflection. `updated_since` narrows the fetch
-    # server-side, so there's no per-reflection due filter here.
-    # external_links is preloaded so the per-reflection import_link /
-    # external_site reads the applier makes don't each hit the database.
+    # server-side, so there's no per-reflection due filter here. Ordering
+    # and external_links preloading happen per batch in tally_all
+    # (in_batches orders by primary key; preload can't survive its
+    # id-range re-query).
     def reflections(site)
       Observation.where.not(reflected_at: nil).
         joins(:external_links).merge(ExternalLink.import).
-        where(external_links: { external_site_id: site.id }).
-        order(:id).
-        preload(external_links: :external_site)
+        where(external_links: { external_site_id: site.id })
     end
   end
 end

--- a/app/classes/inat/reflection_batch_resyncer.rb
+++ b/app/classes/inat/reflection_batch_resyncer.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class Inat
+  # Scheduled daily refresh of the read-only reflections due for sync
+  # (#4215): the same per-reflection resync as the "Sync now" button
+  # (Inat::ReflectionResync), driven over the whole reflection population
+  # instead of one occurrence, and with no Turbo broadcast -- nobody is
+  # watching a scheduled run. iNat ids are chunked to the fetcher's
+  # per-call maximum, so a run is a handful of API calls rather than one
+  # per reflection.
+  #
+  # "Due" is a reflection whose iNat link was last synced longer ago than
+  # RESYNC_INTERVAL (or never). The interval sits just under a day so a
+  # daily run always re-qualifies a reflection while skipping one a user
+  # just refreshed by hand. Oldest-synced first, so a run cut short still
+  # makes progress on the stalest.
+  class ReflectionBatchResyncer
+    RESYNC_INTERVAL = 20.hours
+    # iNat returns at most PAGE_SIZE results for one id-list query, so a
+    # larger chunk would silently drop the overflow.
+    CHUNK_SIZE = ObsFetcher::PAGE_SIZE
+
+    def initialize(fetcher: ObsFetcher.new, applier: ReflectionResync.new)
+      @fetcher = fetcher
+      @applier = applier
+    end
+
+    # Runs the batch and returns a status => count Hash across every
+    # reflection processed (empty when iNaturalist isn't configured or
+    # nothing is due).
+    def resync_all
+      site = ExternalSite.find_by(name: ExternalSite::INATURALIST_NAME)
+      return {} unless site
+
+      counts = Hash.new(0)
+      due_reflections(site).each_slice(CHUNK_SIZE) do |chunk|
+        tally_chunk(chunk, counts)
+      end
+      # Only advance the source watermark on a clean run: a transient
+      # fetch failure leaves its reflections still due (their per-link
+      # last_synced_at is untouched), so the source isn't fully synced.
+      site.update!(last_successful_sync_at: Time.zone.now) unless
+        counts[:fetch_failed].positive?
+      counts
+    end
+
+    private
+
+    def tally_chunk(chunk, counts)
+      by_id, failed = @fetcher.fetch_batch(
+        chunk.map { |reflection| ReflectionResync.inat_id(reflection) }
+      )
+      chunk.each do |reflection|
+        result = @applier.call(reflection, by_id, failed)
+        counts[result.status] += 1
+      end
+    end
+
+    # Read-only reflections whose iNat import link is due for a refresh.
+    # external_links is preloaded so the per-reflection import_link /
+    # external_site reads the applier makes don't each hit the database.
+    def due_reflections(site)
+      last_synced = ExternalLink[:last_synced_at]
+      Observation.where.not(reflected_at: nil).
+        joins(:external_links).merge(ExternalLink.import).
+        where(external_links: { external_site_id: site.id }).
+        where(last_synced.eq(nil).or(last_synced.lt(RESYNC_INTERVAL.ago))).
+        order(last_synced.asc).
+        preload(external_links: :external_site)
+    end
+  end
+end

--- a/app/classes/inat/reflection_batch_resyncer.rb
+++ b/app/classes/inat/reflection_batch_resyncer.rb
@@ -33,7 +33,11 @@ class Inat
       return {} unless site
 
       counts = Hash.new(0)
-      due_reflections(site).each_slice(CHUNK_SIZE) do |chunk|
+      due_reflections(site).each_slice(CHUNK_SIZE).with_index do |chunk, i|
+        # Pace chunks to iNat's ~1 req/sec guidance -- the fetcher paces
+        # only its own paginating callers, not one call per chunk here.
+        # No wait before the first chunk.
+        sleep(ObsFetcher::INTER_PAGE_SLEEP) if i.positive?
         tally_chunk(chunk, counts)
       end
       # Only advance the source watermark on a clean run: a transient

--- a/app/classes/inat/reflection_resync.rb
+++ b/app/classes/inat/reflection_resync.rb
@@ -86,8 +86,11 @@ class Inat
       Result.new(status: :source_deleted, observation: obs)
     end
 
+    # update_column, not update!, so stamping the sync time isn't blocked
+    # by validating unrelated fields on the link (e.g. a pre-existing
+    # invalid URL) and doesn't bump its updated_at.
     def mark_synced(obs)
-      self.class.inat_link(obs).update!(last_synced_at: Time.zone.now)
+      self.class.inat_link(obs).update_column(:last_synced_at, Time.zone.now)
     end
 
     # Sync is owned by the admin account: anyone logged in may trigger

--- a/app/classes/inat/reflection_resync.rb
+++ b/app/classes/inat/reflection_resync.rb
@@ -36,21 +36,33 @@ class Inat
 
     # Turn one reflection plus the batch's (by_id, failed) into a Result.
     #   fetch failed (transient)  -> :fetch_failed, nothing touched;
-    #   id absent from results    -> :source_deleted, MO data kept, logged;
-    #   id present                -> :synced / :unchanged.
-    def call(reflection, by_id, failed)
+    #   id present                -> :synced / :unchanged;
+    #   id absent from results    -> depends on `absent:`.
+    #
+    # `absent:` is what a missing id means, which depends on how the
+    # batch was fetched. A full fetch (the "Sync now" button) queried
+    # every id, so a missing one is gone from iNat -> :deleted. An
+    # incremental fetch (updated_since) returns only changed ids, so a
+    # missing one merely didn't change -> :unchanged, untouched.
+    def call(reflection, by_id, failed, absent: :deleted)
       return failed_result(reflection) if failed
 
       raw = by_id[self.class.inat_id(reflection).to_s]
-      return deleted(reflection) unless raw
+      return apply(reflection, Inat::Obs.new(JSON.generate(raw))) if raw
 
-      apply(reflection, Inat::Obs.new(JSON.generate(raw)))
+      absent == :deleted ? deleted(reflection) : unchanged(reflection)
     end
 
     private
 
     def failed_result(reflection)
       Result.new(status: :fetch_failed, observation: reflection)
+    end
+
+    # Not in this incremental batch's results, so unchanged on iNat: leave
+    # the reflection alone, don't even stamp -- it wasn't fetched.
+    def unchanged(reflection)
+      Result.new(status: :unchanged, observation: reflection)
     end
 
     # Detect a change from what persists, not from the assigned values:

--- a/app/classes/inat/reflection_resync.rb
+++ b/app/classes/inat/reflection_resync.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "json"
+
+class Inat
+  # Applies one iNaturalist fetch result to one read-only reflection
+  # (#4215): refreshes the source-owned scalar core (date / location /
+  # GPS / notes), handles a source that was deleted on iNat, stamps
+  # `last_synced_at`, and logs the outcome as the admin actor. This is
+  # the per-reflection unit shared by both sync triggers -- the
+  # occurrence-wide "Sync now" button (Inat::ObservationResyncer) and the
+  # scheduled daily batch (Inat::ReflectionBatchResyncer) -- so the
+  # fields touched and the logging stay identical no matter what started
+  # the sync.
+  #
+  # Runs BELOW the read-only edit guard: that guard blocks the web/API
+  # edit actions, while this writes the records directly, so it can
+  # refresh reflections nobody is allowed to hand-edit.
+  class ReflectionResync
+    # Per-reflection outcome; status is one of :synced, :unchanged,
+    # :source_deleted, :fetch_failed.
+    Result = Data.define(:status, :observation)
+
+    # The reflection's iNaturalist import link, or nil when it has none.
+    def self.inat_link(reflection)
+      link = reflection.import_link
+      return nil unless link&.external_site&.name ==
+                        ExternalSite::INATURALIST_NAME
+
+      link
+    end
+
+    def self.inat_id(reflection)
+      inat_link(reflection)&.external_id
+    end
+
+    # Turn one reflection plus the batch's (by_id, failed) into a Result.
+    #   fetch failed (transient)  -> :fetch_failed, nothing touched;
+    #   id absent from results    -> :source_deleted, MO data kept, logged;
+    #   id present                -> :synced / :unchanged.
+    def call(reflection, by_id, failed)
+      return failed_result(reflection) if failed
+
+      raw = by_id[self.class.inat_id(reflection).to_s]
+      return deleted(reflection) unless raw
+
+      apply(reflection, Inat::Obs.new(JSON.generate(raw)))
+    end
+
+    private
+
+    def failed_result(reflection)
+      Result.new(status: :fetch_failed, observation: reflection)
+    end
+
+    # Detect a change from what persists, not from the assigned values:
+    # setting `location` triggers a callback that rewrites `where`, so an
+    # in-memory `changed?` never converges. `saved_changes` (sans the
+    # timestamp) reflects what actually moved.
+    def apply(obs, inat_obs)
+      obs.assign_attributes(scalar_attributes(inat_obs))
+      obs.save! if obs.changed?
+      changed = obs.saved_changes.except("updated_at").present?
+      mark_synced(obs)
+      log_resync(obs) if changed
+      Result.new(status: changed ? :synced : :unchanged, observation: obs)
+    end
+
+    # The iNat obs is gone: keep every MO record intact, record the loss
+    # on the activity log, and still stamp last_synced_at so the check ran.
+    def deleted(obs)
+      mark_synced(obs)
+      obs.log(:log_observation_source_deleted, user: User.admin)
+      Result.new(status: :source_deleted, observation: obs)
+    end
+
+    def mark_synced(obs)
+      self.class.inat_link(obs).update!(last_synced_at: Time.zone.now)
+    end
+
+    # Sync is owned by the admin account: anyone logged in may trigger
+    # the button, and the scheduled batch has no triggering user at all,
+    # so every resync is attributed to the system actor.
+    def log_resync(obs)
+      obs.log(:log_observation_resynced, user: User.admin)
+    end
+
+    # The source-owned scalar fields, straight off the fresh iNat data.
+    # `where` is only set when no Location resolves: a present Location
+    # drives `where` from its own name via a callback, so assigning
+    # `where` too would flip it back and forth and never converge.
+    def scalar_attributes(inat_obs)
+      location = inat_obs.location
+      attrs = { when: inat_obs.when, location: location, lat: inat_obs.lat,
+                lng: inat_obs.lng, gps_hidden: inat_obs.gps_hidden,
+                specimen: inat_obs.specimen?, notes: inat_obs.notes }
+      attrs[:where] = inat_obs.where if location.nil?
+      attrs
+    end
+  end
+end

--- a/app/classes/inat/taxon.rb
+++ b/app/classes/inat/taxon.rb
@@ -33,15 +33,19 @@ class Inat
   class Taxon
     include Inat::Constants
 
-    # Allow hash key access to the iNat observation data
-    delegate :[], to: :@taxon
-
     def initialize(taxon)
       @taxon = taxon
     end
 
+    # Hash-key access to the iNat taxon data -- nil when the observation
+    # has no taxon (an iNat "Unknown", e.g. an ID withdrawn after import,
+    # which a resync can turn an existing reflection into).
+    def [](key) = @taxon&.[](key)
+
     # Returns the matching MO Name, or nil if none found.
     def name
+      return nil if @taxon.nil?
+
       names =
         # iNat "Complex" definition
         # https://www.inaturalist.org/pages/curator+guide#complexes
@@ -57,6 +61,7 @@ class Inat
     # Handles special cases: infrageneric names (which need the genus prepended)
     # and infraspecific names (which need the rank inserted).
     def full_name_string
+      return nil if @taxon.nil?
       return monomial_complex_name_string if monomial_complex?
 
       # iNat infrageneric Observation ID's need special handling because
@@ -71,6 +76,8 @@ class Inat
     end
 
     def importable?
+      return false if @taxon.nil?
+
       ancestor_ids = @taxon[:ancestor_ids]
       return false if ancestor_ids.blank?
 

--- a/app/jobs/inat_reflection_batch_resync_job.rb
+++ b/app/jobs/inat_reflection_batch_resync_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Daily scheduled refresh of every read-only reflection due for sync from
+# its iNaturalist source (#4215). Runs on the :maintenance queue like the
+# other daily housekeeping jobs; the work is a handful of rate-limited
+# iNat API calls, so it belongs in the background, not a request. Sync is
+# owned by the admin account -- see Inat::ReflectionResync -- so no
+# triggering user is carried. See config/recurring.yml for the schedule.
+class InatReflectionBatchResyncJob < ApplicationJob
+  queue_as :maintenance
+
+  def perform
+    counts = Inat::ReflectionBatchResyncer.new.resync_all
+    Rails.logger.info("InatReflectionBatchResyncJob: #{counts.inspect}")
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -35,10 +35,11 @@ production:
     class: DiscardStaleJobsJob
     schedule: every day at 12:32am
   # Daily refresh of read-only iNat reflections from their source (#4215):
-  # re-fetches each due reflection's scalar core in a few rate-limited
-  # batched API calls. Off the midnight cluster above (and off any :00/:03
-  # mark shared with recover_stuck_inat_imports) so it doesn't queue
-  # behind them on the 2-thread :maintenance pool.
+  # fetches only the reflections changed on iNat since the last run
+  # (updated_since) in a few rate-limited batched API calls. Off the
+  # midnight cluster above (and off any :00/:03 mark shared with
+  # recover_stuck_inat_imports) so it doesn't queue behind them on the
+  # 2-thread :maintenance pool.
   resync_inat_reflections:
     class: InatReflectionBatchResyncJob
     schedule: every day at 1:17am

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -34,6 +34,14 @@ production:
   discard_stale_jobs:
     class: DiscardStaleJobsJob
     schedule: every day at 12:32am
+  # Daily refresh of read-only iNat reflections from their source (#4215):
+  # re-fetches each due reflection's scalar core in a few rate-limited
+  # batched API calls. Off the midnight cluster above (and off any :00/:03
+  # mark shared with recover_stuck_inat_imports) so it doesn't queue
+  # behind them on the 2-thread :maintenance pool.
+  resync_inat_reflections:
+    class: InatReflectionBatchResyncJob
+    schedule: every day at 1:17am
   # Transfer itself is event-driven now (TransferImagesJob, started when
   # processing/an iNat batch finishes -- see #4791's target design) --
   # nothing here polls for untransferred images anymore. This is the

--- a/test/classes/inat/obs_fetcher_test.rb
+++ b/test/classes/inat/obs_fetcher_test.rb
@@ -27,6 +27,14 @@ class Inat::ObsFetcherTest < UnitTestCase
     assert_equal(%w[1], by_id.keys)
   end
 
+  def test_fetch_batch_with_no_ids_makes_no_request
+    # No WebMock stub -- if a request went out, WebMock would raise.
+    by_id, failed = Inat::ObsFetcher.new.fetch_batch([nil])
+
+    assert_not(failed)
+    assert_empty(by_id)
+  end
+
   def test_fetch_batch_reports_failure_after_exhausting_retries
     stub_obs_status("1", 429) # TooManyRequests is retryable
     fetcher = Inat::ObsFetcher.new

--- a/test/classes/inat/obs_fetcher_test.rb
+++ b/test/classes/inat/obs_fetcher_test.rb
@@ -15,6 +15,18 @@ class Inat::ObsFetcherTest < UnitTestCase
     assert_equal(1, by_id["1"][:id])
   end
 
+  def test_fetch_batch_narrows_by_updated_since_when_given
+    since = Time.utc(2026, 8, 1, 12, 0, 0)
+    stub_request(:get, obs_url_since("1", since)).
+      to_return(status: 200, body: { results: [{ id: 1 }] }.to_json)
+
+    by_id, failed = Inat::ObsFetcher.new.fetch_batch(%w[1],
+                                                     updated_since: since)
+
+    assert_not(failed)
+    assert_equal(%w[1], by_id.keys)
+  end
+
   def test_fetch_batch_reports_failure_after_exhausting_retries
     stub_obs_status("1", 429) # TooManyRequests is retryable
     fetcher = Inat::ObsFetcher.new
@@ -32,6 +44,12 @@ class Inat::ObsFetcherTest < UnitTestCase
   def obs_url(ids)
     query = { id: ids, per_page: 200,
               order_by: "id", order: "asc" }.to_query
+    "#{API_BASE}/observations?#{query}"
+  end
+
+  def obs_url_since(ids, since)
+    query = { id: ids, per_page: 200, order_by: "id", order: "asc",
+              updated_since: since.utc.iso8601 }.to_query
     "#{API_BASE}/observations?#{query}"
   end
 

--- a/test/classes/inat/reflection_batch_resyncer_test.rb
+++ b/test/classes/inat/reflection_batch_resyncer_test.rb
@@ -5,15 +5,17 @@ require("json")
 
 # Unit tests for Inat::ReflectionBatchResyncer, the scheduled daily sync.
 # The iNat fetch is injected as a fake, so the tests exercise the
-# due-selection, batching, watermark and per-status tallying without
-# hitting the API. The per-reflection apply logic itself is covered by
-# Inat::ReflectionResync / Inat::ObservationResyncer tests.
+# incremental (updated_since) selection, batching, watermark and
+# per-status tallying without hitting the API. The per-reflection apply
+# logic itself is covered by the Inat::ReflectionResync /
+# Inat::ObservationResyncer tests.
 class Inat::ReflectionBatchResyncerTest < UnitTestCase
-  # Stands in for Inat::ObsFetcher — returns a canned [by_id, failed?]
-  # and records the ids it was asked for.
-  FakeFetcher = Struct.new(:batch, :seen_ids) do
-    def fetch_batch(ids)
+  # Stands in for Inat::ObsFetcher -- returns a canned [by_id, failed?]
+  # and records the ids and updated_since it was asked for.
+  FakeFetcher = Struct.new(:batch, :seen_ids, :seen_since) do
+    def fetch_batch(ids, updated_since: nil)
       self.seen_ids = ids
+      self.seen_since = updated_since
       batch
     end
   end
@@ -27,38 +29,58 @@ class Inat::ReflectionBatchResyncerTest < UnitTestCase
     @site = external_sites(:inaturalist)
   end
 
-  def test_syncs_a_due_reflection_and_advances_both_watermarks
-    @link.update_column(:last_synced_at, nil)
+  def test_syncs_a_changed_reflection_and_advances_the_watermark
+    @site.update_column(:last_successful_sync_at, 3.days.ago)
 
     counts = run_batch(found: { @id => @raw })
 
     assert_equal(1, counts[:synced])
     assert_not_nil(@link.reload.last_synced_at, "stamps the per-link time")
-    assert_not_nil(@site.reload.last_successful_sync_at,
-                   "advances the source watermark on a clean run")
+    assert_operator(@site.reload.last_successful_sync_at, :>, 3.days.ago,
+                    "advances the source watermark on a clean run")
   end
 
-  def test_a_reflection_synced_within_the_interval_is_not_due
-    @link.update_column(:last_synced_at, 1.hour.ago)
-
+  def test_passes_the_source_watermark_as_updated_since
+    since = 2.days.ago
+    @site.update_column(:last_successful_sync_at, since)
     fetcher = FakeFetcher.new([{ @id => @raw }, false])
-    counts = Inat::ReflectionBatchResyncer.new(fetcher: fetcher).resync_all
 
-    assert_equal(0, counts[:synced], "a just-synced reflection isn't due")
-    assert_nil(fetcher.seen_ids, "nothing due -> no fetch")
+    Inat::ReflectionBatchResyncer.new(fetcher: fetcher).resync_all
+
+    assert_not_nil(fetcher.seen_since)
+    assert_in_delta(since.to_i, fetcher.seen_since.to_i, 1,
+                    "the fetch is narrowed by the last successful run")
   end
 
-  def test_a_reflection_past_the_interval_is_due
-    @link.update_column(:last_synced_at, 21.hours.ago)
+  def test_first_run_with_no_watermark_fetches_everything
+    @site.update_column(:last_successful_sync_at, nil)
+    fetcher = FakeFetcher.new([{ @id => @raw }, false])
 
-    counts = run_batch(found: { @id => @raw })
+    Inat::ReflectionBatchResyncer.new(fetcher: fetcher).resync_all
 
-    assert_equal(1, counts[:synced])
+    assert_nil(fetcher.seen_since,
+               "no watermark -> full fetch, not an incremental one")
+  end
+
+  # An incremental fetch returns only changed ids, so a reflection absent
+  # from the results is unchanged -- NOT deleted. Deletion detection is
+  # the full-fetch "Sync now" button's job.
+  def test_a_reflection_absent_from_the_results_is_unchanged_not_deleted
+    @obs.rss_log&.update_columns(notes: "20250101000000\n")
+    before = @obs.where
+
+    counts = run_batch(found: {}) # nothing changed since the watermark
+
+    assert_equal(1, counts[:unchanged])
+    assert_equal(0, counts[:source_deleted])
+    assert_equal(before, @obs.reload.where, "unchanged data is left alone")
+    assert_no_match(/log_observation_source_deleted/,
+                    @obs.rss_log.reload.notes.to_s,
+                    "an absent id must not be logged as a deletion")
   end
 
   def test_an_editable_import_is_not_a_reflection_and_is_skipped
     @obs.update_column(:reflected_at, nil)
-    @link.update_column(:last_synced_at, nil)
 
     counts = run_batch(found: { @id => @raw })
 
@@ -66,19 +88,7 @@ class Inat::ReflectionBatchResyncerTest < UnitTestCase
     assert_nil(@link.reload.last_synced_at)
   end
 
-  def test_source_deleted_is_counted_and_mo_data_kept
-    @obs.rss_log&.update_columns(notes: "20250101000000\n")
-    @link.update_column(:last_synced_at, nil)
-    before = @obs.where
-
-    counts = run_batch(found: {}) # id present in neither -> deleted on iNat
-
-    assert_equal(1, counts[:source_deleted])
-    assert_equal(before, @obs.reload.where, "MO data must be kept")
-    assert_not_nil(@link.reload.last_synced_at, "the check still stamps")
-  end
-
-  def test_a_fetch_failure_stamps_nothing_and_holds_the_watermark
+  def test_a_fetch_failure_holds_the_watermark_and_stamps_nothing
     @link.update_column(:last_synced_at, nil)
     @site.update_column(:last_successful_sync_at, nil)
 

--- a/test/classes/inat/reflection_batch_resyncer_test.rb
+++ b/test/classes/inat/reflection_batch_resyncer_test.rb
@@ -101,6 +101,20 @@ class Inat::ReflectionBatchResyncerTest < UnitTestCase
                "a failed run must not advance the source watermark")
   end
 
+  # Stamping the bookkeeping watermark must not run full-record
+  # validation: a production snapshot's iNaturalist site had an invalid
+  # base_url, which blocked an update! but must not block the sync.
+  def test_advances_the_watermark_even_when_the_site_row_is_invalid
+    @site.update_column(:base_url, "not a url")
+    @site.update_column(:last_successful_sync_at, 3.days.ago)
+    assert(@site.invalid?, "the site row must be invalid for this test")
+
+    run_batch(found: { @id => @raw })
+
+    assert_operator(@site.reload.last_successful_sync_at, :>, 3.days.ago,
+                    "the watermark advances despite the invalid site row")
+  end
+
   def test_no_inaturalist_site_is_a_no_op
     @site.destroy!
 

--- a/test/classes/inat/reflection_batch_resyncer_test.rb
+++ b/test/classes/inat/reflection_batch_resyncer_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require("test_helper")
+require("json")
+
+# Unit tests for Inat::ReflectionBatchResyncer, the scheduled daily sync.
+# The iNat fetch is injected as a fake, so the tests exercise the
+# due-selection, batching, watermark and per-status tallying without
+# hitting the API. The per-reflection apply logic itself is covered by
+# Inat::ReflectionResync / Inat::ObservationResyncer tests.
+class Inat::ReflectionBatchResyncerTest < UnitTestCase
+  # Stands in for Inat::ObsFetcher — returns a canned [by_id, failed?]
+  # and records the ids it was asked for.
+  FakeFetcher = Struct.new(:batch, :seen_ids) do
+    def fetch_batch(ids)
+      self.seen_ids = ids
+      batch
+    end
+  end
+
+  def setup
+    @obs = observations(:imported_inat_obs)
+    @obs.update_column(:reflected_at, Time.zone.now)
+    @link = @obs.import_link
+    @id = @link.external_id.to_s
+    @raw = mock_raw("calostoma_lutescens")
+    @site = external_sites(:inaturalist)
+  end
+
+  def test_syncs_a_due_reflection_and_advances_both_watermarks
+    @link.update_column(:last_synced_at, nil)
+
+    counts = run_batch(found: { @id => @raw })
+
+    assert_equal(1, counts[:synced])
+    assert_not_nil(@link.reload.last_synced_at, "stamps the per-link time")
+    assert_not_nil(@site.reload.last_successful_sync_at,
+                   "advances the source watermark on a clean run")
+  end
+
+  def test_a_reflection_synced_within_the_interval_is_not_due
+    @link.update_column(:last_synced_at, 1.hour.ago)
+
+    fetcher = FakeFetcher.new([{ @id => @raw }, false])
+    counts = Inat::ReflectionBatchResyncer.new(fetcher: fetcher).resync_all
+
+    assert_equal(0, counts[:synced], "a just-synced reflection isn't due")
+    assert_nil(fetcher.seen_ids, "nothing due -> no fetch")
+  end
+
+  def test_a_reflection_past_the_interval_is_due
+    @link.update_column(:last_synced_at, 21.hours.ago)
+
+    counts = run_batch(found: { @id => @raw })
+
+    assert_equal(1, counts[:synced])
+  end
+
+  def test_an_editable_import_is_not_a_reflection_and_is_skipped
+    @obs.update_column(:reflected_at, nil)
+    @link.update_column(:last_synced_at, nil)
+
+    counts = run_batch(found: { @id => @raw })
+
+    assert_equal(0, counts.values.sum, "an editable import has nothing to do")
+    assert_nil(@link.reload.last_synced_at)
+  end
+
+  def test_source_deleted_is_counted_and_mo_data_kept
+    @obs.rss_log&.update_columns(notes: "20250101000000\n")
+    @link.update_column(:last_synced_at, nil)
+    before = @obs.where
+
+    counts = run_batch(found: {}) # id present in neither -> deleted on iNat
+
+    assert_equal(1, counts[:source_deleted])
+    assert_equal(before, @obs.reload.where, "MO data must be kept")
+    assert_not_nil(@link.reload.last_synced_at, "the check still stamps")
+  end
+
+  def test_a_fetch_failure_stamps_nothing_and_holds_the_watermark
+    @link.update_column(:last_synced_at, nil)
+    @site.update_column(:last_successful_sync_at, nil)
+
+    counts = run_batch(found: {}, failed: true)
+
+    assert_equal(1, counts[:fetch_failed])
+    assert_nil(@link.reload.last_synced_at,
+               "a transient failure stamps nothing")
+    assert_nil(@site.reload.last_successful_sync_at,
+               "a failed run must not advance the source watermark")
+  end
+
+  def test_no_inaturalist_site_is_a_no_op
+    @site.destroy!
+
+    assert_equal({}, Inat::ReflectionBatchResyncer.new.resync_all)
+  end
+
+  private
+
+  def run_batch(found:, failed: false)
+    fetcher = FakeFetcher.new([found, failed])
+    Inat::ReflectionBatchResyncer.new(fetcher: fetcher).resync_all
+  end
+
+  def mock_raw(filename)
+    JSON.parse(File.read("test/inat/#{filename}.txt"),
+               symbolize_names: true)[:results].first
+  end
+end

--- a/test/classes/inat/taxon_test.rb
+++ b/test/classes/inat/taxon_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# Inat::Taxon must tolerate an observation with no taxon -- an iNat
+# "Unknown", e.g. an identification withdrawn after import, which a
+# resync can turn an existing reflection into. A batch resync over real
+# data crashed here before the guards were added.
+class Inat::TaxonTest < UnitTestCase
+  def test_a_nil_taxon_is_handled_without_raising
+    taxon = Inat::Taxon.new(nil)
+
+    assert_nil(taxon[:name], "hash access on a nil taxon returns nil")
+    assert_nil(taxon.name, "no MO Name matches a nil taxon")
+    assert_nil(taxon.full_name_string)
+    assert_not(taxon.importable?, "a nil taxon is not importable")
+  end
+end

--- a/test/jobs/inat_reflection_batch_resync_job_test.rb
+++ b/test/jobs/inat_reflection_batch_resync_job_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class InatReflectionBatchResyncJobTest < ActiveJob::TestCase
+  # The scheduled batch runs off the :maintenance pool, like the other
+  # daily housekeeping jobs (config/recurring.yml).
+  def test_enqueues_on_the_maintenance_queue
+    assert_enqueued_with(job: InatReflectionBatchResyncJob,
+                         queue: "maintenance") do
+      InatReflectionBatchResyncJob.perform_later
+    end
+  end
+
+  # The job is a thin wrapper: it drives Inat::ReflectionBatchResyncer and
+  # carries no triggering user (sync is admin-owned, #4215).
+  def test_perform_delegates_to_the_batch_resyncer
+    called = false
+    fake = Object.new
+    fake.define_singleton_method(:resync_all) do
+      called = true
+      { synced: 0 }
+    end
+
+    Inat::ReflectionBatchResyncer.stub(:new, ->(**) { fake }) do
+      InatReflectionBatchResyncJob.perform_now
+    end
+
+    assert(called, "the job should run the batch resyncer")
+  end
+end


### PR DESCRIPTION
## Summary

PR 3 of the #4215 sync work (#4208 umbrella): the **daily scheduled job** from #4215's first acceptance criterion — "Batches external IDs in chunks and queries the source API by ID list, filtered by `updated_since`" — so imported Observations stay current without anyone pressing the "Sync now" button that shipped in #4853.

**Incremental by `updated_since` (the criterion).** Each run reads the source watermark (`external_sites.last_successful_sync_at`), passes it as `updated_since` on every id-chunk fetch, and so pulls back only the reflections whose iNaturalist source changed since the last clean run. Work scales with how much changed, not with the population size. The first run (no watermark) is a full reconciliation; the watermark is stamped from the run's start, so a change made mid-run is re-caught next time (re-applying unchanged data is a no-op). A run with any fetch failure does not advance the watermark, so its window is re-covered next time.

**One per-reflection path, two triggers.** The per-reflection refresh (scalar core, `last_synced_at` stamping, admin-attributed logging) moves out of `Inat::ObservationResyncer` into `Inat::ReflectionResync`, shared by the occurrence-wide "Sync now" button and the new batch. `ObservationResyncer` keeps its occurrence framing and Turbo broadcast and delegates the per-reflection work; its behavior is unchanged (its full test suite stays green).

**Deletion detection is deliberately the button's job, not the batch's.** Because an incremental fetch returns only changed ids, an id missing from the results means *unchanged*, not *deleted* — so `ReflectionResync#call` gains an `absent:` mode: the batch treats a missing id as unchanged, while the full-fetch "Sync now" button keeps `absent = deleted`. The scheduled job therefore does not proactively detect an iNaturalist source deletion. That's an accepted tradeoff (discussed with @mo-nathan): a vanished source only appends a log line, deletions are rare, and the button still catches them on-demand via its full fetch. **No separate deletion sweep** — one can be added when "mark orphaned + keep" needs to do more than log.

**Mechanics.** iNaturalist ids are chunked to the fetcher's per-call maximum (`ObsFetcher::PAGE_SIZE`, 200) and paced ~1s apart (`ObsFetcher::INTER_PAGE_SLEEP`, skipping the first) so a large run stays within iNaturalist's ~60/min guidance. `InatReflectionBatchResyncJob` runs it daily at 1:17am on the `:maintenance` queue, off the midnight housekeeping cluster, carrying no user. No Turbo broadcast — a scheduled run has no viewer.

**Scope.** Scalar core only (date / location / GPS / notes), matching the "Sync now" path. Image / sequence / naming-taxon diffs are later slices (the naming one gated on the votes/namings provenance marker).

## Robustness (from a full-reconciliation run against a production snapshot)

A first-run resync over 5,746 reflections (4.7 min, ~9.7s per 200-id fetch; 0 scalar-core changes — scalar drift is low, the taxon/naming drift a later slice handles) surfaced two pre-existing crashes now fixed here:

- `Inat::Taxon` assumed a non-nil taxon hash, so a fetched iNaturalist "Unknown" observation (identification withdrawn after import) crashed `snapshot` → `inat_taxon_name`. Guarded its public entry points. This path is shared with import and the "Sync now" button.
- Stamping the source watermark with `update!` ran full-record validation and was rejected because the snapshot's iNaturalist `ExternalSite` has an invalid `base_url`. Both the per-link and source sync timestamps now use `update_column` — a bookkeeping write should not validate unrelated fields or bump `updated_at`.

## Test plan

- `bin/rails test test/classes/inat/reflection_batch_resyncer_test.rb test/classes/inat/observation_resyncer_test.rb test/classes/inat/obs_fetcher_test.rb test/jobs/inat_reflection_batch_resync_job_test.rb test/jobs/inat_observation_resync_job_test.rb test/controllers/observations/inat_resyncs_controller_test.rb` — 34 tests green. New coverage: the watermark is passed as `updated_since`; a first run with no watermark does a full fetch; an id absent from an incremental result is `unchanged` (not `source_deleted`, no deletion log); a fetch failure holds the watermark; the watermark advances on a clean run; `ObsFetcher` adds `updated_since` to the query when given. The refactor leaves the existing occurrence-path/button and deleted-source tests unchanged.
- The scheduled job is verifiable by reading `config/recurring.yml`; no manual step.

<!-- changelog -->
article: yes
Sync imported Observations from iNaturalist automatically
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
