### PR TITLE
Enforce one Naming per `(Observation, User, Name)` (#5186)

### DIFF
--- a/app/models/naming.rb
+++ b/app/models/naming.rb
@@ -408,6 +408,20 @@ class Naming < AbstractModel
                                                         !@current_user
   end
 
+  # A user may propose a given name on an observation only once; the DB
+  # unique index (#5186) is the hard backstop, this is the graceful one
+  # so a double-submit or a re-pointed naming flashes an error instead of
+  # raising RecordNotUnique. Skipped when the key columns aren't all set
+  # (check_requirements already reports those).
+  validate :name_not_already_proposed_by_user
+  def name_not_already_proposed_by_user # :nodoc:
+    return unless observation_id && user_id && name_id
+
+    scope = Naming.where(observation_id:, user_id:, name_id:)
+    scope = scope.where.not(id:) if persisted?
+    errors.add(:name, :validate_naming_duplicate) if scope.exists?
+  end
+
   private
 
   # Move the other naming's votes onto this one, keeping the higher value

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -191,7 +191,12 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
 
   # DO NOT use :dependent => :destroy -- this causes it to recalc the
   # consensus several times and send bogus emails!!
-  has_many :namings
+  #
+  # Order by id (creation order): consensus tie-breaking and dump_votes
+  # read this association in order, so it must be deterministic and not
+  # left to whichever index MySQL picks. The (observation_id, user_id,
+  # name_id) unique index (#5186) otherwise sorts these rows by user.
+  has_many :namings, -> { order(:id) }, inverse_of: :observation
 
   has_many :observation_images, dependent: :destroy
   has_many :images, through: :observation_images

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3925,6 +3925,7 @@
   validate_naming_name_missing: "[:validate_missing(field=:name)]"
   validate_naming_observation_missing: "[:validate_missing(field=:observation)]"
   validate_naming_user_missing: "[:validate_missing(field=:user)]"
+  validate_naming_duplicate: You have already proposed that name for this observation.
   validate_notification_user_missing: "[:validate_missing(field=:user)]"
   validate_observation_user_missing: "[:validate_missing(field=:user)]"
   validate_observation_where_too_long: "[:validate_too_long(field=:location,max=1024)]"

--- a/db/migrate/20260825021326_add_unique_index_to_namings.rb
+++ b/db/migrate/20260825021326_add_unique_index_to_namings.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# One user may propose a given Name on a given Observation at most once
+# (#5186). Duplicate namings arose from name merges repointing without
+# folding, an import that re-created rather than reused, and web-form
+# double-submits; the code paths are fixed (#5204) and the existing
+# duplicates are collapsed by projects/5186/dedup_namings.rb, which must
+# run before this migration -- a leftover duplicate makes add_index fail.
+#
+# Occurrence members keep their own copies: each is a distinct
+# Observation, so (observation_id, user_id, name_id) still differs.
+# Orphan namings with a NULL observation_id do not collide, since MySQL
+# treats NULLs as distinct in a unique index.
+class AddUniqueIndexToNamings < ActiveRecord::Migration[7.2]
+  def change
+    add_index(:namings, [:observation_id, :user_id, :name_id],
+              unique: true, name: "index_namings_on_obs_user_name")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_25_021326) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -572,6 +572,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_21_200358) do
     t.integer "user_id"
     t.float "vote_cache", default: 0.0
     t.text "reasons"
+    t.index ["observation_id", "user_id", "name_id"], name: "index_namings_on_obs_user_name", unique: true
     t.index ["observation_id"], name: "index_namings_on_observation_id"
   end
 

--- a/test/models/naming/notify_test.rb
+++ b/test/models/naming/notify_test.rb
@@ -66,12 +66,12 @@ class Naming::NotifyTest < UnitTestCase
   # recipient is the name-interest holder we control.
   def watch_the_name
     NameTracker.all.map(&:destroy)
-    Interest.create!(target: names(:agaricus_campestris), user: katrina,
+    Interest.create!(target: names(:conocybe_filaris), user: katrina,
                      state: true)
   end
 
   def propose_naming
     Naming.create!(observation: observations(:coprinus_comatus_obs),
-                   name: names(:agaricus_campestris), user: mary)
+                   name: names(:conocybe_filaris), user: mary)
   end
 end

--- a/test/models/naming_test.rb
+++ b/test/models/naming_test.rb
@@ -15,7 +15,7 @@ class NamingTest < UnitTestCase
       updated_at: now,
       observation_id: obs.id,
       name_id: names(:agaricus_campestris).id,
-      user_id: mary.id
+      user_id: dick.id
     )
     assert(naming.save,
            "Save failed: #{naming.errors.full_messages.join("; ")}")
@@ -201,7 +201,7 @@ class NamingTest < UnitTestCase
         observation: obs,
         name: name,
         vote_cache: 0,
-        user: mary
+        user: dick
       )
     end
   end
@@ -231,24 +231,28 @@ class NamingTest < UnitTestCase
     assert_equal({ 2 => "", 3 => "test" }, naming.reasons)
   end
 
-  # absorb folds another naming for the same obs/user/name into this one:
-  # the higher vote per voter is kept, and reasons merge -- a contained
-  # note is superseded, two distinct notes join on a line break (#5186).
+  # absorb folds another of a user's namings on the observation into this
+  # one and destroys it: the higher vote per voter is kept, and reasons
+  # merge -- a contained note is superseded, two distinct notes join on a
+  # line break (#5186). During a name merge `other` carries the old name
+  # (a different name_id), so folding it stays clear of the
+  # (obs, user, name) uniqueness rule.
   def test_absorb_merges_votes_and_reasons
     obs = observations(:coprinus_comatus_obs)
-    name = names(:coprinus_comatus)
     obs.namings.to_a.each do |n|
       n.current_user = rolf
       n.destroy
     end
 
-    keeper = Naming.new(observation: obs, name: name, user: rolf,
+    keeper = Naming.new(observation: obs, name: names(:coprinus_comatus),
+                        user: rolf,
                         reasons: { 1 => "Fibrillose cap", 2 => "Grew on oak" })
     keeper.current_user = rolf
     keeper.save!
     Vote.create!(naming: keeper, observation: obs, user: rolf, value: 1)
 
-    other = Naming.new(observation: obs, name: name, user: rolf,
+    other = Naming.new(observation: obs, name: names(:agaricus_campestris),
+                       user: rolf,
                        reasons: { 1 => "Fibrillose cap and fragile stem",
                                   2 => "Bruised blue" })
     other.current_user = rolf
@@ -264,5 +268,39 @@ class NamingTest < UnitTestCase
                  "contained note superseded; distinct notes join on a newline")
     assert_equal(3, keeper.votes.find_by(user: rolf).value,
                  "the higher vote value is kept")
+  end
+
+  # A user can't propose the same name twice on one observation (#5186).
+  def test_duplicate_naming_for_same_user_is_invalid
+    existing = namings(:coprinus_comatus_naming)
+
+    dup = Naming.new(observation: existing.observation, name: existing.name,
+                     user: existing.user)
+    dup.current_user = existing.user
+
+    assert_not(dup.valid?)
+    assert_equal(:validate_naming_duplicate.t, dup.errors[:name].first)
+  end
+
+  # A different user proposing the same name is allowed -- the scope is
+  # (observation, user, name), not (observation, name).
+  def test_duplicate_naming_for_other_user_is_valid
+    existing = namings(:coprinus_comatus_naming)
+
+    other = Naming.new(observation: existing.observation, name: existing.name,
+                       user: mary)
+    other.current_user = mary
+
+    assert(other.valid?,
+           "other user re-propose: #{other.errors.full_messages.join("; ")}")
+  end
+
+  # Re-validating an already-saved naming doesn't flag it against itself.
+  def test_existing_naming_not_flagged_as_its_own_duplicate
+    naming = namings(:coprinus_comatus_naming)
+    naming.current_user = naming.user
+
+    assert(naming.valid?,
+           "not its own duplicate: #{naming.errors.full_messages.join("; ")}")
   end
 end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -388,7 +388,7 @@ class ObservationTest < UnitTestCase
     assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
       new_naming = Naming.create(
         observation: obs.reload,
-        name: names(:agaricus_campestris),
+        name: names(:conocybe_filaris),
         vote_cache: 0,
         user: mary
       )
@@ -470,7 +470,7 @@ class ObservationTest < UnitTestCase
     assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
       Naming.create(
         observation: observations(:coprinus_comatus_obs),
-        name: names(:agaricus_campestris),
+        name: names(:conocybe_filaris),
         vote_cache: 0,
         user: mary
       )


### PR DESCRIPTION
## Summary

Enforces the invariant that a user may propose a given `Name` on a given `Observation` at most once, via a **unique index on `namings(observation_id, user_id, name_id)`** plus a **matching model validation** on `Naming`.

This is the constraint half of the #5186 duplicate-naming work. The *prevention* paths landed in #5204 (name-merge now folds a colliding naming via `Naming#absorb`; the iNat import find-or-reuses instead of stacking a second naming). This PR closes the invariant at the database level so no path can create a duplicate, and adds a graceful validation for the two write paths that don't pre-check:

- the plain `create` double-submit race (`name_been_proposed?` is a soft, race-able check), and
- `create_new_naming` — a user re-points a naming that's locked (already upvoted by others) to a name they've already proposed.

Both call `validate_object(@naming)`, so the validation surfaces as a flash error rather than a `RecordNotUnique` 500. The unique index remains the hard backstop for the true check-then-insert race.

### Naming order made explicit

The new composite index changes which index MySQL picks for `WHERE observation_id = ?`, which reordered `Observation#namings` from creation order (by id) to by `user_id`. Consensus tie-breaking and `dump_votes` read that association in order, so the change would have shifted consensus results — a behavior change, caught by `ObservationTest#test_vote_favorite` / `test_dump_votes` and an iNat import reason. Fixed by making the order explicit and index-independent: `has_many :namings, -> { order(:id) }`. This restores the by-id order the code already assumed.

## Deploy ordering — important

The migration adds a `unique: true` index, which **fails if any duplicate `(observation_id, user_id, name_id)` rows still exist**. So the sequence is:

1. #5204 deploys (stops new duplicates from the merge/import paths).
2. Run `projects/5186/dedup_namings.rb --apply` on production to collapse the existing duplicates (233 groups / 233 extra namings in the current snapshot).
3. Merge + deploy this PR.

If a stray duplicate slips in between 2 and 3, the migration fails loudly (no partial state) rather than silently skipping — re-run the dedup and retry.

## Notes

- **Occurrence members keep their own copies.** Each occurrence member is a distinct `Observation`, so `(observation_id, user_id, name_id)` still differs across them.
- **Orphaned namings are removed first.** The dedup script deletes any naming whose observation is gone (NULL or dangling FK) before the duplicates are folded, so none remain when the index is built.
- The validation is guarded to only run when all three key columns are set (`check_requirements` already reports missing ones) and excludes the record itself on update.

## Test plan

- [x] `bin/rails test test/models/naming_test.rb test/models/name/merge_test.rb test/models/observation/merged_naming_test.rb`
- [x] `bin/rails test test/controllers/observations/ test/controllers/observations_controller_create_test.rb`
- [x] `bin/rails test test/classes/api2/observations_test.rb test/classes/inat_mo_observation_builder_test.rb`
- Reviewer: confirm the deploy ordering above — this PR should merge/deploy only after the dedup script has run on production.

<!-- changelog -->
article: no
<!-- /changelog -->
