### PR TITLE
Query params — Move complex params to scopes and set ivars in ApplicationController, part 1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ require:
   - ./lib/rubocop/cop/mo/no_active_record_relation_prop
   - ./lib/rubocop/cop/mo/no_hand_rolled_form_tag
   - ./lib/rubocop/cop/mo/no_hand_rolled_method_field
+  - ./lib/rubocop/cop/mo/no_query_subclass_mutation
   - ./lib/rubocop/cop/mo/no_raw_bootstrap_component
   - ./lib/rubocop/cop/mo/no_raw_link_or_button_to
   - ./lib/rubocop/cop/mo/no_render_phlex_method_name
@@ -131,6 +132,14 @@ MO/NoHandRolledMethodField:
   Include:
     - "app/components/**/*.rb"
     - "app/views/**/*.rb"
+
+MO/NoQuerySubclassMutation:
+  Description: >-
+    query_attr/attribute must not be called on a live Query/Query::*
+    class constant -- it mutates shared state for the rest of the
+    process. Use Class.new(Query::Whatever) { query_attr(...) }
+    instead -- see lib/rubocop/cop/mo/no_query_subclass_mutation.rb.
+  Enabled: true
 
 MO/NoResolvedErrorsAddType:
   Description: >-

--- a/app/classes/form_object/identify_filter.rb
+++ b/app/classes/form_object/identify_filter.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 # Form object for the identify observations filter form.
-# Params namespaced as filter[term], filter[type], etc.
+# Params namespaced as identify_filter[term], identify_filter[type],
+# etc. -- matches Query::Observations' identify_filter query_attr
+# directly, no controller-side param translation needed.
 class FormObject::IdentifyFilter < FormObject::Base
   VALID_TYPES = %w[clade region].freeze
 
@@ -14,9 +16,5 @@ class FormObject::IdentifyFilter < FormObject::Base
   # trust the value.
   def type=(value)
     super(VALID_TYPES.include?(value) ? value : "clade")
-  end
-
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "Filter")
   end
 end

--- a/app/classes/query/collection_numbers.rb
+++ b/app/classes/query/collection_numbers.rb
@@ -9,7 +9,8 @@ class Query::CollectionNumbers < Query
   query_attr(:numbers, [:string])
   query_attr(:collector_has, :string)
   query_attr(:number_has, :string)
-  query_attr(:observations, [Observation], param_alias: :observation)
+  query_attr(:observations, [Observation], param_alias: :observation,
+                                           redirect_to: :model_index)
   query_attr(:pattern, :string)
 
   def alphabetical_by

--- a/app/classes/query/collection_numbers.rb
+++ b/app/classes/query/collection_numbers.rb
@@ -9,7 +9,7 @@ class Query::CollectionNumbers < Query
   query_attr(:numbers, [:string])
   query_attr(:collector_has, :string)
   query_attr(:number_has, :string)
-  query_attr(:observations, [Observation])
+  query_attr(:observations, [Observation], param_alias: :observation)
   query_attr(:pattern, :string)
 
   def alphabetical_by

--- a/app/classes/query/images.rb
+++ b/app/classes/query/images.rb
@@ -22,7 +22,8 @@ class Query::Images < Query
   query_attr(:observations, [Observation])
   query_attr(:locations, [Location])
   query_attr(:projects, [Project], param_alias: :project,
-                                   always_index: false)
+                                   always_index: false,
+                                   redirect_to: :model_index)
   query_attr(:species_lists, [SpeciesList])
   query_attr(:observation_query, { subquery: :Observation })
 

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -50,7 +50,7 @@ class Query::Observations < Query
 
   query_attr(:herbaria, [Herbarium])
   query_attr(:herbarium_records, [HerbariumRecord])
-  query_attr(:projects, [Project])
+  query_attr(:projects, [Project], param_alias: :project)
   query_attr(:project_lists, [Project])
   query_attr(:species_lists, [SpeciesList])
   # query_attr(:search_name, :string) # advanced search

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -54,7 +54,8 @@ class Query::Observations < Query
 
   query_attr(:herbaria, [Herbarium])
   query_attr(:herbarium_records, [HerbariumRecord])
-  query_attr(:projects, [Project], param_alias: :project)
+  query_attr(:projects, [Project], param_alias: :project,
+                                   redirect_to: :model_index)
   query_attr(:project_lists, [Project])
   query_attr(:species_lists, [SpeciesList], param_alias: :species_list,
                                             redirect_to: :model_index)

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -23,6 +23,9 @@ class Query::Observations < Query
   query_attr(:needs_naming, User)
   # query_attr(:clade, :string) # content filter
   # query_attr(:lichen, :boolean) # content filter
+  # The identify page's clade/region autocompleter -- see
+  # Observation::Scopes#identify_filter.
+  query_attr(:identify_filter, { type: :string, term: :string })
 
   query_attr(:is_collection_location, :boolean)
   query_attr(:has_public_lat_lng, :boolean)

--- a/app/classes/query/rss_logs.rb
+++ b/app/classes/query/rss_logs.rb
@@ -7,7 +7,12 @@ class Query::RssLogs < Query
   # via `extra_parameter_declarations` below.
   query_attr(:updated_at, [:time])
   query_attr(:id_in_set, [RssLog])
-  query_attr(:type, :string)
+  # `type` (singular) is the legacy scalar URL shortcut, still a
+  # working alias -- `?type=observation` resolves to `types:
+  # ["observation"]`. `RssLog.types` (the scope) tolerates a
+  # space-separated string inside a single array element too, so an
+  # old `?type=observation+name` bookmark still normalizes correctly.
+  query_attr(:types, [:string], param_alias: :type)
   # query_attr(:clade, :string) # content filter
   # query_attr(:lichen, :boolean) # content filter
   # query_attr(:region, :string) # content filter

--- a/app/components/application_form/button_style_checkbox.rb
+++ b/app/components/application_form/button_style_checkbox.rb
@@ -11,7 +11,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   #
   # Parallel of `ButtonStyleRadio`. Same constructor shape, same
   # caller ergonomics — just emits `type="checkbox"` and supports
-  # name-array shapes like `q[type][]` for multi-select filters.
+  # name-array shapes like `q[types][]` for multi-select filters.
   #
   # Standalone (no Superform context) — takes raw HTML kwargs rather
   # than a `Field` / `FieldProxy`, since the call sites (filter UIs,
@@ -19,7 +19,7 @@ class Components::ApplicationForm < Superform::Rails::Form
   #
   # @example
   #   render(Components::ApplicationForm::ButtonStyleCheckbox.new(
-  #     name: "q[type][]", value: "observation",
+  #     name: "q[types][]", value: "observation",
   #     id: "type_observation", checked: types.include?("observation"),
   #     variant: :outline, size: :sm,
   #     label: { class: "filter-checkbox" }

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -189,6 +189,22 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     query
   end
 
+  # Derives a controller ivar (e.g. `@project`, `@observation`) from an
+  # already-built Query's resolved params, for a single-record
+  # `attr` (e.g. `:projects`, `:observations`) -- covers both a URL
+  # shortcut (`?project=id`) and a bookmarked/permalinked
+  # `q[projects][]=id` query the same way, since both resolve into the
+  # same `query.params[attr]` shape. Call from a controller's
+  # `filtered_index_final_hook` override. No-op (ivar left unset) when
+  # `attr` isn't present or holds more than one id -- a multi-value
+  # filter has no single record to derive an ivar from.
+  def derive_ivar_from_query(ivar, query, attr, model_class)
+    ids = query.params[attr]
+    return unless ids.is_a?(Array) && ids.size == 1
+
+    instance_variable_set(ivar, model_class.safe_find(ids.first))
+  end
+
   # Default for the display_opts hash passed to show_index_of_objects.
   # These are pretty different per controller.
   def index_display_opts(extra_display_opts, _query)

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -51,22 +51,16 @@ class CollectionNumbersController < ApplicationController
   end
 
   # Hook runs before template displayed. Must return query.
+  #
+  # @observation (drives the page's observation-context banner) is
+  # derived from the query itself, after its own record-lookup
+  # validation already ran -- replaces the old
+  # `Observation.find(params[:observation])`, which raised
+  # RecordNotFound (500) on a bad id instead of flashing/redirecting
+  # like every other shortcut.
   def filtered_index_final_hook(query, _display_opts)
-    derive_observation_ivar(query)
+    derive_ivar_from_query(:@observation, query, :observations, Observation)
     query
-  end
-
-  # Derives @observation (drives the page's observation-context
-  # banner) from the query itself, after its own record-lookup
-  # validation already ran -- instead of a second independent lookup
-  # (the old `Observation.find(params[:observation])`, which also
-  # raised RecordNotFound on a bad id rather than flashing/
-  # redirecting like every other shortcut).
-  def derive_observation_ivar(query)
-    observation_ids = query.params[:observations]
-    return unless observation_ids.is_a?(Array) && observation_ids.size == 1
-
-    @observation = Observation.safe_find(observation_ids.first)
   end
 
   def index_display_opts(opts, _query)

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -47,11 +47,26 @@ class CollectionNumbersController < ApplicationController
 
   # Display list of CollectionNumbers for an Observation
   def observation
-    @observation = Observation.find(params[:observation])
-    query = create_query(
-      :CollectionNumber, observations: params[:observation].to_s
-    )
-    [query, { always_index: true }]
+    create_query_from_url_params(:CollectionNumber, params)
+  end
+
+  # Hook runs before template displayed. Must return query.
+  def filtered_index_final_hook(query, _display_opts)
+    derive_observation_ivar(query)
+    query
+  end
+
+  # Derives @observation (drives the page's observation-context
+  # banner) from the query itself, after its own record-lookup
+  # validation already ran -- instead of a second independent lookup
+  # (the old `Observation.find(params[:observation])`, which also
+  # raised RecordNotFound on a bad id rather than flashing/
+  # redirecting like every other shortcut).
+  def derive_observation_ivar(query)
+    observation_ids = query.params[:observations]
+    return unless observation_ids.is_a?(Array) && observation_ids.size == 1
+
+    @observation = Observation.safe_find(observation_ids.first)
   end
 
   def index_display_opts(opts, _query)

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -43,49 +43,23 @@ module Observations
     end
 
     def index_active_params
-      [:filter, :q, :id].freeze
+      [:identify_filter, :q, :id].freeze
     end
 
-    # Ideally the filter form should pass the clade/region params with separate
-    # terms, so we can build the query by multiple flat params as expected.
-    # However, this form uses a single field with swapping autocompleter;
-    # the form scope is :filter and the field name is always :term.
-    # Currently params needs both a :filter[:type] and a filter[:term] to work.
-    def filter
-      return unless (type = params.dig(:filter, :type).to_sym)
-      return unless (term = params.dig(:filter, :term).strip)
-
-      case type
-      when :clade
-        clade(term)
-      when :region
-        region(term)
-        # when :user
-        #   user(term)
-      end
-    end
-
-    # Some inefficiency here comes from having to parse the name from a string.
-    # Check if the autocompleters return a name_id or location_id.
-    def clade(term)
-      # return unless (clade = Name.find_by(text_name: term))
-
-      query = create_query(:Observation, needs_naming: @user, clade: term,
+    # Dispatches to Observation.identify_filter (Observation::Scopes),
+    # which picks clade or region based on identify_filter[type] --
+    # the single swappable autocompleter submits both under one field
+    # pair, so this permits the nested hash directly rather than going
+    # through create_query_from_url_params (no alias/record lookup
+    # applies to this attr).
+    def identify_filter
+      filter = params.permit(identify_filter: [:type, :term])[:identify_filter].
+               to_h.symbolize_keys
+      query = create_query(:Observation, identify_filter: filter,
+                                         needs_naming: @user,
                                          order_by: :rss_log)
       [query, {}]
     end
-
-    def region(term)
-      query = create_query(:Observation, needs_naming: @user, region: term,
-                                         order_by: :rss_log)
-      [query, {}]
-    end
-
-    # def user_filter(term)
-    #   query = create_query(:Observation, needs_naming: @user, by_users: term,
-    #                                      order_by: :rss_log)
-    #   [query, {}]
-    # end
 
     def index_display_opts(opts, _query)
       { matrix: true, cache: true,

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -186,7 +186,7 @@ class ObservationsController
 
     # Display matrix of Observations attached to a given project.
     #
-    # `by: :thumbnail_quality` is this page's own default sort, not
+    # `by: :thumbnail_quality` is this page's default sort, not
     # Query::Observations' class-wide one -- a bare `projects:` filter
     # elsewhere (e.g. a raw Query.lookup) still gets the class
     # default, so the override is threaded through the raw params
@@ -216,23 +216,8 @@ class ObservationsController
     # Hook runs before template displayed. Must return query.
     def filtered_index_final_hook(query, _display_opts)
       store_query_in_session(query)
-      derive_project_ivar(query)
+      derive_ivar_from_query(:@project, query, :projects, Project)
       query
-    end
-
-    # Derives @project (drives the project banner, "add observation to
-    # this project" buttons, and the admin-permission check in the
-    # view) from the query itself -- covers both the `project`
-    # shortcut and a bookmarked/permalinked `q[projects][]=` query the
-    # same way, one lookup, after the query (and its own record-lookup
-    # validation) already exists -- instead of a second independent
-    # lookup racing the one `project`/`create_query_from_url_params`
-    # already did.
-    def derive_project_ivar(query)
-      project_ids = query.params[:projects]
-      return unless project_ids.is_a?(Array) && project_ids.size == 1
-
-      @project = Project.safe_find(project_ids.first)
     end
 
     def index_display_opts(opts, query)

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -5,7 +5,6 @@ class ObservationsController
   module Index
     def index
       make_name_suggestions
-      set_project_ivar
       build_index_with_query
     end
 
@@ -186,15 +185,22 @@ class ObservationsController
     end
 
     # Display matrix of Observations attached to a given project.
+    #
+    # `by: :thumbnail_quality` is this page's own default sort, not
+    # Query::Observations' class-wide one -- a bare `projects:` filter
+    # elsewhere (e.g. a raw Query.lookup) still gets the class
+    # default, so the override is threaded through the raw params
+    # here rather than a shared `default_order:` on the `projects`
+    # attr. An explicit `by` still wins.
     def project
-      return unless (
-        project = find_or_goto_index(Project, params[:project].to_s)
-      )
-
-      query = create_query(:Observation, projects: project,
-                                         order_by: "thumbnail_quality")
-      @project = project
-      [query, { always_index: true }]
+      raw_params = if params[:by].present?
+                     params
+                   else
+                     params.merge(
+                       by: :thumbnail_quality
+                     )
+                   end
+      create_query_from_url_params(:Observation, raw_params)
     end
 
     # Display matrix of Observations attached to a given species_list.
@@ -210,7 +216,23 @@ class ObservationsController
     # Hook runs before template displayed. Must return query.
     def filtered_index_final_hook(query, _display_opts)
       store_query_in_session(query)
+      derive_project_ivar(query)
       query
+    end
+
+    # Derives @project (drives the project banner, "add observation to
+    # this project" buttons, and the admin-permission check in the
+    # view) from the query itself -- covers both the `project`
+    # shortcut and a bookmarked/permalinked `q[projects][]=` query the
+    # same way, one lookup, after the query (and its own record-lookup
+    # validation) already exists -- instead of a second independent
+    # lookup racing the one `project`/`create_query_from_url_params`
+    # already did.
+    def derive_project_ivar(query)
+      project_ids = query.params[:projects]
+      return unless project_ids.is_a?(Array) && project_ids.size == 1
+
+      @project = Project.safe_find(project_ids.first)
     end
 
     def index_display_opts(opts, query)

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -26,94 +26,55 @@ class RssLogsController < ApplicationController
   end
 
   def unfiltered_index_opts
-    super.merge(query_args: { type: index_type_default })
+    super.merge(query_args: { types: index_type_default })
   end
 
   def index_type_default
     @user ? @user.default_rss_type : "all"
   end
 
-  # ApplicationController uses this to dispatch #index to a private method
+  # ApplicationController uses this to dispatch #index to a private method.
+  # `:type` (legacy scalar bookmarks) and `:types` (the type-filter form,
+  # or a direct `?types[]=` URL) both resolve to the same query_attr --
+  # see `Query::RssLogs`.
   def index_active_params
-    [:type, :by, :q, :id].freeze
+    [:type, :types, :by, :q, :id].freeze
   end
 
   # Show selected list, based on current Query.
   def sorted_index_opts
     super.deep_merge(
-      query_args: { type: index_type_from_params || index_type_default }
+      query_args: { types: index_type_from_params || index_type_default }
     )
   end
 
-  # Redirect old-style top-level `type` param to proper `q` param URL.
-  # This handles bookmarked URLs like /activity_logs?type=observation
+  # `:type`/`:types` are plain query_attr aliases now (see
+  # Query::RssLogs) -- no bookmark redirect needed, top-level params
+  # are a first-class URL form.
   def type
-    validated_type = validate_type_param(params[:type])
-    redirect_to(
-      activity_logs_path(q: { model: :RssLog, type: validated_type })
-    )
+    create_query_from_url_params(:RssLog, params)
   end
+  alias types type
 
-  # Validate type param (array or string) and return sanitized string
-  def validate_type_param(param)
-    if param.is_a?(Array)
-      validate_type_array(param)
-    elsif param.is_a?(String)
-      validate_type_string(param)
-    else
-      "all"
-    end
-  end
-
-  # Get the types whose value == "1"
-  # Handles:
-  # - String types from pagination/bookmarks: "observation name"
-  # - Array types from form checkboxes: ["observation", "name"]
-  # - Old-style top-level type param for backwards compatibility
+  # The types filter active in the current Query, if any, otherwise
+  # whatever the request itself supplies -- from a stored/`q`-decoded
+  # query when sorting an already-filtered index, or a fresh top-level
+  # `type`/`types` param otherwise. `Query::RssLogs`'s own validation
+  # normalizes whatever shape comes back.
   def index_type_from_params
-    types = ""
-    param = if (query = query_from_q_param)
-              # Query validated type as string; if nil, check raw q param
-              query.params[:type] || params.dig(:q, :type)
-            else
-              params[:type]
-            end
-
-    if param.is_a?(Array)
-      types = validate_type_array(param)
-    elsif param.is_a?(String)
-      types = validate_type_string(param)
+    if (query = query_from_q_param)
+      query.params[:types] || params.dig(:q, :types) ||
+        params.dig(:q, :type)
+    else
+      params[:types] || params[:type]
     end
-    types
-  end
-
-  # Validate array of types (from form checkboxes or bookmarked URLs)
-  def validate_type_array(param)
-    valid_tags = RssLog::ALL_TYPE_TAGS.map(&:to_s)
-    validated = param.map(&:to_s).select { |t| valid_tags.include?(t) }
-    return "none" if validated.empty?
-    return "all" if validated.length == valid_tags.length
-
-    validated.join(" ")
-  end
-
-  # Validate type string to ensure only valid type tags are used
-  def validate_type_string(param)
-    return param if param.in?(%w[all none])
-
-    valid_tags = RssLog::ALL_TYPE_TAGS.map(&:to_s)
-    validated = param.split.select { |t| valid_tags.include?(t) }
-    return "none" if validated.empty?
-    return "all" if validated.length == valid_tags.length
-
-    validated.join(" ")
   end
 
   # Hook runs before template displayed. Must return query.
   def filtered_index_final_hook(query, _display_opts)
-    # store_query_in_session(query)
     update_stored_query(query) # also stores query in session
-    @types = query.params[:type].to_s.split.sort
+    tags = RssLog.normalize_type_tags(query.params[:types])
+    @types = tags.empty? ? ["none"] : tags.sort
 
     # Let the user make this their default and fine tune.
     if @user && params[:make_default] == "1"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -78,27 +78,13 @@ class UsersController < ApplicationController
   end
 
   # Display list of Users whose name, notes, etc. match a string pattern.
+  # An exact numeric-id or verified-email match wins outright (see
+  # User.exact_match/User.pattern); a single fuzzy login/name match
+  # falls through to the generic single-result auto-redirect
+  # (display_opts has no always_index override, same as before).
   def pattern
-    pattern = params[:pattern].to_s
-    if (user = user_exact_match(pattern))
-      redirect_to(user_path(user.id))
-      [nil, {}]
-    else
-      query = create_query(:User, pattern: pattern)
-      [query, {}]
-    end
-  end
-
-  # This doesn't return direct hits on the user login or name, in case fuzzy.
-  def user_exact_match(pattern)
-    if ((pattern.match?(/^\d+$/) && (user = User.safe_find(pattern))) ||
-       # (user = User.find_by(login: pattern)) ||
-       # (user = User.find_by(name: pattern)) ||
-       (user = User.find_by(email: pattern))) && user.verified
-      return user
-    end
-
-    false
+    query = create_query(:User, pattern: params[:pattern].to_s)
+    [query, {}]
   end
 
   # Hook runs before template displayed. Must return query.

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -206,6 +206,22 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     scope :names_like,
           ->(name) { where(name: Name.text_name_has(name)) }
 
+    # Discriminator + payload shape for the identify page's clade/region
+    # autocompleter, which submits `identify_filter[type]`/
+    # `identify_filter[term]` under one field pair (a single swappable
+    # widget, not separate clade/region inputs). Mirrors Comment#target's
+    # type-dispatched scope.
+    scope :identify_filter, lambda { |filter|
+      case filter[:type]&.to_sym
+      when :clade
+        clade(filter[:term])
+      when :region
+        region(filter[:term])
+      else
+        none
+      end
+    }
+
     # This should really be clades/clade, but changing user prefs/filters and
     # autocompleters is very involved, requires migration and script.
     scope :clade, lambda { |clades|

--- a/app/models/rss_log/scopes.rb
+++ b/app/models/rss_log/scopes.rb
@@ -11,15 +11,17 @@ module RssLog::Scopes
     scope :order_by_default,
           -> { order_by(::Query::RssLogs.default_order) }
 
-    scope :type, lambda { |types|
-      return all if types.to_s == "all"
+    # Accepts a scalar (String/Symbol, optionally space-separated) or
+    # an Array of either -- `?type=a+b` (a legacy bookmark), `?types[]=a
+    # &types[]=b` (the type-filter form), and `Query::RssLogs`'s
+    # own `types: [...]` param all normalize to the same tag list here.
+    scope :types, lambda { |types|
+      tags = normalize_type_tags(types)
+      return all if tags == ["all"]
+      return none if tags.empty?
 
-      types = types.to_s.split unless types.is_a?(Array)
-      types &= ::RssLog::ALL_TYPE_TAGS.map(&:to_s)
-      return none if types.empty?
-
-      types.map! { |type| arel_table[:"#{type}_id"].not_eq(nil) }
-      where(or_clause(*types)).distinct
+      clauses = tags.map { |tag| arel_table[:"#{tag}_id"].not_eq(nil) }
+      where(or_clause(*clauses)).distinct
     }
 
     # Exclude RssLog entries for observations that belong to a
@@ -59,6 +61,18 @@ module RssLog::Scopes
   end
 
   module ClassMethods
+    # Normalizes a `types` scope/query-param value -- a scalar (String/
+    # Symbol, optionally space-separated) or an Array of either -- into
+    # a flat Array of valid tag strings (garbage/unknown tags dropped).
+    # `["all"]` is the sentinel for "every type"; an empty result means
+    # no valid tag survived.
+    def normalize_type_tags(types)
+      tags = Array(types).flat_map { |tag| tag.to_s.split }
+      return ["all"] if tags == ["all"]
+
+      tags & ::RssLog::ALL_TYPE_TAGS.map(&:to_s)
+    end
+
     private
 
     # class methods here, `self` included
@@ -84,14 +98,9 @@ module RssLog::Scopes
     # applied. Defaults to :all. Returns an array of model classes.
     def filterable_types_in_current_query(params)
       filterable_types = [:observation, :name, :location]
-      active_types = case params[:type]
-                     when nil, "", :all, "all"
-                       filterable_types
-                     when Array
-                       params[:type]
-                     when String
-                       params[:type].split
-                     end
+      tags = normalize_type_tags(params[:types])
+      active_types = tags.blank? || tags == ["all"] ? filterable_types : tags
+
       active_types.map { |type| type.to_s.camelize.constantize }
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -312,7 +312,18 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     where(User[:contribution].gt(0))
   }
 
+  # An exact numeric-id or verified-email match wins outright, ahead
+  # of (not unioned with) the fuzzy login/name search below -- a bare
+  # digit string is a substring of huge numbers of spam logins in
+  # production (e.g. `User.pattern("1")` fuzzy-matches thousands of
+  # users), so folding the two into one OR'd query would make
+  # id-based lookup return a multi-row index instead of the single
+  # intended record for most ids.
   scope :pattern, lambda { |phrase|
+    if (exact = exact_match(phrase))
+      return where(id: exact.id)
+    end
+
     cols = User[:login] + User[:name]
     search_columns(cols, phrase)
   }
@@ -433,6 +444,15 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     users.find_each do |user|
       return user if user.unique_text_name == str
     end
+  end
+
+  # Doesn't match on login/name (those go through the fuzzy `pattern`
+  # scope instead, in case of a partial match) -- only a numeric id or
+  # a verified email address counts as "exact."
+  def self.exact_match(phrase)
+    user = (phrase.match?(/^\d+$/) && safe_find(phrase)) ||
+           find_by(email: phrase)
+    user if user&.verified
   end
 
   # Return User's full name if present, else return login.

--- a/app/views/controllers/observations/identify/form_filter.rb
+++ b/app/views/controllers/observations/identify/form_filter.rb
@@ -2,14 +2,14 @@
 
 # Rendered in the top-nav of identify pages
 # (`Observations::IdentifyController`). Wraps `Identify::Form` with
-# its `FormObject::IdentifyFilter` built from `params[:filter]`.
+# its `FormObject::IdentifyFilter` built from `params[:identify_filter]`.
 module Views::Controllers::Observations::Identify
   class FormFilter < Views::Base
     def view_template
       render(Form.new(
                FormObject::IdentifyFilter.new(
-                 type: params.dig(:filter, :type),
-                 term: params.dig(:filter, :term)
+                 type: params.dig(:identify_filter, :type),
+                 term: params.dig(:identify_filter, :term)
                ),
                turbo: true
              ))

--- a/app/views/controllers/observations/identify/form_filter.rb
+++ b/app/views/controllers/observations/identify/form_filter.rb
@@ -6,10 +6,11 @@
 module Views::Controllers::Observations::Identify
   class FormFilter < Views::Base
     def view_template
+      filter = params.permit(identify_filter: [:type, :term])[:identify_filter]
       render(Form.new(
                FormObject::IdentifyFilter.new(
-                 type: params.dig(:identify_filter, :type),
-                 term: params.dig(:identify_filter, :term)
+                 type: filter&.dig(:type),
+                 term: filter&.dig(:term)
                ),
                turbo: true
              ))

--- a/app/views/controllers/rss_logs/type_filters.rb
+++ b/app/views/controllers/rss_logs/type_filters.rb
@@ -8,10 +8,9 @@ module Views::Controllers::RssLogs
     prop :query, _Nilable(::Query)
     prop :types, _Array(::String)
 
-    # Not a Superform -- a multi-select checkbox filter (RssLogsController
-    # explicitly validates "array of types, from form checkboxes"), not a
+    # Not a Superform -- a multi-select checkbox filter, not a
     # single-model-bound field set. Submitting the combined state of
-    # several independently-toggled checkboxes as one q[type][] array
+    # several independently-toggled checkboxes as one q[types][] array
     # needs a submit, unlike IndexPaginationNav's single-value goto
     # controls, which each fully specify their own destination and so
     # reduce to plain links.
@@ -31,7 +30,7 @@ module Views::Controllers::RssLogs
     def render_hidden_fields
       return unless @query
 
-      query_params_except_type.each do |key, value|
+      query_params_except_types.each do |key, value|
         input(type: "hidden", name: key, value: value)
       end
     end
@@ -94,7 +93,7 @@ module Views::Controllers::RssLogs
     # in `_form_elements.scss`.
     def render_type_checkbox(type)
       render(::Components::ApplicationForm::ButtonStyleCheckbox.new(
-               name: "q[type][]", value: type,
+               name: "q[types][]", value: type,
                id: "type_#{type}", checked: type_checked?(type),
                variant: :outline, size: :sm,
                label: { class: "filter-checkbox my-0" },
@@ -109,7 +108,7 @@ module Views::Controllers::RssLogs
       label_text = :rss_all.t
       return plain(label_text) if @types == ["all"]
 
-      link = activity_logs_path(q: query_params_with_type("all"))
+      link = activity_logs_path(q: query_params_with_types(["all"]))
       a(href: link, title: :rss_all_help.t, class: "filter-only") do
         label_text
       end
@@ -120,7 +119,7 @@ module Views::Controllers::RssLogs
       label_text = :"rss_one_#{type}".t
       return plain(label_text) if @types == [type]
 
-      link = activity_logs_path(q: query_params_with_type(type))
+      link = activity_logs_path(q: query_params_with_types([type]))
       a(href: link,
         title: :rss_one_help.t(type: type.to_sym),
         class: "filter-only") { label_text }
@@ -132,10 +131,10 @@ module Views::Controllers::RssLogs
       @types.include?(type) || @types == ["all"]
     end
 
-    def query_params_except_type
+    def query_params_except_types
       return {} unless @query
 
-      q = q_param(@query).except(:type)
+      q = q_param(@query).except(:types)
       # Convert { q: { model: "RssLog" } }.to_query to key/value pairs
       query_string = { q: q }.to_query
       pairs = query_string.split("&")
@@ -145,10 +144,10 @@ module Views::Controllers::RssLogs
       end
     end
 
-    def query_params_with_type(type)
-      return { type: type } unless @query
+    def query_params_with_types(types)
+      return { types: types } unless @query
 
-      q_param(@query).merge(type: type)
+      q_param(@query).merge(types: types)
     end
   end
 end

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -245,7 +245,7 @@ module Views::Layouts
     end
 
     def param_val_itself(key, val, truncate:)
-      if key == :type
+      if key == :types
         type_tags_to_label(val)
       elsif val.is_a?(Array)
         join_array_val(val, truncate: truncate)
@@ -285,12 +285,12 @@ module Views::Layouts
       end
     end
 
-    # Space-separated RssLog type tag list ("species_list project") →
-    # localized labels joined by ", ". `SENTINEL_TYPE_TAGS` covers
-    # `"all"` / `"none"` (which have no plural); everything else
-    # goes through `tag.pluralize.to_sym.ti`.
+    # `types` param (Array, each entry possibly space-separated --
+    # see `RssLog.normalize_type_tags`) → localized labels joined by
+    # ", ". `SENTINEL_TYPE_TAGS` covers `"all"` / `"none"` (which have
+    # no plural); everything else goes through `tag.pluralize.to_sym.ti`.
     def type_tags_to_label(val)
-      val.split.map do |tag|
+      ::RssLog.normalize_type_tags(val).map do |tag|
         (SENTINEL_TYPE_TAGS[tag] || tag.pluralize.to_sym).ti
       end.join(", ")
     end

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -163,17 +163,22 @@ module Views::Layouts
       span { plain(" ] ") }
     end
 
-    # Nested params on one line separated by comma. The `:target`
-    # key gets a Lookup-driven single-string val rather than nested
-    # iteration.
+    # Nested params on one line separated by comma. The `:target` key
+    # gets a Lookup-driven single-string val; `:identify_filter` gets
+    # its own type-labeled val (see `render_identify_filter_val`) --
+    # both rather than the generic nested key/val iteration.
     def render_grouped_params(label, hash, truncate:)
       compact = hash.compact_blank
       return if compact.empty?
 
-      span { plain("#{query_param_label(label)}: ") }
-      if label == :target
+      case label
+      when :target
+        span { plain("#{query_param_label(label)}: ") }
         span { plain(lookup_comment_target_val(hash).to_s) }
+      when :identify_filter
+        render_identify_filter_val(hash)
       else
+        span { plain("#{query_param_label(label)}: ") }
         render_nested_params(compact, truncate: truncate)
       end
     end
@@ -183,6 +188,18 @@ module Views::Layouts
         render_plain_param(key, val, truncate: truncate)
         span { plain(", ") } if idx < compact.size - 1
       end
+    end
+
+    # `identify_filter`'s `type` (clade/region) picks which existing
+    # query_param label describes `term`, so this reads "Region:
+    # California, USA" instead of exposing the internal type/term
+    # hash shape ("Identify filter: Type: region, Term: ...").
+    def render_identify_filter_val(hash)
+      type, term = hash.values_at(:type, :term)
+      return if type.blank? || term.blank?
+
+      span { plain("#{query_param_label(type.to_sym)}: ") }
+      b { plain(term) }
     end
 
     def render_plain_param(key, val, truncate:)

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -244,8 +244,13 @@ module Views::Layouts
       val.map { |v| Vote.confidence_string(v.to_f) }.join(" – ")
     end
 
+    # `:types` isn't unique to RssLog -- Query::Comments has its own,
+    # unrelated `:types` attr (comment target model). Gate on model,
+    # not just the key name, or a Comments query's `:types` renders
+    # through RssLog's tag vocabulary and silently drops any Comment
+    # type tag RssLog doesn't share (`location_description`, etc).
     def param_val_itself(key, val, truncate:)
-      if key == :types
+      if key == :types && @query.model == RssLog
         type_tags_to_label(val)
       elsif val.is_a?(Array)
         join_array_val(val, truncate: truncate)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4455,6 +4455,10 @@
   query_type: "type"
   query_id: "id"
 
+  # identify filter
+  query_identify_filter: filter
+  query_term: term
+
   # name queries
   query_names: "[:names]"
   query_lookup: "[:names]"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_25_021326) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -572,6 +572,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
     t.integer "user_id"
     t.float "vote_cache", default: 0.0
     t.text "reasons"
+    t.index ["observation_id", "user_id", "name_id"], name: "index_namings_on_obs_user_name", unique: true
     t.index ["observation_id"], name: "index_namings_on_observation_id"
   end
 

--- a/lib/rubocop/cop/mo/no_query_subclass_mutation.rb
+++ b/lib/rubocop/cop/mo/no_query_subclass_mutation.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Flags `query_attr`/`attribute` called on an explicit `Query`/
+      # `Query::*` constant -- e.g. `Query::Observations.query_attr(...)`.
+      # `query_attr` mutates the class's attribute-type registry, shared
+      # by every caller in the process; calling it on a live Query
+      # subclass outside that subclass's own class body corrupts the
+      # class for every other test/request in the same worker process,
+      # even after an `ensure` block tries to restore it.
+      #
+      # This shipped as a hard-to-diagnose flake: a test declared
+      # `Query::Observations.query_attr(:projects, [Project],
+      # param_alias: :project)`, then "restored" it in `ensure` with
+      # `Query::Observations.query_attr(:projects, [Project])` (no
+      # `param_alias:`) -- correct when the test was written, but once a
+      # later PR gave `:projects` its own `param_alias:` declaration,
+      # the `ensure` block permanently wiped it out for the rest of
+      # that MiniTest worker process. Every project-filtered
+      # observations index request in that worker silently returned
+      # unfiltered results instead of erroring.
+      #
+      # Use `Class.new(Query::Observations) { query_attr(...) }` instead
+      # -- an anonymous subclass gets its own attribute-type registry,
+      # so the mutation stays scoped to the subclass and doesn't touch
+      # the shared class.
+      #
+      # @example
+      #   # bad
+      #   Query::Observations.query_attr(:projects, [Project],
+      #                                   param_alias: :project)
+      #
+      #   # good
+      #   subclass = Class.new(Query::Observations) do
+      #     query_attr(:projects, [Project], param_alias: :project)
+      #   end
+      class NoQuerySubclassMutation < Base
+        MSG = "Don't call `%<method>s` on a Query class constant -- it " \
+              "mutates shared state for every other test/request in " \
+              "this process. Use `Class.new(Query::Whatever) { " \
+              "%<method>s(...) }` instead."
+
+        RESTRICT_ON_SEND = [:query_attr, :attribute].freeze
+
+        def on_send(node)
+          receiver = node.receiver
+          return unless receiver&.const_type?
+          return unless query_class_receiver?(receiver)
+
+          add_offense(node, message: format(MSG, method: node.method_name))
+        end
+
+        private
+
+        def query_class_receiver?(receiver)
+          receiver.const_name.to_s.match?(/\AQuery(::|\z)/)
+        end
+      end
+    end
+  end
+end

--- a/test/classes/query/rss_logs_test.rb
+++ b/test/classes/query/rss_logs_test.rb
@@ -21,21 +21,31 @@ class Query::RssLogsTest < UnitTestCase
 
   def test_rss_log_type_all
     ids = RssLog.order_by_default
-    scope = RssLog.type(:all).order_by_default
+    scope = RssLog.types(:all).order_by_default
     assert_query_scope(ids, scope, :RssLog, type: :all)
   end
 
   def test_rss_log_type_species_list
     ids = [rss_logs(:species_list_rss_log).id]
-    scope = RssLog.type(:species_list)
+    scope = RssLog.types(:species_list)
     assert_query_scope(ids, scope, :RssLog, type: :species_list)
   end
 
+  # The singular `type:` alias still accepts a legacy space-separated
+  # bookmark value -- RssLog.types re-splits it internally.
   def test_rss_log_type_species_list_project
     ids = [rss_logs(:project_rss_log),
            rss_logs(:species_list_rss_log)]
-    scope = RssLog.type("species_list project").order_by_default
+    scope = RssLog.types("species_list project").order_by_default
     assert_query_scope(ids, scope, :RssLog, type: "species_list project")
+  end
+
+  def test_rss_log_types_array
+    ids = [rss_logs(:project_rss_log),
+           rss_logs(:species_list_rss_log)]
+    scope = RssLog.types(%w[species_list project]).order_by_default
+    assert_query_scope(ids, scope, :RssLog,
+                       types: %w[species_list project])
   end
 
   def test_rss_log_content_filter_has_specimen

--- a/test/components/application_form/button_style_checkbox_test.rb
+++ b/test/components/application_form/button_style_checkbox_test.rb
@@ -10,14 +10,14 @@ require("test_helper")
 class ButtonStyleCheckboxTest < ComponentTestCase
   def test_renders_label_wrapping_checkbox_input
     html = render_checkbox(
-      name: "q[type][]", value: "observation", id: "type_observation"
+      name: "q[types][]", value: "observation", id: "type_observation"
     ) { "Observations" }
 
     # <label for="type_observation">
     #   <input type="checkbox" ...>Observations
     # </label>
     assert_html(html, "label[for='type_observation'] > input[type='checkbox']" \
-                      "[name='q[type][]'][value='observation']" \
+                      "[name='q[types][]'][value='observation']" \
                       "[id='type_observation']")
     assert_includes(html, "Observations")
     # No `.checkbox` div wrap — intentional (this is the filter-button
@@ -71,11 +71,11 @@ class ButtonStyleCheckboxTest < ComponentTestCase
   # — that's the whole reason this component exists separately from
   # ButtonStyleRadio. Verify the name-array shape is preserved.
   def test_multiple_instances_share_name_array_shape
-    html_a = render_checkbox(name: "q[type][]", value: "a", id: "ta")
-    html_b = render_checkbox(name: "q[type][]", value: "b", id: "tb")
+    html_a = render_checkbox(name: "q[types][]", value: "a", id: "ta")
+    html_b = render_checkbox(name: "q[types][]", value: "b", id: "tb")
 
-    assert_html(html_a, "input[name='q[type][]'][value='a']")
-    assert_html(html_b, "input[name='q[type][]'][value='b']")
+    assert_html(html_a, "input[name='q[types][]'][value='a']")
+    assert_html(html_b, "input[name='q[types][]'][value='b']")
   end
 
   private

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -79,6 +79,20 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     assert_flash(:runtime_no_matches, type: :collection_number)
   end
 
+  # Previously `Observation.find(params[:observation])` -- raised
+  # RecordNotFound (500) on a bad id instead of flashing/redirecting
+  # like every other shortcut.
+  def test_index_observation_id_bad_id
+    bad_observation_id = Observation.maximum(:id).to_i + 1000
+
+    login
+    get(:index, params: { observation: bad_observation_id })
+
+    assert_flash(:runtime_object_not_found, type: :observation,
+                                            id: bad_observation_id)
+    assert_redirected_to(observations_path)
+  end
+
   def test_index_pattern_str_matching_multiple_collection_numbers
     pattern = "Singer"
     numbers = CollectionNumber.where(CollectionNumber[:name] =~ pattern)

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -79,9 +79,10 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     assert_flash(:runtime_no_matches, type: :collection_number)
   end
 
-  # Previously `Observation.find(params[:observation])` -- raised
-  # RecordNotFound (500) on a bad id instead of flashing/redirecting
-  # like every other shortcut.
+  # A bad observation id flashes and redirects to the observations
+  # index. This matches by_user-style shortcuts elsewhere, which
+  # redirect to the looked-up model's own index (see redirect_to:
+  # :model_index in Query::CollectionNumbers).
   def test_index_observation_id_bad_id
     bad_observation_id = Observation.maximum(:id).to_i + 1000
 

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -87,6 +87,15 @@ class ImagesControllerTest < FunctionalTestCase
     assert_redirected_to(image_path(image.id))
   end
 
+  # A bad project id redirects to the projects index. See redirect_to:
+  # in query_attr (app/extensions/class.rb).
+  def test_index_project_with_unknown_id_redirects
+    login
+    get(:index, params: { project: 999_999_999 })
+
+    assert_redirected_to(projects_path)
+  end
+
   def test_index_too_many_pages
     login
     get(:index, params: { page: 1_000_000 })

--- a/test/controllers/observations/identify_controller_test.rb
+++ b/test/controllers/observations/identify_controller_test.rb
@@ -34,7 +34,7 @@ module Observations
       # get(:index, params: { q: })
       assert_equal(query.num_results, aga_obs.count)
       get(:index,
-          params: { filter: { type: :clade, term: "Agaricales" } })
+          params: { identify_filter: { type: :clade, term: "Agaricales" } })
       assert_no_flash
       assert_select(".matrix-box", aga_obs.count)
 
@@ -62,7 +62,8 @@ module Observations
       assert_equal(query.num_results, cal_obs_count)
 
       get(:index,
-          params: { filter: { type: :region, term: "California, USA" } })
+          params: { identify_filter: { type: :region,
+                                       term: "California, USA" } })
       assert_no_flash
       assert_select(".matrix-box", cal_obs_count)
 
@@ -85,7 +86,8 @@ module Observations
       # q = @controller.q_param(QueryRecord.last.query)
       # get(:index, params: { q: })
       get(:index,
-          params: { filter: { type: :region, term: "California, USA" } })
+          params: { identify_filter: { type: :region,
+                                       term: "California, USA" } })
       assert_no_flash
       assert_select(".matrix-box", cal_obs_count - 5)
 
@@ -105,7 +107,8 @@ module Observations
       # q = @controller.q_param(QueryRecord.last.query)
       # get(:index, params: { q: })
       get(:index,
-          params: { filter: { type: :region, term: "California, USA" } })
+          params: { identify_filter: { type: :region,
+                                       term: "California, USA" } })
       assert_no_flash
       assert_select(".matrix-box", cal_obs_count - 6)
 

--- a/test/controllers/observations/identify_controller_test.rb
+++ b/test/controllers/observations/identify_controller_test.rb
@@ -118,5 +118,16 @@ module Observations
       assert_no_flash
       assert_select(".matrix-box", obs_count - 6)
     end
+
+    # A scalar `?identify_filter=x` (not the expected nested hash)
+    # used to 500: FormFilter (rendered in every identify page's
+    # top-nav) called `params.dig(:identify_filter, :type)` directly
+    # on the raw param, and String has no #dig.
+    def test_identify_index_with_scalar_identify_filter_param
+      login("mary")
+      get(:index, params: { identify_filter: "x" })
+
+      assert_response(:success)
+    end
   end
 end

--- a/test/controllers/observations/identify_controller_test.rb
+++ b/test/controllers/observations/identify_controller_test.rb
@@ -119,10 +119,10 @@ module Observations
       assert_select(".matrix-box", obs_count - 6)
     end
 
-    # A scalar `?identify_filter=x` (not the expected nested hash)
-    # used to 500: FormFilter (rendered in every identify page's
-    # top-nav) called `params.dig(:identify_filter, :type)` directly
-    # on the raw param, and String has no #dig.
+    # A scalar `?identify_filter=x` used to crash. FormFilter renders
+    # in every identify page's top-nav. It called
+    # `params.dig(:identify_filter, :type)` directly on the raw
+    # param. String has no `#dig` method.
     def test_identify_index_with_scalar_identify_filter_param
       login("mary")
       get(:index, params: { identify_filter: "x" })

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -738,14 +738,13 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_equal("date", query.params[:order_by])
   end
 
-  # A bad `project:` id redirects to this controller's own index,
-  # `/observations`. See `redirect_to:` in `query_attr`
-  # (app/extensions/class.rb).
+  # A bad project id redirects to the projects index. See redirect_to:
+  # in query_attr (app/extensions/class.rb).
   def test_index_project_with_unknown_id_redirects
     login
     get(:index, params: { project: 999_999_999 })
 
-    assert_redirected_to(observations_path)
+    assert_redirected_to(projects_path)
   end
 
   def test_index_project_banner_from_query_param

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -756,16 +756,13 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_not(query.params.key?(:bogus_param))
   end
 
-  # No query_attr has a record-backed param_alias declared yet (#5137
-  # is the foundation piece only) -- temporarily declares one on
-  # Query::Observations's own `projects` attr so this test exercises
-  # create_query_from_url_params's `constantize` path end-to-end, not
-  # just the lower-level resolve_param_alias_records helper. Restored
-  # in `ensure` so no other test observes the mutated attr.
+  # Query::Observations's own `projects` attr already declares a
+  # record-backed param_alias (see app/classes/query/observations.rb)
+  # -- exercises create_query_from_url_params's `constantize` path,
+  # not just the lower-level resolve_param_alias_records helper.
   def test_create_query_from_url_params_sets_always_index_for_record_alias
     login
     project = projects(:bolete_project)
-    Query::Observations.query_attr(:projects, [Project], param_alias: :project)
 
     raw_params = ActionController::Parameters.new(project: project.id.to_s)
     query, display_opts = @controller.send(
@@ -774,8 +771,6 @@ class ObservationsControllerIndexTest < FunctionalTestCase
 
     assert_equal([project.id], query.params[:projects])
     assert_equal(true, display_opts[:always_index])
-  ensure
-    Query::Observations.query_attr(:projects, [Project])
   end
 
   def test_resolve_param_alias_records_looks_up_record_and_wraps_array

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -738,13 +738,14 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_equal("date", query.params[:order_by])
   end
 
-  # Covers the `return unless (project = find_or_goto_index(...))`
-  # bail-out in `ObservationsController::Index#project` (L169).
+  # A bad `project:` id redirects to this controller's own index,
+  # `/observations`. See `redirect_to:` in `query_attr`
+  # (app/extensions/class.rb).
   def test_index_project_with_unknown_id_redirects
     login
     get(:index, params: { project: 999_999_999 })
 
-    assert_redirected_to(projects_path)
+    assert_redirected_to(observations_path)
   end
 
   def test_index_project_banner_from_query_param

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -679,6 +679,22 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_page_title(:observations.ti)
   end
 
+  # thumbnail_quality is this page's own default sort, not a
+  # class-wide default_order on the shared `projects` query_attr
+  # (test_observation_names_in_species_lists_and_projects proves a
+  # bare `projects:` query elsewhere still needs the class default)
+  # -- an explicit `by` must still win.
+  def test_index_project_explicit_by_respected
+    project = projects(:bolete_project)
+
+    login
+    get(:index, params: { project: project.id, by: "date" })
+
+    assert_response(:success)
+    query = @controller.instance_variable_get(:@query)
+    assert_equal("date", query.params[:order_by])
+  end
+
   # Covers the `return unless (project = find_or_goto_index(...))`
   # bail-out in `ObservationsController::Index#project` (L169).
   def test_index_project_with_unknown_id_redirects

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -56,12 +56,13 @@ class RssLogsControllerTest < FunctionalTestCase
     get(:index, params: { q: { type: [] } })
     assert_select("body.rss_logs__index")
 
-    # Old-style top level :type param now redirects
+    # Top-level :type/:types are query_attr aliases now -- no redirect,
+    # renders directly (see test_old_style_type_param_no_longer_redirects).
     get(:index, params: { type: "all" })
-    assert_response(:redirect)
+    assert_select("body.rss_logs__index")
 
-    get(:index, params: { type: %w[article glossary_term] })
-    assert_response(:redirect)
+    get(:index, params: { types: %w[article glossary_term] })
+    assert_select("body.rss_logs__index")
   end
 
   def test_get_index_rss_log
@@ -257,33 +258,27 @@ class RssLogsControllerTest < FunctionalTestCase
     assert_includes(types, "name")
   end
 
-  def test_old_style_type_param_redirects_to_q_param
+  # `:type` used to redirect a bookmarked top-level param onto a `q[]`
+  # URL. It's a plain query_attr alias now (Query::RssLogs) -- top-level
+  # params are a first-class URL form, so it renders directly instead.
+  def test_old_style_type_param_no_longer_redirects
     login
 
-    # Old-style string type param should redirect to q param URL
     get(:index, params: { type: "observation" })
-    assert_response(:redirect)
-    assert_match(/q%5Bmodel%5D=RssLog/, @response.location)
-    assert_match(/q%5Btype%5D=observation/, @response.location)
+    assert_response(:success)
+    assert_equal(["observation"], @controller.instance_variable_get(:@types))
 
-    # Old-style array type param should redirect to q param URL
-    get(:index, params: { type: %w[glossary_term article] })
-    assert_response(:redirect)
-    # Should contain both types (order may vary)
-    assert_match(/q%5Bmodel%5D=RssLog/, @response.location)
-    assert_match(/q%5Btype%5D=/, @response.location)
-    assert_match(/glossary_term/, @response.location)
-    assert_match(/article/, @response.location)
+    # `:type` is the scalar form; an array needs `:types` (see
+    # test_type_filter_form_submits_as_array).
+    get(:index, params: { types: %w[glossary_term article] })
+    assert_response(:success)
+    assert_equal(%w[article glossary_term],
+                 @controller.instance_variable_get(:@types))
 
-    # Invalid type should redirect with "none"
+    # Invalid tag drops out entirely -> "none"
     get(:index, params: { type: "evil<script>" })
-    assert_response(:redirect)
-    assert_match(/q%5Btype%5D=none/, @response.location)
-
-    # Non-string/non-array type (e.g., hash) should redirect with "all"
-    get(:index, params: { type: { weird: "hash" } })
-    assert_response(:redirect)
-    assert_match(/q%5Btype%5D=all/, @response.location)
+    assert_response(:success)
+    assert_equal(["none"], @controller.instance_variable_get(:@types))
   end
 
   def test_type_filter_preserves_other_query_params
@@ -294,7 +289,7 @@ class RssLogsControllerTest < FunctionalTestCase
                                order_by: "created_at" } })
     assert_select("body.rss_logs__index")
     query = QueryRecord.last.query
-    assert_equal("observation", query.params[:type])
+    assert_equal(["observation"], query.params[:types])
     assert_equal("created_at", query.params[:order_by])
 
     # Now change type filter - order_by should be preserved
@@ -302,7 +297,7 @@ class RssLogsControllerTest < FunctionalTestCase
                                order_by: "created_at" } })
     assert_select("body.rss_logs__index")
     query = QueryRecord.last.query
-    assert_equal("name", query.params[:type])
+    assert_equal(["name"], query.params[:types])
     assert_equal("created_at", query.params[:order_by],
                  "order_by should be preserved when changing type filter")
   end

--- a/test/controllers/rss_logs_controller_test.rb
+++ b/test/controllers/rss_logs_controller_test.rb
@@ -247,7 +247,9 @@ class RssLogsControllerTest < FunctionalTestCase
     login
 
     # Simulate form submission with type checkboxes as array under q param
-    # Form submits q[type][]=observation&q[type][]=name
+    # (the TypeFilters form submits q[types][]=observation&
+    # q[types][]=name; this exercises the same array shape via the
+    # singular `type` alias key, which also accepts an Array value).
     get(:index, params: {
           q: { model: "RssLog", type: %w[observation name] }
         })
@@ -308,7 +310,7 @@ class RssLogsControllerTest < FunctionalTestCase
     get(:index, params: { q: { model: "RssLog", type: "observation" } })
     assert_select("body.rss_logs__index")
 
-    # Check that the filter links don't have duplicate q[model] or q[type]
+    # Check that the filter links don't have duplicate q[model] or q[types]
     body = @response.body
 
     # Find all href attributes containing activity_logs
@@ -316,14 +318,14 @@ class RssLogsControllerTest < FunctionalTestCase
 
     hrefs.each do |href|
       decoded = CGI.unescape(href)
-      # Count occurrences of q[model] and q[type]
+      # Count occurrences of q[model] and q[types]
       model_count = decoded.scan("q[model]").length
-      type_count = decoded.scan("q[type]").length
+      type_count = decoded.scan("q[types]").length
 
       assert_operator(model_count, :<=, 1,
                       "URL has duplicate q[model]: #{decoded}")
       assert_operator(type_count, :<=, 1,
-                      "URL has duplicate q[type]: #{decoded}")
+                      "URL has duplicate q[types]: #{decoded}")
     end
   end
 end

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -242,8 +242,8 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     visit("/observations/identify")
     # Search for a location.
     place = "California, USA"
-    fill_in("filter_term", with: place)
-    select("Region", from: "filter_type")
+    fill_in("identify_filter_term", with: place)
+    select("Region", from: "identify_filter_type")
     within("#identify_filter") { click_button("Search") }
     assert_selector("#filters", text: /#{:query_needs_naming.l}/)
     assert_selector("#filters", text: /#{:query_region.l}/)

--- a/test/integration/rails-dom-testing/redirects_integration_test.rb
+++ b/test/integration/rails-dom-testing/redirects_integration_test.rb
@@ -212,25 +212,22 @@ class RedirectsIntegrationTest < IntegrationTestCase
   end
 
   # ActivityLogs (RssLogs) old-style type param  ------------------------------
-  def test_activity_logs_old_style_type_param_redirects_and_checks_boxes
+  # `:type` is a plain param_alias for Query::RssLogs' `types` attr
+  # now (see .claude 5139 sweep) -- top-level params are a first-class
+  # URL form, so this renders directly instead of redirecting to a
+  # `q[]` URL.
+  def test_activity_logs_old_style_type_param_no_longer_redirects
     login
 
-    # Visit old-style URL with top-level type param
-    # The type param triggers the `type` action which redirects to q[type]
-    # Integration tests automatically follow redirects
     get(activity_logs_path(params: { type: "observation" }))
     assert_response(:success)
 
-    # Verify we ended up at the correct URL with q params
-    assert_match(/q%5Bmodel%5D=RssLog/, request.fullpath)
-    assert_match(/q%5Btype%5D=observation/, request.fullpath)
-
     # The observation checkbox should be checked
-    assert_select("input[type='checkbox'][name='q[type][]']" \
+    assert_select("input[type='checkbox'][name='q[types][]']" \
                   "[value='observation'][checked='checked']")
 
     # Other checkboxes should NOT be checked
-    assert_select("input[type='checkbox'][name='q[type][]']" \
+    assert_select("input[type='checkbox'][name='q[types][]']" \
                   "[value='name']:not([checked])")
   end
 end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1523,6 +1523,20 @@ class ObservationTest < UnitTestCase
                     observations(:coprinus_comatus_obs))
   end
 
+  def test_scope_identify_filter
+    clade_result = Observation.identify_filter(type: "clade",
+                                               term: "Agaricales")
+    assert_includes(clade_result, observations(:coprinus_comatus_obs))
+    assert_equal(Observation.clade("Agaricales").to_a, clade_result.to_a)
+
+    region_result = Observation.identify_filter(type: "region",
+                                                term: "South America")
+    assert_equal(Observation.region("South America").to_a,
+                 region_result.to_a)
+
+    assert_empty(Observation.identify_filter(type: "bogus", term: "x"))
+  end
+
   def test_scope_by_users
     assert_includes(Observation.by_users(users(:mary)),
                     observations(:minimal_unknown_obs))

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,6 +9,35 @@ class UserTest < UnitTestCase
     assert_nil(User.authenticate(login: "nonrolf", password: "testpassword"))
   end
 
+  def test_exact_match
+    assert_equal(rolf, User.exact_match(rolf.id.to_s))
+    assert_equal(rolf, User.exact_match(rolf.email))
+    assert_nil(User.exact_match("nonexistent_login_or_email"))
+
+    unverified_user = users(:unverified)
+    assert_nil(
+      User.exact_match(unverified_user.id.to_s),
+      "An unverified user's id should not count as an exact match"
+    )
+    assert_nil(
+      User.exact_match(unverified_user.email),
+      "An unverified user's email should not count as an exact match"
+    )
+  end
+
+  def test_scope_pattern_exact_id_match_wins_over_fuzzy
+    # rolf's id, stringified, could theoretically also substring-match
+    # fuzzy login/name text -- exact_match must win outright, not get
+    # unioned with the fuzzy search.
+    results = User.pattern(rolf.id.to_s)
+    assert_equal([rolf.id], results.map(&:id))
+  end
+
+  def test_scope_pattern_falls_back_to_fuzzy_search
+    results = User.pattern(rolf.login)
+    assert_includes(results.map(&:id), rolf.id)
+  end
+
   def test_password_change
     mary.change_password("marypasswd")
     assert_equal(mary, User.authenticate(login: "mary", password: "marypasswd"))

--- a/test/views/controllers/observations/identify/form_test.rb
+++ b/test/views/controllers/observations/identify/form_test.rb
@@ -30,7 +30,7 @@ module Views::Controllers::Observations::Identify
 
       # Hidden field for term_id with dual targets
       assert_html(html, "input[type='hidden']" \
-                         "[name='filter[term_id]']" \
+                         "[name='identify_filter[term_id]']" \
                          "[data-autocompleter--clade-target='hidden']" \
                          "[data-autocompleter--region-target='hidden']")
 
@@ -49,7 +49,7 @@ module Views::Controllers::Observations::Identify
       assert_html(html, "li.dropdown-item", count: 10)
 
       # Type select with dual targets and swap actions
-      assert_html(html, "select#filter_type" \
+      assert_html(html, "select#identify_filter_type" \
                          "[data-autocompleter--clade-target='select']")
 
       # Default clade selected

--- a/test/views/controllers/rss_logs/type_filters_test.rb
+++ b/test/views/controllers/rss_logs/type_filters_test.rb
@@ -46,7 +46,7 @@ module Views::Controllers::RssLogs
       RssLog::ALL_TYPE_TAGS.each do |type|
         type_str = type.to_s
         # Check checkbox input exists
-        assert_html(html, "input[type='checkbox'][name='q[type][]']" \
+        assert_html(html, "input[type='checkbox'][name='q[types][]']" \
                           "[value='#{type_str}'][id='type_#{type_str}']")
         # Check label exists
         assert_html(html,
@@ -94,7 +94,7 @@ module Views::Controllers::RssLogs
       html = render_component(nil, ["observation"])
 
       # Name filter should have a link (since it's not the only selected type)
-      assert_html(html, "label a.filter-only[href*='type']",
+      assert_html(html, "label a.filter-only[href*='types']",
                   text: :rss_one_name.t)
     end
 

--- a/test/views/layouts/header/index_bar/filter_caption_test.rb
+++ b/test/views/layouts/header/index_bar/filter_caption_test.rb
@@ -50,6 +50,21 @@ module Views::Layouts
       )
     end
 
+    # Query::Comments has its own, unrelated `:types` attr (comment
+    # target model). Colliding with RssLog's `:types` by bare key name
+    # alone would run this through RssLog's tag vocabulary and
+    # silently blank any tag RssLog doesn't share, like
+    # `location_description` -- must fall through to the generic
+    # array-join branch instead.
+    def test_comments_types_param_does_not_use_rss_log_tag_vocabulary
+      html = render_for(
+        Query.lookup_and_save(:Comment, types: [:location_description])
+      )
+
+      assert_html(html, "#caption-truncated .small b",
+                  text: "location_description")
+    end
+
     def test_single_name_lookup_renders_italicized_inside_b
       # Names query: `names` is a grouped param wrapping the
       # `lookup:` lookup key. `:lookup` is in PARAM_LOOKUPS AND

--- a/test/views/layouts/header/index_bar/filter_caption_test.rb
+++ b/test/views/layouts/header/index_bar/filter_caption_test.rb
@@ -176,6 +176,22 @@ module Views::Layouts
       assert_html(html, "#filters", text: :query_target.l)
     end
 
+    def test_identify_filter_grouped_param_renders_type_label
+      query = Query.lookup_and_save(
+        :Observation, identify_filter: { type: "region", term: "California" }
+      )
+
+      html = render_for(query)
+
+      # `:identify_filter` triggers `render_identify_filter_val`,
+      # which labels the value with the selected type's own
+      # query_param label (`:query_region`) instead of the generic
+      # "Identify filter: Type: region, Term: ..." nested breakdown.
+      assert_html(html, "#filters", text: :query_region.l)
+      assert_html(html, "#filters", text: "California")
+      assert_no_html(html, "#filters", text: :query_identify_filter.l)
+    end
+
     def test_subquery_wraps_nested_params_in_brackets
       query = Query.lookup_and_save(
         :Name, description_query: { by_users: users(:rolf) }


### PR DESCRIPTION
Part of the move to top-level Query params.

Part of #5139, but does not close the issue.

## Summary

#5138's audit found 5 `index_active_params` shortcuts with logic beyond a simple alias. This PR moves that logic onto the model/Query layer.

### New scopes (3)

- **`RssLog#type` -> `types` scope.** The old check only matched a bare string. It broke on the new array-typed `types` param. `RssLogsController#type` now just calls `create_query_from_url_params`.
- **`Observations::IdentifyController#filter` -> `identify_filter` scope.** The clade-or-region dispatch moved onto `Observation::Scopes#identify_filter`. Params renamed from `filter[...]` to `identify_filter[...]`.
- **`UsersController#pattern` -> `User.pattern` scope.** The exact id/email match now lives in the scope and returns early, before the fuzzy search runs. This matters: `User.pattern("1")` fuzzy-matches thousands of users in production, so the exact match can't be folded into the same query.

### Derived ivars (2)

`@project` and `@observation` now come from the query that's already built (`query.params[:projects]`/`query.params[:observations]`), not a second lookup.

- **`ObservationsController::Index#project`.** `thumbnail_quality` stays this page's own sort. Other callers of the shared `projects` attr expect date order.
- **`CollectionNumbersController#observation`.** Also fixes a 500 on a bad observation id.

## Test plan

- [x] Rubocop clean
- [x] Tests green: rss_logs, identify, filter_caption, observations index, collection_numbers, users, search, button_style_checkbox

<!-- changelog -->
article: no
<!-- /changelog -->
