### PR TITLE
Rename `Votes::Table` to `Tally`; thread consensus through vote modal

### DIFF
--- a/app/controllers/observations/namings/votes_controller.rb
+++ b/app/controllers/observations/namings/votes_controller.rb
@@ -10,7 +10,7 @@ module Observations::Namings
     # Has its own route for non-js access and testing.
     # The HTML response renders the Phlex `Index` view (which
     # derives consensus internally from `naming.observation`); the
-    # turbo response renders the Phlex `Table` inside a Modal.
+    # turbo response renders the Phlex `Tally` inside a Modal.
     def index
       @naming = find_or_goto_index(Naming, params[:naming_id].to_s)
       return unless @naming
@@ -41,7 +41,8 @@ module Observations::Namings
       render(Views::Controllers::Observations::Namings::Votes::Modal.new(
                naming: display_naming, user: @user,
                modal_id: "modal_naming_votes_#{@naming.id}",
-               title: "#{:show_namings_consensus.t} "
+               title: "#{:show_namings_consensus.t} ",
+               consensus: consensus
              ))
     end
 

--- a/app/views/controllers/observations/namings/votes/index.rb
+++ b/app/views/controllers/observations/namings/votes/index.rb
@@ -2,24 +2,24 @@
 
 # Action view for `observations/namings/votes#index` — the
 # standalone vote-breakdown page for a single naming. Body is
-# just the `Table` rendering; the page title carries the
+# just the `Tally` rendering; the page title carries the
 # naming's display name.
 #
 module Views::Controllers::Observations::Namings::Votes
   class Index < Views::FullPageBase
     # HTML index renders against a raw `Naming` because the page
-    # title reads `unique_format_name`. The modal-rendered Table
-    # accepts MergedNaming too (see Table's prop).
+    # title reads `unique_format_name`. The modal-rendered
+    # Tally accepts MergedNaming too (see its prop).
     prop :naming, ::Naming
 
     def view_template
       add_page_title(:show_votes_title.t(
                        name: viewer_aware_unique_format_name(@naming)
                      ))
-      # Table derives its own consensus from `naming.observation`
-      # when not explicitly passed, so the controller doesn't need
-      # to hold one just for this render path.
-      render(Table.new(naming: @naming))
+      # Tally derives its own consensus from
+      # `naming.observation` when not explicitly passed, so the
+      # controller doesn't need to hold one just for this render path.
+      render(Tally.new(naming: @naming))
     end
   end
 end

--- a/app/views/controllers/observations/namings/votes/modal.rb
+++ b/app/views/controllers/observations/namings/votes/modal.rb
@@ -3,7 +3,7 @@
 # Turbo-stream wrapper for the per-naming vote-breakdown modal —
 # the response body for `votes#index` when requested with
 # `format: :turbo_stream`. Composes `Components::Modal` with the
-# `Table` in the body slot.
+# `Tally` table in the body slot.
 #
 # Lives as a thin wrapper because `ActionController#render` treats
 # a trailing `do |x| … end` block as a layout block rather than
@@ -18,6 +18,12 @@ module Views::Controllers::Observations::Namings::Votes
     prop :user, _Nilable(::User), default: nil
     prop :modal_id, String
     prop :title, String
+    # Optional. Lets a caller that already built a NamingConsensus
+    # (e.g. VotesController#render_votes_modal, which needs one to
+    # resolve the display naming) pass it through to `Tally` instead
+    # of `Tally` silently constructing its own second one.
+    prop :consensus, _Nilable(::Observation::NamingConsensus),
+         default: nil
 
     def view_template
       # Must stay `render(::Components::Modal.new(...))`, not bare
@@ -33,7 +39,7 @@ module Views::Controllers::Observations::Namings::Votes
           trusted_html(@naming.display_name_brief_authors(@user).t.small_author)
         end
         modal.with_body do
-          render(Table.new(naming: @naming))
+          render(Tally.new(naming: @naming, consensus: @consensus))
         end
       end
     end

--- a/app/views/controllers/observations/namings/votes/tally.rb
+++ b/app/views/controllers/observations/namings/votes/tally.rb
@@ -20,7 +20,7 @@
 # in `.claude/rules/phlex_reference.md`.
 #
 module Views::Controllers::Observations::Namings::Votes
-  class Table < Views::Base
+  class Tally < Views::Base
     prop :naming, _Union(::Naming, ::Observation::MergedNaming)
     # Optional. When the caller already has a NamingConsensus
     # (controller mutation paths), pass it; otherwise the view

--- a/test/views/controllers/observations/namings/votes/tally_test.rb
+++ b/test/views/controllers/observations/namings/votes/tally_test.rb
@@ -3,7 +3,7 @@
 require("test_helper")
 
 module Views::Controllers::Observations::Namings::Votes
-  class TableTest < ComponentTestCase
+  class TallyTest < ComponentTestCase
     def setup
       super
       @naming = namings(:coprinus_comatus_naming)
@@ -84,7 +84,7 @@ module Views::Controllers::Observations::Namings::Votes
     private
 
     def render_table(naming: @naming)
-      render(Table.new(naming: naming))
+      render(Tally.new(naming: naming))
     end
   end
 end


### PR DESCRIPTION
## Summary

- Renamed `Votes::Table` to `Votes::Tally` -- clearer name for what the class does.
- Found and fixed a bug while researching Kit-syntax naming collisions: `VotesController#render_votes_modal` builds a `NamingConsensus` (a non-trivial query -- its constructor eagerly loads all namings + votes for the observation) to resolve the display naming, then discards it -- `Modal` had no `consensus:` prop to relay it, so `Tally` silently built a second, redundant one on every vote-modal open. Added `Modal#consensus` and threaded the controller's existing consensus through. Confirmed this changes nothing about what gets computed, only removes the duplicate work: `Observation::MergedNaming#observation` is always the same object the controller's consensus was built from (`build_merged_namings` passes `observation: @observation`).

## Test plan

- [x] Rubocop on all touched files -- clean
- [x] `test/views/controllers/observations/namings/votes/tally_test.rb` -- green
- [x] `test/controllers/observations/namings/votes_controller_test.rb` (covers both the HTML and turbo_stream/merged-naming paths) -- green

<!-- changelog -->
article: no
<!-- /changelog -->
