### PR TITLE
Exclude MO's own back-link field from the iNat snapshot

### DIFF
--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -378,7 +378,14 @@ class Inat
       "#{self[:location]} +/-#{self[:public_positional_accuracy]} m"
     end
 
+    # Excludes MO's own "Mushroom Observer URL" back-link (field 5005): MO
+    # writes it onto the iNat obs after import, so keeping it here would
+    # make every back-linked reflection's snapshot differ from its stored
+    # (pre-back-link) form on the first resync. The snapshot mirrors iNat's
+    # own data, not MO's annotations of it.
     def obs_fields(fields)
+      fields = Array(fields).
+               reject { |f| f[:field_id] == MO_URL_OBSERVATION_FIELD_ID }
       return :none.t if fields.empty?
 
       "\n#{one_line_per_field(fields)}"

--- a/test/classes/inat_obs_test.rb
+++ b/test/classes/inat_obs_test.rb
@@ -164,6 +164,38 @@ class InatObsTest < UnitTestCase
     assert_nil(mock_obs.when)
   end
 
+  # MO's own "Mushroom Observer URL" back-link (field 5005) is excluded
+  # from the snapshot -- MO writes it onto the iNat obs after import, so
+  # keeping it would make the reflection's snapshot differ from its stored
+  # form on the first resync.
+  def test_obs_fields_excludes_mo_url_back_link
+    obs = Inat::Obs.new(JSON.generate(
+                          ofvs: [
+                            { field_id: MO_URL_OBSERVATION_FIELD_ID,
+                              name: "Mushroom Observer URL",
+                              value: "https://mushroomobserver.org/1" },
+                            { field_id: 42, name: "Voucher Number",
+                              value: "AN 0432" }
+                          ]
+                        ))
+    result = obs.obs_fields(obs.inat_obs_fields)
+
+    assert_not(result.include?("Mushroom Observer URL"),
+               "MO's own back-link must not appear in the snapshot")
+    assert(result.include?("Voucher Number: AN 0432"),
+           "other iNat fields are kept")
+  end
+
+  def test_obs_fields_none_when_only_mo_url_back_link
+    obs = Inat::Obs.new(JSON.generate(
+                          ofvs: [{ field_id: MO_URL_OBSERVATION_FIELD_ID,
+                                   name: "Mushroom Observer URL",
+                                   value: "https://mushroomobserver.org/1" }]
+                        ))
+
+    assert_equal(:none.t, obs.obs_fields(obs.inat_obs_fields))
+  end
+
   def test_inat_observation_fields
     assert(mock_observation("trametes").inat_obs_fields.any?)
     assert(mock_observation("evernia").inat_obs_fields.none?)


### PR DESCRIPTION
## Summary

The iNat snapshot stored in an imported observation's notes lists every iNat observation field — including field 5005, **"Mushroom Observer URL"**, which MO itself writes onto the iNat observation after import as a back-link.

At import the field isn't present yet, so the stored snapshot records `Observation fields: none`. On resync, iNat returns the observation *with* the field, so the freshly-built snapshot reads `Observation fields: … Mushroom Observer URL: https://mushroomobserver.org/…` and differs from the stored one — so the daily resync (#4215) flags `notes` as changed for **every back-linked reflection**. It's MO seeing its own back-link reflected back through iNat.

Measured against a production snapshot: a full first pass reported 5,742 of 5,746 reflections "changed", driven by this. A 15-reflection convergence sample went from **15/15 `notes` changes to 4/15** with this fix (the remaining 4, plus `lat`/`lng`/`specimen` drift, are per-obs changes that reflect iNat drift).

**Fix:** exclude field 5005 in `Inat::Obs#obs_fields`, so the snapshot mirrors iNat's own data rather than MO's annotation of it. This makes the resync convergent (no spurious first-pass rewrite of ~every reflection, no burst of `log_observation_resynced` entries) and drops a redundant self-link from imported notes.

Only the snapshot is affected — `inat_obs_fields` stays intact for the #4585 extract/comparator, which needs the raw field list.

## Test plan

- `bin/rails test test/classes/inat_obs_test.rb` — green, including `test_obs_fields_excludes_mo_url_back_link` (field 5005 is dropped, other fields kept) and `test_obs_fields_none_when_only_mo_url_back_link`.
- Verified against a fresh production snapshot: the convergence sample's `notes` change rate fell from 15/15 to 4/15.

<!-- changelog -->
article: no
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
