### PR TITLE
Constrain the batch resync to MO's `Mushroom Observer URL` field (#4215)

### DIFF
--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -71,7 +71,7 @@ class Inat
       # not already exported from or imported to MO
       # (field written by iNat's defunct Import from MO feature,
       # Pulk's mirror script, and ObservationImporter)
-      without_field: "Mushroom Observer URL"
+      without_field: MO_URL_OBSERVATION_FIELD_NAME
     }.freeze
 
     # A work-around because iNat has no "has a date" filter;

--- a/app/classes/inat/constants.rb
+++ b/app/classes/inat/constants.rb
@@ -54,6 +54,9 @@ class Inat
     IMPORTABLE_ICONIC_TAXA_ARG = IMPORTABLE_ICONIC_TAXA.join(",").freeze
 
     MO_URL_OBSERVATION_FIELD_ID = 5005
+    # iNat's `field:` search filter matches on the field name, not id
+    # (field:5005 returns nothing); this is the name of field 5005.
+    MO_URL_OBSERVATION_FIELD_NAME = "Mushroom Observer URL"
 
     # Extracts the MO observation id from a "Mushroom Observer URL" field
     # value, tolerating the URL variants that appear in the wild (current,

--- a/app/classes/inat/obs_fetcher.rb
+++ b/app/classes/inat/obs_fetcher.rb
@@ -82,8 +82,9 @@ class Inat
       # colon is significant to iNat's parser, so it can't go through
       # to_query (which escapes the colon to %3A). Append it raw,
       # url-encoding the name (spaces as %20, matching iNat).
-      qs += "&field:#{CGI.escape(field_present).gsub("+", "%20")}" if
-        field_present
+      if field_present
+        qs += "&field:#{CGI.escape(field_present).gsub("+", "%20")}"
+      end
       qs
     end
 

--- a/app/classes/inat/obs_fetcher.rb
+++ b/app/classes/inat/obs_fetcher.rb
@@ -35,14 +35,15 @@ class Inat
     # since then, so an incremental sync fetches only what moved. Left
     # nil, the batch returns every id -- and only then does an id missing
     # from the results mean "deleted on iNat" rather than "unchanged".
-    def fetch_batch(external_ids, updated_since: nil)
+    def fetch_batch(external_ids, updated_since: nil, field_present: nil)
       ids = external_ids.compact.uniq
       # An empty id list would query iNat with no `id` filter (i.e. every
       # observation), so short-circuit to an empty (non-failed) result.
       return [{}, false] if ids.empty?
 
       by_id = {}
-      fetch_page(ids, updated_since: updated_since).each do |raw|
+      fetch_page(ids, updated_since: updated_since,
+                      field_present: field_present).each do |raw|
         by_id[raw[:id].to_s] = raw
       end
       [by_id, false]
@@ -52,14 +53,17 @@ class Inat
 
     private
 
-    def fetch_page(ids, updated_since: nil, attempt: 1)
-      response = get("observations?#{page_query(ids, updated_since)}")
+    def fetch_page(ids, updated_since: nil, field_present: nil, attempt: 1)
+      response = get(
+        "observations?#{page_query(ids, updated_since, field_present)}"
+      )
       JSON.parse(response.body, symbolize_names: true)[:results] || []
     rescue *RETRYABLE_ERRORS, JSON::ParserError => e
       raise(FetchError.new(e.message)) if attempt > MAX_RETRIES
 
       backoff_for_retry(e, ids, attempt)
-      fetch_page(ids, updated_since: updated_since, attempt: attempt + 1)
+      fetch_page(ids, updated_since: updated_since,
+                      field_present: field_present, attempt: attempt + 1)
     end
 
     def backoff_for_retry(error, ids, attempt)
@@ -69,11 +73,18 @@ class Inat
       sleep(backoff)
     end
 
-    def page_query(ids, updated_since = nil)
+    def page_query(ids, updated_since = nil, field_present = nil)
       query = { id: ids.join(","), per_page: PAGE_SIZE,
                 order_by: "id", order: "asc" }
       query[:updated_since] = updated_since.utc.iso8601 if updated_since
-      query.to_query
+      qs = query.to_query
+      # iNat's observation-field filter is literally `field:<Name>` -- the
+      # colon is significant to iNat's parser, so it can't go through
+      # to_query (which escapes the colon to %3A). Append it raw,
+      # url-encoding the name (spaces as %20, matching iNat).
+      qs += "&field:#{CGI.escape(field_present).gsub("+", "%20")}" if
+        field_present
+      qs
     end
 
     def get(path)

--- a/app/classes/inat/reflection_batch_resyncer.rb
+++ b/app/classes/inat/reflection_batch_resyncer.rb
@@ -65,9 +65,14 @@ class Inat
     end
 
     def tally_chunk(chunk, counts, since)
+      # Constrain to obs carrying MO's "Mushroom Observer URL" back-link --
+      # the marker that says "this is a synced MO reflection". Every id
+      # here already has it, so it doesn't change the set; it enforces the
+      # invariant and mirrors the field-based discovery this will grow into.
       by_id, failed = @fetcher.fetch_batch(
         chunk.map { |reflection| ReflectionResync.inat_id(reflection) },
-        updated_since: since
+        updated_since: since,
+        field_present: Inat::Constants::MO_URL_OBSERVATION_FIELD_NAME
       )
       chunk.each do |reflection|
         result = @applier.call(reflection, by_id, failed, absent: :unchanged)

--- a/app/classes/inat/reflection_batch_resyncer.rb
+++ b/app/classes/inat/reflection_batch_resyncer.rb
@@ -22,13 +22,21 @@ class Inat
   # run is a handful of API calls rather than one per reflection. No Turbo
   # broadcast -- a scheduled run has no viewer.
   class ReflectionBatchResyncer
+    include Inat::Constants
+
     # iNat returns at most PAGE_SIZE results for one id-list query, so a
     # larger chunk would silently drop the overflow.
     CHUNK_SIZE = ObsFetcher::PAGE_SIZE
 
+    # Messages for reflections whose iNat "Mushroom Observer URL" back-link
+    # points at the wrong MO obs (see #check_back_link); the job sends
+    # these to #alerts.
+    attr_reader :back_link_alerts
+
     def initialize(fetcher: ObsFetcher.new, applier: ReflectionResync.new)
       @fetcher = fetcher
       @applier = applier
+      @back_link_alerts = []
     end
 
     # Runs the batch and returns a status => count Hash across every
@@ -72,12 +80,36 @@ class Inat
       by_id, failed = @fetcher.fetch_batch(
         chunk.map { |reflection| ReflectionResync.inat_id(reflection) },
         updated_since: since,
-        field_present: Inat::Constants::MO_URL_OBSERVATION_FIELD_NAME
+        field_present: MO_URL_OBSERVATION_FIELD_NAME
       )
       chunk.each do |reflection|
+        raw = by_id[ReflectionResync.inat_id(reflection).to_s]
+        check_back_link(reflection, raw) if raw
         result = @applier.call(reflection, by_id, failed, absent: :unchanged)
         counts[result.status] += 1
       end
+    end
+
+    # The iNat "Mushroom Observer URL" field should point back to this
+    # reflection's own MO obs. A mismatch means the field was edited on
+    # iNat, or points at the wrong obs -- collect it for the job to send to
+    # #alerts, but don't repair it: the ExternalLink stays authoritative
+    # for the sync. Field ABSENCE isn't checked here (the field: filter
+    # already excludes it); the periodic reconciliation job (#5200) covers
+    # cleared/deleted fields.
+    def check_back_link(reflection, raw)
+      value = mo_url_field_value(raw)
+      return if value.to_s[MO_URL_FIELD_VALUE_ID_RE, 1].to_i == reflection.id
+
+      @back_link_alerts <<
+        "Reflection obs #{reflection.id} (iNat " \
+        "#{ReflectionResync.inat_id(reflection)}): Mushroom Observer URL " \
+        "field = #{value.inspect}, expected .../#{reflection.id}"
+    end
+
+    def mo_url_field_value(raw)
+      Array(raw[:ofvs]).
+        find { |f| f[:field_id] == MO_URL_OBSERVATION_FIELD_ID }&.dig(:value)
     end
 
     # Advance the source watermark only on a clean run: a transient fetch

--- a/app/jobs/inat_reflection_batch_resync_job.rb
+++ b/app/jobs/inat_reflection_batch_resync_job.rb
@@ -10,7 +10,11 @@ class InatReflectionBatchResyncJob < ApplicationJob
   queue_as :maintenance
 
   def perform
-    counts = Inat::ReflectionBatchResyncer.new.resync_all
+    resyncer = Inat::ReflectionBatchResyncer.new
+    counts = resyncer.resync_all
     Rails.logger.info("InatReflectionBatchResyncJob: #{counts.inspect}")
+    # A back-link pointing at the wrong MO obs is rare and needs a human
+    # look, not an auto-repair (#5196 discussion) -- route each to #alerts.
+    resyncer.back_link_alerts.each { |message| alert(message) }
   end
 end

--- a/test/classes/inat/obs_fetcher_test.rb
+++ b/test/classes/inat/obs_fetcher_test.rb
@@ -47,6 +47,17 @@ class Inat::ObsFetcherTest < UnitTestCase
     assert_empty(by_id)
   end
 
+  def test_field_present_appends_the_inat_field_filter
+    fetcher = Inat::ObsFetcher.new
+    with_field = fetcher.send(:page_query, %w[1 2], nil,
+                              "Mushroom Observer URL")
+
+    assert_includes(with_field, "field:Mushroom%20Observer%20URL",
+                    "the field: filter is appended raw (colon unescaped)")
+    assert_not(fetcher.send(:page_query, %w[1 2], nil, nil).include?("field:"),
+               "no field filter when none is given")
+  end
+
   private
 
   def obs_url(ids)

--- a/test/classes/inat/reflection_batch_resyncer_test.rb
+++ b/test/classes/inat/reflection_batch_resyncer_test.rb
@@ -127,6 +127,32 @@ class Inat::ReflectionBatchResyncerTest < UnitTestCase
                     "the watermark advances despite the invalid site row")
   end
 
+  # The MO URL back-link field should point at the reflection's own obs;
+  # a match raises no alert.
+  def test_no_back_link_alert_when_the_field_points_at_the_reflection
+    raw = @raw.merge(ofvs: [mo_url_ofv(@obs.id)])
+    resyncer = Inat::ReflectionBatchResyncer.new(
+      fetcher: FakeFetcher.new([{ @id => raw }, false])
+    )
+
+    resyncer.resync_all
+
+    assert_empty(resyncer.back_link_alerts)
+  end
+
+  # A back-link pointing at a different MO obs is collected for #alerts.
+  def test_back_link_alert_when_the_field_points_elsewhere
+    raw = @raw.merge(ofvs: [mo_url_ofv(@obs.id + 999)])
+    resyncer = Inat::ReflectionBatchResyncer.new(
+      fetcher: FakeFetcher.new([{ @id => raw }, false])
+    )
+
+    resyncer.resync_all
+
+    assert_equal(1, resyncer.back_link_alerts.size)
+    assert_includes(resyncer.back_link_alerts.first, @obs.id.to_s)
+  end
+
   def test_no_inaturalist_site_is_a_no_op
     @site.destroy!
 
@@ -143,5 +169,11 @@ class Inat::ReflectionBatchResyncerTest < UnitTestCase
   def mock_raw(filename)
     JSON.parse(File.read("test/inat/#{filename}.txt"),
                symbolize_names: true)[:results].first
+  end
+
+  def mo_url_ofv(mo_id)
+    { field_id: Inat::Constants::MO_URL_OBSERVATION_FIELD_ID,
+      name: "Mushroom Observer URL",
+      value: "https://mushroomobserver.org/#{mo_id}" }
   end
 end

--- a/test/classes/inat/reflection_batch_resyncer_test.rb
+++ b/test/classes/inat/reflection_batch_resyncer_test.rb
@@ -12,10 +12,11 @@ require("json")
 class Inat::ReflectionBatchResyncerTest < UnitTestCase
   # Stands in for Inat::ObsFetcher -- returns a canned [by_id, failed?]
   # and records the ids and updated_since it was asked for.
-  FakeFetcher = Struct.new(:batch, :seen_ids, :seen_since) do
-    def fetch_batch(ids, updated_since: nil)
+  FakeFetcher = Struct.new(:batch, :seen_ids, :seen_since, :seen_field) do
+    def fetch_batch(ids, updated_since: nil, field_present: nil)
       self.seen_ids = ids
       self.seen_since = updated_since
+      self.seen_field = field_present
       batch
     end
   end
@@ -50,6 +51,17 @@ class Inat::ReflectionBatchResyncerTest < UnitTestCase
     assert_not_nil(fetcher.seen_since)
     assert_in_delta(since.to_i, fetcher.seen_since.to_i, 1,
                     "the fetch is narrowed by the last successful run")
+  end
+
+  # Every batch fetch is constrained to obs carrying MO's back-link field,
+  # the marker that says "this is a synced MO reflection".
+  def test_constrains_the_fetch_to_the_mo_url_field
+    fetcher = FakeFetcher.new([{ @id => @raw }, false])
+
+    Inat::ReflectionBatchResyncer.new(fetcher: fetcher).resync_all
+
+    assert_equal(Inat::Constants::MO_URL_OBSERVATION_FIELD_NAME,
+                 fetcher.seen_field)
   end
 
   def test_first_run_with_no_watermark_fetches_everything

--- a/test/jobs/inat_reflection_batch_resync_job_test.rb
+++ b/test/jobs/inat_reflection_batch_resync_job_test.rb
@@ -21,11 +21,45 @@ class InatReflectionBatchResyncJobTest < ActiveJob::TestCase
       called = true
       { synced: 0 }
     end
+    fake.define_singleton_method(:back_link_alerts) { [] }
 
     Inat::ReflectionBatchResyncer.stub(:new, ->(**) { fake }) do
       InatReflectionBatchResyncJob.perform_now
     end
 
     assert(called, "the job should run the batch resyncer")
+  end
+
+  # A back-link mismatch collected during the run is routed to #alerts.
+  def test_back_link_alerts_are_sent_to_alerts
+    fake = Object.new
+    fake.define_singleton_method(:resync_all) { { synced: 0 } }
+    fake.define_singleton_method(:back_link_alerts) do
+      ["Reflection obs 1: Mushroom Observer URL field mismatch"]
+    end
+
+    alerts = capture_alerts do
+      Inat::ReflectionBatchResyncer.stub(:new, ->(**) { fake }) do
+        InatReflectionBatchResyncJob.perform_now
+      end
+    end
+
+    assert_equal(1, alerts.size)
+    assert_includes(alerts.first.message, "Mushroom Observer URL field")
+  end
+
+  private
+
+  # Records exceptions handed to the #alerts pipeline while alerting is
+  # forced active (mirrors the helper in the other job tests).
+  def capture_alerts(&block)
+    alerts = []
+    ExceptionNotifier.stub(:notifiers, [:slack]) do
+      ExceptionNotifier.stub(:notify_exception,
+                             lambda { |exception, **_o|
+                               alerts << exception
+                             }, &block)
+    end
+    alerts
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to the merged batch resync (#5194). The daily resync now constrains its iNat fetch to observations carrying MO's **"Mushroom Observer URL"** observation field (id 5005) — the back-link MO writes onto every iNat observation it imports, and the marker that says "this is a synced MO reflection."

`Inat::ObsFetcher#fetch_batch` gains a `field_present:` option; `ReflectionBatchResyncer` passes the field name. iNat's `field:` search filter matches on the field **name**, not id (`field:5005` returns nothing), and the colon is significant to iNat's parser so it can't go through `to_query` (which would escape it to `%3A`) — it's appended raw with the name url-encoded.

**This does not change the set** (as expected), verified two ways against a production snapshot:
- A 200-id sample returned the same 200 observations with and without the filter (0 dropped).
- A live `fetch_batch` of 5 reflection ids with the filter returned all 5, each carrying field 5005.

Its value now: it enforces the invariant that the sync only touches observations still marked as MO reflections. Its value later: it's the same mechanism the scale-independent discovery query will use — `field:Mushroom Observer URL&updated_since=T` returns only MO's changed reflections in ~2 calls/day regardless of population (a probe found 176,501 MO-linked observations on iNat, 1,480 changed in a 4-day window). That larger rework — replacing the id-list enumeration with the field query — is a separate #4215 follow-up; this lands the field-filter plumbing and the invariant.

Scoped to the batch only; the "Sync now" button (full fetch, absent = deleted) is unchanged.

## Back-link value comparison (from the #5196 review)

Also added here (keeping this sequence of closely-related changes on one PR): during the run, each fetched obs's `Mushroom Observer URL` value is compared to the MO obs its `ExternalLink` points at (`ReflectionBatchResyncer#check_back_link`). A mismatch — the field edited on iNat, or pointing at a different obs — is collected and routed to #alerts by the job for a human to review, **not** auto-repaired: the `ExternalLink` stays authoritative for the sync. Editing the field bumps the observation's `updated_at`, so the incremental fetch still surfaces it. A 60-obs sample is 60/60 clean today, so this is a tripwire, not a known problem.

Field *absence* (cleared/deleted) is out of this path — the `field:` filter excludes it — and is covered by a periodic reconciliation job tracked in #5200 (does not need to land before NAMA).

## Test plan

- `bin/rails test test/classes/inat/obs_fetcher_test.rb test/classes/inat/reflection_batch_resyncer_test.rb` — green, including `test_field_present_appends_the_inat_field_filter` (the raw `field:Mushroom%20Observer%20URL` is appended, colon unescaped) and `test_constrains_the_fetch_to_the_mo_url_field` (the batch passes the field name).

<!-- changelog -->
article: no
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
