### PR TITLE
Fall back to Query's `default_order` on an invalid `order_by`

### DIFF
--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -75,6 +75,13 @@ module Query::Modules::Validation
     @validation_errors << [:query_validation_order_by_unsupported,
                            { models: model.name.pluralize, key:, model:,
                              base: }]
+    # Clear the bad value so `add_default_order_if_none_specified` treats
+    # it as unset and substitutes the model/attr's own `default_order` --
+    # otherwise it survives validation and reaches
+    # AbstractModel::OrderingScopes#order_by's dispatcher, which silently
+    # falls back to `all` (id: :desc) instead, ignoring the model's
+    # declared default.
+    @params[:order_by] = nil
   end
 
   private

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -108,9 +108,16 @@ class QueryTest < UnitTestCase
   end
 
   def test_validate_params_order_by_unsupported
-    assert_validation_errors(
-      Query.lookup(:Name, order_by: "totally_bogus_sort_key")
-    )
+    query = Query.lookup(:Name, order_by: "totally_bogus_sort_key")
+    assert_validation_errors(query)
+    # The bad value must not survive validation -- otherwise it reaches
+    # AbstractModel::OrderingScopes#order_by's dispatcher, which silently
+    # falls back to `all` (id: :desc) instead of the model's own
+    # default_order.
+    assert_nil(query.params[:order_by],
+               "Invalid order_by should be cleared, not left in params")
+    assert_equal(:name, query.default_order,
+                 "Should fall back to Query::Names.default_order")
   end
 
   def test_validate_params_instances_users

--- a/test/controllers/observations/downloads_controller_test.rb
+++ b/test/controllers/observations/downloads_controller_test.rb
@@ -47,6 +47,23 @@ module Observations
       )
     end
 
+    # `params[:by]` reaches `find_or_create_query` unguarded (no
+    # `order_by_or_flash_if_unknown` check, unlike a controller's own
+    # sorted_index) -- an invalid value must still fall back to the
+    # model's default_order rather than silently sorting by id: :desc.
+    def test_new_invalid_by_falls_back_to_default_order
+      login(:rolf)
+      get(:new, params: { by: "totally_bogus_sort_key" })
+
+      assert_response(:success)
+      query = @controller.instance_variable_get(:@query)
+      assert_nil(
+        query.params[:order_by],
+        "Invalid `by` should be cleared, not passed through to Query"
+      )
+      assert_equal(Query::Observations.default_order, query.default_order)
+    end
+
     def test_download_observation_index
       obs = Observation.reorder(id: :asc).where(user: mary)
       assert(obs.length >= 4)

--- a/test/controllers/observations/species_lists_controller_test.rb
+++ b/test/controllers/observations/species_lists_controller_test.rb
@@ -50,6 +50,25 @@ module Observations
              "other_lists must exclude the observation")
     end
 
+    # `params[:by]` reaches `Query.lookup` unguarded in `set_list_ivars`
+    # (no `order_by_or_flash_if_unknown` check) -- an invalid value must
+    # still fall back to the model's default_order rather than silently
+    # sorting by id: :desc.
+    def test_edit_invalid_by_falls_back_to_default_order
+      obs = observations(:coprinus_comatus_obs)
+      login
+
+      get(:edit, params: { id: obs.id, by: "totally_bogus_sort_key" })
+
+      assert_response(:success)
+      all_lists = assigns(:all_lists)
+      assert_nil(
+        all_lists.params[:order_by],
+        "Invalid `by` should be cleared, not passed through to Query"
+      )
+      assert_equal(Query::SpeciesLists.default_order, all_lists.default_order)
+    end
+
     def test_add_observation_to_species_list
       spl = species_lists(:first_species_list)
       obs = observations(:coprinus_comatus_obs)


### PR DESCRIPTION
Makes behavior consistent when an invalid `order_by` param is sent to a controller's index.

## Summary

`add_default_order_if_none_specified` only substitutes a model/attr's `default_order` when `order_by` is blank -- an invalid value (present but unsupported) survives validation untouched and reaches `AbstractModel::OrderingScopes#order_by`'s dispatcher, which silently falls back to `all` (`id: :desc`) instead of the declared default.

Clears the value in `validate_order_by!` once the validation error is recorded, so the blank-check downstream catches the invalid case too and falls back to the correct default.

This is reachable today through two controllers that pass `params[:by]` straight into Query construction with no guard, unlike a controller's `sorted_index` (which checks the value against `order_by_<key>` and substitutes `default_sort_order` before the value reaches Query):

- `Observations::DownloadsController#new`/`#create` -- `find_or_create_query(:Observation, order_by: params[:by])`
- `Observations::SpeciesListsController#set_list_ivars` -- `order_by = params[:by] || :date`

An invalid `?by=` on an observation download or the "add to species list" panel silently sorts by `id: :desc` today instead of the model's declared default. Added a regression test against each controller (confirmed both fail without this fix, by temporarily reverting it and re-running them).

Migrating `:by` (the URL shortcut for `order_by`) onto the shared `create_query_from_url_params` path, planned for #5138, would otherwise route every index page's invalid-sort case through this same gap too -- worth landing on its own first.

## Test plan

- [x] Rubocop -- clean
- [x] Extended `test_validate_params_order_by_unsupported` to assert the value is cleared and `default_order` falls back correctly
- [x] Full `query_test.rb` -- green
- [x] New regression tests in `observations/downloads_controller_test.rb` and `observations/species_lists_controller_test.rb`, confirmed to fail without the fix

<!-- changelog -->
article: no
<!-- /changelog -->
