### PR TITLE
Write a placeholder `name_list_data.js` if missing before tests run

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,6 +66,26 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative("../config/environment")
 require("rails/test_help")
 
+# RefreshNameListerCacheJob writes this file from a DB query, but
+# nothing guarantees it exists on a fresh checkout -- a CI runner has
+# no name_list_data.js until something runs the job. Every layout
+# renders javascript_importmap_tags, which pins the whole
+# app/javascript/src directory, so any page render fails with
+# Sprockets::Rails::Helper::AssetNotPrecompiledError until it does. A
+# syntactically valid placeholder with empty data satisfies the pin
+# before parallelize forks workers, so every worker finds a file on
+# disk from the start; RefreshNameListerCacheJobTest overwrites it
+# with fixture-backed data when that job's own test runs.
+cache_file = MO.name_lister_cache_file
+unless File.exist?(cache_file)
+  FileUtils.mkpath(File.dirname(cache_file))
+  File.write(cache_file, <<~JS)
+    export let NL_GENERA = [];
+    export let NL_SPECIES = [];
+    export let NL_NAMES = [];
+  JS
+end
+
 %w[
   bullet_helper
 


### PR DESCRIPTION
## Summary

Every layout renders `javascript_importmap_tags`, which pins the whole `app/javascript/src` directory -- including `name_list_data.js`, a gitignored file `RefreshNameListerCacheJob` generates from a DB query. Nothing creates that file on a fresh checkout, so any page render on a fresh CI runner fails with `Sprockets::Rails::Helper::AssetNotPrecompiledError`. Invisible on a dev machine once the file exists from a prior run (or a prior `RefreshNameListerCacheJobTest` run).

Reproduced locally: deleted the file, confirmed a previously-passing controller test fails the same way, across a 12-worker parallel run.

Writes a syntactically valid placeholder (empty data arrays) in `test_helper.rb` if the file doesn't already exist, before `parallelize` forks workers -- every worker then finds a file on disk from the start regardless of test order. `RefreshNameListerCacheJobTest` already deletes and regenerates the file with fixture-backed data when it runs; confirmed that's unaffected.

## Test plan

- [x] Rubocop -- clean
- [x] Deleted the file, ran the previously-failing controller test -- passes
- [x] Deleted the file, ran a different controller test across a 12-worker parallel run -- passes
- [x] `test/jobs/refresh_name_lister_cache_job_test.rb` -- still overwrites the placeholder with fixture data and passes

<!-- changelog -->
article: no
<!-- /changelog -->
