### PR TITLE
Add new cop `MO/NoUncapturedTestLogging`; fix three tests it flagged

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ require:
   - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
   - ./lib/rubocop/cop/mo/no_render_phlex_method_name
   - ./lib/rubocop/cop/mo/no_resolved_errors_add_type
+  - ./lib/rubocop/cop/mo/no_uncaptured_test_logging
   - ./lib/rubocop/cop/mo/prefer_kit_syntax
   - ./lib/rubocop/cop/mo/redundant_render_view_invalid
   - ./lib/rubocop/cop/mo/self_status_outside_invalid_method
@@ -213,6 +214,18 @@ MO/NoRenderPhlexMethodName:
   Enabled: true
   Include:
     - "app/controllers/**/*.rb"
+
+MO/NoUncapturedTestLogging:
+  Description: >-
+    A test method that deliberately triggers a failure (a literal
+    raise/fail inside a .stub(...) block or define_singleton_method)
+    must also stub/capture the resulting warn/Rails.logger.error/
+    Rails.logger.warn call, or it prints to the test suite's console
+    looking like a failure elsewhere -- see
+    lib/rubocop/cop/mo/no_uncaptured_test_logging.rb.
+  Enabled: true
+  Include:
+    - "test/**/*.rb"
 
 MO/PreferKitSyntax:
   Description: >-

--- a/lib/rubocop/cop/mo/no_uncaptured_test_logging.rb
+++ b/lib/rubocop/cop/mo/no_uncaptured_test_logging.rb
@@ -57,11 +57,21 @@ module RuboCop
           return if captures_logging?(node)
           return if expects_propagation?(node)
           return if simulates_io_failure?(node)
+          return if wrapped_in_capture_io?(node)
 
           add_offense(node)
         end
 
         private
+
+        # MiniTest's capture_io redirects $stdout/$stderr for the whole
+        # block -- any warn/puts a rescue makes inside it is already
+        # swallowed, whether or not the test reads it back.
+        def wrapped_in_capture_io?(node)
+          node.each_descendant(:send).any? do |send_node|
+            send_node.method?(:capture_io)
+          end
+        end
 
         def simulates_io_failure?(node)
           node.each_descendant(:send).any? do |send_node|

--- a/lib/rubocop/cop/mo/no_uncaptured_test_logging.rb
+++ b/lib/rubocop/cop/mo/no_uncaptured_test_logging.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Flags a test method that deliberately triggers a failure -- a
+      # literal `raise`/`fail` written inside the test, typically
+      # inside a `.stub(...)` block or `define_singleton_method` --
+      # without also stubbing/capturing the logging call the
+      # resulting rescue path makes (`warn`, `Rails.logger.error`,
+      # `Rails.logger.warn`, or a custom `log` method). Left
+      # un-stubbed, that log line hits the test logger, which writes
+      # to $stdout -- the deliberate failure then dumps into the
+      # test suite's console output looking like a failure in an
+      # unrelated test.
+      #
+      # @example
+      #   # bad
+      #   def test_isolates_one_users_failure
+      #     SomeMailer.stub(:build, ->(*) { raise("boom") }) do
+      #       SomeService.run
+      #     end
+      #   end
+      #
+      #   # good
+      #   def test_isolates_one_users_failure
+      #     logged = nil
+      #     Rails.logger.stub(:error, ->(msg) { logged = msg }) do
+      #       SomeMailer.stub(:build, ->(*) { raise("boom") }) do
+      #         SomeService.run
+      #       end
+      #     end
+      #     assert_includes(logged, "boom")
+      #   end
+      class NoUncapturedTestLogging < Base
+        MSG = "This test deliberately triggers a failure (raise) but " \
+              "doesn't stub/capture the resulting warn/logger call -- " \
+              "it prints to the test suite's console looking like a " \
+              "failure elsewhere. Stub Rails.logger.error/warn (or the " \
+              "relevant log method) to capture it instead."
+
+        LOG_METHOD_NAMES = [:warn, :error, :log].freeze
+
+        # Stubbing one of these to raise simulates a low-level I/O failure,
+        # not a domain-logic one. MO's own rescues around them (File,
+        # Tempfile, Open3, RestClient::Request) don't call Rails.logger --
+        # they degrade silently (return false, retry, add a validation
+        # error) or route through a caller-supplied, already-captured
+        # output sink. A domain-class stub (Name, ExternalLink, API2, ...)
+        # gets no such exemption -- its rescue path logging is unconfirmed.
+        IO_PRIMITIVE_RECEIVERS = [:File, :Tempfile, :Open3, :Dir, :FileUtils,
+                                  :IO, :RestClient].freeze
+
+        def on_def(node)
+          return unless node.method_name.to_s.start_with?("test_")
+          return unless deliberate_raise?(node)
+          return if captures_logging?(node)
+          return if expects_propagation?(node)
+          return if simulates_io_failure?(node)
+
+          add_offense(node)
+        end
+
+        private
+
+        def simulates_io_failure?(node)
+          node.each_descendant(:send).any? do |send_node|
+            next false unless send_node.method?(:stub) ||
+                              send_node.method?(:define_singleton_method)
+
+            io_primitive_receiver?(send_node.receiver)
+          end
+        end
+
+        def io_primitive_receiver?(receiver)
+          return false unless receiver&.const_type?
+
+          root = receiver.const_name.to_s.split("::").first
+          IO_PRIMITIVE_RECEIVERS.include?(root&.to_sym)
+        end
+
+        def deliberate_raise?(node)
+          node.each_descendant(:send).any? do |send_node|
+            [:raise, :fail].include?(send_node.method_name)
+          end
+        end
+
+        # `assert_raises`/`assert_nothing_raised` means the raise is
+        # meant to propagate straight out to the test's own
+        # assertion, not be swallowed by a production rescue clause
+        # that logs before continuing -- no log call to capture.
+        def expects_propagation?(node)
+          node.each_descendant(:send).any? do |send_node|
+            [:assert_raises, :assert_nothing_raised].include?(
+              send_node.method_name
+            )
+          end
+        end
+
+        def captures_logging?(node)
+          node.each_descendant(:send).any? do |send_node|
+            stub_capturing_log?(send_node) || singleton_log_override?(send_node)
+          end
+        end
+
+        def stub_capturing_log?(send_node)
+          return false unless send_node.method?(:stub)
+
+          log_method_arg?(send_node)
+        end
+
+        def singleton_log_override?(send_node)
+          return false unless send_node.method?(:define_singleton_method)
+
+          log_method_arg?(send_node)
+        end
+
+        def log_method_arg?(send_node)
+          arg = send_node.arguments.first
+          arg&.sym_type? && LOG_METHOD_NAMES.include?(arg.value)
+        end
+      end
+    end
+  end
+end

--- a/test/classes/inat/import_digest_test.rb
+++ b/test/classes/inat/import_digest_test.rb
@@ -115,12 +115,19 @@ class Inat::ImportDigestTest < UnitTestCase
     end
 
     # Dick's digest should still be enqueued even though Katrina's
-    # mailer build raised.
-    assert_enqueued_jobs(1, only: ActionMailer::MailDeliveryJob) do
-      InatImportDigestMailer.stub(:build, failing_build) do
-        Inat::ImportDigest.deliver_for(@import)
+    # mailer build raised. Capture the rescue's Rails.logger.error call
+    # instead of letting it through -- the test logger writes to
+    # $stdout, so the deliberate "boom" otherwise dumps into the
+    # suite's console output looking like a failure elsewhere.
+    logged = nil
+    Rails.logger.stub(:error, ->(msg) { logged = msg }) do
+      assert_enqueued_jobs(1, only: ActionMailer::MailDeliveryJob) do
+        InatImportDigestMailer.stub(:build, failing_build) do
+          Inat::ImportDigest.deliver_for(@import)
+        end
       end
     end
+    assert_includes(logged, "boom")
   end
 
   private

--- a/test/classes/inat_mo_observation_builder_test.rb
+++ b/test/classes/inat_mo_observation_builder_test.rb
@@ -184,7 +184,16 @@ class InatMoObservationBuilderTest < UnitTestCase
   def test_override_name_falls_back_when_resolution_raises
     builder = builder_for(name_override: "Boletus edulis")
     builder.define_singleton_method(:find_or_create_name) { |_| raise("boom") }
-    assert_nil(builder.send(:override_name))
+
+    # Capture the rescue's Rails.logger.warn call instead of letting it
+    # through -- the test logger writes to $stdout, so the deliberate
+    # "boom" otherwise dumps into the suite's console output looking
+    # like a failure elsewhere.
+    logged = nil
+    Rails.logger.stub(:warn, ->(msg) { logged = msg }) do
+      assert_nil(builder.send(:override_name))
+    end
+    assert_includes(logged, "boom")
   end
 
   # No override field => no override name.

--- a/test/controllers/api2_controller_test.rb
+++ b/test/controllers/api2_controller_test.rb
@@ -730,6 +730,9 @@ class API2ControllerTest < FunctionalTestCase
     get(:observations, params: params.merge(format: :xml, detail: :high))
   end
 
+  # rubocop:disable MO/NoUncapturedTestLogging -- Api2Controller's rescue
+  # (render_api_results/index) only builds an API2::RenderFailed error;
+  # neither it nor RenderFailed#initialize calls Rails.logger.
   def test_render_api_results_rescue_wraps_unexpected_errors
     boom = RuntimeError.new("unexpected")
     API2.stub(:execute, ->(_) { raise(boom) }) do
@@ -757,6 +760,7 @@ class API2ControllerTest < FunctionalTestCase
     assert_equal("true", error["fatal"],
                  "RenderFailed error should be fatal")
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   def test_routing
     assert_routing({ path: "/api2/comments", method: :delete },

--- a/test/controllers/lookups_controller_test.rb
+++ b/test/controllers/lookups_controller_test.rb
@@ -132,6 +132,8 @@ class LookupsControllerTest < FunctionalTestCase
     assert_redirected_to(glossary_term_path(term.id))
   end
 
+  # rubocop:disable MO/NoUncapturedTestLogging -- find_name_matches's
+  # rescue only calls flash_error, no Rails.logger call to capture.
   def test_lookup_name_with_error
     login
     # Stub a method used inside `lookup_name` to provoke an error
@@ -141,6 +143,7 @@ class LookupsControllerTest < FunctionalTestCase
 
     assert_flash_error
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   def test_lookup_observation
     login

--- a/test/jobs/image_loader_job_test.rb
+++ b/test/jobs/image_loader_job_test.rb
@@ -72,6 +72,11 @@ class ImageLoaderJobTest < ActiveJob::TestCase
     end
   end
 
+  # rubocop:disable MO/NoUncapturedTestLogging -- the "test" message is
+  # deliberate: ImageLoaderJob's rescue only warns to $stdout when
+  # `e.message != "test"` (see its Rails.env.test? guard), so this
+  # message value itself suppresses the console noise. Its other log
+  # call writes to a job-log file, not $stdout.
   def test_image_download_fails
     with_stubs do
       MockBucket.stub(:new, -> { raise("test") }) do
@@ -80,4 +85,5 @@ class ImageLoaderJobTest < ActiveJob::TestCase
       end
     end
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -168,15 +168,22 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions
     raiser = ->(*) { raise(ActiveRecord::RecordInvalid.new(ExternalLink.new)) }
-    ExternalLink.stub(:create!, raiser) do
-      assert_no_difference(
-        "Observation.count",
-        "A cross-referenced iNat obs is skipped even when the " \
-        "self-heal link fails"
-      ) do
-        InatImportJob.perform_now(@inat_import)
+    # Inat::ObservationImporter#create_crosslink logs the validation
+    # failure via Rails.logger.warn -- capture it instead of letting it
+    # print to the test suite's console.
+    logged = nil
+    Rails.logger.stub(:warn, ->(msg) { logged = msg }) do
+      ExternalLink.stub(:create!, raiser) do
+        assert_no_difference(
+          "Observation.count",
+          "A cross-referenced iNat obs is skipped even when the " \
+          "self-heal link fails"
+        ) do
+          InatImportJob.perform_now(@inat_import)
+        end
       end
     end
+    assert_includes(logged, "failed to create remote_manual ExternalLink")
 
     assert_nil(
       ExternalLink.find_by(external_id: @parsed_results.first[:id].to_s,
@@ -983,6 +990,9 @@ class InatImportJobTest < ActiveJob::TestCase
   # (the import ExternalLink's unique index). The importer should swallow
   # it and log a "race" skip — same effect as the already_imported?
   # pre-check.
+  # rubocop:disable MO/NoUncapturedTestLogging -- the rescue's log() call
+  # (Inat::ObservationImporter -> ApplicationJob#log) writes to the job
+  # log file, not Rails.logger/$stdout.
   def test_import_handles_record_not_unique_race
     create_ivars_from_filename("calostoma_lutescens")
     @user.update(inat_username: @inat_import.inat_username)
@@ -1007,6 +1017,7 @@ class InatImportJobTest < ActiveJob::TestCase
                  job_log_file.read,
                  "Should log a race-skip when RecordNotUnique fires")
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   def test_import_update_inat_username_if_job_succeeds
     updated_inat_username = "updatedInatUsername"
@@ -1061,6 +1072,9 @@ class InatImportJobTest < ActiveJob::TestCase
 
   # Prove that import continues with subsequent observations
   # when an error occurs during import of one observation
+  # rubocop:disable MO/NoUncapturedTestLogging -- log_with_response_error
+  # writes to the job log file and the InatImport#response_errors column,
+  # not Rails.logger/$stdout.
   def test_import_multiple_continues_after_error
     create_ivars_from_filename("listed_ids")
 
@@ -1112,6 +1126,7 @@ class InatImportJobTest < ActiveJob::TestCase
       define_method(:notes, original_notes_method)
     end
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   # Prove that "Import all my iNat observations imports" multiple obsservations
   # NOTE: It would be complicated to prove that it imports multiple pages.
@@ -1681,6 +1696,9 @@ class InatImportJobTest < ActiveJob::TestCase
 
   # -------- rescue Exception / non_rescuable? tests
 
+  # rubocop:disable MO/NoUncapturedTestLogging -- perform's `rescue
+  # Exception` branch only calls log() (job log file) and
+  # add_response_error (DB column), not Rails.logger/$stdout.
   def test_perform_records_unexpected_non_standard_exception
     create_ivars_from_filename("calostoma_lutescens")
     stub_token_requests
@@ -1699,6 +1717,7 @@ class InatImportJobTest < ActiveJob::TestCase
     assert_equal("Done", @inat_import.state,
                  "Import should be marked Done after unexpected exception")
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   def test_non_rescuable_true_for_remaining_fatal_types
     job = InatImportJob.new

--- a/test/models/external_link_test.rb
+++ b/test/models/external_link_test.rb
@@ -133,6 +133,9 @@ class ExternalLinkTest < UnitTestCase
   # An iNat observation link is validated by its strict base_url + numeric
   # id shape (inat_url?), not FormatURL's looser host/path match, so
   # FormatURL is not called for it.
+  # rubocop:disable MO/NoUncapturedTestLogging -- canary: FormatURL.new
+  # is skipped for an iNat link on this passing path, so the stub raise
+  # doesn't fire and there's nothing to capture.
   def test_inaturalist_link_skips_format_url
     site = external_sites(:inaturalist)
     obs = observations(:minimal_unknown_obs)
@@ -146,6 +149,7 @@ class ExternalLinkTest < UnitTestCase
       assert_equal(url, link.url, "iNat link URL should be saved unchanged")
     end
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   # iNat URLs must be only the base url plus an observation numeric id,
   # e.g. /observations/12345.

--- a/test/models/image/processor/gap_detector_test.rb
+++ b/test/models/image/processor/gap_detector_test.rb
@@ -93,6 +93,8 @@ class Image::Processor::GapDetectorTest < UnitTestCase
     assert_empty(result[:regenerated])
   end
 
+  # rubocop:disable MO/NoUncapturedTestLogging -- GapDetector.new with no
+  # block leaves @log nil, so its rescue's log() call is a no-op here.
   def test_only_attempts_regeneration_once_per_image_per_run
     image = images(:turned_over_image)
     image.update_columns(transferred: true)
@@ -113,6 +115,7 @@ class Image::Processor::GapDetectorTest < UnitTestCase
     assert_equal(1, call_count,
                  "regeneration should only be attempted once per image")
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   # A remote listing that failed outright (#4974) verified nothing --
   # treating every path in the chunk as missing would trigger a mass

--- a/test/models/image/processor/verifier_test.rb
+++ b/test/models/image/processor/verifier_test.rb
@@ -241,6 +241,10 @@ class Image::Processor::VerifierTest < UnitTestCase
   # A raised exception (e.g. missing rsync binary, Errno::ENOENT) from one
   # file's transfer must not abort the rest of the run -- every other
   # mismatched file still needs its chance to upload.
+  # rubocop:disable MO/NoUncapturedTestLogging -- the log IS captured,
+  # via the `messages` array passed to Verifier.new's block (Verifier's
+  # own injectable-log convention), not Rails.logger.stub. The assertion
+  # below reads it back.
   def test_transfer_continues_after_one_file_raises
     image = images(:turned_over_image)
     seed_locally_complete(image)
@@ -266,6 +270,7 @@ class Image::Processor::VerifierTest < UnitTestCase
       msg.include?("Failed to upload") && msg.include?("boom")
     end)
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   def test_transfer_takes_an_active_record_relation
     image = images(:turned_over_image)

--- a/test/models/image/processor_test.rb
+++ b/test/models/image/processor_test.rb
@@ -251,6 +251,8 @@ class Image::ProcessorTest < UnitTestCase
   # false. A raised exception on one server must not abort the loop any
   # more than a returned false does -- the next server must still get
   # its chance.
+  # rubocop:disable MO/NoUncapturedTestLogging -- try_fetch_orig's rescue
+  # just returns false, no Rails.logger call to capture.
   def test_make_sure_we_have_full_size_locally_tries_next_server_after_raise
     image = images(:in_situ_image)
     FileUtils.cp(JPG_FIXTURE, "#{remote_server_path(1)}/orig/#{image.id}.jpg")
@@ -278,6 +280,7 @@ class Image::ProcessorTest < UnitTestCase
 
     assert_path_exists("#{local_root}/orig/#{image.id}.jpg")
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   def test_requires_image
     assert_raises(RuntimeError) { Image::Processor.new(image: nil) }

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -2714,6 +2714,8 @@ class ObservationTest < UnitTestCase
     assert_equal(loc.name, obs.where)
   end
 
+  # rubocop:disable MO/NoUncapturedTestLogging -- Observation.define_a_location's
+  # rescue retries and re-raises; it has no Rails.logger call to capture.
   def test_define_a_location_retries_once_on_deadlock
     calls = 0
     relation = Object.new
@@ -2729,6 +2731,7 @@ class ObservationTest < UnitTestCase
     end
     assert_equal(2, calls, "update should be retried after one deadlock")
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   def test_define_a_location_reraises_repeated_deadlock
     relation = Object.new

--- a/test/script/backfill_mycoportal_export_links_test.rb
+++ b/test/script/backfill_mycoportal_export_links_test.rb
@@ -311,6 +311,9 @@ class BackfillMycoportalExportLinksTest < UnitTestCase
     )
   end
 
+  # rubocop:disable MO/NoUncapturedTestLogging -- run_script's warn IS
+  # captured, by the capture_io in the shared run_script_against helper
+  # (not visible in this method's own body).
   def test_invalid_record_is_logged_and_skipped
     image = images(:in_situ_image)
     stubbed_error = lambda do |*|
@@ -330,6 +333,7 @@ class BackfillMycoportalExportLinksTest < UnitTestCase
     )
     assert_nil(link_for(image))
   end
+  # rubocop:enable MO/NoUncapturedTestLogging
 
   def test_progress_logging_at_interval
     subject = build

--- a/test/views/controllers/admin/users/bonuses_form_test.rb
+++ b/test/views/controllers/admin/users/bonuses_form_test.rb
@@ -35,6 +35,8 @@ module Views::Controllers::Admin::Users
     # passed) — the `rescue` only exists for environments where that
     # route helper isn't available. Stub it to raise to exercise the
     # fallback directly.
+    # rubocop:disable MO/NoUncapturedTestLogging -- form_action's rescue
+    # just returns a fallback string, no Rails.logger call to capture.
     def test_form_action_falls_back_when_admin_route_raises
       form = render_form_instance
       form.define_singleton_method(:admin_user_path) do |*|
@@ -43,6 +45,7 @@ module Views::Controllers::Admin::Users
 
       assert_equal("/admin/users/#{@user_stats.user_id}", form.form_action)
     end
+    # rubocop:enable MO/NoUncapturedTestLogging
 
     private
 

--- a/test/views/controllers/comments/comment_item_test.rb
+++ b/test/views/controllers/comments/comment_item_test.rb
@@ -108,6 +108,9 @@ module Views::Controllers::Comments
       assert_no_html(html, "h4")
     end
 
+    # rubocop:disable MO/NoUncapturedTestLogging -- target_name_link/
+    # target_type's rescues just substitute placeholder text, no
+    # Rails.logger call to capture.
     def test_show_name_with_deleted_target_falls_back_to_deleted_text
       # `target_name_link` and `target_type` are wrapped in
       # `rescue StandardError` so a comment outliving its target
@@ -129,6 +132,7 @@ module Views::Controllers::Comments
       assert_includes(html, :comment_list_deleted.t)
       assert_includes(html, :runtime_object_deleted.to_s)
     end
+    # rubocop:enable MO/NoUncapturedTestLogging
 
     # ---- avatar -----------------------------------------------------
 

--- a/test/views/controllers/species_lists/listing_test.rb
+++ b/test/views/controllers/species_lists/listing_test.rb
@@ -70,6 +70,8 @@ module Views::Controllers::SpeciesLists
 
     # `place` rescues StandardError from `place_name.t` and falls back
     # to `:unknown.ti`. Stub `place_name` to raise so the rescue fires.
+    # rubocop:disable MO/NoUncapturedTestLogging -- place's rescue just
+    # falls back to :unknown.ti, no Rails.logger call to capture.
     def test_place_falls_back_to_unknown_when_place_name_raises
       @species_list.define_singleton_method(:place_name) do
         raise(StandardError.new("bad place"))
@@ -78,6 +80,7 @@ module Views::Controllers::SpeciesLists
 
       assert_html(html, "span", text: :unknown.ti.as_displayed)
     end
+    # rubocop:enable MO/NoUncapturedTestLogging
 
     # `remove` wins when both flags set — defensive guard.
     def test_remove_wins_when_both_remove_and_add_set


### PR DESCRIPTION
## Summary

Adds `MO/NoUncapturedTestLogging`: flags a test method that deliberately triggers a failure (a literal `raise`/`fail` inside a `.stub(...)` block or `define_singleton_method`) without also stubbing/capturing the resulting `Rails.logger`/`warn` call the production rescue path makes. Left un-stubbed, that log line hits the test logger's `$stdout` destination, dumping into the suite's console output looking like a failure in an unrelated test -- the pattern this PR was prompted by (an iNat retry warning and an `InatImportDigestMailer` error log line showing up in unrelated test runs).

- Excludes `assert_raises`/`assert_nothing_raised` -- the raise is meant to propagate to the test's own assertion, not be swallowed by a rescue that logs.
- Excludes stubs of stdlib/vendor I/O primitives (`File`, `Tempfile`, `Open3`, `Dir`, `FileUtils`, `IO`, `RestClient`) -- confirmed by reading each one's production rescue path (`Image#save_to_temp_file`, `Observation.define_a_location`, `IpStats#blocked_ips_current?`, `FieldSlip::QRDecoder.remote_codes`, `ParallelTestConfigService`) that MO's own rescues around these don't call `Rails.logger`, only domain-class failures do.
- Excludes tests wrapped in MiniTest's `capture_io` -- it redirects `$stdout`/`$stderr` for the whole block, so a `warn`/`puts` inside it is already suppressed.

Fixed the three tests the cop found with a `Rails.logger` call in their production rescue path (`Inat::ImportDigest`'s mailer-isolation test, `InatMoObservationBuilder`'s name-override-resolution test, and `Inat::ObservationImporter#create_crosslink`'s validation-failure test) to stub `Rails.logger` and assert on the captured message instead of letting the message print.

The remaining flagged tests were individually triaged by reading each one's production rescue path and confirmed as false positives -- no logging call in the rescue, or the rescue routes through a job-log file / `output_handler` / injectable callback that isn't console output. Each is inline-disabled with the specific reason found at that site.

## Test plan

- [x] Rubocop -- clean repo-wide
- [x] Every touched test file -- all green (18 files, individually run)

<!-- changelog -->
article: no
<!-- /changelog -->
