### PR TITLE
Drop the live network check from URL validation (`FormatURL`)

### DIFF
--- a/app/classes/format_url.rb
+++ b/app/classes/format_url.rb
@@ -5,7 +5,10 @@
 #
 # Main accessors
 #
-# valid?::        True if it works, and if it matches any provided base_url
+# valid?::        True if the URL is well-formed (http/https, with a host),
+#                 and if it matches any provided base_url. Does NOT check
+#                 that the URL is reachable -- a persisted-record validation
+#                 must not make a live network request on every save.
 #
 # formatted::     Returns formatted URL:
 #                 - will automatically prepend scheme "https://"
@@ -17,8 +20,6 @@
 #
 # Without base_url:
 #   fred = FormatURL.new("en.m.wikipedia.org/wiki/Citrus_indica")
-#   fred.url_exists?
-#     true
 #   fred.valid?
 #     true
 #   fred.formatted
@@ -29,8 +30,6 @@
 #     "http://mycoportal.org/portal/collections/list.php?catnum=AN%200432",
 #     "https://www.mycoportal.org/portal/collections/"
 #   )
-#   fred.url_exists?
-#     true
 #   fred.formatted
 #     "https://www.mycoportal.org/portal/collections/list.php?catnum=AN%200432"
 #
@@ -44,7 +43,7 @@
 # uri.to_s      #=> "http://foo.com/posts?id=30&limit=5#time=1305298413"
 #
 class FormatURL
-  attr_reader :url, :base_url, :url_only, :url_exists, :errors
+  attr_reader :url, :base_url, :url_only, :errors
 
   def initialize(url = "", base_url = "", scheme: "https")
     @original_url = url
@@ -53,15 +52,12 @@ class FormatURL
     @base_url = URI.parse(space_check(base_url))
     @scheme = scheme
     @url_only = @base_url.host.blank?
-    @url_exists = url_exists?(@url.to_s)
   end
 
   def valid?
-    unless nothing_funny?(@original_url) &&
-           (@url.is_a?(URI::HTTPS) || @url.is_a?(URI::HTTP)) &&
-           @url.host && @url_exists
-      return false
-    end
+    return false unless nothing_funny?(@original_url) &&
+                        (@url.is_a?(URI::HTTPS) || @url.is_a?(URI::HTTP)) &&
+                        @url.host.present?
     return true if @url_only
 
     # Check the URL pattern against the base_url provided.
@@ -88,8 +84,8 @@ class FormatURL
     ""
   end
 
-  # Enforce scheme for incoming urls. Guards against scheme missing, which
-  # causes `url_exists?` to return false
+  # Enforce scheme for incoming urls. Without a scheme, URI.parse yields a
+  # URI::Generic (not HTTP/HTTPS), so valid? would reject it.
   def add_enforced_scheme_if_missing(scheme)
     return "" unless nothing_funny?(@original_url)
 
@@ -106,41 +102,6 @@ class FormatURL
   def host_and_path_match?
     @url.host.delete_prefix("www.") == @base_url.host.delete_prefix("www.") &&
       @url.path.match?(@base_url.path)
-  end
-
-  # Goes after any redirect and makes sure we can access the redirected URL
-  # Returns false if http code starts with 4 - error on our side.
-  # Calls URI.parse(url) again here because we may need to reparse a redirect
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
-  def url_exists?(url)
-    return false if url.to_s == ""
-
-    url = URI.parse(url)
-    return false if url.host.blank?
-    return true if ENV["RAILS_ENV"] == "test"
-
-    request = format_request(url)
-    path = url.path if url.path.present?
-    response = request.request_head(path || "/")
-
-    if response.is_a?(Net::HTTPRedirection)
-      url_exists?(response["location"])
-    else
-      response.code[0] != "4"
-    end
-  # false if can't find the server
-  rescue Errno::ECONNREFUSED, Errno::ENOENT, Socket::ResolutionError
-    false
-  end
-  # https://stackoverflow.com/a/18582395/3357635'
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
-
-  def format_request(url)
-    request = Net::HTTP.new(url.host, url.port)
-    request.use_ssl = (url.scheme == "https")
-    request
   end
 
   def use_www_if_base_does

--- a/app/classes/format_url.rb
+++ b/app/classes/format_url.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-# Can simply validate one url as a working url,
-# or check it conforms to a the format of a provided base_url.
+# Validates a url's format -- an http/https scheme with a host -- and
+# optionally that it matches the format of a provided base_url. Does not
+# check that the url is reachable.
 #
 # Main accessors
 #

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -138,9 +138,10 @@ class ExternalLink < AbstractModel
     url
   end
 
-  # iNaturalist's Cloudflare CDN blocks automated HEAD requests with 403,
-  # causing FormatURL#url_exists? to fail. Skip the reachability check,
-  # validating the URL format against a regexp instead.
+  # An iNat observation link is its base_url followed by a numeric id and
+  # nothing more, so validate that shape directly rather than through
+  # FormatURL's looser host/path match (which would also accept trailing
+  # path segments).
   def inat_url?(base_url)
     url.to_s.match?(/\A#{Regexp.escape(base_url)}\d+\z/) && url
   end

--- a/test/classes/format_url_test.rb
+++ b/test/classes/format_url_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+# FormatURL validates URL *format* only. It runs inside ExternalSite and
+# ExternalLink validation on every save, so it must not make a live
+# network request -- a reachability check here previously fired a HEAD
+# per save and 403'd on iNaturalist, making the iNaturalist site row
+# unsaveable.
+class FormatURLTest < UnitTestCase
+  def test_well_formed_urls_are_valid
+    assert(FormatURL.new("https://example.org/x").valid?)
+    assert(FormatURL.new("http://example.org").valid?)
+    # a bare host gets the https scheme prepended, then validates
+    assert(FormatURL.new("example.org/x").valid?)
+  end
+
+  def test_malformed_urls_are_invalid
+    assert_not(FormatURL.new("not a url").valid?, "whitespace is rejected")
+    assert_not(FormatURL.new("").valid?, "empty yields no host")
+  end
+
+  def test_matches_the_shape_of_a_provided_base_url
+    base = "https://www.mycoportal.org/portal/collections/"
+    assert(FormatURL.new("#{base}list.php?catnum=1", base).valid?)
+    assert_not(FormatURL.new("https://elsewhere.org/x", base).valid?,
+               "a different host does not match the base_url")
+  end
+
+  # iNaturalist's CDN 403s an automated HEAD; validity must not depend on
+  # reachability, and the network method must be gone entirely.
+  def test_reachability_is_not_checked
+    assert(FormatURL.new("https://www.inaturalist.org/observations/").valid?,
+           "a well-formed URL is valid even where a HEAD would 403")
+    assert_not(FormatURL.private_method_defined?(:url_exists?),
+               "the live reachability check must be gone")
+  end
+end

--- a/test/models/external_link_test.rb
+++ b/test/models/external_link_test.rb
@@ -130,9 +130,9 @@ class ExternalLinkTest < UnitTestCase
     assert_empty(link.errors[:url], "Valid URL should have no url errors")
   end
 
-  # iNaturalist's Cloudflare CDN blocks automated HEAD requests with 403,
-  # causing FormatURL#url_exists? to return false and silently drop the link.
-  # For iNat URLs constructed from base_url, skip FormatURL entirely.
+  # An iNat observation link is validated by its strict base_url + numeric
+  # id shape (inat_url?), not FormatURL's looser host/path match, so
+  # FormatURL is not called for it.
   def test_inaturalist_link_skips_format_url
     site = external_sites(:inaturalist)
     obs = observations(:minimal_unknown_obs)


### PR DESCRIPTION
## Summary

`FormatURL#valid?` made a live HTTP `HEAD` request (`FormatURL#url_exists?`) to check that a URL was reachable. Its only two callers are `ExternalSite#check_url_syntax` and `ExternalLink` validation, so **every save of either record fired a network request** — slow, impolite to the remote host, and dependent on that host being up and answering `HEAD`s. A single job that touches many links or sites would repeat the same `HEAD` over and over.

It also **rejected well-formed URLs**: iNaturalist's CDN answers an automated `HEAD` with `403`, and `url_exists?` treated any `4xx` as "does not exist" — so the iNaturalist `ExternalSite` row could not pass validation. Only a `RAILS_ENV=test` short-circuit inside `url_exists?` kept the test suite from hitting this, which is why it went unnoticed. (Surfaced while running the iNat reflection resync, #4215, against a production snapshot.)

**The fix:** validate URL *format* only — scheme is `http`/`https`, a host is present, and the URL matches any provided `base_url`. `url_exists?` and its `Net::HTTP` machinery are removed entirely (nothing else used them). `host.present?` preserves the hostless-URL rejection that `url_exists?`'s `host.blank?` check used to provide.

`ExternalLink`'s iNaturalist special-case (`inat_url?`) stays — with its now-obsolete comment corrected. It was added to dodge the `403`; it now simply serves as a stricter `base_url` + numeric-id shape check (tighter than `FormatURL`'s host/path match), so it is kept rather than folded into the general path, to avoid loosening iNat link validation.

Adds the `FormatURL` tests the class lacked (format validity, `base_url` shape matching, and that reachability is not checked / the network method is gone).

## Test plan

- `bin/rails test test/classes/format_url_test.rb test/models/external_site_test.rb test/models/external_link_test.rb` — 34 green.
- Manual: in the console, `FormatURL.new("https://www.inaturalist.org/observations/").valid?` is now `true` (was `false`), and the iNaturalist `ExternalSite` row validates. Validation makes no network request.

<!-- changelog -->
article: yes
Fix false Invalid URL errors on some External Links
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
