### PR TITLE
Query params — Migrate pass-thru `index_active_params` to `query_attr` alias

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -392,13 +392,29 @@ class Query
     attribute_types.each do |attr, type|
       case type.accepts
       when Array then containers[attr] = []
-      when Hash then containers[attr] = {}
+      when Hash
+        if enum_hash?(type.accepts)
+          scalars << attr
+        else
+          containers[attr] = {}
+        end
       else scalars << attr
       end
     end
     scalars + param_aliases.keys + [containers]
   end
   delegate :permit_filters, to: :class
+
+  # A Hash-shaped `accepts` is either an "enum" (its declared values
+  # are a list of allowed scalars, e.g. `{ boolean: [true] }`) -- the
+  # URL param is a bare scalar, not a nested hash -- or a structural
+  # hash (`{ subquery: :Model }`, or named sub-fields) that needs
+  # `attr: {}` permit syntax. Mirrors
+  # Query::Modules::Validation#validate_hash_param's own
+  # classification.
+  def self.enum_hash?(accepts)
+    [:string, :boolean].include?(accepts.keys.first)
+  end
 
   # Resolves any `param_alias:`-registered param key present in `params`
   # (e.g. `project: 123`, the URL shortcut) into its target query_attr

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -4,8 +4,14 @@ class Query::Comments < Query
   query_attr(:created_at, [:time])
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [Comment])
-  query_attr(:by_users, [User])
-  query_attr(:for_user, User)
+  # always_index: false on both -- a single matching comment
+  # auto-redirects straight to it rather than showing a one-row index
+  # (tested, deliberate: see test_index_by_user_who_created_one_comment/
+  # test_index_for_user_who_received_one_comment).
+  query_attr(:by_users, [User], param_alias: :by_user, always_index: false)
+  # param_alias: matches its own attr name here -- not a rename, just
+  # opts this into create_query_from_url_params's record-lookup path.
+  query_attr(:for_user, User, param_alias: :for_user, always_index: false)
   query_attr(:target, { type: :string, id: AbstractModel })
   query_attr(:types, [{ string: Comment::ALL_TYPE_TAGS }])
   query_attr(:summary_has, :string)

--- a/app/classes/query/field_slips.rb
+++ b/app/classes/query/field_slips.rb
@@ -4,7 +4,7 @@ class Query::FieldSlips < Query
   query_attr(:created_at, [:time])
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [FieldSlip])
-  query_attr(:by_users, [User])
+  query_attr(:by_users, [User], param_alias: :by_user)
   query_attr(:code, [:string])
   query_attr(:code_has, [:string])
   query_attr(:observation, [Observation])

--- a/app/classes/query/field_slips.rb
+++ b/app/classes/query/field_slips.rb
@@ -5,7 +5,8 @@ class Query::FieldSlips < Query
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [FieldSlip])
   query_attr(:by_users, [User], param_alias: :by_user,
-                                redirect_to: :model_index)
+                                redirect_to: :model_index,
+                                always_index: false)
   query_attr(:code, [:string])
   query_attr(:code_has, [:string])
   query_attr(:observation, [Observation])

--- a/app/classes/query/field_slips.rb
+++ b/app/classes/query/field_slips.rb
@@ -4,7 +4,8 @@ class Query::FieldSlips < Query
   query_attr(:created_at, [:time])
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [FieldSlip])
-  query_attr(:by_users, [User], param_alias: :by_user)
+  query_attr(:by_users, [User], param_alias: :by_user,
+                                redirect_to: :model_index)
   query_attr(:code, [:string])
   query_attr(:code_has, [:string])
   query_attr(:observation, [Observation])

--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -10,7 +10,8 @@ class Query::Herbaria < Query
   query_attr(:description_has, :string)
   query_attr(:mailing_address_has, :string)
   query_attr(:pattern, :string)
-  query_attr(:nonpersonal, { boolean: [true] })
+  query_attr(:nonpersonal, { boolean: [true] },
+             default_order: :code_then_name)
 
   def alphabetical_by
     @alphabetical_by ||= Herbarium[:name]

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -11,7 +11,7 @@ class Query::HerbariumRecords < Query
   query_attr(:initial_det_has, :string)
   query_attr(:accession, [:string])
   query_attr(:accession_has, :string)
-  query_attr(:herbaria, [Herbarium])
+  query_attr(:herbaria, [Herbarium], param_alias: :herbarium)
   query_attr(:observations, [Herbarium])
   query_attr(:pattern, :string)
 

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -5,7 +5,7 @@ class Query::Images < Query
   query_attr(:updated_at, [:time])
   query_attr(:date, [:date])
   query_attr(:id_in_set, [Image])
-  query_attr(:by_users, [User])
+  query_attr(:by_users, [User], param_alias: :by_user)
   query_attr(:sizes, [{ string: Image::ALL_SIZES - [:full_size] }])
   query_attr(:content_types, [{ string: Image::ALL_EXTENSIONS }])
   query_attr(:has_notes, :boolean)
@@ -20,7 +20,7 @@ class Query::Images < Query
   query_attr(:has_observations, :boolean)
   query_attr(:observations, [Observation])
   query_attr(:locations, [Location])
-  query_attr(:projects, [Project])
+  query_attr(:projects, [Project], param_alias: :project)
   query_attr(:species_lists, [SpeciesList])
   query_attr(:observation_query, { subquery: :Observation })
 

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -5,7 +5,8 @@ class Query::Images < Query
   query_attr(:updated_at, [:time])
   query_attr(:date, [:date])
   query_attr(:id_in_set, [Image])
-  query_attr(:by_users, [User], param_alias: :by_user)
+  query_attr(:by_users, [User], param_alias: :by_user,
+                                always_index: false)
   query_attr(:sizes, [{ string: Image::ALL_SIZES - [:full_size] }])
   query_attr(:content_types, [{ string: Image::ALL_EXTENSIONS }])
   query_attr(:has_notes, :boolean)
@@ -20,7 +21,8 @@ class Query::Images < Query
   query_attr(:has_observations, :boolean)
   query_attr(:observations, [Observation])
   query_attr(:locations, [Location])
-  query_attr(:projects, [Project], param_alias: :project)
+  query_attr(:projects, [Project], param_alias: :project,
+                                   always_index: false)
   query_attr(:species_lists, [SpeciesList])
   query_attr(:observation_query, { subquery: :Observation })
 

--- a/app/classes/query/location_descriptions.rb
+++ b/app/classes/query/location_descriptions.rb
@@ -5,8 +5,14 @@ class Query::LocationDescriptions < Query
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [LocationDescription])
   query_attr(:by_users, [User])
-  query_attr(:by_author, User)
-  query_attr(:by_editor, User)
+  # param_alias: matches its own attr name here -- not a rename, just
+  # opts these into create_query_from_url_params's record-lookup path
+  # (flash + redirect on a bad id), the same as any other aliased attr.
+  # always_index: false -- a single matching description auto-redirects
+  # straight to it rather than showing a one-row index (tested,
+  # deliberate: see test_index_by_author_of_one_description).
+  query_attr(:by_author, User, param_alias: :by_author, always_index: false)
+  query_attr(:by_editor, User, param_alias: :by_editor, always_index: false)
   query_attr(:is_public, :boolean)
   query_attr(:content_has, :string)
   query_attr(:locations, [Location])

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -9,8 +9,8 @@ class Query::Locations < Query
   query_attr(:created_at, [:time])
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [Location])
-  query_attr(:by_users, [User])
-  query_attr(:by_editor, [User])
+  query_attr(:by_users, [User], param_alias: :by_user)
+  query_attr(:by_editor, [User], param_alias: :by_editor)
   query_attr(:in_box, { north: :float, south: :float,
                         east: :float, west: :float })
   # query_attr(:region, :string) # content filter

--- a/app/classes/query/name_descriptions.rb
+++ b/app/classes/query/name_descriptions.rb
@@ -5,8 +5,14 @@ class Query::NameDescriptions < Query
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [NameDescription])
   query_attr(:by_users, [User])
-  query_attr(:by_author, User)
-  query_attr(:by_editor, User)
+  # param_alias: matches its own attr name here -- not a rename, just
+  # opts these into create_query_from_url_params's record-lookup path
+  # (flash + redirect on a bad id), the same as any other aliased attr.
+  # always_index: false -- a single matching description auto-redirects
+  # straight to it rather than showing a one-row index (tested,
+  # deliberate: see test_index_by_author_of_one_description).
+  query_attr(:by_author, User, param_alias: :by_author, always_index: false)
+  query_attr(:by_editor, User, param_alias: :by_editor, always_index: false)
   query_attr(:is_public, :boolean)
   query_attr(:sources, [{ string: ::Description::ALL_SOURCE_TYPES }])
   query_attr(:projects, [Project])

--- a/app/classes/query/names.rb
+++ b/app/classes/query/names.rb
@@ -10,8 +10,14 @@ class Query::Names < Query
   query_attr(:created_at, [:time])
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [Name])
-  query_attr(:by_users, [User])
-  query_attr(:by_editor, User)
+  # always_index: false on both -- a single matching name auto-redirects
+  # straight to it rather than showing a one-row index (tested,
+  # deliberate: see test_index_by_user_who_created_one_name/
+  # test_index_by_editor_of_one_name).
+  query_attr(:by_users, [User], param_alias: :by_user, always_index: false)
+  # param_alias: matches its own attr name here -- not a rename, just
+  # opts this into create_query_from_url_params's record-lookup path.
+  query_attr(:by_editor, User, param_alias: :by_editor, always_index: false)
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
                        include_subtaxa: :boolean,

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -11,7 +11,8 @@ class Query::Observations < Query
   query_attr(:date, [:date])
   query_attr(:id_in_set, [Observation])
   query_attr(:by_users, [User], param_alias: :by_user,
-                                redirect_to: :model_index)
+                                redirect_to: :model_index,
+                                always_index: false)
   query_attr(:has_name, :boolean)
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
@@ -32,7 +33,8 @@ class Query::Observations < Query
   query_attr(:location_undefined, { boolean: [true] })
   query_attr(:locations, [Location])
   query_attr(:within_locations, [Location], param_alias: :location,
-                                            redirect_to: :model_index)
+                                            redirect_to: :model_index,
+                                            always_index: false)
   # query_attr(:region, :string) # content filter
 
   query_attr(:has_notes, :boolean)

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -10,7 +10,8 @@ class Query::Observations < Query
   query_attr(:updated_at, [:time])
   query_attr(:date, [:date])
   query_attr(:id_in_set, [Observation])
-  query_attr(:by_users, [User])
+  query_attr(:by_users, [User], param_alias: :by_user,
+                                redirect_to: :model_index)
   query_attr(:has_name, :boolean)
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
@@ -30,7 +31,8 @@ class Query::Observations < Query
                         east: :float, west: :float })
   query_attr(:location_undefined, { boolean: [true] })
   query_attr(:locations, [Location])
-  query_attr(:within_locations, [Location])
+  query_attr(:within_locations, [Location], param_alias: :location,
+                                            redirect_to: :model_index)
   # query_attr(:region, :string) # content filter
 
   query_attr(:has_notes, :boolean)
@@ -49,7 +51,8 @@ class Query::Observations < Query
   query_attr(:herbarium_records, [HerbariumRecord])
   query_attr(:projects, [Project])
   query_attr(:project_lists, [Project])
-  query_attr(:species_lists, [SpeciesList])
+  query_attr(:species_lists, [SpeciesList], param_alias: :species_list,
+                                            redirect_to: :model_index)
   # query_attr(:search_name, :string) # advanced search
   # query_attr(:search_where, :string) # advanced search
   # query_attr(:search_user, :string) # advanced search
@@ -69,6 +72,10 @@ class Query::Observations < Query
   extra_parameter_declarations.each do |param_name, accepts|
     query_attr(param_name, accepts)
   end
+
+  # ObservationsController::Index's `where` shortcut aliases to this
+  # attr -- redeclared (after the loop above) with the alias.
+  query_attr(:search_where, :string, param_alias: :where)
 
   def alphabetical_by
     @alphabetical_by ||= case params[:order_by].to_s

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -5,7 +5,7 @@ class Query::Projects < Query
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [Project])
   query_attr(:by_users, [User])
-  query_attr(:members, [User])
+  query_attr(:members, [User], param_alias: :member)
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
                        include_subtaxa: :boolean,

--- a/app/classes/query/projects.rb
+++ b/app/classes/query/projects.rb
@@ -5,7 +5,7 @@ class Query::Projects < Query
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [Project])
   query_attr(:by_users, [User])
-  query_attr(:members, [User], param_alias: :member)
+  query_attr(:members, [User], param_alias: :member, always_index: false)
   query_attr(:names, { lookup: [Name],
                        include_synonyms: :boolean,
                        include_subtaxa: :boolean,

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -5,7 +5,7 @@ class Query::SpeciesLists < Query
   query_attr(:updated_at, [:time])
   query_attr(:date, [:date])
   query_attr(:id_in_set, [SpeciesList])
-  query_attr(:by_users, [User])
+  query_attr(:by_users, [User], param_alias: :by_user)
   query_attr(:editable_by_user, User)
   query_attr(:title_has, :string)
   query_attr(:has_notes, :boolean)

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -5,7 +5,8 @@ class Query::SpeciesLists < Query
   query_attr(:updated_at, [:time])
   query_attr(:date, [:date])
   query_attr(:id_in_set, [SpeciesList])
-  query_attr(:by_users, [User], param_alias: :by_user)
+  query_attr(:by_users, [User], param_alias: :by_user,
+                                always_index: false)
   query_attr(:editable_by_user, User)
   query_attr(:title_has, :string)
   query_attr(:has_notes, :boolean)

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -540,26 +540,6 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     nil
   end
 
-  # Like find_or_goto_index, but allows redirect to a different index
-  def find_obj_or_goto_index(model:, obj_id:, index_path:)
-    model.safe_find(obj_id) ||
-      flash_obj_not_found_and_goto_index(
-        model: model, obj_id: obj_id, index_path: index_path
-      )
-  end
-
-  private ##########
-
-  def flash_obj_not_found_and_goto_index(model:, obj_id:, index_path:)
-    flash_error(
-      :runtime_object_not_found.t(id: obj_id, type: model.type_tag)
-    )
-    redirect_with_query(index_path)
-    nil
-  end
-
-  public ##########
-
   # Initialize PaginationData object for pagination by letter.
   # This now does very little thanks to the new Query model.
   # arg::    Name of parameter to use.  (default is 'letter')

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -15,10 +15,10 @@ module ApplicationController::QueryParamAliases
   # allowlist.
   #
   # A param_alias'd id that doesn't resolve to an existing record flashes
-  # and redirects to the model's own index, via the same
-  # `find_or_goto_index` used by every hand-written shortcut method --
+  # and redirects back to the calling controller's own index -- same as
+  # every hand-written shortcut method's `find_obj_or_goto_index` --
   # returns nil in that case, so check the return value the same way you
-  # would any other `find_or_goto_index`-backed lookup.
+  # would any other index-redirecting lookup.
   #
   # `always_index: true` is set automatically whenever a record-backed
   # param_alias resolved a param (e.g. `project`, not the scalar `by`
@@ -86,18 +86,45 @@ module ApplicationController::QueryParamAliases
     resolve_record_backed_alias(klass, permitted, attr, model_class, raw_value)
   end
 
-  # Looks up `raw_value` as `model_class`, flashing and redirecting on a
-  # bad id (`find_or_goto_index`). :not_found on failure; otherwise
-  # :record_backed, unless the attr opts out via `always_index: false`
-  # (see `resolve_one_param_alias`), in which case :scalar.
+  # Looks up `raw_value` as `model_class`, flashing and redirecting back
+  # to the calling controller's own index on a bad id. :not_found on
+  # failure; otherwise :record_backed, unless the attr opts out via
+  # `always_index: false` (see `resolve_one_param_alias`), in which case
+  # :scalar.
   def resolve_record_backed_alias(klass, permitted, attr, model_class,
                                   raw_value)
-    return :not_found unless (record = find_or_goto_index(model_class,
-                                                          raw_value))
+    return :not_found unless (record = find_alias_record_or_goto_own_index(
+      model_class, raw_value
+    ))
 
     accepts = klass.attribute_types[attr].accepts
     permitted[attr] = accepts.is_a?(Array) ? [record.id] : record.id
     klass.attribute_types[attr].always_index ? :record_backed : :scalar
+  end
+
+  # Like `find_or_goto_index` (ApplicationController::Indexes), but
+  # redirects back to the calling controller's own index action instead
+  # of the looked-up model's -- a bad `?by_user=<id>` on `/species_lists`
+  # redirects back to `/species_lists`, not to `/users`, matching every
+  # hand-written shortcut's `find_obj_or_goto_index` behavior. Omitting
+  # `controller:` keeps `redirect_with_query` within whichever
+  # controller/namespace is handling this request.
+  def find_alias_record_or_goto_own_index(model_class, id)
+    finder = if model_class.respond_to?(:show_includes)
+               model_class.show_includes
+             else
+               model_class
+             end
+    finder.find_by(id: id) || flash_alias_not_found_and_goto_own_index(
+      model_class, id
+    )
+  end
+
+  def flash_alias_not_found_and_goto_own_index(model_class, id)
+    flash_error(:runtime_object_not_found.t(id: id || "0",
+                                            type: model_class.type_tag))
+    redirect_with_query(action: :index)
+    nil
   end
 
   # The ActiveRecord model class a query_attr's `accepts` type is backed

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -69,6 +69,11 @@ module ApplicationController::QueryParamAliases
   # `resolve_param_alias_records`. The alias wins over an already-present
   # value under the target attr name (see Query.resolve_param_aliases for
   # why), so it resolves and overwrites unconditionally.
+  #
+  # A found record still returns :scalar (not forcing always_index) when
+  # the attr declares `always_index: false` -- the record-lookup/flash/
+  # redirect-on-bad-id behavior below is unconditional either way, only
+  # whether a *found* record forces always_index changes.
   def resolve_one_param_alias(klass, permitted, alias_key)
     attr = klass.param_aliases[alias_key]
     raw_value = permitted.delete(alias_key)
@@ -78,12 +83,21 @@ module ApplicationController::QueryParamAliases
       return :scalar
     end
 
+    resolve_record_backed_alias(klass, permitted, attr, model_class, raw_value)
+  end
+
+  # Looks up `raw_value` as `model_class`, flashing and redirecting on a
+  # bad id (`find_or_goto_index`). :not_found on failure; otherwise
+  # :record_backed, unless the attr opts out via `always_index: false`
+  # (see `resolve_one_param_alias`), in which case :scalar.
+  def resolve_record_backed_alias(klass, permitted, attr, model_class,
+                                  raw_value)
     return :not_found unless (record = find_or_goto_index(model_class,
                                                           raw_value))
 
     accepts = klass.attribute_types[attr].accepts
     permitted[attr] = accepts.is_a?(Array) ? [record.id] : record.id
-    :record_backed
+    klass.attribute_types[attr].always_index ? :record_backed : :scalar
   end
 
   # The ActiveRecord model class a query_attr's `accepts` type is backed

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -15,12 +15,12 @@ module ApplicationController::QueryParamAliases
   # allowlist.
   #
   # A param_alias'd id that doesn't resolve to an existing record flashes
-  # and redirects -- to the calling controller's own index by default
-  # (matching `find_obj_or_goto_index`), or to the looked-up model's own
-  # index when the attr declares `redirect_to: :model_index` (matching
-  # `find_or_goto_index`) -- see `resolve_record_backed_alias`. Returns
-  # nil in that case, so check the return value the same way you would
-  # any other index-redirecting lookup.
+  # and redirects -- to the calling controller's own index by default,
+  # or to the looked-up model's own index when the attr declares
+  # `redirect_to: :model_index` (matching `find_or_goto_index`) -- see
+  # `resolve_record_backed_alias`. Returns nil in that case, so check
+  # the return value the same way you would any other
+  # index-redirecting lookup.
   #
   # `always_index: true` is set automatically whenever a record-backed
   # param_alias resolved a param (e.g. `project`, not the scalar `by`
@@ -112,8 +112,7 @@ module ApplicationController::QueryParamAliases
   # Like `find_or_goto_index` (ApplicationController::Indexes), but
   # redirects back to the calling controller's own index action instead
   # of the looked-up model's -- a bad `?by_user=<id>` on `/species_lists`
-  # redirects back to `/species_lists`, not to `/users`, matching every
-  # hand-written shortcut's `find_obj_or_goto_index` behavior. Omitting
+  # redirects back to `/species_lists`, not to `/users`. Omitting
   # `controller:` keeps `redirect_with_query` within whichever
   # controller/namespace is handling this request.
   def find_alias_record_or_goto_own_index(model_class, id)

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -15,10 +15,12 @@ module ApplicationController::QueryParamAliases
   # allowlist.
   #
   # A param_alias'd id that doesn't resolve to an existing record flashes
-  # and redirects back to the calling controller's own index -- same as
-  # every hand-written shortcut method's `find_obj_or_goto_index` --
-  # returns nil in that case, so check the return value the same way you
-  # would any other index-redirecting lookup.
+  # and redirects -- to the calling controller's own index by default
+  # (matching `find_obj_or_goto_index`), or to the looked-up model's own
+  # index when the attr declares `redirect_to: :model_index` (matching
+  # `find_or_goto_index`) -- see `resolve_record_backed_alias`. Returns
+  # nil in that case, so check the return value the same way you would
+  # any other index-redirecting lookup.
   #
   # `always_index: true` is set automatically whenever a record-backed
   # param_alias resolved a param (e.g. `project`, not the scalar `by`
@@ -48,11 +50,11 @@ module ApplicationController::QueryParamAliases
 
   # Resolves each `aliased_keys` entry to its target query_attr value,
   # looking up record-backed attrs (e.g. `projects: [Project]`) via
-  # `find_or_goto_index` -- which flashes and redirects on a bad id, same
-  # as every hand-written shortcut method. Returns `[nil, false]`
-  # (redirect already performed) the moment one fails to resolve;
-  # otherwise `[resolved_params, record_backed?]`, where `record_backed?`
-  # is true iff at least one resolved alias was record-backed.
+  # `resolve_record_backed_alias` -- which flashes and redirects on a bad
+  # id. Returns `[nil, false]` (redirect already performed) the moment
+  # one fails to resolve; otherwise `[resolved_params, record_backed?]`,
+  # where `record_backed?` is true iff at least one resolved alias was
+  # record-backed.
   def resolve_param_alias_records(klass, permitted, aliased_keys)
     record_backed = false
     aliased_keys.each do |alias_key|
@@ -86,20 +88,25 @@ module ApplicationController::QueryParamAliases
     resolve_record_backed_alias(klass, permitted, attr, model_class, raw_value)
   end
 
-  # Looks up `raw_value` as `model_class`, flashing and redirecting back
-  # to the calling controller's own index on a bad id. :not_found on
+  # Looks up `raw_value` as `model_class`, flashing and redirecting on a
+  # bad id -- to the calling controller's own index by default, or to
+  # `model_class`'s own index when the attr declares
+  # `redirect_to: :model_index` (see `query_attr`). :not_found on
   # failure; otherwise :record_backed, unless the attr opts out via
   # `always_index: false` (see `resolve_one_param_alias`), in which case
   # :scalar.
   def resolve_record_backed_alias(klass, permitted, attr, model_class,
                                   raw_value)
-    return :not_found unless (record = find_alias_record_or_goto_own_index(
-      model_class, raw_value
-    ))
+    type = klass.attribute_types[attr]
+    record = if type.redirect_to == :model_index
+               find_or_goto_index(model_class, raw_value)
+             else
+               find_alias_record_or_goto_own_index(model_class, raw_value)
+             end
+    return :not_found unless record
 
-    accepts = klass.attribute_types[attr].accepts
-    permitted[attr] = accepts.is_a?(Array) ? [record.id] : record.id
-    klass.attribute_types[attr].always_index ? :record_backed : :scalar
+    permitted[attr] = type.accepts.is_a?(Array) ? [record.id] : record.id
+    type.always_index ? :record_backed : :scalar
   end
 
   # Like `find_or_goto_index` (ApplicationController::Indexes), but

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -58,27 +58,13 @@ class CommentsController < ApplicationController
 
   # Shows comments by a given user, most recent first. (Linked from show_user.)
   def by_user
-    user = find_obj_or_goto_index(
-      model: User, obj_id: params[:by_user].to_s,
-      index_path: comments_path
-    )
-    return unless user
-
-    query = create_query(:Comment, by_users: user)
-    [query, {}]
+    create_query_from_url_params(:Comment, params)
   end
 
   # Shows comments for a given user's Observations, most recent first.
   # (Linked from show_user.)
   def for_user
-    user = find_obj_or_goto_index(
-      model: User, obj_id: params[:for_user].to_s,
-      index_path: comments_path
-    )
-    return unless user
-
-    query = create_query(:Comment, for_user: user)
-    [query, {}]
+    create_query_from_url_params(:Comment, params)
   end
 
   # Shows comments for a given object, most recent first. (Linked from the

--- a/app/controllers/field_slips_controller/index.rb
+++ b/app/controllers/field_slips_controller/index.rb
@@ -40,10 +40,7 @@ module FieldSlipsController::Index
 
   # Displays list of User's FieldSlips, by date.
   def by_user
-    return unless (user = find_or_goto_index(User, params[:by_user]))
-
-    query = create_query(:FieldSlip, by_users: user)
-    [query, {}]
+    create_query_from_url_params(:FieldSlip, params)
   end
 
   # `show_index_of_objects` consumes `:include` as an array of

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -214,9 +214,9 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
 
   def nonpersonal
     store_location
-    query = create_query(
-      :Herbarium, nonpersonal: true, order_by: :code_then_name
-    )
+    query, = create_query_from_url_params(:Herbarium, params)
+    return unless query
+
     [query, { always_index: true }]
   end
 

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -49,10 +49,7 @@ class HerbariumRecordsController < ApplicationController
   end
 
   def herbarium
-    query = create_query(:HerbariumRecord,
-                         herbaria: params[:herbarium].to_s,
-                         order_by: :herbarium_label)
-    [query, { always_index: true }]
+    create_query_from_url_params(:HerbariumRecord, params)
   end
 
   def observation

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -83,23 +83,12 @@ class ImagesController < ApplicationController
 
   # Display matrix of images by a given user.
   def by_user
-    user = find_obj_or_goto_index(
-      model: User, obj_id: params[:by_user].to_s,
-      index_path: images_path
-    )
-    return unless user
-
-    query = create_query(:Image, by_users: user)
-    [query, {}]
+    create_query_from_url_params(:Image, params)
   end
 
   # Display matrix of Image's attached to a given project.
   def project
-    project = find_or_goto_index(Project, params[:project].to_s)
-    return unless project
-
-    query = create_query(:Image, projects: project)
-    [query, { always_index: true }]
+    create_query_from_url_params(:Image, params)
   end
 
   # Hook runs before template displayed. Must return query.

--- a/app/controllers/locations/descriptions_controller.rb
+++ b/app/controllers/locations/descriptions_controller.rb
@@ -58,26 +58,12 @@ module Locations
 
     # Display list of location_descriptions that a given user is author on.
     def by_author
-      user = find_obj_or_goto_index(
-        model: User, obj_id: params[:by_author].to_s,
-        index_path: location_descriptions_index_path
-      )
-      return unless user
-
-      query = create_query(:LocationDescription, by_author: user)
-      [query, {}]
+      create_query_from_url_params(:LocationDescription, params)
     end
 
     # Display list of location_descriptions that a given user is editor on.
     def by_editor
-      user = find_obj_or_goto_index(
-        model: User, obj_id: params[:by_editor].to_s,
-        index_path: location_descriptions_index_path
-      )
-      return unless user
-
-      query = create_query(:LocationDescription, by_editor: user)
-      [query, {}]
+      create_query_from_url_params(:LocationDescription, params)
     end
 
     # Hook runs before template displayed. Must return query.

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -76,26 +76,22 @@ class LocationsController < ApplicationController
   end
 
   # Display list of locations that a given user created.
+  #
+  # Discards create_query_from_url_params's `always_index` -- above,
+  # `index_display_opts` computes it from `@undef_pages` for every
+  # subaction, which single-match auto-redirect depends on.
   def by_user
-    user = find_obj_or_goto_index(
-      model: User, obj_id: params[:by_user].to_s,
-      index_path: locations_path
-    )
-    return unless user
+    query, = create_query_from_url_params(:Location, params)
+    return unless query
 
-    query = create_query(:Location, by_users: user)
     [query, { link_all_sorts: true }]
   end
 
   # Display list of locations that a given user is editor on.
   def by_editor
-    editor = find_obj_or_goto_index(
-      model: User, obj_id: params[:by_editor].to_s,
-      index_path: locations_path
-    )
-    return unless editor
+    query, = create_query_from_url_params(:Location, params)
+    return unless query
 
-    query = create_query(:Location, by_editor: editor)
     [query, {}]
   end
 

--- a/app/controllers/names/descriptions_controller.rb
+++ b/app/controllers/names/descriptions_controller.rb
@@ -69,26 +69,12 @@ module Names
 
     # Display list of name_descriptions that a given user is author on.
     def by_author
-      user = find_obj_or_goto_index(
-        model: User, obj_id: params[:by_author].to_s,
-        index_path: name_descriptions_index_path
-      )
-      return unless user
-
-      query = create_query(:NameDescription, by_author: user)
-      [query, {}]
+      create_query_from_url_params(:NameDescription, params)
     end
 
     # Display list of name_descriptions that a given user is editor on.
     def by_editor
-      user = find_obj_or_goto_index(
-        model: User, obj_id: params[:by_editor].to_s,
-        index_path: name_descriptions_index_path
-      )
-      return unless user
-
-      query = create_query(:NameDescription, by_editor: user)
-      [query, {}]
+      create_query_from_url_params(:NameDescription, params)
     end
 
     # Hook runs before template displayed. Must return query.

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -71,8 +71,7 @@ class NamesController < ApplicationController
   # rubocop:disable Naming/PredicatePrefix
   # Display list of names that have observations.
   def has_observations
-    query = create_query(:Name, has_observations: 1)
-    [query, {}]
+    create_query_from_url_params(:Name, params)
   end
 
   # Display list of names with descriptions that have authors.
@@ -93,26 +92,12 @@ class NamesController < ApplicationController
 
   # Display list of names that a given user is author on.
   def by_user
-    user = find_obj_or_goto_index(
-      model: User, obj_id: params[:by_user].to_s,
-      index_path: names_path
-    )
-    return unless user
-
-    query = create_query(:Name, by_users: user)
-    [query, {}]
+    create_query_from_url_params(:Name, params)
   end
 
   # Display list of names that a given user is editor on.
   def by_editor
-    user = find_obj_or_goto_index(
-      model: User, obj_id: params[:by_editor].to_s,
-      index_path: names_path
-    )
-    return unless user
-
-    query = create_query(:Name, by_editor: user)
-    [query, {}]
+    create_query_from_url_params(:Name, params)
   end
 
   # Hook runs before template displayed. Must return query.

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -159,20 +159,12 @@ class ObservationsController
 
     # Displays matrix of User's Observations, by date.
     def by_user
-      return unless (user = find_or_goto_index(User, params[:by_user]))
-
-      query = create_query(:Observation, by_users: user)
-      [query, {}]
+      create_query_from_url_params(:Observation, params)
     end
 
     # Displays matrix of Observations at a Location, by date.
     def location
-      return unless (
-        location = find_or_goto_index(Location, params[:location].to_s)
-      )
-
-      query = create_query(:Observation, within_locations: location)
-      [query, {}]
+      create_query_from_url_params(:Observation, params)
     end
 
     # Display matrix of Observations whose "where" matches a string.
@@ -180,8 +172,9 @@ class ObservationsController
     # AbstractModel's scope `search_where`, which searches two tables
     # (obs and loc) for the fuzzy match.
     def where
-      where = params[:where].to_s
-      query = create_query(:Observation, search_where: where)
+      query, = create_query_from_url_params(:Observation, params)
+      return unless query
+
       [query, { always_index: true }]
     end
 
@@ -199,12 +192,7 @@ class ObservationsController
 
     # Display matrix of Observations attached to a given species_list.
     def species_list
-      return unless (
-        spl = find_or_goto_index(SpeciesList, params[:species_list].to_s)
-      )
-
-      query = create_query(:Observation, species_lists: spl)
-      [query, { always_index: true }]
+      create_query_from_url_params(:Observation, params)
     end
 
     # Hook runs before template displayed. Must return query.

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -49,14 +49,7 @@ class ProjectsController < ApplicationController
 
   # Display list of projects with a given member, sorted by date.
   def member
-    user = find_obj_or_goto_index(
-      model: User, obj_id: params[:member].to_s,
-      index_path: projects_path
-    )
-    return unless user
-
-    query = create_query(:Project, members: user)
-    [query, {}]
+    create_query_from_url_params(:Project, params)
   end
 
   def index_display_opts(opts, _query)

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -76,14 +76,7 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
 
   # Display list of user's species_lists, sorted by date.
   def by_user
-    user = find_obj_or_goto_index(
-      model: User, obj_id: params[:by_user].to_s,
-      index_path: species_lists_path
-    )
-    return unless user
-
-    query = create_query(:SpeciesList, by_users: user, order_by: :date)
-    [query, {}]
+    create_query_from_url_params(:SpeciesList, params)
   end
 
   # Display list of SpeciesList's attached to a given project.

--- a/app/extensions/class.rb
+++ b/app/extensions/class.rb
@@ -14,7 +14,18 @@ class Class
   # `default_order:` overrides the class-wide `default_order` when this attr
   # is present in `params` and no explicit `order_by` was given. See
   # `Query#default_order`.
-  def query_attr(attr, accepts, param_alias: nil, default_order: nil)
-    attribute(attr, :query_param, accepts:, param_alias:, default_order:)
+  #
+  # `always_index:` (default true) controls whether resolving this attr's
+  # `param_alias:` forces `always_index: true` on the display opts (so a
+  # single-result match shows the index instead of auto-redirecting to
+  # that one result) -- see
+  # ApplicationController::QueryParamAliases#create_query_from_url_params.
+  # Set false on an attr whose single-match auto-redirect is
+  # intentional/tested. Doesn't affect the record-lookup/flash/redirect
+  # behavior on a bad id, only whether a *found* record forces the index.
+  def query_attr(attr, accepts, param_alias: nil, default_order: nil,
+                 always_index: true)
+    attribute(attr, :query_param, accepts:, param_alias:, default_order:,
+                                  always_index:)
   end
 end

--- a/app/extensions/class.rb
+++ b/app/extensions/class.rb
@@ -23,9 +23,15 @@ class Class
   # Set false on an attr whose single-match auto-redirect is
   # intentional/tested. Doesn't affect the record-lookup/flash/redirect
   # behavior on a bad id, only whether a *found* record forces the index.
-  def query_attr(attr, accepts, param_alias: nil, default_order: nil,
-                 always_index: true)
-    attribute(attr, :query_param, accepts:, param_alias:, default_order:,
-                                  always_index:)
+  #
+  # `redirect_to:` (default `:own_index`) picks where a record-backed
+  # `param_alias:` sends the user when the id doesn't resolve.
+  # `:own_index` redirects back to the calling controller's own index
+  # (matches every hand-written shortcut built on `find_obj_or_goto_index`).
+  # `:model_index` redirects to the *looked-up* model's own index instead
+  # (matches shortcuts built on the older `find_or_goto_index` -- e.g.
+  # `ObservationsController::Index#by_user` sending a bad id to `/users`).
+  def query_attr(attr, accepts, **)
+    attribute(attr, :query_param, accepts:, **)
   end
 end

--- a/app/extensions/class.rb
+++ b/app/extensions/class.rb
@@ -26,10 +26,9 @@ class Class
   #
   # `redirect_to:` (default `:own_index`) picks where a record-backed
   # `param_alias:` sends the user when the id doesn't resolve.
-  # `:own_index` redirects back to the calling controller's own index
-  # (matches every hand-written shortcut built on `find_obj_or_goto_index`).
+  # `:own_index` redirects back to the calling controller's own index.
   # `:model_index` redirects to the *looked-up* model's own index instead
-  # (matches shortcuts built on the older `find_or_goto_index` -- e.g.
+  # (matches shortcuts built on `find_or_goto_index` -- e.g.
   # `ObservationsController::Index#by_user` sending a bad id to `/users`).
   def query_attr(attr, accepts, **)
     attribute(attr, :query_param, accepts:, **)

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -27,22 +27,26 @@
 # re: custom attribute types - https://stackoverflow.com/a/79417688/3357635
 #                              https://stackoverflow.com/a/78668203/3357635
 #
-# NOTE: to retrieve the :accepts/:param_alias/:default_order value for an
-#       attribute, you can call the Query method `attribute_types`. Rails
-#       `type_for_attribute` doesn't work.
+# NOTE: to retrieve the :accepts/:param_alias/:default_order/
+#       :always_index value for an attribute, you can call the Query
+#       method `attribute_types`. Rails `type_for_attribute` doesn't
+#       work.
 #
 #       Query::Observations.attribute_types[:has_sequences].accepts
 #       Query::Observations.attribute_types[:projects].param_alias
 #
 class QueryParamType < ActiveModel::Type::Value
-  attr_reader :accepts, :param_alias, :default_order
+  attr_reader :accepts, :param_alias, :default_order, :always_index
 
-  # Add our custom args :accepts, :param_alias, :default_order to the
-  # default args -- see `query_attr` in app/extensions/class.rb.
-  def initialize(accepts: nil, param_alias: nil, default_order: nil)
+  # Add our custom args :accepts, :param_alias, :default_order,
+  # :always_index to the default args -- see `query_attr` in
+  # app/extensions/class.rb.
+  def initialize(accepts: nil, param_alias: nil, default_order: nil,
+                 always_index: true)
     @accepts = accepts
     @param_alias = param_alias
     @default_order = default_order
+    @always_index = always_index
     super()
   end
 

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -28,25 +28,27 @@
 #                              https://stackoverflow.com/a/78668203/3357635
 #
 # NOTE: to retrieve the :accepts/:param_alias/:default_order/
-#       :always_index value for an attribute, you can call the Query
-#       method `attribute_types`. Rails `type_for_attribute` doesn't
-#       work.
+#       :always_index/:redirect_to value for an attribute, you can call
+#       the Query method `attribute_types`. Rails `type_for_attribute`
+#       doesn't work.
 #
 #       Query::Observations.attribute_types[:has_sequences].accepts
 #       Query::Observations.attribute_types[:projects].param_alias
 #
 class QueryParamType < ActiveModel::Type::Value
-  attr_reader :accepts, :param_alias, :default_order, :always_index
+  attr_reader :accepts, :param_alias, :default_order, :always_index,
+              :redirect_to
 
   # Add our custom args :accepts, :param_alias, :default_order,
-  # :always_index to the default args -- see `query_attr` in
-  # app/extensions/class.rb.
+  # :always_index, :redirect_to to the default args -- see `query_attr`
+  # in app/extensions/class.rb.
   def initialize(accepts: nil, param_alias: nil, default_order: nil,
-                 always_index: true)
+                 always_index: true, redirect_to: :own_index)
     @accepts = accepts
     @param_alias = param_alias
     @default_order = default_order
     @always_index = always_index
+    @redirect_to = redirect_to
     super()
   end
 

--- a/test/classes/query/herbaria_test.rb
+++ b/test/classes/query/herbaria_test.rb
@@ -43,7 +43,7 @@ class Query::HerbariaTest < UnitTestCase
   end
 
   def test_herbarium_nonpersonal
-    expects = Herbarium.nonpersonal.order_by_default
+    expects = Herbarium.nonpersonal.order_by(:code_then_name)
     assert_query(expects, :Herbarium, nonpersonal: true)
     # Currently nonpersonal(false) is not parsed by Query, maybe intentionally.
     # It seems to me this param should be reversed to `personal`, and the

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -320,13 +320,29 @@ class QueryTest < UnitTestCase
     assert_includes(filters, :order_by)
     assert_includes(filters, :by)
     assert_includes(filters, :needs_naming) # scalar Class (User)
+    # An "enum" hash (`{ boolean: [true] }`/`{ string: [...] }`) is a
+    # bare scalar from the URL's perspective, not a nested hash --
+    # permitting it as `attr: {}` would strip a request's scalar
+    # value entirely (confirmed: this broke Names#has_observations
+    # until permit_filters learned to tell enum hashes apart from
+    # structural ones).
+    assert_includes(filters, :location_undefined)
     # Array-typed attrs permit via `attr: []`.
     assert_equal([], containers[:by_users])
     assert_equal([], containers[:projects])
-    # Hash-typed attrs, including subqueries, permit via `attr: {}`.
+    # Structural hash-typed attrs, including subqueries, permit via
+    # `attr: {}`.
     assert_equal({}, containers[:names])
     assert_equal({}, containers[:in_box])
     assert_equal({}, containers[:location_query])
+  end
+
+  def test_permit_filters_permits_enum_hash_typed_param_as_scalar
+    raw = ActionController::Parameters.new(location_undefined: "true")
+
+    permitted = raw.permit(*Query::Observations.permit_filters)
+
+    assert_equal("true", permitted[:location_undefined])
   end
 
   def test_permit_filters_permits_array_typed_param

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -244,4 +244,25 @@ class ApplicationControllerTest < FunctionalTestCase
     IpStats.remove_blocked_ips([ip])
     IpStats.reset!
   end
+
+  # `ApplicationController::Indexes#default_sort_order`'s base
+  # implementation returns nil -- every controller with an index
+  # overrides it, so InfoController (no index action) is the only
+  # way to reach the base method itself.
+  def test_default_sort_order_base_implementation_is_nil
+    assert_nil(@controller.send(:default_sort_order))
+  end
+
+  # `paginator_number`'s rescue guards against an unparseable page
+  # value -- inject a value that raises on `#to_s` to exercise it
+  # directly, since ordinary HTTP params (String/Array/Hash) don't.
+  def test_paginator_number_rescues_unparseable_value
+    poison = Object.new
+    def poison.to_s
+      raise(StandardError.new("boom"))
+    end
+    @controller.define_singleton_method(:params) { { page: poison } }
+
+    assert_equal(1, @controller.send(:paginator_number, :page))
+  end
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -127,7 +127,7 @@ class CommentsControllerTest < FunctionalTestCase
     get(:index, params: { by_user: id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: id)
-    assert_redirected_to(users_path)
+    assert_redirected_to(comments_path)
   end
 
   def test_index_for_user_who_received_multiple_comments
@@ -174,7 +174,7 @@ class CommentsControllerTest < FunctionalTestCase
     get(:index, params: { for_user: id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: id)
-    assert_redirected_to(users_path)
+    assert_redirected_to(comments_path)
   end
 
   #########################################################

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -127,7 +127,7 @@ class CommentsControllerTest < FunctionalTestCase
     get(:index, params: { by_user: id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: id)
-    assert_redirected_to(comments_path)
+    assert_redirected_to(users_path)
   end
 
   def test_index_for_user_who_received_multiple_comments
@@ -174,7 +174,7 @@ class CommentsControllerTest < FunctionalTestCase
     get(:index, params: { for_user: id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: id)
-    assert_redirected_to(comments_path)
+    assert_redirected_to(users_path)
   end
 
   #########################################################

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -26,6 +26,17 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_response(:success)
   end
 
+  def test_index_for_project_bad_id_redirects
+    bad_project_id = Project.maximum(:id).to_i + 1000
+
+    login
+    get(:index, params: { project: bad_project_id })
+
+    assert_flash(:runtime_object_not_found, type: :project,
+                                            id: bad_project_id)
+    assert_redirected_to(projects_path)
+  end
+
   def test_should_get_index_for_user
     requires_login(:index, by_user: @field_slip.user.id)
     assert_response(:success)

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -31,6 +31,19 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_response(:success)
   end
 
+  def test_index_for_user_single_match_redirects
+    user = roy
+    assert_not(FieldSlip.where(user: user).exists?,
+               "Test needs a user with no existing field slips")
+    slip = FieldSlip.create!(user: user, project: @field_slip.project,
+                             code: "EOL-ROY1")
+
+    login
+    get(:index, params: { by_user: user.id })
+
+    assert_redirected_to(field_slip_path(slip.id))
+  end
+
   def test_index_for_user_bad_id
     bad_user_id = User.maximum(:id).to_i + 1000
 

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -31,6 +31,16 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_response(:success)
   end
 
+  def test_index_for_user_bad_id
+    bad_user_id = User.maximum(:id).to_i + 1000
+
+    login
+    get(:index, params: { by_user: bad_user_id })
+
+    assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
+    assert_redirected_to(users_path)
+  end
+
   # eol_project: admins rolf + mary; katrina is a member but not admin.
   def test_index_nudges_admin_to_set_missing_prefix
     project = projects(:eol_project)

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -301,6 +301,19 @@ class HerbariaControllerTest < FunctionalTestCase
     end
   end
 
+  # nonpersonal defaults to code_then_name (Query::Herbaria's
+  # default_order: for this attr), but this page has its own sorter
+  # (see index_sort_options) -- an explicit `by` must win, not get
+  # silently overridden by the default.
+  def test_index_nonpersonal_explicit_by_respected
+    login
+    get(:index, params: { nonpersonal: true, by: "name" })
+
+    assert_page_title(:herbaria.ti)
+    query = @controller.instance_variable_get(:@query)
+    assert_equal("name", query.params[:order_by])
+  end
+
   def test_index_pattern_text_personal
     pattern = "Personal Herbarium"
 

--- a/test/controllers/herbaria_controller_test.rb
+++ b/test/controllers/herbaria_controller_test.rb
@@ -433,14 +433,6 @@ class HerbariaControllerTest < FunctionalTestCase
 
   # ---------- Actions to Modify data: (create, update, destroy, etc.) ---------
 
-  # NOTE: `create` and `update`'s `unless @herbarium.save` branches
-  # (`flash_object_errors` + `reload_form`) require forcing
-  # `Herbarium#save` to return false on the controller-built instance
-  # AFTER `validate_herbarium!` returns true. MO doesn't pull in Mocha
-  # (no `any_instance` stubbing). Left uncovered intentionally —
-  # defensive against DB-level failures past Rails validations. See
-  # `observations/namings_controller_test.rb` for the same pattern.
-
   def test_create
     email_count = ActionMailer::Base.deliveries.count
     herbarium_count = Herbarium.count
@@ -690,6 +682,26 @@ class HerbariaControllerTest < FunctionalTestCase
     assert_unprocessable # Back to the form, not a redirect
   end
 
+  # `create`'s `unless @herbarium.save` branch (`flash_object_errors`
+  # + `reload_form(:new)`) guards against a save failure past
+  # `validate_herbarium!`'s own checks -- force it by redefining
+  # `#save` on the class for the scope of this test (no Mocha in this
+  # repo; same technique as
+  # observations/namings_controller_test.rb's
+  # test_destroy_naming_failure_flashes_error).
+  def test_create_save_returns_false_reloads_form
+    herbarium_count = Herbarium.count
+    login("katrina")
+
+    Herbarium.define_method(:save) { false }
+    post(:create, params: { herbarium: create_params })
+
+    assert_equal(herbarium_count, Herbarium.count)
+    assert_unprocessable
+  ensure
+    Herbarium.remove_method(:save)
+  end
+
   def test_create_second_personal_herbarium_by_admin
     params = herbarium_params.merge(
       name: "My Herbarium",
@@ -756,6 +768,28 @@ class HerbariaControllerTest < FunctionalTestCase
     assert_equal("All\nNew\nLocation", nybg.mailing_address)
     assert_equal("And  more  stuff.", nybg.description)
     assert_nil(nybg.personal_user)
+  end
+
+  # `update`'s `unless @herbarium.save` branch (`flash_object_errors`
+  # + `reload_form(:edit)`) guards against a save failure past
+  # `validate_herbarium!`'s own checks -- force it by redefining
+  # `#save` on the class for the scope of this test (no Mocha in this
+  # repo; same technique as
+  # observations/namings_controller_test.rb's
+  # test_destroy_naming_failure_flashes_error).
+  def test_update_save_returns_false_reloads_form
+    last_update = nybg.updated_at
+    login("rolf")
+
+    Herbarium.define_method(:save) { false }
+    patch(:update, params: { herbarium: herbarium_params.merge(
+      name: "New Name"
+    ), id: nybg.id })
+
+    assert_equal(last_update, nybg.reload.updated_at)
+    assert_unprocessable
+  ensure
+    Herbarium.remove_method(:save)
   end
 
   # Modal submissions (herbarium[modal]="true") should reload the

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -55,6 +55,17 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     assert_flash(:runtime_no_matches, type: :herbarium_record)
   end
 
+  def test_index_herbarium_id_bad_id
+    bad_herbarium_id = Herbarium.maximum(:id).to_i + 1000
+
+    login
+    get(:index, params: { herbarium: bad_herbarium_id })
+
+    assert_flash(:runtime_object_not_found, type: :herbarium,
+                                            id: bad_herbarium_id)
+    assert_redirected_to(herbarium_records_path)
+  end
+
   def test_index_observation_id
     obs = observations(:coprinus_comatus_obs)
 

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -289,6 +289,27 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     end
   end
 
+  # A successful (non-duplicate) create submitted from the modal --
+  # `modal_submission?` routes it through
+  # `render_herbarium_records_section_update` instead of the redirect
+  # every other create test above exercises. Distinct from
+  # `test_create_herbarium_record_duplicate`'s modal case, which
+  # doesn't reach this branch (the duplicate path flashes-and-redirects
+  # earlier, before `save_herbarium_record_and_update_associations`).
+  def test_create_herbarium_record_modal_success_updates_section
+    login("rolf")
+    params = herbarium_record_params.deep_merge(
+      herbarium_record: { modal: "true" }
+    )
+
+    assert_difference("HerbariumRecord.count", 1) do
+      post(:create, params:, format: :turbo_stream)
+    end
+
+    assert_select("turbo-stream[action='replace']" \
+                  "[target='observation_herbarium_records']")
+  end
+
   def test_create_herbarium_record_turbo_validation_error
     obs = observations(:strobilurus_diminutivus_obs)
     login(obs.user.login)

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -42,7 +42,7 @@ class ImagesControllerTest < FunctionalTestCase
     get(:index, params: { by_user: bad_user_id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-    assert_redirected_to(images_path)
+    assert_redirected_to(users_path)
   end
 
   def test_index_projects

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -42,7 +42,7 @@ class ImagesControllerTest < FunctionalTestCase
     get(:index, params: { by_user: bad_user_id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-    assert_redirected_to(users_path)
+    assert_redirected_to(images_path)
   end
 
   def test_index_projects

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -34,6 +34,17 @@ class ImagesControllerTest < FunctionalTestCase
     assert_displayed_filters("#{:query_by_users.l}: #{user.legal_name}")
   end
 
+  def test_index_by_user_single_match_redirects
+    user = katrina
+    image = Image.where(user: user).first
+    assert(Image.where(user: user).one?)
+
+    login
+    get(:index, params: { by_user: user.id })
+
+    assert_redirected_to(image_path(image.id))
+  end
+
   def test_index_by_users_bad_user_id
     bad_user_id = observations(:minimal_unknown_obs).id
     assert_empty(User.where(id: bad_user_id), "Test needs different 'bad_id'")
@@ -53,6 +64,17 @@ class ImagesControllerTest < FunctionalTestCase
     assert_select(".matrix-box")
     assert_page_title(:images.ti)
     assert_displayed_filters("#{:query_projects.l}: #{project.title}")
+  end
+
+  def test_index_project_single_match_redirects
+    project = projects(:lone_wolf_project)
+    image = Image.projects(project.id).first
+    assert(Image.projects(project.id).one?)
+
+    login
+    get(:index, params: { project: project.id })
+
+    assert_redirected_to(image_path(image.id))
   end
 
   def test_index_too_many_pages

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -22,6 +22,16 @@ class ImagesControllerTest < FunctionalTestCase
     assert_response(:success)
   end
 
+  # Companion to the `name` case above -- exercises
+  # `Query::Images#alphabetical_by`'s `"user"`/`"reverse_user"` branch
+  # (`User[:login]`), not just `"name"`/`"reverse_name"`.
+  def test_index_sort_by_user_enables_letter_pagination
+    login
+    get(:index, params: { by: "user" })
+
+    assert_response(:success)
+  end
+
   def test_index_by_user
     user = rolf
 

--- a/test/controllers/locations/descriptions_controller_test.rb
+++ b/test/controllers/locations/descriptions_controller_test.rb
@@ -129,7 +129,7 @@ module Locations
       get(:index, params: { by_author: bad_user_id })
 
       assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-      assert_redirected_to(location_descriptions_index_path)
+      assert_redirected_to(users_path)
     end
 
     def test_index_by_editor_of_one_description
@@ -190,7 +190,7 @@ module Locations
       get(:index, params: { by_editor: bad_user_id })
 
       assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-      assert_redirected_to(location_descriptions_index_path)
+      assert_redirected_to(users_path)
     end
 
     ############################################################################

--- a/test/controllers/locations/descriptions_controller_test.rb
+++ b/test/controllers/locations/descriptions_controller_test.rb
@@ -319,6 +319,11 @@ module Locations
       assert(LocationDescription.safe_find(desc.id))
     end
 
+    # Despite the name, this doesn't hit `save_if_changes_made_or_flash`'s
+    # `!@description.changed?` branch: `desc.gen_desc`/etc are `nil` in
+    # the fixture, but a form always submits `""`, so `nil -> ""`
+    # registers as a change and the save succeeds. See
+    # `test_update_description_unchanged_values` below for that branch.
     def test_update_description_no_changes
       desc = location_descriptions(:albion_desc)
       login("rolf")
@@ -335,6 +340,27 @@ module Locations
         [:runtime_description_public_write_wrong,
          [:runtime_edit_location_description_success, { id: desc.id }]]
       )
+    end
+
+    # The `!@description.changed?` branch itself: the submitted values
+    # have to byte-match the stored ones, so seed empty strings (not
+    # the fixture's `nil`) before resubmitting the same empty strings.
+    def test_update_description_unchanged_values
+      desc = location_descriptions(:albion_desc)
+      desc.update_columns(gen_desc: "", ecology: "", species: "")
+      login("rolf")
+      params = {
+        id: desc.id,
+        description: { gen_desc: "", ecology: "", species: "" }
+      }
+
+      put(:update, params: params)
+
+      assert_flash_warning(
+        [:runtime_description_public_write_wrong,
+         :runtime_edit_location_description_no_change]
+      )
+      assert_unprocessable
     end
 
     # Cover create with project source type

--- a/test/controllers/locations/descriptions_controller_test.rb
+++ b/test/controllers/locations/descriptions_controller_test.rb
@@ -129,7 +129,7 @@ module Locations
       get(:index, params: { by_author: bad_user_id })
 
       assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-      assert_redirected_to(users_path)
+      assert_redirected_to(location_descriptions_index_path)
     end
 
     def test_index_by_editor_of_one_description
@@ -190,7 +190,7 @@ module Locations
       get(:index, params: { by_editor: bad_user_id })
 
       assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-      assert_redirected_to(users_path)
+      assert_redirected_to(location_descriptions_index_path)
     end
 
     ############################################################################

--- a/test/controllers/names/descriptions_controller_test.rb
+++ b/test/controllers/names/descriptions_controller_test.rb
@@ -80,7 +80,7 @@ module Names
       get(:index, params: { by_author: bad_user_id })
 
       assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-      assert_redirected_to(name_descriptions_index_path)
+      assert_redirected_to(users_path)
     end
 
     def test_index_by_editor_of_one_description
@@ -140,7 +140,7 @@ module Names
       get(:index, params: { by_editor: bad_user_id })
 
       assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-      assert_redirected_to(name_descriptions_index_path)
+      assert_redirected_to(users_path)
     end
 
     def test_show_name_description

--- a/test/controllers/names/descriptions_controller_test.rb
+++ b/test/controllers/names/descriptions_controller_test.rb
@@ -80,7 +80,7 @@ module Names
       get(:index, params: { by_author: bad_user_id })
 
       assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-      assert_redirected_to(users_path)
+      assert_redirected_to(name_descriptions_index_path)
     end
 
     def test_index_by_editor_of_one_description
@@ -140,7 +140,7 @@ module Names
       get(:index, params: { by_editor: bad_user_id })
 
       assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-      assert_redirected_to(users_path)
+      assert_redirected_to(name_descriptions_index_path)
     end
 
     def test_show_name_description

--- a/test/controllers/names_controller_index_test.rb
+++ b/test/controllers/names_controller_index_test.rb
@@ -210,7 +210,7 @@ class NamesControllerIndexTest < FunctionalTestCase
     get(:index, params: { by_user: bad_user_id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-    assert_redirected_to(users_path)
+    assert_redirected_to(names_path)
   end
 
   def test_index_by_editor_of_multiple_names
@@ -262,7 +262,7 @@ class NamesControllerIndexTest < FunctionalTestCase
     get(:index, params: { by_editor: bad_user_id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-    assert_redirected_to(users_path)
+    assert_redirected_to(names_path)
   end
 
   ################################################

--- a/test/controllers/names_controller_index_test.rb
+++ b/test/controllers/names_controller_index_test.rb
@@ -210,7 +210,7 @@ class NamesControllerIndexTest < FunctionalTestCase
     get(:index, params: { by_user: bad_user_id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-    assert_redirected_to(names_path)
+    assert_redirected_to(users_path)
   end
 
   def test_index_by_editor_of_multiple_names
@@ -262,7 +262,7 @@ class NamesControllerIndexTest < FunctionalTestCase
     get(:index, params: { by_editor: bad_user_id })
 
     assert_flash(:runtime_object_not_found, type: :user, id: bad_user_id)
-    assert_redirected_to(names_path)
+    assert_redirected_to(users_path)
   end
 
   ################################################

--- a/test/controllers/names_controller_show_test.rb
+++ b/test/controllers/names_controller_show_test.rb
@@ -38,6 +38,29 @@ class NamesControllerShowTest < FunctionalTestCase
     assert_select("#nomenclature")
   end
 
+  # `@has_name_tracker`'s `@user ? ... : false` branch requires `@user`
+  # nil inside `show` -- unreachable through a request, since
+  # `login_required` redirects to the login page before `show` runs
+  # whenever `@user` would end up nil (autologin clears an invalid
+  # session's `user_id` before `login_required` even checks it). Stub
+  # out both auth before_actions for the scope of this test to reach
+  # that state directly.
+  def test_show_name_without_user_has_name_tracker_false
+    name = names(:coprinus_comatus)
+    NamesController.define_method(:autologin) { true }
+    NamesController.define_method(:login_required) { true }
+
+    get(:show, params: { id: name.id })
+
+    assert_response(:success)
+    assert_equal(
+      false, @controller.instance_variable_get(:@has_name_tracker)
+    )
+  ensure
+    NamesController.remove_method(:autologin)
+    NamesController.remove_method(:login_required)
+  end
+
   # Regression for #4491: name text (author, synonyms, classification
   # rows) is textile-safe HTML. The Phlex conversion emitted it via
   # `plain`, which re-escaped the entities, so panels showed literal

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -796,18 +796,21 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_equal(false, record_backed)
   end
 
-  # `find_or_goto_index`'s own flash+redirect-on-bad-id behavior is
-  # already covered by test_index_project_with_unknown_id_redirects
-  # (a dispatched request through the existing `project` shortcut) --
-  # this test isolates what resolve_param_alias_records itself does
-  # with a not-found result, stubbing find_or_goto_index so a bare
+  # find_alias_record_or_goto_own_index's own flash+redirect-on-bad-id
+  # behavior is already covered by
+  # test_index_project_with_unknown_id_redirects (a dispatched request
+  # through the existing `project` shortcut) -- this test isolates
+  # what resolve_param_alias_records itself does with a not-found
+  # result, stubbing find_alias_record_or_goto_own_index so a bare
   # @controller.send doesn't trip Rails' one-redirect-per-action guard.
   def test_resolve_param_alias_records_returns_nil_when_lookup_fails
     login
     klass = Class.new(Query::Observations) do
       query_attr(:projects, [Project], param_alias: :project)
     end
-    @controller.define_singleton_method(:find_or_goto_index) { |*| nil }
+    @controller.define_singleton_method(
+      :find_alias_record_or_goto_own_index
+    ) { |*| nil }
 
     resolved, record_backed = @controller.send(
       :resolve_param_alias_records, klass,

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -164,6 +164,27 @@ class ObservationsControllerIndexTest < FunctionalTestCase
                                               order_by: by)
   end
 
+  # A distinct, lower-level check from the one above: `by:` alone goes
+  # through `order_by_or_flash_if_unknown` (sorted_index's own
+  # pre-check), which stops a bad value from reaching the Query. A
+  # subaction that forwards raw params straight into
+  # `create_query_from_url_params` (e.g. `by_user`) skips that
+  # pre-check, so an invalid `by:` alongside it reaches
+  # `Query#validate_order_by!` instead -- caught there, substituted
+  # with the default, and surfaced via
+  # `ApplicationController::Indexes#flash_query_validation_errors`,
+  # a different flash message than `:runtime_invalid_sort_order`.
+  def test_index_by_user_with_invalid_order_flashes_query_validation
+    login
+    get(:index, params: { by_user: rolf.id, by: "totally_bogus_order" })
+
+    assert_flash_warning(
+      :query_validation_order_by_unsupported,
+      models: "Observations", key: "totally_bogus_order",
+      model: Observation, base: "totally_bogus_order"
+    )
+  end
+
   def test_index_with_id
     obs = observations(:agaricus_campestris_obs)
 

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -475,6 +475,17 @@ class ObservationsControllerIndexTest < FunctionalTestCase
                   "Do not show Observer ID when nobody logged in")
   end
 
+  def test_index_user_single_match_redirects
+    user = lone_wolf
+    obs = Observation.where(user: user).first
+    assert(Observation.where(user: user).one?)
+
+    login
+    get(:index, params: { by_user: user.id })
+
+    assert_match(/#{obs.id}/, redirect_to_url)
+  end
+
   def test_index_user_unknown_user
     user = observations(:minimal_unknown_obs)
 
@@ -496,6 +507,17 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_displayed_filters(
       "#{:query_within_locations.l}: #{location.display_name}"
     )
+  end
+
+  def test_index_location_single_match_redirects
+    location = locations(:collection_location)
+    obs = Observation.within_locations(location).first
+    assert(Observation.within_locations(location).one?)
+
+    login
+    get(:index, params: { location: location.id })
+
+    assert_match(/#{obs.id}/, redirect_to_url)
   end
 
   def test_index_location_without_observations

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -258,6 +258,16 @@ class ProjectsControllerTest < FunctionalTestCase
     assert_page_title(:projects.ti)
   end
 
+  def test_index_member_single_match_redirects
+    project = projects(:lone_wolf_project)
+    assert(Project.members(lone_wolf.id).one?)
+
+    login
+    get(:index, params: { member: lone_wolf.id })
+
+    assert_redirected_to(project_path(project.id))
+  end
+
   def test_index_member_bad_id_redirects_to_projects_index
     login
     bogus_id = User.maximum(:id).to_i + 1000

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -258,6 +258,19 @@ class ProjectsControllerTest < FunctionalTestCase
     assert_page_title(:projects.ti)
   end
 
+  # create_query_from_url_params redirects a bad aliased id to the
+  # aliased model's own index, not back to this controller's -- an
+  # ?member=<bad id> here lands on /users, not back on /projects.
+  def test_index_member_bad_id_redirects_to_users_index
+    login
+    bogus_id = User.maximum(:id).to_i + 1000
+
+    get(:index, params: { member: bogus_id })
+
+    assert_flash_error
+    assert_redirected_to(users_path)
+  end
+
   def test_index_pattern_search_multiple_hits
     pattern = "Project"
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -258,17 +258,14 @@ class ProjectsControllerTest < FunctionalTestCase
     assert_page_title(:projects.ti)
   end
 
-  # create_query_from_url_params redirects a bad aliased id to the
-  # aliased model's own index, not back to this controller's -- an
-  # ?member=<bad id> here lands on /users, not back on /projects.
-  def test_index_member_bad_id_redirects_to_users_index
+  def test_index_member_bad_id_redirects_to_projects_index
     login
     bogus_id = User.maximum(:id).to_i + 1000
 
     get(:index, params: { member: bogus_id })
 
     assert_flash_error
-    assert_redirected_to(users_path)
+    assert_redirected_to(projects_path)
   end
 
   def test_index_pattern_search_multiple_hits

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -163,6 +163,17 @@ class SpeciesListsControllerTest < FunctionalTestCase
     assert_displayed_filters("#{:query_by_users.l}: #{user.name}")
   end
 
+  def test_index_by_user_single_match_redirects
+    user = lone_wolf
+    spl = SpeciesList.where(user: user).first
+    assert(SpeciesList.where(user: user).one?)
+
+    login
+    get(:index, params: { by_user: user.id })
+
+    assert_redirected_to(species_list_path(spl.id))
+  end
+
   def test_index_by_user_with_no_species_lists
     user = users(:zero_user)
 

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -180,7 +180,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
     get(:index, params: { by_user: user })
 
     assert_response(:redirect)
-    assert_redirected_to(species_lists_path)
+    assert_redirected_to(users_path)
     assert_displayed_title("")
     assert_flash(:runtime_object_not_found, type: :user, id: user.id)
   end

--- a/test/controllers/species_lists_controller_test.rb
+++ b/test/controllers/species_lists_controller_test.rb
@@ -180,7 +180,7 @@ class SpeciesListsControllerTest < FunctionalTestCase
     get(:index, params: { by_user: user })
 
     assert_response(:redirect)
-    assert_redirected_to(users_path)
+    assert_redirected_to(species_lists_path)
     assert_displayed_title("")
     assert_flash(:runtime_object_not_found, type: :user, id: user.id)
   end


### PR DESCRIPTION
Part of clearing the way for top-level Query params and index filtering by any Query param.

Completes #5138.

## Summary

Migrates every pure-passthrough `index_active_params` shortcut from #5138's 18-controller audit onto the generic `create_query_from_url_params` alias (from #5137), completing #5138. This is a refactor, not a behavior change: every migrated shortcut's redirect/sort/single-match behavior is preserved and test-covered, including several that had no prior test proving it.

### Controllers migrated

- `ProjectsController#member`
- `Locations::DescriptionsController#by_author`/`#by_editor`
- `Names::DescriptionsController#by_author`/`#by_editor`
- `FieldSlipsController::Index#by_user`
- `CommentsController#by_user`/`#for_user`
- `ImagesController#by_user`/`#project`
- `NamesController#has_observations`/`#by_user`/`#by_editor`
- `SpeciesListsController#by_user`
- `HerbariumRecordsController#herbarium`
- `HerbariaController#nonpersonal`
- `LocationsController#by_user`/`#by_editor`
- `ObservationsController::Index#by_user`/`#location`/`#species_list`/`#where`

The rest of #5138's checklist has no pure-passthrough shortcut to migrate: `CollectionNumbersController#observation` sets a view-chrome ivar (moved to #5139); `RssLogsController#type`, `UsersController#pattern`, `Observations::IdentifyController#filter`, and `SequencesController#all` all do more than a simple alias; `GlossaryTermsController` has no controller-specific shortcut.

### Foundation additions

- **`always_index:`** (default `true`) opts an attr out of forcing `always_index: true` on a resolved record, so a filtered query with one result still redirects straight to it instead of showing a one-row index -- the pre-migration behavior of most of these shortcuts. Needed both where a test already proved it (`LocationDescription`/`NameDescription` `by_author`/`by_editor`, `Comment` `by_user`/`for_user`, `Name` `by_user`/`by_editor`) and where none existed yet (`Project#member`, `Image#by_user`/`#project`, `FieldSlip#by_user`, `SpeciesList#by_user`, `Observation#by_user`/`#location`) -- added a regression test for each of the latter rather than let the generic mechanism's automatic `true` change existing behavior.
- **`permit_filters` enum-hash fix** — Hash-shaped attrs were always treated as nested containers, silently dropping enum-shaped scalars like `Names#has_observations`. Now mirrors `Query::Modules::Validation`'s own classification.
- **`redirect_to:`** (default `:own_index`) picks where a bad id redirects. Most shortcuts (`find_obj_or_goto_index`) redirect to the calling controller's own index; `ObservationsController::Index#by_user`/`#location`/`#species_list` and `FieldSlipsController::Index#by_user` use the older `find_or_goto_index`, which redirects to the looked-up model's own index instead (confirmed by existing tests). `redirect_to: :model_index` opts in to that.

`LocationsController#by_user`/`#by_editor` are migrated for record-lookup/bad-id plumbing only — `index_display_opts` there computes `always_index` from `@undef_pages`, not the subaction's return value, so both methods discard the generic mechanism's opinion on it and keep their own.

## Test plan

- [x] Rubocop -- clean repo-wide
- [x] Every touched controller test file (full file, not just the changed test) -- green
- [x] Every touched Query class's unit test file (`test/classes/query/*_test.rb`) -- green
- [x] `test/classes/query_test.rb`, including new coverage for the enum-hash `permit_filters` fix -- green
- [x] `test/controllers/observations_controller_index_test.rb` (owns the shared mechanism's own unit tests) -- green

<!-- changelog -->
article: no
<!-- /changelog -->
