### PR TITLE
Give `Observation` an `identify_filter` scope; drop clade/region dispatch (#5139)

### DIFF
--- a/app/classes/form_object/identify_filter.rb
+++ b/app/classes/form_object/identify_filter.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 # Form object for the identify observations filter form.
-# Params namespaced as filter[term], filter[type], etc.
+# Params namespaced as identify_filter[term], identify_filter[type],
+# etc. -- matches Query::Observations' identify_filter query_attr
+# directly, no controller-side param translation needed.
 class FormObject::IdentifyFilter < FormObject::Base
   VALID_TYPES = %w[clade region].freeze
 
@@ -14,9 +16,5 @@ class FormObject::IdentifyFilter < FormObject::Base
   # trust the value.
   def type=(value)
     super(VALID_TYPES.include?(value) ? value : "clade")
-  end
-
-  def self.model_name
-    ActiveModel::Name.new(self, nil, "Filter")
   end
 end

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -23,6 +23,9 @@ class Query::Observations < Query
   query_attr(:needs_naming, User)
   # query_attr(:clade, :string) # content filter
   # query_attr(:lichen, :boolean) # content filter
+  # The identify page's clade/region autocompleter -- see
+  # Observation::Scopes#identify_filter.
+  query_attr(:identify_filter, { type: :string, term: :string })
 
   query_attr(:is_collection_location, :boolean)
   query_attr(:has_public_lat_lng, :boolean)

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -43,49 +43,23 @@ module Observations
     end
 
     def index_active_params
-      [:filter, :q, :id].freeze
+      [:identify_filter, :q, :id].freeze
     end
 
-    # Ideally the filter form should pass the clade/region params with separate
-    # terms, so we can build the query by multiple flat params as expected.
-    # However, this form uses a single field with swapping autocompleter;
-    # the form scope is :filter and the field name is always :term.
-    # Currently params needs both a :filter[:type] and a filter[:term] to work.
-    def filter
-      return unless (type = params.dig(:filter, :type).to_sym)
-      return unless (term = params.dig(:filter, :term).strip)
-
-      case type
-      when :clade
-        clade(term)
-      when :region
-        region(term)
-        # when :user
-        #   user(term)
-      end
-    end
-
-    # Some inefficiency here comes from having to parse the name from a string.
-    # Check if the autocompleters return a name_id or location_id.
-    def clade(term)
-      # return unless (clade = Name.find_by(text_name: term))
-
-      query = create_query(:Observation, needs_naming: @user, clade: term,
+    # Dispatches to Observation.identify_filter (Observation::Scopes),
+    # which picks clade or region based on identify_filter[type] --
+    # the single swappable autocompleter submits both under one field
+    # pair, so this permits the nested hash directly rather than going
+    # through create_query_from_url_params (no alias/record lookup
+    # applies to this attr).
+    def identify_filter
+      filter = params.permit(identify_filter: [:type, :term])[:identify_filter].
+               to_h.symbolize_keys
+      query = create_query(:Observation, identify_filter: filter,
+                                         needs_naming: @user,
                                          order_by: :rss_log)
       [query, {}]
     end
-
-    def region(term)
-      query = create_query(:Observation, needs_naming: @user, region: term,
-                                         order_by: :rss_log)
-      [query, {}]
-    end
-
-    # def user_filter(term)
-    #   query = create_query(:Observation, needs_naming: @user, by_users: term,
-    #                                      order_by: :rss_log)
-    #   [query, {}]
-    # end
 
     def index_display_opts(opts, _query)
       { matrix: true, cache: true,

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -206,6 +206,22 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     scope :names_like,
           ->(name) { where(name: Name.text_name_has(name)) }
 
+    # Discriminator + payload shape for the identify page's clade/region
+    # autocompleter, which submits `identify_filter[type]`/
+    # `identify_filter[term]` under one field pair (a single swappable
+    # widget, not separate clade/region inputs). Mirrors Comment#target's
+    # type-dispatched scope.
+    scope :identify_filter, lambda { |filter|
+      case filter[:type]&.to_sym
+      when :clade
+        clade(filter[:term])
+      when :region
+        region(filter[:term])
+      else
+        none
+      end
+    }
+
     # This should really be clades/clade, but changing user prefs/filters and
     # autocompleters is very involved, requires migration and script.
     scope :clade, lambda { |clades|

--- a/app/views/controllers/observations/identify/form_filter.rb
+++ b/app/views/controllers/observations/identify/form_filter.rb
@@ -2,14 +2,14 @@
 
 # Rendered in the top-nav of identify pages
 # (`Observations::IdentifyController`). Wraps `Identify::Form` with
-# its `FormObject::IdentifyFilter` built from `params[:filter]`.
+# its `FormObject::IdentifyFilter` built from `params[:identify_filter]`.
 module Views::Controllers::Observations::Identify
   class FormFilter < Views::Base
     def view_template
       render(Form.new(
                FormObject::IdentifyFilter.new(
-                 type: params.dig(:filter, :type),
-                 term: params.dig(:filter, :term)
+                 type: params.dig(:identify_filter, :type),
+                 term: params.dig(:identify_filter, :term)
                ),
                turbo: true
              ))

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -163,17 +163,22 @@ module Views::Layouts
       span { plain(" ] ") }
     end
 
-    # Nested params on one line separated by comma. The `:target`
-    # key gets a Lookup-driven single-string val rather than nested
-    # iteration.
+    # Nested params on one line separated by comma. The `:target` key
+    # gets a Lookup-driven single-string val; `:identify_filter` gets
+    # its own type-labeled val (see `render_identify_filter_val`) --
+    # both rather than the generic nested key/val iteration.
     def render_grouped_params(label, hash, truncate:)
       compact = hash.compact_blank
       return if compact.empty?
 
-      span { plain("#{query_param_label(label)}: ") }
-      if label == :target
+      case label
+      when :target
+        span { plain("#{query_param_label(label)}: ") }
         span { plain(lookup_comment_target_val(hash).to_s) }
+      when :identify_filter
+        render_identify_filter_val(hash)
       else
+        span { plain("#{query_param_label(label)}: ") }
         render_nested_params(compact, truncate: truncate)
       end
     end
@@ -183,6 +188,18 @@ module Views::Layouts
         render_plain_param(key, val, truncate: truncate)
         span { plain(", ") } if idx < compact.size - 1
       end
+    end
+
+    # `identify_filter`'s `type` (clade/region) picks which existing
+    # query_param label describes `term`, so this reads "Region:
+    # California, USA" instead of exposing the internal type/term
+    # hash shape ("Identify filter: Type: region, Term: ...").
+    def render_identify_filter_val(hash)
+      type, term = hash.values_at(:type, :term)
+      return if type.blank? || term.blank?
+
+      span { plain("#{query_param_label(type.to_sym)}: ") }
+      b { plain(term) }
     end
 
     def render_plain_param(key, val, truncate:)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4455,6 +4455,10 @@
   query_type: "type"
   query_id: "id"
 
+  # identify filter
+  query_identify_filter: filter
+  query_term: term
+
   # name queries
   query_names: "[:names]"
   query_lookup: "[:names]"

--- a/test/controllers/observations/identify_controller_test.rb
+++ b/test/controllers/observations/identify_controller_test.rb
@@ -34,7 +34,7 @@ module Observations
       # get(:index, params: { q: })
       assert_equal(query.num_results, aga_obs.count)
       get(:index,
-          params: { filter: { type: :clade, term: "Agaricales" } })
+          params: { identify_filter: { type: :clade, term: "Agaricales" } })
       assert_no_flash
       assert_select(".matrix-box", aga_obs.count)
 
@@ -62,7 +62,8 @@ module Observations
       assert_equal(query.num_results, cal_obs_count)
 
       get(:index,
-          params: { filter: { type: :region, term: "California, USA" } })
+          params: { identify_filter: { type: :region,
+                                       term: "California, USA" } })
       assert_no_flash
       assert_select(".matrix-box", cal_obs_count)
 
@@ -85,7 +86,8 @@ module Observations
       # q = @controller.q_param(QueryRecord.last.query)
       # get(:index, params: { q: })
       get(:index,
-          params: { filter: { type: :region, term: "California, USA" } })
+          params: { identify_filter: { type: :region,
+                                       term: "California, USA" } })
       assert_no_flash
       assert_select(".matrix-box", cal_obs_count - 5)
 
@@ -105,7 +107,8 @@ module Observations
       # q = @controller.q_param(QueryRecord.last.query)
       # get(:index, params: { q: })
       get(:index,
-          params: { filter: { type: :region, term: "California, USA" } })
+          params: { identify_filter: { type: :region,
+                                       term: "California, USA" } })
       assert_no_flash
       assert_select(".matrix-box", cal_obs_count - 6)
 

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -242,8 +242,8 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
     visit("/observations/identify")
     # Search for a location.
     place = "California, USA"
-    fill_in("filter_term", with: place)
-    select("Region", from: "filter_type")
+    fill_in("identify_filter_term", with: place)
+    select("Region", from: "identify_filter_type")
     within("#identify_filter") { click_button("Search") }
     assert_selector("#filters", text: /#{:query_needs_naming.l}/)
     assert_selector("#filters", text: /#{:query_region.l}/)

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1523,6 +1523,20 @@ class ObservationTest < UnitTestCase
                     observations(:coprinus_comatus_obs))
   end
 
+  def test_scope_identify_filter
+    clade_result = Observation.identify_filter(type: "clade",
+                                               term: "Agaricales")
+    assert_includes(clade_result, observations(:coprinus_comatus_obs))
+    assert_equal(Observation.clade("Agaricales").to_a, clade_result.to_a)
+
+    region_result = Observation.identify_filter(type: "region",
+                                                term: "South America")
+    assert_equal(Observation.region("South America").to_a,
+                 region_result.to_a)
+
+    assert_empty(Observation.identify_filter(type: "bogus", term: "x"))
+  end
+
   def test_scope_by_users
     assert_includes(Observation.by_users(users(:mary)),
                     observations(:minimal_unknown_obs))

--- a/test/views/controllers/observations/identify/form_test.rb
+++ b/test/views/controllers/observations/identify/form_test.rb
@@ -30,7 +30,7 @@ module Views::Controllers::Observations::Identify
 
       # Hidden field for term_id with dual targets
       assert_html(html, "input[type='hidden']" \
-                         "[name='filter[term_id]']" \
+                         "[name='identify_filter[term_id]']" \
                          "[data-autocompleter--clade-target='hidden']" \
                          "[data-autocompleter--region-target='hidden']")
 
@@ -49,7 +49,7 @@ module Views::Controllers::Observations::Identify
       assert_html(html, "li.dropdown-item", count: 10)
 
       # Type select with dual targets and swap actions
-      assert_html(html, "select#filter_type" \
+      assert_html(html, "select#identify_filter_type" \
                          "[data-autocompleter--clade-target='select']")
 
       # Default clade selected

--- a/test/views/layouts/header/index_bar/filter_caption_test.rb
+++ b/test/views/layouts/header/index_bar/filter_caption_test.rb
@@ -176,6 +176,22 @@ module Views::Layouts
       assert_html(html, "#filters", text: :query_target.l)
     end
 
+    def test_identify_filter_grouped_param_renders_type_label
+      query = Query.lookup_and_save(
+        :Observation, identify_filter: { type: "region", term: "California" }
+      )
+
+      html = render_for(query)
+
+      # `:identify_filter` triggers `render_identify_filter_val`,
+      # which labels the value with the selected type's own
+      # query_param label (`:query_region`) instead of the generic
+      # "Identify filter: Type: region, Term: ..." nested breakdown.
+      assert_html(html, "#filters", text: :query_region.l)
+      assert_html(html, "#filters", text: "California")
+      assert_no_html(html, "#filters", text: :query_identify_filter.l)
+    end
+
     def test_subquery_wraps_nested_params_in_brackets
       query = Query.lookup_and_save(
         :Name, description_query: { by_users: users(:rolf) }


### PR DESCRIPTION
## Summary

Part of #5139. `Observations::IdentifyController#filter` hand-dispatched a single clade-or-region autocompleter submission (`filter[type]`/`filter[term]`) to two separate query-building methods. Moves that dispatch onto a new `Observation.identify_filter` scope, and declares it as a structural-hash `query_attr` on `Query::Observations` -- the same shape `Comment#target` (`{ type:, id: }`) already uses for its own type-discriminated dispatch.

### What changed

- `Observation::Scopes#identify_filter` -- picks `clade`/`region` based on `filter[:type]`, falling back to `none` for anything else.
- `Query::Observations` -- `query_attr(:identify_filter, { type: :string, term: :string })`.
- `Observations::IdentifyController` -- `filter`/`clade`/`region` (3 methods) collapse into one `identify_filter` method that permits the nested hash and calls `create_query` directly, merging in `needs_naming: @user`/`order_by: :rss_log` (session-scoped context the URL doesn't supply, so this doesn't go through `create_query_from_url_params`).
- URL/form namespace renamed `filter[...]` -> `identify_filter[...]` to match the attr name directly -- this is an internal identify-page form, not a bookmark-compat surface, so there's no reason to route it through a mismatched alias. `FormObject::IdentifyFilter`'s `model_name` override (which forced the old `"Filter"` namespace) is gone; Superform's default derivation already produces `identify_filter`.
- Added `query_identify_filter`/`query_term` to `en.txt` for the index-bar filter caption (a new top-level attr name needs its own label).

## Test plan

- [x] Rubocop -- clean
- [x] `test/controllers/observations/identify_controller_test.rb` -- green, params renamed to `identify_filter[...]`
- [x] `test/views/controllers/observations/identify/form_test.rb` -- green, field name/id assertions updated
- [x] `test/models/observation_test.rb` -- green, new `test_scope_identify_filter` covering the clade/region/unknown-type dispatch
- [x] `test/classes/query/observations_test.rb` -- green

<!-- changelog -->
article: no
<!-- /changelog -->
