### PR TITLE
Stop the iNat resync from overwriting coordinates with obscured data (#4215)

### DIFF
--- a/app/classes/inat/obs.rb
+++ b/app/classes/inat/obs.rb
@@ -102,6 +102,13 @@ class Inat
     def gps_hidden = @obs[:geoprivacy].present?
     # rubocop:enable Naming/PredicateMethod
 
+    # True when iNat has blurred the public coordinate for any reason --
+    # user geoprivacy OR automatic taxon geoprivacy (which #gps_hidden,
+    # reading only :geoprivacy, misses). iNat's :obscured folds both. A
+    # missing flag is treated as obscured, so an unexpected response keeps
+    # a blurred coordinate from overwriting MO's accurate one (#4215).
+    def obscured? = @obs[:obscured] != false
+
     def license = Inat::License.new(@obs[:license_code]).mo_license
 
     def notes

--- a/app/classes/inat/reflection_resync.rb
+++ b/app/classes/inat/reflection_resync.rb
@@ -105,16 +105,15 @@ class Inat
     # drives `where` from its own name via a callback, so assigning
     # `where` too would flip it back and forth and never converge.
     def scalar_attributes(inat_obs)
-      location = inat_obs.location
-      # specimen is intentionally not synced: iNat gives no reliable signal
-      # (Inat::Obs#specimen? is hardcoded false), and MO's specimen is set by
-      # MO-side herbarium records / collection numbers a user may add to a
-      # reflection -- syncing it could only unset a legitimate true.
-      attrs = { when: inat_obs.when, location: location, lat: inat_obs.lat,
-                lng: inat_obs.lng, gps_hidden: inat_obs.gps_hidden,
-                notes: inat_obs.notes }
-      attrs[:where] = inat_obs.where if location.nil?
-      attrs
+      # Coordinates and place are NOT synced. The batch resync fetches iNat
+      # unauthenticated (Inat::ApiToken is per-user; the scheduled job runs
+      # as no user), so it sees only iNat's obscured public coordinate --
+      # mirroring that would overwrite the authenticated import's accurate
+      # coordinate with a blurred one on every gps_hidden observation. The
+      # first run degraded 1,421 reflections this way (#4215) before this
+      # was caught. specimen is likewise MO-owned (see git history). Only
+      # the observation date and the iNat snapshot notes are safe to mirror.
+      { when: inat_obs.when, notes: inat_obs.notes }
     end
   end
 end

--- a/app/classes/inat/reflection_resync.rb
+++ b/app/classes/inat/reflection_resync.rb
@@ -104,16 +104,29 @@ class Inat
     # `where` is only set when no Location resolves: a present Location
     # drives `where` from its own name via a callback, so assigning
     # `where` too would flip it back and forth and never converge.
+    # Date, notes and the obscured flag always mirror the source; specimen
+    # is MO-owned (see git history) and left alone. Coordinates sync only
+    # when iNat is NOT obscuring the location -- the resync fetches iNat
+    # unauthenticated (Inat::ApiToken is per-user; both the scheduled batch
+    # and "Sync now" run as no user), so an obscured observation yields
+    # only iNat's blurred public coordinate, which would overwrite the
+    # authenticated import's accurate one. The first run degraded 1,421
+    # reflections that way (#4215) before this gate was added.
     def scalar_attributes(inat_obs)
-      # Coordinates and place are NOT synced. The batch resync fetches iNat
-      # unauthenticated (Inat::ApiToken is per-user; the scheduled job runs
-      # as no user), so it sees only iNat's obscured public coordinate --
-      # mirroring that would overwrite the authenticated import's accurate
-      # coordinate with a blurred one on every gps_hidden observation. The
-      # first run degraded 1,421 reflections this way (#4215) before this
-      # was caught. specimen is likewise MO-owned (see git history). Only
-      # the observation date and the iNat snapshot notes are safe to mirror.
-      { when: inat_obs.when, notes: inat_obs.notes }
+      attrs = { when: inat_obs.when, notes: inat_obs.notes,
+                gps_hidden: inat_obs.obscured? }
+      attrs.merge!(location_attributes(inat_obs)) unless inat_obs.obscured?
+      attrs
+    end
+
+    # A present Location drives `where` from its own name via a callback,
+    # so `where` is set only when no Location resolves (otherwise the two
+    # flip back and forth without converging).
+    def location_attributes(inat_obs)
+      location = inat_obs.location
+      attrs = { location: location, lat: inat_obs.lat, lng: inat_obs.lng }
+      attrs[:where] = inat_obs.where if location.nil?
+      attrs
     end
   end
 end

--- a/test/classes/inat/observation_resyncer_test.rb
+++ b/test/classes/inat/observation_resyncer_test.rb
@@ -34,9 +34,28 @@ class Inat::ObservationResyncerTest < UnitTestCase
     assert_equal(:synced, result.status)
     @obs.reload
     assert_equal(@fresh.when, @obs.when, "date should mirror the source")
-    assert_equal(@fresh.location, @obs.location, "location mirrors the source")
     assert_equal(@fresh.notes, @obs.notes, "notes should mirror the source")
     assert_not_nil(@link.reload.last_synced_at, "should stamp last_synced_at")
+  end
+
+  # Coordinates and place are NOT synced: the public fetch sees only iNat's
+  # obscured coordinate, so the accurate imported one is left intact -- the
+  # source data here would move location to "Earth" but must not (#4215).
+  def test_synced_leaves_the_coordinates_and_place_intact
+    assert_not_equal(@fresh.location, @obs.location, "test needs a diff")
+    @obs.update_columns(lat: 12.3456789, lng: -98.7654321, gps_hidden: true)
+    @obs.reload
+    original = @obs.slice(:lat, :lng, :gps_hidden, :where)
+    original_location = @obs.location
+
+    resync(found: { @id => @raw })
+
+    @obs.reload
+    assert_equal(original_location, @obs.location, "location left intact")
+    assert_equal(original["lat"], @obs.lat, "lat left intact")
+    assert_equal(original["lng"], @obs.lng, "lng left intact")
+    assert_equal(original["gps_hidden"], @obs.gps_hidden, "gps_hidden intact")
+    assert_equal(original["where"], @obs.where, "where left intact")
   end
 
   # specimen is MO-side (herbarium records / collection numbers a user may

--- a/test/classes/inat/observation_resyncer_test.rb
+++ b/test/classes/inat/observation_resyncer_test.rb
@@ -28,6 +28,8 @@ class Inat::ObservationResyncerTest < UnitTestCase
     @fresh = Inat::Obs.new(JSON.generate(@raw))
   end
 
+  # calostoma_lutescens is open (obscured: false), so its precise public
+  # coordinate mirrors into MO along with date and notes.
   def test_synced_updates_scalar_core_and_stamps_last_synced_at
     result = resync(found: { @id => @raw }).first
 
@@ -35,26 +37,30 @@ class Inat::ObservationResyncerTest < UnitTestCase
     @obs.reload
     assert_equal(@fresh.when, @obs.when, "date should mirror the source")
     assert_equal(@fresh.notes, @obs.notes, "notes should mirror the source")
+    assert_equal(@fresh.location, @obs.location, "location mirrors the source")
+    # MO rounds coordinates to 4 decimals (Location.parse_latitude).
+    assert_in_delta(@fresh.lat, @obs.lat.to_f, 1e-4, "lat mirrors the source")
+    assert_in_delta(@fresh.lng, @obs.lng.to_f, 1e-4, "lng mirrors the source")
+    assert_not(@obs.gps_hidden, "an open source is not gps_hidden")
     assert_not_nil(@link.reload.last_synced_at, "should stamp last_synced_at")
   end
 
-  # Coordinates and place are NOT synced: the public fetch sees only iNat's
-  # obscured coordinate, so the accurate imported one is left intact -- the
-  # source data here would move location to "Earth" but must not (#4215).
-  def test_synced_leaves_the_coordinates_and_place_intact
-    assert_not_equal(@fresh.location, @obs.location, "test needs a diff")
-    @obs.update_columns(lat: 12.3456789, lng: -98.7654321, gps_hidden: true)
+  # An obscured source yields only iNat's blurred coordinate, so MO's
+  # accurate imported one is left intact; gps_hidden mirrors the obscuring
+  # so MO hides the coordinate it keeps (#4215).
+  def test_an_obscured_source_hides_gps_but_keeps_the_coordinate
+    @obs.update_columns(lat: 12.3456789, lng: -98.7654321, gps_hidden: false)
     @obs.reload
-    original = @obs.slice(:lat, :lng, :gps_hidden, :where)
+    original = @obs.slice(:lat, :lng, :where)
     original_location = @obs.location
 
-    resync(found: { @id => @raw })
+    resync(found: { @id => obscured_raw })
 
     @obs.reload
+    assert(@obs.gps_hidden, "gps_hidden mirrors the iNat obscuring")
     assert_equal(original_location, @obs.location, "location left intact")
     assert_equal(original["lat"], @obs.lat, "lat left intact")
     assert_equal(original["lng"], @obs.lng, "lng left intact")
-    assert_equal(original["gps_hidden"], @obs.gps_hidden, "gps_hidden intact")
     assert_equal(original["where"], @obs.where, "where left intact")
   end
 
@@ -295,5 +301,11 @@ class Inat::ObservationResyncerTest < UnitTestCase
   def mock_raw(filename)
     JSON.parse(File.read("test/inat/#{filename}.txt"),
                symbolize_names: true)[:results].first
+  end
+
+  # The open calostoma raw, flipped to obscured -- the flag iNat sets when
+  # it blurs the public coordinate (user or taxon geoprivacy).
+  def obscured_raw
+    @raw.merge(obscured: true)
   end
 end


### PR DESCRIPTION
## Summary

The initial `InatReflectionBatchResyncJob` run degraded the coordinates of **1,421 protected (`gps_hidden`) observations**, replacing each accurate imported coordinate with iNaturalist's obscured public one. This PR fixes the resync so it can no longer do that, while still syncing coordinates that are safe to sync.

**Root cause.** The resync fetches iNat **unauthenticated** — `Inat::ApiToken` is per-user, and both the scheduled batch (`Inat::ReflectionBatchResyncer`) and the "Sync now" button (`Inat::ObservationResyncer`) run with no user — so for an obscured observation it sees only iNat's **blurred public** coordinate. The original import runs authenticated (the user's token) and stores the accurate coordinate, flagged `gps_hidden`. `Inat::ReflectionResync#scalar_attributes` mirrored `location`/`lat`/`lng`/`gps_hidden`/`where` unconditionally, so every resync of a `gps_hidden` observation overwrote the accurate coordinate with a blurred one (0.001°–0.5° off, ≈100 m–50 km).

## The audit

A field-by-field diff of yesterday's pre-sync snapshot against the post-sync database (tooling in `projects/inat-resync-audit/`, local/gitignored):

- **1,421** observations had `lat`/`lng` changed — **every one is `gps_hidden`**.
- Decimal precision was **equal** on 1,395 of them: the coordinates *shifted*, they were not merely rounded (MO already rounds to 4 decimals). The shift magnitudes cluster in iNat's obscuring band (1,142 in 0.05°–0.5°).
- `notes` changes (1,720) are legitimate (new suggested IDs in the snapshot); one `when` change is an iNat date edit.

## The fix — gate coordinate sync on iNat's obscuring

Adds `Inat::Obs#obscured?`, reading iNat's `obscured` boolean. This is the right signal because it folds **both** user geoprivacy **and** automatic taxon geoprivacy — the latter missed by `#gps_hidden`, which only reads `:geoprivacy`, so a threatened-taxon observation (`geoprivacy: null`, `taxon_geoprivacy: "obscured"`) would otherwise slip through. A missing flag counts as obscured (fail-safe).

`scalar_attributes` now:

- **always** mirrors `when`, `notes`, and `gps_hidden` (so MO's hide state tracks iNat's obscuring — if iNat newly obscures an observation, MO hides the accurate coordinate it keeps; if iNat opens one, MO reveals it);
- mirrors `location`/`lat`/`lng`/`where` **only when the source is not obscured** — when iNat is open, its public coordinate *is* the accurate one (`public_positional_accuracy == positional_accuracy`), so MO picks up coordinate corrections.

`specimen` stays MO-owned and untouched. Covers both the daily batch and "Sync now" (they share `ReflectionResync`).

## Remediation (separate, one-time)

Restoring the 1,421 already-degraded coordinates from the pre-sync snapshot is a local script (`projects/inat-resync-audit/restore_precise_coords.rb`, dry-run by default), not part of this PR. All 1,421 are `gps_hidden`, so once this fix ships they will not be re-degraded (an obscured source no longer touches coordinates).

## Test plan

- [x] `bin/rails test test/classes/inat/` (158) and the job tests (66)
- `test_synced_updates_scalar_core_and_stamps_last_synced_at` — an open source (calostoma, `obscured: false`) mirrors date, notes, coordinates, and `gps_hidden: false`.
- `test_an_obscured_source_hides_gps_but_keeps_the_coordinate` — an obscured source sets `gps_hidden` true and leaves `lat`/`lng`/`where`/`location` untouched.

<!-- changelog -->
article: no
<!-- /changelog -->
