### PR TITLE
Fail tests that leak console output, leave trace of which ones do

### DIFF
--- a/test/classes/inat/import_digest_test.rb
+++ b/test/classes/inat/import_digest_test.rb
@@ -115,12 +115,19 @@ class Inat::ImportDigestTest < UnitTestCase
     end
 
     # Dick's digest should still be enqueued even though Katrina's
-    # mailer build raised.
-    assert_enqueued_jobs(1, only: ActionMailer::MailDeliveryJob) do
-      InatImportDigestMailer.stub(:build, failing_build) do
-        Inat::ImportDigest.deliver_for(@import)
+    # mailer build raised. Capture the rescue's Rails.logger.error call
+    # instead of letting it through -- the test logger writes to
+    # $stdout, so the deliberate "boom" otherwise dumps into the
+    # suite's console output looking like a failure elsewhere.
+    logged = nil
+    Rails.logger.stub(:error, ->(msg) { logged = msg }) do
+      assert_enqueued_jobs(1, only: ActionMailer::MailDeliveryJob) do
+        InatImportDigestMailer.stub(:build, failing_build) do
+          Inat::ImportDigest.deliver_for(@import)
+        end
       end
     end
+    assert_includes(logged, "boom")
   end
 
   private

--- a/test/classes/inat_mo_observation_builder_test.rb
+++ b/test/classes/inat_mo_observation_builder_test.rb
@@ -184,7 +184,16 @@ class InatMoObservationBuilderTest < UnitTestCase
   def test_override_name_falls_back_when_resolution_raises
     builder = builder_for(name_override: "Boletus edulis")
     builder.define_singleton_method(:find_or_create_name) { |_| raise("boom") }
-    assert_nil(builder.send(:override_name))
+
+    # Capture the rescue's Rails.logger.warn call instead of letting it
+    # through -- the test logger writes to $stdout, so the deliberate
+    # "boom" otherwise dumps into the suite's console output looking
+    # like a failure elsewhere.
+    logged = nil
+    Rails.logger.stub(:warn, ->(msg) { logged = msg }) do
+      assert_nil(builder.send(:override_name))
+    end
+    assert_includes(logged, "boom")
   end
 
   # No override field => no override name.
@@ -300,6 +309,11 @@ class InatMoObservationBuilderTest < UnitTestCase
     call_count = 0
     builder = builder_for
     builder.define_singleton_method(:sleep) { |*| } # skip backoff waits
+    # Capture the retry backoff's warn() instead of letting it print --
+    # bare Kernel#warn isn't Rails.logger, so config.log_level doesn't
+    # filter it, and it dumps straight into the test suite's console.
+    warnings = []
+    builder.define_singleton_method(:warn) { |msg| warnings << msg }
 
     API2.stub(:execute, lambda { |_params|
       call_count += 1
@@ -313,6 +327,8 @@ class InatMoObservationBuilderTest < UnitTestCase
     assert_equal(3, call_count,
                  "Should retry an image download failure, succeed on the " \
                  "third attempt")
+    assert_equal(2, warnings.size,
+                 "Should warn once per retry, not on the final success")
   end
 
   def test_upload_inat_image_raises_after_exhausting_retries
@@ -320,6 +336,11 @@ class InatMoObservationBuilderTest < UnitTestCase
     call_count = 0
     builder = builder_for
     builder.define_singleton_method(:sleep) { |*| } # skip backoff waits
+    # Capture the retry backoff's warn() instead of letting it print --
+    # bare Kernel#warn isn't Rails.logger, so config.log_level doesn't
+    # filter it, and it dumps straight into the test suite's console.
+    warnings = []
+    builder.define_singleton_method(:warn) { |msg| warnings << msg }
 
     API2.stub(:execute, lambda { |_params|
       call_count += 1
@@ -332,6 +353,9 @@ class InatMoObservationBuilderTest < UnitTestCase
                    "Error should identify the failing iNat photo")
     end
 
+    assert_equal(Inat::MoObservationBuilder::ImageHandling::
+                 MAX_UPLOAD_RETRIES, warnings.size,
+                 "Should warn once per retry, not on the final failure")
     assert_equal(Inat::MoObservationBuilder::ImageHandling::
                  MAX_UPLOAD_RETRIES + 1, call_count,
                  "Should try once, retry until the cap is reached, " \

--- a/test/components/application_form/date_field_test.rb
+++ b/test/components/application_form/date_field_test.rb
@@ -33,12 +33,19 @@ class DateFieldTest < ComponentTestCase
     assert_html(form, "input[type='text']#collection_number_when_1i")
     assert_html(form, "input[name='collection_number[when(1i)]'][size='4']")
 
-    # Verify order: day, month, year (3i before 2i before 1i)
-    day_pos = form.index("_3i")
-    month_pos = form.index("_2i")
-    year_pos = form.index("_1i")
-    assert(day_pos < month_pos && month_pos < year_pos,
-           "Expected order day(_3i), month(_2i), year(_1i)")
+    # Verify order: day, month, year (3i before 2i before 1i). Scoped
+    # to the date-selects wrapper's own children via Nokogiri element
+    # order, not a substring search over the whole form -- the
+    # authenticity_token hidden field is a random per-render value
+    # that can coincidentally contain "_1i"/"_2i"/"_3i".
+    date_selects = Nokogiri::HTML5.fragment(form).at_css("div.date-selects")
+    field_ids = date_selects.css("select, input").pluck("id")
+    assert_equal(
+      %w[collection_number_when_3i collection_number_when_2i
+         collection_number_when_1i],
+      field_ids,
+      "Expected order day(_3i), month(_2i), year(_1i)"
+    )
   end
 
   def test_date_field_with_append_slot

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -168,15 +168,22 @@ class InatImportJobTest < ActiveJob::TestCase
 
     stub_inat_interactions
     raiser = ->(*) { raise(ActiveRecord::RecordInvalid.new(ExternalLink.new)) }
-    ExternalLink.stub(:create!, raiser) do
-      assert_no_difference(
-        "Observation.count",
-        "A cross-referenced iNat obs is skipped even when the " \
-        "self-heal link fails"
-      ) do
-        InatImportJob.perform_now(@inat_import)
+    # Inat::ObservationImporter#create_crosslink logs the validation
+    # failure via Rails.logger.warn -- capture it instead of letting it
+    # print to the test suite's console.
+    logged = nil
+    Rails.logger.stub(:warn, ->(msg) { logged = msg }) do
+      ExternalLink.stub(:create!, raiser) do
+        assert_no_difference(
+          "Observation.count",
+          "A cross-referenced iNat obs is skipped even when the " \
+          "self-heal link fails"
+        ) do
+          InatImportJob.perform_now(@inat_import)
+        end
       end
     end
+    assert_includes(logged, "failed to create remote_manual ExternalLink")
 
     assert_nil(
       ExternalLink.find_by(external_id: @parsed_results.first[:id].to_s,

--- a/test/no_test_console_noise.rb
+++ b/test/no_test_console_noise.rb
@@ -61,9 +61,23 @@ module NoTestConsoleNoise
               "it (Rails.logger.stub, capture_io, etc.) instead of " \
               "letting it print:\n\n#{leaked}"
     if ENFORCE
-      fail_result(result, message)
+      attach_leak(result, message)
     else
       record_leak(message)
+    end
+  end
+
+  # Every minitest-reporters reporter displays only `result.failure`
+  # (`failures.first`) -- none iterate the full array. So a leak on a
+  # test that's already failing/erroring/skipped can't be a second
+  # array entry, or it's silently invisible everywhere. Append it onto
+  # the existing failure's message instead; only a test that would
+  # otherwise have passed gets a new one.
+  def attach_leak(result, message)
+    if result.failures.empty?
+      fail_result(result, message)
+    else
+      append_to_message(result.failures.first, message)
     end
   end
 
@@ -75,6 +89,15 @@ module NoTestConsoleNoise
     flunk(message)
   rescue Minitest::Assertion => e
     result.failures << e
+  end
+
+  # Neither Minitest::Assertion nor Minitest::UnexpectedError expose a
+  # public message setter (UnexpectedError even computes #message
+  # dynamically from its wrapped error) -- a singleton override is the
+  # one approach that works uniformly across both.
+  def append_to_message(failure, message)
+    original = failure.message
+    failure.define_singleton_method(:message) { "#{original}\n\n#{message}" }
   end
 
   def record_leak(message)

--- a/test/no_test_console_noise.rb
+++ b/test/no_test_console_noise.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-# Report-only pass: wraps every test's execution, capturing
-# $stdout/$stderr for that test alone, and appends anything
-# unexpectedly written there to REPORT_PATH instead of failing the
-# test. A test that already redirects its own output (capture_io,
-# Rails.logger.stub) doesn't leak anything here, since that redirect
-# happens inside this wrapper's span and is restored before it ends.
+# Wraps every test's execution, capturing $stdout/$stderr for that
+# test alone. A test that already redirects its own output
+# (capture_io, Rails.logger.stub) doesn't leak anything here, since
+# that redirect happens inside this wrapper's span and is restored
+# before it ends. Anything else written there fails the test
+# (ENFORCE = true) -- set false to log leaks to REPORT_PATH instead
+# of failing, for an initial sweep against the full suite.
 #
 # Redirects at the OS file-descriptor level (STDOUT.reopen), not by
 # reassigning the $stdout global -- Rails.logger's underlying
@@ -15,12 +16,9 @@
 # swap doesn't touch it. Reopening STDOUT's file descriptor mutates
 # that same captured object in place, so every writer is redirected
 # regardless of which reference it holds.
-#
-# Once a run against the full suite is clean, flip ENFORCE to true so
-# a leak becomes a test failure instead of a report line.
 module NoTestConsoleNoise
   REPORT_PATH = Rails.root.join("tmp/test_console_noise_report.txt")
-  ENFORCE = false
+  ENFORCE = true
 
   def run
     # rubocop:disable Style/GlobalStdStream -- this hook redirects the
@@ -45,7 +43,7 @@ module NoTestConsoleNoise
     # rubocop:enable Style/GlobalStdStream
 
     leaked = read_and_close(out_tempfile) + read_and_close(err_tempfile)
-    record_leak(leaked) if leaked.present?
+    handle_leak(result, leaked) if leaked.present?
     result
   end
 
@@ -58,8 +56,29 @@ module NoTestConsoleNoise
     content
   end
 
-  def record_leak(leaked)
-    entry = "#{self.class}##{name}\n#{leaked}#{"-" * 40}\n"
+  def handle_leak(result, leaked)
+    message = "Unexpected console output during this test -- capture " \
+              "it (Rails.logger.stub, capture_io, etc.) instead of " \
+              "letting it print:\n\n#{leaked}"
+    if ENFORCE
+      fail_result(result, message)
+    else
+      record_leak(message)
+    end
+  end
+
+  # flunk raises through Minitest::Assertions (included in every Test)
+  # so the failure gets a proper backtrace; `super`'s Result.from(self)
+  # already ran by the time this fires, so the failure has to go onto
+  # that Result directly, not onto self.failures.
+  def fail_result(result, message)
+    flunk(message)
+  rescue Minitest::Assertion => e
+    result.failures << e
+  end
+
+  def record_leak(message)
+    entry = "#{self.class}##{name}\n#{message}#{"-" * 40}\n"
     File.open(REPORT_PATH, "a") do |f|
       f.flock(File::LOCK_EX)
       f.write(entry)

--- a/test/no_test_console_noise.rb
+++ b/test/no_test_console_noise.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Report-only pass: wraps every test's execution, capturing
+# $stdout/$stderr for that test alone, and appends anything
+# unexpectedly written there to REPORT_PATH instead of failing the
+# test. A test that already redirects its own output (capture_io,
+# Rails.logger.stub) doesn't leak anything here, since that redirect
+# happens inside this wrapper's span and is restored before it ends.
+#
+# Redirects at the OS file-descriptor level (STDOUT.reopen), not by
+# reassigning the $stdout global -- Rails.logger's underlying
+# Logger::LogDevice captures a direct reference to the STDOUT object
+# at boot (config.logger = Logger.new($stdout) in
+# config/environments/test.rb), so a plain `$stdout = StringIO.new`
+# swap doesn't touch it. Reopening STDOUT's file descriptor mutates
+# that same captured object in place, so every writer is redirected
+# regardless of which reference it holds.
+#
+# Once a run against the full suite is clean, flip ENFORCE to true so
+# a leak becomes a test failure instead of a report line.
+module NoTestConsoleNoise
+  REPORT_PATH = Rails.root.join("tmp/test_console_noise_report.txt")
+  ENFORCE = false
+
+  def run
+    out_tempfile = Tempfile.new("test_stdout")
+    err_tempfile = Tempfile.new("test_stderr")
+    original_stdout = $stdout.dup
+    original_stderr = $stderr.dup
+    result = nil
+    begin
+      $stdout.reopen(out_tempfile)
+      $stderr.reopen(err_tempfile)
+      result = super
+    ensure
+      $stdout.reopen(original_stdout)
+      $stderr.reopen(original_stderr)
+      original_stdout.close
+      original_stderr.close
+    end
+
+    leaked = read_and_close(out_tempfile) + read_and_close(err_tempfile)
+    record_leak(leaked) if leaked.present?
+    result
+  end
+
+  private
+
+  def read_and_close(tempfile)
+    tempfile.rewind
+    content = tempfile.read
+    tempfile.close!
+    content
+  end
+
+  def record_leak(leaked)
+    entry = "#{self.class}##{name}\n#{leaked}#{"-" * 40}\n"
+    File.open(REPORT_PATH, "a") do |f|
+      f.flock(File::LOCK_EX)
+      f.write(entry)
+      f.flock(File::LOCK_UN)
+    end
+  end
+end
+
+Minitest::Test.prepend(NoTestConsoleNoise)

--- a/test/no_test_console_noise.rb
+++ b/test/no_test_console_noise.rb
@@ -23,21 +23,26 @@ module NoTestConsoleNoise
   ENFORCE = false
 
   def run
+    # rubocop:disable Style/GlobalStdStream -- this hook redirects the
+    # process's STDOUT/STDERR file descriptors, not the reassignable
+    # $stdout/$stderr globals (see the class comment) -- autocorrecting
+    # these to $stdout/$stderr defeats the point.
     out_tempfile = Tempfile.new("test_stdout")
     err_tempfile = Tempfile.new("test_stderr")
-    original_stdout = $stdout.dup
-    original_stderr = $stderr.dup
+    original_stdout = STDOUT.dup
+    original_stderr = STDERR.dup
     result = nil
     begin
-      $stdout.reopen(out_tempfile)
-      $stderr.reopen(err_tempfile)
+      STDOUT.reopen(out_tempfile)
+      STDERR.reopen(err_tempfile)
       result = super
     ensure
-      $stdout.reopen(original_stdout)
-      $stderr.reopen(original_stderr)
+      STDOUT.reopen(original_stdout)
+      STDERR.reopen(original_stderr)
       original_stdout.close
       original_stderr.close
     end
+    # rubocop:enable Style/GlobalStdStream
 
     leaked = read_and_close(out_tempfile) + read_and_close(err_tempfile)
     record_leak(leaked) if leaked.present?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,6 +66,14 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative("../config/environment")
 require("rails/test_help")
 
+# MiniExiftool caches its tag list in a pstore file on first use,
+# printing two lines to $stderr while generating it -- invisible on a
+# dev machine where the cache already exists from a prior run, but
+# guaranteed noise on a fresh CI runner. Parallel test workers fork
+# from this process, so warming the cache here (before parallelize
+# forks them) means every worker finds the file already on disk.
+MiniExiftool.all_tags
+
 %w[
   no_test_console_noise
   bullet_helper

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,6 +67,7 @@ require_relative("../config/environment")
 require("rails/test_help")
 
 %w[
+  no_test_console_noise
   bullet_helper
 
   general_extensions


### PR DESCRIPTION
Fails tests that leak console output, which may be expected as the test is written but looks like an error to a dev unfamiliar with the test. Suggests rewrite methods.

## Summary

Adds `NoTestConsoleNoise` (`test/no_test_console_noise.rb`): wraps every test, redirecting `STDOUT`/`STDERR` at the file-descriptor level. Anything unexpectedly written there fails the test with the leaked content in the failure message, instead of printing into the suite's console output looking like a failure in an unrelated test.

Redirects at the file-descriptor level rather than reassigning `$stdout`/`$stderr` -- `Rails.logger` captures a direct reference to the `STDOUT` object at boot, so a global reassignment wouldn't reach it.

Fixed every test the hook currently flags:

- `Inat::ImportDigestTest#test_isolates_one_users_mailer_failure_from_the_rest` -- `Rails.logger.error` on a mailer-build failure.
- `InatMoObservationBuilderTest#test_upload_inat_image_retries_transient_download_failure` and `#test_upload_inat_image_raises_after_exhausting_retries` -- the tests that prompted this investigation. The retry backoff's bare `warn(...)` wasn't stubbed, only the accompanying `sleep`.
- `InatImportJobTest#test_import_crosslink_creation_failure_logged_and_still_skipped` -- `Inat::ObservationImporter#create_crosslink`'s `Rails.logger.warn` on a validation failure.

## Test plan

- [x] Full suite run, enforce mode on -- green

<!-- changelog -->
article: no
<!-- /changelog -->
