### PR TITLE
Treat field slip codes case-insensitively (#5199)

### DIFF
--- a/app/classes/api2/field_slip_api.rb
+++ b/app/classes/api2/field_slip_api.rb
@@ -102,7 +102,7 @@ class API2
     end
 
     def validate_unique_code!(code, exclude: nil)
-      existing = FieldSlip.find_by(code: code)
+      existing = FieldSlip.find_by(code: code.to_s.upcase)
       return unless existing && existing != exclude
 
       raise(CodeAlreadyUsed.new(code))

--- a/app/classes/api2/observation_api.rb
+++ b/app/classes/api2/observation_api.rb
@@ -160,7 +160,7 @@ class API2
     def add_field_slip_code(observation)
       return unless @code
 
-      field_slip = FieldSlip.find_by(code: @code)
+      field_slip = FieldSlip.find_by(code: @code.upcase)
       unless field_slip
         field_slip = FieldSlip.create!(code: @code, user: @user)
         field_slip.current_user = @user

--- a/app/controllers/observations_controller/field_slips.rb
+++ b/app/controllers/observations_controller/field_slips.rb
@@ -54,7 +54,7 @@ module ObservationsController::FieldSlips
   # the review page would just sit on its scan button -- say why, and
   # that saving the review is what links this observation to the slip.
   def explain_in_use_slip(code)
-    slip = FieldSlip.find_by(code: code)
+    slip = FieldSlip.find_by(code: code.upcase)
     occurrence = slip&.occurrence
     return unless occurrence
     # Checked against the slip's freshly loaded occurrence, not

--- a/app/controllers/observations_controller/new.rb
+++ b/app/controllers/observations_controller/new.rb
@@ -253,7 +253,7 @@ module ObservationsController::New
   # user pressed "Add" on can override the slip's own project.
   def add_field_slip_project(code)
     project = Project.safe_find(params[:project]) ||
-              FieldSlip.find_by(code: code)&.project
+              FieldSlip.find_by(code: code.to_s.upcase)&.project
     return unless project&.current? || project&.admin?(@user)
     return unless project&.member?(@user)
 

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -135,7 +135,10 @@ class FieldSlipExtract < AbstractModel
   def code_mismatch
     read = value_for(template.code_field).to_s.strip
     attached = observation&.field_slip&.code.to_s.strip
-    return nil if read.blank? || attached.blank? || read == attached
+    # Field slip codes are case-insensitive (stored upcased), so a
+    # case-only difference -- e.g. a hand-made slip's "NAMAtest" vs the
+    # stored "NAMATEST" -- is not a mismatch.
+    return nil if read.blank? || attached.blank? || read.casecmp?(attached)
 
     [read, attached]
   end

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -178,6 +178,17 @@ class FieldSlipExtractTest < UnitTestCase
     assert_nil(extract.code_mismatch)
   end
 
+  # A case-only difference is not a mismatch -- field slip codes are
+  # case-insensitive (#5199): a hand-made slip photographed as
+  # "nemf-10222" still matches the attached "NEMF-10222".
+  def test_code_mismatch_nil_when_codes_differ_only_in_case
+    slip = FieldSlip.create!(code: "NEMF-10222", user: @obs.user)
+    attach_slip(slip)
+    extract = record(fields: { "Field Slip Code" => "nemf-10222" })
+
+    assert_nil(extract.code_mismatch)
+  end
+
   # The strongest signal that this photo is not this observation's slip.
   def test_code_mismatch_reports_both_codes
     slip = FieldSlip.create!(code: "NEMF-10222", user: @obs.user)


### PR DESCRIPTION
## Summary

Fixes #5199. When a photographed field slip's code differed from the attached slip's code only in **case** — e.g. a hand-made `2026-NAMAtest-093` vs the stored `2026-NAMATEST-093` — the scan review page raised a spurious "code mismatch" warning flash.

`FieldSlipExtract#code_mismatch` compared the read code to the attached code with a case-sensitive `==`. Field slip codes are always **upcased** on write (`FieldSlip#code=`), so the stored value is uppercase while the read value is the raw model reading — a mixed-case, hand-made slip therefore always tripped the warning. Compare with `casecmp?` instead (the idiom already used a few lines below in `unknown_location_alias`).

## Related hardening — the four remaining case-sensitive lookups

Per Nathan's note on the issue ("in general fieldslip codes should always be considered case insensitive"), I audited the `FieldSlip.find_by(code: …)` call sites. Most already upcase their input (`attacher`, `field_slip_for_code`, `find_or_create_by_code`, the show page, the review form). Four passed raw/QR/param values into a case-sensitive lookup, so a mixed-case code silently failed to resolve to its stored slip:

- `API2::ObservationAPI#add_field_slip_code` — attaching by a lower-case code missed the existing slip and tried to create a duplicate.
- `API2::FieldSlipAPI#validate_unique_code!` — a case-variant of an existing code passed the friendly uniqueness check, then failed at the DB unique index instead.
- `ObservationsController::FieldSlips#explain_in_use_slip` — the in-use-slip explanation didn't render for a mixed-case slip.
- `ObservationsController::New#add_field_slip_project` — the slip's project wasn't derived for a mixed-case code.

Each now upcases the input to the stored form. These are one-line normalizations consistent with the existing pattern; verified against the field-slip model / API / attacher / controller suites (61 tests, no regressions).

## Test plan

- `bin/rails test test/models/field_slip_extract_test.rb` — green, including `test_code_mismatch_nil_when_codes_differ_only_in_case` (a photographed `nemf-10222` no longer mismatches the attached `NEMF-10222`).
- `bin/rails test test/models/field_slip_test.rb test/classes/api2/field_slips_test.rb test/classes/field_slip/attacher_test.rb test/controllers/observations/field_slips_controller_test.rb` — 61 green, confirming the lookup changes don't regress existing behavior.

<!-- changelog -->
article: yes
Fix a false warning when scanning a mixed-case Field Slip
<!-- /changelog -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPMv2YTuAkun3UNCgigTPu
