### PR TITLE
Stop the iNat resync from clearing an observation's specimen flag

### DIFF
--- a/app/classes/inat/reflection_resync.rb
+++ b/app/classes/inat/reflection_resync.rb
@@ -106,9 +106,13 @@ class Inat
     # `where` too would flip it back and forth and never converge.
     def scalar_attributes(inat_obs)
       location = inat_obs.location
+      # specimen is intentionally not synced: iNat gives no reliable signal
+      # (Inat::Obs#specimen? is hardcoded false), and MO's specimen is set by
+      # MO-side herbarium records / collection numbers a user may add to a
+      # reflection -- syncing it could only unset a legitimate true.
       attrs = { when: inat_obs.when, location: location, lat: inat_obs.lat,
                 lng: inat_obs.lng, gps_hidden: inat_obs.gps_hidden,
-                specimen: inat_obs.specimen?, notes: inat_obs.notes }
+                notes: inat_obs.notes }
       attrs[:where] = inat_obs.where if location.nil?
       attrs
     end

--- a/test/classes/inat/observation_resyncer_test.rb
+++ b/test/classes/inat/observation_resyncer_test.rb
@@ -39,6 +39,17 @@ class Inat::ObservationResyncerTest < UnitTestCase
     assert_not_nil(@link.reload.last_synced_at, "should stamp last_synced_at")
   end
 
+  # specimen is MO-side (herbarium records / collection numbers a user may
+  # add to a reflection); iNat gives no reliable signal, so a resync must
+  # leave it alone rather than reset it to false.
+  def test_resync_does_not_unset_specimen
+    @obs.update_column(:specimen, true)
+
+    resync(found: { @id => @raw })
+
+    assert(@obs.reload.specimen, "resync must not unset a true specimen")
+  end
+
   # Sync is owned by the admin account: anyone logged in may trigger it
   # and the scheduled batch has no triggering user, so every resync log
   # is attributed to the system actor.


### PR DESCRIPTION
## Summary

`Inat::Obs#specimen?` is **hardcoded to return `false`** — it was disabled because iNat's "Voucher Specimen Taken" observation field is unreliable (observers use it for DNA sampling as often as vouchering). But the resync (#4215) still set `specimen: inat_obs.specimen?` in `scalar_attributes`, so **every resync forces `specimen` to `false`**.

For a reflection whose `specimen` is `true` — backed by MO-side herbarium records / collection numbers, which users are allowed to add to a read-only reflection — that clears a correct flag. Measured against a production snapshot: **19 of 5,746 reflections carry `specimen=true`, and each has a herbarium record + a collection number** (vouchered collections). A convergence sample showed `specimen` flipping true→false on 6/15, driven entirely by this.

This is a data-integrity bug, and it's already live in the **"Sync now" button** (same `ReflectionResync` code), so a user syncing a vouchered reflection today would clear its specimen.

**Fix:** drop `specimen` from `scalar_attributes`. Since `specimen?` always returns `false`, syncing it can only no-op or clear a correct flag — there's no case where it sets a correct `true`. `specimen` belongs to the MO-side records, which the resync must not touch.

## Test plan

- `bin/rails test test/classes/inat/observation_resyncer_test.rb` — green, including `test_resync_does_not_unset_specimen` (a `specimen=true` reflection stays true through a resync).
- Verified against a fresh production snapshot: `specimen` no longer appears in the resync's change set (was 6/15 in the convergence sample).

<!-- changelog -->
article: yes
Keep the specimen flag when syncing an imported Observation
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
