### PR TITLE
Query params — Finish `index_active_params` -> `create_query_from_url_params` sweep

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -292,6 +292,7 @@ class Query
   include Query::Modules::Seek
   include Query::Modules::WindowCache
   include Query::Modules::Validation
+  include Query::Modules::HashValidation
 
   attr_writer :record
 

--- a/app/classes/query/comments.rb
+++ b/app/classes/query/comments.rb
@@ -12,7 +12,7 @@ class Query::Comments < Query
   # param_alias: matches its own attr name here -- not a rename, just
   # opts this into create_query_from_url_params's record-lookup path.
   query_attr(:for_user, User, param_alias: :for_user, always_index: false)
-  query_attr(:target, { type: :string, id: AbstractModel })
+  query_attr(:target, { polymorphic: Comment::ALL_TYPES })
   query_attr(:types, [{ string: Comment::ALL_TYPE_TAGS }])
   query_attr(:summary_has, :string)
   query_attr(:content_has, :string)

--- a/app/classes/query/field_slips.rb
+++ b/app/classes/query/field_slips.rb
@@ -10,8 +10,8 @@ class Query::FieldSlips < Query
   query_attr(:code, [:string])
   query_attr(:code_has, [:string])
   query_attr(:observation, [Observation])
-  query_attr(:project, [Project])
-  query_attr(:projects, [Project])
+  query_attr(:projects, [Project], param_alias: :project,
+                                   redirect_to: :model_index)
 
   def self.default_order
     :code_then_date

--- a/app/classes/query/herbarium_records.rb
+++ b/app/classes/query/herbarium_records.rb
@@ -12,7 +12,8 @@ class Query::HerbariumRecords < Query
   query_attr(:accession, [:string])
   query_attr(:accession_has, :string)
   query_attr(:herbaria, [Herbarium], param_alias: :herbarium)
-  query_attr(:observations, [Herbarium])
+  query_attr(:observations, [Observation], param_alias: :observation,
+                                           redirect_to: :model_index)
   query_attr(:pattern, :string)
 
   def alphabetical_by

--- a/app/classes/query/locations.rb
+++ b/app/classes/query/locations.rb
@@ -11,6 +11,8 @@ class Query::Locations < Query
   query_attr(:id_in_set, [Location])
   query_attr(:by_users, [User], param_alias: :by_user)
   query_attr(:by_editor, [User], param_alias: :by_editor)
+  query_attr(:projects, [Project], param_alias: :project,
+                                   redirect_to: :model_index)
   query_attr(:in_box, { north: :float, south: :float,
                         east: :float, west: :float })
   # query_attr(:region, :string) # content filter
@@ -18,6 +20,7 @@ class Query::Locations < Query
   query_attr(:notes_has, :string)
   query_attr(:pattern, :string)
   query_attr(:regexp, :string)
+  query_attr(:in_country, :string, param_alias: :country)
   # query_attr(:search_name, :string) # advanced search
   # query_attr(:search_where, :string) # advanced search
   # query_attr(:search_user, :string) # advanced search

--- a/app/classes/query/modules/hash_validation.rb
+++ b/app/classes/query/modules/hash_validation.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+##############################################################################
+#
+#  :module: HashValidation
+#
+#  Validates every Hash-shaped query_attr convention: an enum
+#  (`{ string: [...] }`/`{ boolean: [true] }`), a subquery
+#  (`{ subquery: :Model }`), a polymorphic record
+#  (`{ polymorphic: [Model, ...] }`), or a plain set of named fields.
+#  Query::Modules::Validation handles scalar and array param
+#  validation instead. `validate_hash_param` is the dispatch point,
+#  called from Query::Modules::Validation#scalar_validate.
+#
+module Query::Modules::HashValidation
+  private
+
+  def validate_hash_param(param, val, param_type)
+    if [:string, :boolean].include?(param_type.keys.first)
+      validate_enum(param, val, param_type)
+    elsif param_type.keys.first == :subquery
+      validate_subquery(param, val, param_type)
+    elsif param_type.keys.first == :polymorphic
+      validate_polymorphic(param, val, param_type)
+    else
+      validate_nested_params(param, val, param_type)
+    end
+  end
+
+  # For results, don't compact_blank, because sometimes we want `false`
+  def validate_nested_params(_param, val, param_type)
+    val2 = {}
+    param_type.each do |key, arg_type|
+      val2[key] = validate_value(arg_type, key, val[key])
+    end
+    val2.compact
+  end
+
+  # Validate the subquery's params by creating another Query instance
+  # and save it in @subqueries to facilitate access
+  def validate_subquery(param, val, param_type)
+    if param_type.keys.length != 1
+      return add_validation_error(:query_validation_invalid_subquery,
+                                  param: param.to_s, model:)
+    end
+    submodel = param_type.values.first
+    subquery = Query.create_query(submodel, val)
+    @subqueries[param] = subquery
+    @validation_errors += subquery.validation_errors
+    subquery.params
+  end
+
+  def validate_enum(param, val, hash)
+    if hash.keys.length != 1
+      return add_validation_error(:query_validation_invalid_enum_keys,
+                                  param: param.to_s, model:)
+    end
+
+    arg_type = hash.keys.first
+    set = hash.values.first
+    unless set.is_a?(Array)
+      return add_validation_error(:query_validation_invalid_enum_not_array,
+                                  param: param.to_s, model:)
+    end
+
+    validate_enum_value(param, val, arg_type, set)
+  end
+
+  def validate_enum_value(param, val, arg_type, set)
+    val2 = scalar_validate(param, val, arg_type)
+    if (arg_type == :string) && set.include?(val2.to_s.to_sym)
+      val2.to_s.to_sym
+    elsif set.exclude?(val2)
+      add_validation_error(:query_validation_param_not_in_set,
+                           param: param.to_s, set: set.inspect)
+    else
+      val2
+    end
+  end
+
+  # A polymorphic record filter. Accepts a `{ type:, id: }` hash, the
+  # shape an index filter param sends (e.g. Comment#target merging
+  # `params[:type]`/`params[:target]`). Also accepts a live instance
+  # of one of `param_type`'s allowed classes, for a Ruby caller
+  # building the query directly. Either way, resolves to the
+  # `{ type:, id: }` hash of primitives Query persists. Verifies the
+  # type is one of the declared classes and the id exists, so callers
+  # don't have to duplicate that lookup.
+  def validate_polymorphic(param, val, param_type)
+    types = param_type.values.first
+    return validate_polymorphic_instance(param, val, types) if
+      val.is_a?(AbstractModel)
+
+    validate_polymorphic_hash(param, val, types)
+  end
+
+  def validate_polymorphic_instance(param, val, types)
+    unless types.include?(val.class)
+      add_validation_error(:query_validation_invalid_polymorphic_type,
+                           param: param.to_s, type: val.class.name)
+      return invalid_polymorphic_value
+    end
+    return valid_polymorphic_record(val) if val.id
+
+    add_validation_error(:query_validation_record_unsaved,
+                         param: param.to_s, type: val.class)
+    invalid_polymorphic_value
+  end
+
+  def validate_polymorphic_hash(param, val, types)
+    model = resolve_polymorphic_type(param, val, types)
+    return invalid_polymorphic_value unless model
+
+    record = resolve_polymorphic_record(param, val, model)
+    return invalid_polymorphic_value unless record
+
+    valid_polymorphic_record(record)
+  end
+
+  def resolve_polymorphic_type(param, val, types)
+    type_name = val.is_a?(Hash) ? val[:type].to_s : val.inspect
+    model = types.find { |t| t.name == type_name }
+    return model if model
+
+    add_validation_error(:query_validation_invalid_polymorphic_type,
+                         param: param.to_s, type: type_name)
+    nil
+  end
+
+  def resolve_polymorphic_record(param, val, model)
+    record = model.safe_find(val[:id])
+    return record if record
+
+    add_validation_error(:query_validation_polymorphic_not_found,
+                         param: param.to_s, type: model.type_tag,
+                         id: val[:id].inspect)
+    nil
+  end
+
+  def valid_polymorphic_record(record)
+    { type: record.class.name, id: record.id }
+  end
+
+  # A validation failure still has to leave the attr present.
+  # Otherwise Query::Modules::Initialization's skippable_values treats
+  # it as absent and skips the scope entirely, leaving the query
+  # unfiltered instead of empty. `Comment.target`'s own `type && id`
+  # guard turns this into `none`. FilterCaption's
+  # `lookup_comment_target_val` bails out on a blank type/id instead
+  # of trying to `constantize` a type string with no backing class.
+  def invalid_polymorphic_value
+    { type: nil, id: nil }
+  end
+end

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -72,9 +72,8 @@ module Query::Modules::Validation
     base = key.to_s.delete_prefix("reverse_")
     return if model.private_methods(false).include?(:"order_by_#{base}")
 
-    @validation_errors << [:query_validation_order_by_unsupported,
-                           { models: model.name.pluralize, key:, model:,
-                             base: }]
+    add_validation_error(:query_validation_order_by_unsupported,
+                         models: model.name.pluralize, key:, model:, base:)
     # Clear the bad value so `add_default_order_if_none_specified` treats
     # it as unset and substitutes the model/attr's own `default_order` --
     # otherwise it survives validation and reaches
@@ -85,6 +84,16 @@ module Query::Modules::Validation
   end
 
   private
+
+  # Every validator failure is a `[tag, args]` pair appended to
+  # `@validation_errors` (see `validation_error_messages` above) --
+  # this is the one place that builds that pair, so call sites read
+  # as a single statement instead of repeating the array literal +
+  # explicit `nil` return every time.
+  def add_validation_error(tag, **args)
+    @validation_errors << [tag, args]
+    nil
+  end
 
   def validate_value(param_type, param, val)
     if param_type.is_a?(Array)
@@ -135,10 +144,9 @@ module Query::Modules::Validation
     when Hash
       validate_hash_param(param, val, param_type)
     else
-      @validation_errors << [:query_validation_invalid_declaration,
-                             { param: param.to_s, model:,
-                               type_class: param_type.class.name }]
-      nil
+      add_validation_error(:query_validation_invalid_declaration,
+                           param: param.to_s, model:,
+                           type_class: param_type.class.name)
     end
   end
 
@@ -146,70 +154,9 @@ module Query::Modules::Validation
     if param_type.respond_to?(:descends_from_active_record?)
       validate_record(param, val, param_type)
     else
-      @validation_errors << [:query_validation_unknown_class_param,
-                             { param_type:, param: param.to_s, model: }]
-      nil
+      add_validation_error(:query_validation_unknown_class_param,
+                           param_type:, param: param.to_s, model:)
     end
-  end
-
-  def validate_hash_param(param, val, param_type)
-    if [:string, :boolean].include?(param_type.keys.first)
-      validate_enum(param, val, param_type)
-    elsif param_type.keys.first == :subquery
-      validate_subquery(param, val, param_type)
-    else
-      validate_nested_params(param, val, param_type)
-    end
-  end
-
-  # For results, don't compact_blank, because sometimes we want `false`
-  def validate_nested_params(_param, val, param_type)
-    val2 = {}
-    param_type.each do |key, arg_type|
-      val2[key] = validate_value(arg_type, key, val[key])
-    end
-    val2.compact
-  end
-
-  # Validate the subquery's params by creating another Query instance
-  # and save it in @subqueries to facilitate access
-  def validate_subquery(param, val, param_type)
-    if param_type.keys.length != 1
-      @validation_errors << [:query_validation_invalid_subquery,
-                             { param: param.to_s, model: }]
-      return nil
-    end
-    submodel = param_type.values.first
-    subquery = Query.create_query(submodel, val)
-    @subqueries[param] = subquery
-    @validation_errors += subquery.validation_errors
-    subquery.params
-  end
-
-  def validate_enum(param, val, hash)
-    if hash.keys.length != 1
-      @validation_errors << [:query_validation_invalid_enum_keys,
-                             { param: param.to_s, model: }]
-      return nil
-    end
-
-    arg_type = hash.keys.first
-    set = hash.values.first
-    unless set.is_a?(Array)
-      @validation_errors << [:query_validation_invalid_enum_not_array,
-                             { param: param.to_s, model: }]
-      return nil
-    end
-
-    val2 = scalar_validate(param, val, arg_type)
-    if (arg_type == :string) && set.include?(val2.to_s.to_sym)
-      val2 = val2.to_s.to_sym
-    elsif set.exclude?(val2)
-      @validation_errors << [:query_validation_param_not_in_set,
-                             { param: param.to_s, set: set.inspect }]
-      val2 = nil
-    end
-    val2
   end
 
   # Disable cop because we do mean to symbols with boolean names
@@ -223,9 +170,7 @@ module Query::Modules::Validation
     when nil
       nil
     else
-      @validation_errors << [:query_validation_boolean,
-                             { param: param.to_s, val: }]
-      nil
+      add_validation_error(:query_validation_boolean, param: param.to_s, val:)
     end
   end
   # rubocop:enable Lint/BooleanSymbol
@@ -247,9 +192,8 @@ module Query::Modules::Validation
        (val.is_a?(String) && val.match(/^-?(\d+(\.\d+)?|\.\d+)$/))
       val.to_f
     else
-      @validation_errors << [:query_validation_float,
-                             { param: param.to_s, val: val.inspect }]
-      nil
+      add_validation_error(:query_validation_float,
+                           param: param.to_s, val: val.inspect)
     end
   end
 
@@ -258,9 +202,8 @@ module Query::Modules::Validation
   def validate_record(param, val, type = ActiveRecord::Base)
     if val.is_a?(type)
       unless val.id
-        @validation_errors << [:query_validation_record_unsaved,
-                               { param: param.to_s, type: }]
-        return nil
+        return add_validation_error(:query_validation_record_unsaved,
+                                    param: param.to_s, type:)
       end
 
       set_cached_parameter_instance(param, val)
@@ -270,27 +213,24 @@ module Query::Modules::Validation
     elsif val.is_a?(String)
       validate_string_for_record(param, val, type)
     else
-      @validation_errors << [:query_validation_record,
-                             { param: param.to_s, type:, val: val.inspect }]
-      nil
+      add_validation_error(:query_validation_record,
+                           param: param.to_s, type:, val: val.inspect)
     end
   end
 
   def validate_string_for_record(param, val, type)
     return val unless param == :id_in_set
 
-    @validation_errors << [:query_validation_id_in_set, { type:, val: }]
-    nil
+    add_validation_error(:query_validation_id_in_set, type:, val:)
   end
 
   def validate_string(param, val)
     if val.is_any?(Integer, Float, String, Symbol)
       val.to_s
     else
-      @validation_errors << [:query_validation_string,
-                             { param: param.to_s, class: val.class,
-                               val: val.inspect }]
-      nil
+      add_validation_error(:query_validation_string,
+                           param: param.to_s, class: val.class,
+                           val: val.inspect)
     end
   end
 
@@ -305,9 +245,7 @@ module Query::Modules::Validation
     elsif (val2 = parse_date(val)).acts_like?(:date)
       format_date(val2)
     else
-      @validation_errors << [:query_validation_date,
-                             { param: param.to_s, val: }]
-      nil
+      add_validation_error(:query_validation_date, param: param.to_s, val:)
     end
   end
 
@@ -331,9 +269,8 @@ module Query::Modules::Validation
     elsif (val2 = parse_time(val)).acts_like?(:time)
       format_time(val2)
     else
-      @validation_errors << [:query_validation_time,
-                             { param: param.to_s, class: val.class.name, val: }]
-      nil
+      add_validation_error(:query_validation_time,
+                           param: param.to_s, class: val.class.name, val:)
     end
   end
 

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -20,14 +20,36 @@ class Query::Observations < Query
                        include_immediate_subtaxa: :boolean,
                        exclude_original_names: :boolean,
                        include_all_name_proposals: :boolean,
-                       exclude_consensus: :boolean })
+                       exclude_consensus: :boolean },
+             default_order: :confidence)
+  # Each of these is a named preset of `names:` options, backed by a
+  # same-named Observation scope (Observation::Scopes) -- see there
+  # for what each preset means. `[:string]`, not `:string`, so the
+  # FilterCaption's Lookup-driven rendering (PARAM_LOOKUPS) applies --
+  # it expects an Array, matching every other name-lookup attr.
+  query_attr(:look_alikes, [:string], default_order: :confidence)
+  # `[:name_parents]`, not `[:string]` -- the stored value is the
+  # matched name's parent ids, not the searched name itself, so the
+  # filter caption shows the parent (see `validate_name_parents`
+  # below and Observation::Scopes#related_taxa).
+  query_attr(:related_taxa, [:name_parents], default_order: :confidence)
+  # param_alias matches the URL shortcut (`?name=`) -- attr itself is
+  # `any_name`, not `name`, to avoid colliding with `Observation.name`
+  # (see Observation::Scopes#any_name).
+  query_attr(:any_name, [:string], param_alias: :name,
+                                   default_order: :confidence)
+  query_attr(:name_proposed, [:string], default_order: :confidence)
+  query_attr(:this_name, [:string], default_order: :confidence)
+  query_attr(:other_names, [:string], default_order: :confidence)
   query_attr(:confidence, [:float])
   query_attr(:needs_naming, User)
   # query_attr(:clade, :string) # content filter
   # query_attr(:lichen, :boolean) # content filter
   # The identify page's clade/region autocompleter -- see
-  # Observation::Scopes#identify_filter.
-  query_attr(:identify_filter, { type: :string, term: :string })
+  # Observation::Scopes#identify_filter. default_order matches the
+  # identify page's own default (Observations::IdentifyController).
+  query_attr(:identify_filter, { type: :string, term: :string },
+             default_order: :rss_log)
 
   query_attr(:is_collection_location, :boolean)
   query_attr(:has_public_lat_lng, :boolean)
@@ -94,5 +116,17 @@ class Query::Observations < Query
 
   def self.default_order
     :date
+  end
+
+  private
+
+  # Custom scalar type for `related_taxa` (a Symbol `accepts`, same
+  # dispatch convention as `validate_string`/`validate_boolean` --
+  # see Query::Modules::Validation#scalar_validate). Resolves the
+  # searched name string/id to its approved name's parent ids at
+  # validation time, so the stored query param is what the filter
+  # caption and `Observation.related_taxa` scope both need.
+  def validate_name_parents(_param, val)
+    Name.parent_ids_for(val)
   end
 end

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -20,8 +20,7 @@ class Query::Observations < Query
                        include_immediate_subtaxa: :boolean,
                        exclude_original_names: :boolean,
                        include_all_name_proposals: :boolean,
-                       exclude_consensus: :boolean },
-             default_order: :confidence)
+                       exclude_consensus: :boolean })
   # Each of these is a named preset of `names:` options, backed by a
   # same-named Observation scope (Observation::Scopes) -- see there
   # for what each preset means. `[:string]`, not `:string`, so the

--- a/app/classes/query/species_lists.rb
+++ b/app/classes/query/species_lists.rb
@@ -24,7 +24,8 @@ class Query::SpeciesLists < Query
                        exclude_original_names: :boolean,
                        include_all_name_proposals: :boolean,
                        exclude_consensus: :boolean })
-  query_attr(:projects, [Project])
+  query_attr(:projects, [Project], param_alias: :project,
+                                   redirect_to: :model_index)
   query_attr(:observation_query, { subquery: :Observation })
 
   def alphabetical_by

--- a/app/classes/tab/name/obs_link.rb
+++ b/app/classes/tab/name/obs_link.rb
@@ -19,7 +19,8 @@
 #
 # Subclasses MUST implement:
 #   #label_key      — Symbol for the link label (e.g. `:obss_of_this_name`)
-#   #build_query    — returns the (saved) `Query::Observations` instance
+#   #filter_attr    — Query::Observations attr for this Tab's preset
+#                      (e.g. `:this_name`, `:any_name`)
 #
 # The base inherits `Tab::QueryLink`'s memoized `#query` and
 # `#path` (via `controller.add_q_param(observations_path, query)`).
@@ -62,8 +63,18 @@ class Tab::Name::ObsLink < Tab::QueryLink
 
   private
 
+  def build_query
+    q = Query.create_query(:Observation, filter_attr => @name.id)
+    q.save
+    q
+  end
+
   def label_key
     raise(NotImplementedError.new("#{self.class}#label_key"))
+  end
+
+  def filter_attr
+    raise(NotImplementedError.new("#{self.class}#filter_attr"))
   end
 
   def target_params

--- a/app/classes/tab/name/obs_link/any_name.rb
+++ b/app/classes/tab/name/obs_link/any_name.rb
@@ -10,13 +10,7 @@ class Tab::Name::ObsLink::AnyName < Tab::Name::ObsLink
     :obss_of_taxon
   end
 
-  def build_query
-    q = Query.create_query(
-      :Observation,
-      names: { lookup: @name.id, include_synonyms: true },
-      order_by: :confidence
-    )
-    q.save
-    q
+  def filter_attr
+    :any_name
   end
 end

--- a/app/classes/tab/name/obs_link/name_proposed.rb
+++ b/app/classes/tab/name/obs_link/name_proposed.rb
@@ -11,13 +11,7 @@ class Tab::Name::ObsLink::NameProposed < Tab::Name::ObsLink
     :obss_name_proposed
   end
 
-  def build_query
-    q = Query.create_query(
-      :Observation,
-      names: { lookup: @name.id, include_all_name_proposals: true },
-      order_by: :confidence
-    )
-    q.save
-    q
+  def filter_attr
+    :name_proposed
   end
 end

--- a/app/classes/tab/name/obs_link/other_names.rb
+++ b/app/classes/tab/name/obs_link/other_names.rb
@@ -11,14 +11,7 @@ class Tab::Name::ObsLink::OtherNames < Tab::Name::ObsLink
     :taxon_obss_other_names
   end
 
-  def build_query
-    q = Query.create_query(
-      :Observation,
-      names: { lookup: @name.id, include_synonyms: true,
-               exclude_original_names: true },
-      order_by: :confidence
-    )
-    q.save
-    q
+  def filter_attr
+    :other_names
   end
 end

--- a/app/classes/tab/name/obs_link/taxon_proposed.rb
+++ b/app/classes/tab/name/obs_link/taxon_proposed.rb
@@ -12,15 +12,7 @@ class Tab::Name::ObsLink::TaxonProposed < Tab::Name::ObsLink
     :obss_taxon_proposed
   end
 
-  def build_query
-    q = Query.create_query(
-      :Observation,
-      names: { lookup: @name.id, include_synonyms: true,
-               include_all_name_proposals: true,
-               exclude_consensus: true },
-      order_by: :confidence
-    )
-    q.save
-    q
+  def filter_attr
+    :look_alikes
   end
 end

--- a/app/classes/tab/name/obs_link/this_name.rb
+++ b/app/classes/tab/name/obs_link/this_name.rb
@@ -10,11 +10,7 @@ class Tab::Name::ObsLink::ThisName < Tab::Name::ObsLink
     :obss_of_this_name
   end
 
-  def build_query
-    q = Query.create_query(:Observation,
-                           names: { lookup: @name.id },
-                           order_by: :confidence)
-    q.save
-    q
+  def filter_attr
+    :this_name
   end
 end

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -189,20 +189,23 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     query
   end
 
-  # Derives a controller ivar (e.g. `@project`, `@observation`) from an
-  # already-built Query's resolved params, for a single-record
-  # `attr` (e.g. `:projects`, `:observations`) -- covers both a URL
-  # shortcut (`?project=id`) and a bookmarked/permalinked
-  # `q[projects][]=id` query the same way, since both resolve into the
-  # same `query.params[attr]` shape. Call from a controller's
-  # `filtered_index_final_hook` override. No-op (ivar left unset) when
-  # `attr` isn't present or holds more than one id -- a multi-value
-  # filter has no single record to derive an ivar from.
+  # Sets @project/@observation-style ivars from a Query's resolved
+  # params. Call it from filtered_index_final_hook. No-op when attr
+  # is absent or holds more than one id.
   def derive_ivar_from_query(ivar, query, attr, model_class)
     ids = query.params[attr]
     return unless ids.is_a?(Array) && ids.size == 1
 
-    instance_variable_set(ivar, model_class.safe_find(ids.first))
+    instance_variable_set(ivar, resolved_alias_record(attr, ids.first) ||
+                                 model_class.safe_find(ids.first))
+  end
+
+  # Reuses the record already fetched for this attr, instead of
+  # fetching it again. Returns nil if nothing was cached (a
+  # bookmarked query) or the id doesn't match.
+  def resolved_alias_record(attr, id)
+    cached = @resolved_alias_records && @resolved_alias_records[attr]
+    cached if cached&.id == id
   end
 
   # Default for the display_opts hash passed to show_index_of_objects.

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -3,7 +3,7 @@
 #  ==== QueryParamAliases
 #  create_query_from_url_params:: Build a Query from raw request params,
 #                                 resolving any registered `param_alias:`
-#                                 shortcut params along the way.
+#                                 index filter params along the way.
 #
 module ApplicationController::QueryParamAliases
   # Builds a Query for `model_symbol` from raw request params, resolving
@@ -24,7 +24,7 @@ module ApplicationController::QueryParamAliases
   #
   # `always_index: true` is set automatically whenever a record-backed
   # param_alias resolved a param (e.g. `project`, not the scalar `by`
-  # sort alias), matching every hand-written shortcut's existing
+  # sort alias), matching every hand-written index filter param's existing
   # `always_index: true` (an aliased single-result index should show the
   # list, not auto-redirect to the one result). A sort-order change has
   # no such single-result-redirect concern, so `by` alone doesn't trigger
@@ -105,8 +105,16 @@ module ApplicationController::QueryParamAliases
              end
     return :not_found unless record
 
+    # Caches the record so a later ivar-derivation step can reuse it
+    # instead of fetching it again.
+    cache_resolved_alias_record(attr, record)
     permitted[attr] = type.accepts.is_a?(Array) ? [record.id] : record.id
     type.always_index ? :record_backed : :scalar
+  end
+
+  def cache_resolved_alias_record(attr, record)
+    @resolved_alias_records ||= {}
+    @resolved_alias_records[attr] = record
   end
 
   # Like `find_or_goto_index` (ApplicationController::Indexes), but

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -67,21 +67,17 @@ class CommentsController < ApplicationController
     create_query_from_url_params(:Comment, params)
   end
 
-  # Shows comments for a given object, most recent first. (Linked from the
-  # "and more..." thingy at the bottom of truncated embedded comment lists.)
+  # Shows comments for a given object, most recent first. Linked from
+  # the "and more..." link at the bottom of a truncated comment list.
+  # Target validation lives in
+  # `Query::Modules::HashValidation#validate_polymorphic`, shared
+  # with the bookmarked `q[target][...]` query path. It flashes on an
+  # unrecognized type or nonexistent id.
   def target
-    return no_model unless (model = Comment.safe_model_from_name(params[:type]))
-    return unless (target = find_or_goto_index(model, params[:target].to_s))
-
-    query = create_query(:Comment, target: { type: target.class.name,
-                                             id: target.id })
-    [query, {}]
-  end
-
-  def no_model
-    flash_error(:runtime_invalid.t(type: '"type"', value: params[:type].to_s))
-    redirect_back_or_default(action: :index)
-    [nil, {}]
+    create_query_from_url_params(
+      :Comment, params.merge(target: { type: params[:type],
+                                       id: params[:target] })
+    )
   end
 
   def index_display_opts(opts, query)

--- a/app/controllers/field_slips_controller/index.rb
+++ b/app/controllers/field_slips_controller/index.rb
@@ -29,18 +29,18 @@ module FieldSlipsController::Index
 
   # Display list of FieldSlips attached to a given project.
   def project
-    return unless (
-      project = find_or_goto_index(Project, params[:project].to_s)
-    )
-
-    query = create_query(:FieldSlip, projects: project)
-    @project = project
-    [query, { always_index: true }]
+    create_query_from_url_params(:FieldSlip, params)
   end
 
   # Displays list of User's FieldSlips, by date.
   def by_user
     create_query_from_url_params(:FieldSlip, params)
+  end
+
+  # Hook runs before template displayed. Must return query.
+  def filtered_index_final_hook(query, _display_opts)
+    derive_ivar_from_query(:@project, query, :projects, Project)
+    query
   end
 
   # `show_index_of_objects` consumes `:include` as an array of

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -53,11 +53,13 @@ class HerbariumRecordsController < ApplicationController
   end
 
   def observation
-    @observation = Observation.find(params[:observation])
-    query = create_query(:HerbariumRecord,
-                         observations: params[:observation].to_s,
-                         order_by: :herbarium_label)
-    [query, { always_index: true }]
+    create_query_from_url_params(:HerbariumRecord, params)
+  end
+
+  # Hook runs before template displayed. Must return query.
+  def filtered_index_final_hook(query, _display_opts)
+    derive_ivar_from_query(:@observation, query, :observations, Observation)
+    query
   end
 
   def index_display_opts(opts, _query)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -63,15 +63,17 @@ class LocationsController < ApplicationController
 
   # Displays a list of all locations whose country matches the param.
   def country
-    query = create_query(:Location, regexp: "#{params[:country]}$")
+    query, = create_query_from_url_params(:Location, params)
+    return unless query
+
     [query, { link_all_sorts: true }]
   end
 
   # Displays a list of locations of obs whose project matches the param.
   def project
-    obs_query = create_query(:Observation,
-                             projects: Project.find(params[:project]))
-    query = create_query(:Location, observation_query: obs_query.params)
+    query, = create_query_from_url_params(:Location, params)
+    return unless query
+
     [query, { link_all_sorts: true }]
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -78,10 +78,6 @@ class LocationsController < ApplicationController
   end
 
   # Display list of locations that a given user created.
-  #
-  # Discards create_query_from_url_params's `always_index` -- above,
-  # `index_display_opts` computes it from `@undef_pages` for every
-  # subaction, which single-match auto-redirect depends on.
   def by_user
     query, = create_query_from_url_params(:Location, params)
     return unless query
@@ -109,6 +105,13 @@ class LocationsController < ApplicationController
   end
 
   # Paginate the defined locations using the usual helper.
+  #
+  # always_index always comes from @undef_pages here, regardless of
+  # what a subaction's own create_query_from_url_params call
+  # resolved -- country/project/by_user/by_editor above all discard
+  # that value and pass a fixed opts hash instead. Single-match
+  # auto-redirect for this index depends on @undef_pages's
+  # letter-pagination total, not the Query layer's opinion.
   def index_display_opts(opts, _query)
     { always_index: @undef_pages&.num_total&.positive? }.merge(opts)
   end

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -76,18 +76,14 @@ class NamesController < ApplicationController
 
   # Display list of names with descriptions that have authors.
   def has_descriptions
-    @has_descriptions = true # signals to add desc info to name list
-    query = create_query(:Name, has_descriptions: 1)
-    [query, {}]
+    create_query_from_url_params(:Name, params)
   end
   # rubocop:enable Naming/PredicatePrefix
 
   # Display list of the most popular 100 names that don't have descriptions.
   # NOTE: all this extra info and help will be lost if user re-sorts.
   def needs_description
-    @help = :needed_descriptions_help
-    query = create_query(:Name, needs_description: 1)
-    [query, { num_per_page: 100 }]
+    create_query_from_url_params(:Name, params)
   end
 
   # Display list of names that a given user is author on.
@@ -103,15 +99,26 @@ class NamesController < ApplicationController
   # Hook runs before template displayed. Must return query.
   def filtered_index_final_hook(query, _display_opts)
     store_query_in_session(query)
+    @has_descriptions = query.params[:has_descriptions] == true
+    @help = :needed_descriptions_help if query.params[:needs_description]
     query
   end
 
-  def index_display_opts(opts, _query)
+  def index_display_opts(opts, query)
     {
       letters: true,
-      num_per_page: (/^[a-z]/i.match?(params[:letter].to_s) ? 500 : 50),
+      num_per_page: index_num_per_page(query),
       include: [:description]
     }.merge(opts)
+  end
+
+  # Needs-description page shows the 100 most popular unresolved
+  # names; every other sort of the index paginates 50 (500 for a
+  # letter-anchored jump).
+  def index_num_per_page(query)
+    return 100 if query.params[:needs_description]
+
+    /^[a-z]/i.match?(params[:letter].to_s) ? 500 : 50
   end
 
   ###################################

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -49,16 +49,13 @@ module Observations
     # Dispatches to Observation.identify_filter (Observation::Scopes),
     # which picks clade or region based on identify_filter[type] --
     # the single swappable autocompleter submits both under one field
-    # pair, so this permits the nested hash directly rather than going
-    # through create_query_from_url_params (no alias/record lookup
-    # applies to this attr).
+    # pair. `needs_naming` is always this page's current user,
+    # regardless of the optional clade/region sub-filter, so it's
+    # merged in here rather than coming from the URL.
     def identify_filter
-      filter = params.permit(identify_filter: [:type, :term])[:identify_filter].
-               to_h.symbolize_keys
-      query = create_query(:Observation, identify_filter: filter,
-                                         needs_naming: @user,
-                                         order_by: :rss_log)
-      [query, {}]
+      create_query_from_url_params(
+        :Observation, params.merge(needs_naming: @user&.id)
+      )
     end
 
     def index_display_opts(opts, _query)

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -116,44 +116,28 @@ class ObservationsController
       end
     end
 
-    # Displays matrix of Observations with the given name proposed but not
-    # actually that name.
+    # Displays matrix of Observations with the given name proposed, where
+    # that name is not the consensus. `look_alikes` itself is a mode
+    # flag (`?look_alikes=1`); the name comes from the separate `name`
+    # param, same as the `name`/`related_taxa` subactions below.
     def look_alikes
-      query = create_query(
-        :Observation, names: { lookup: [params[:name]],
-                               include_synonyms: true,
-                               include_all_name_proposals: true,
-                               exclude_consensus: true },
-                      order_by: :confidence
+      create_query_from_url_params(
+        :Observation,
+        params.merge(look_alikes: [params[:name]]).except(:name)
       )
-      [query, {}]
     end
 
     # Displays matrix of Observations of subtaxa of the parent of given name.
     def related_taxa
-      query = create_query(
-        :Observation, names: { lookup: parents(params[:name]),
-                               include_subtaxa: true },
-                      order_by: :confidence
+      create_query_from_url_params(
+        :Observation,
+        params.merge(related_taxa: [params[:name]]).except(:name)
       )
-      [query, {}]
     end
 
     # Displays matrix of Observations with the given text_name (or search_name).
     def name
-      query = create_query(
-        :Observation, names: { lookup: [params[:name]],
-                               include_synonyms: true },
-                      order_by: :confidence
-      )
-      [query, {}]
-    end
-
-    def parents(name_str)
-      names = Name.where(id: name_str).to_a
-      names = Name.where(search_name: name_str).to_a if names.empty?
-      names = Name.where(text_name: name_str).to_a if names.empty?
-      names.map { |name| name.approved_name.parents }.flatten.map(&:id).uniq
+      create_query_from_url_params(:Observation, params)
     end
 
     # Displays matrix of User's Observations, by date.

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -70,7 +70,13 @@ class RssLogsController < ApplicationController
     end
   end
 
-  # Hook runs before template displayed. Must return query.
+  # Hook runs before template displayed. Must return query. Unlike
+  # every other controller's version of this hook, this one has a
+  # write side effect (persisting `@user.default_rss_type`), not just
+  # session/ivar bookkeeping -- a future generic dispatcher (issue
+  # #5140) can't assume every `filtered_index_final_hook` override is
+  # safe to collapse away; this one needs to keep running on every
+  # index render, filtered or not.
   def filtered_index_final_hook(query, _display_opts)
     update_stored_query(query) # also stores query in session
     tags = RssLog.normalize_type_tags(query.params[:types])

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -64,14 +64,14 @@ class SequencesController < ApplicationController
     ::Query::Sequences.default_order # :created_at
   end
 
+  # `?all=true` isn't listed here -- `build_index_with_query` already
+  # falls through to `unfiltered_index` when no recognized param has a
+  # value, so a dedicated `:all` subaction dispatching to the exact
+  # same `unfiltered_index` call was a no-op. Left as a documented
+  # URL shape (see the class comment above and `test_index_all`), not
+  # a dispatched param.
   def index_active_params
-    [:all, :by, :q].freeze
-  end
-
-  # This is a param handler. In this controller, people usually want sequences
-  # for an observation. If they want all sequences, use the :all param.
-  def all
-    unfiltered_index
+    [:by, :q].freeze
   end
 
   def index_display_opts(opts, _query)

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -18,7 +18,6 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
   # INDEX
   #
   def index
-    set_project_ivar
     build_index_with_query
   end
 
@@ -81,12 +80,13 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
 
   # Display list of SpeciesList's attached to a given project.
   def project
-    project = find_or_goto_index(Project, params[:project].to_s)
-    return unless project
+    create_query_from_url_params(:SpeciesList, params)
+  end
 
-    query = create_query(:SpeciesList, projects: project)
-    @project = project
-    [query, { always_index: true }]
+  # Hook runs before template displayed. Must return query.
+  def filtered_index_final_hook(query, _display_opts)
+    derive_ivar_from_query(:@project, query, :projects, Project)
+    query
   end
 
   def index_display_opts(opts, query)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -83,8 +83,7 @@ class UsersController < ApplicationController
   # falls through to the generic single-result auto-redirect
   # (display_opts has no always_index override, same as before).
   def pattern
-    query = create_query(:User, pattern: params[:pattern].to_s)
-    [query, {}]
+    create_query_from_url_params(:User, params)
   end
 
   # Hook runs before template displayed. Must return query.

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -218,14 +218,13 @@ class Comment < AbstractModel
   # Pass either { type:, id: } or a commentable model instance.
   # Scope makes sure instance exists.
   scope :target, lambda { |target|
-    if target.is_a?(Hash) && target[:type] && target[:id]
-      type = target[:type]
-      return none unless (model = Comment.safe_model_from_name(type))
+    if target.is_a?(Hash)
+      return none unless target[:type] && target[:id]
+      return none unless (model = Comment.safe_model_from_name(target[:type]))
 
       target = model.safe_find(target[:id])
     elsif target.is_a?(AbstractModel)
-      type = target.class.name
-      return none unless Comment.safe_model_from_name(type)
+      return none unless Comment.safe_model_from_name(target.class.name)
     end
 
     where(target:)

--- a/app/models/field_slip.rb
+++ b/app/models/field_slip.rb
@@ -76,11 +76,6 @@ class FieldSlip < AbstractModel
       where(observations: { id: observation_ids }).distinct
   }
 
-  scope :project, lambda { |project|
-    project_ids = Lookup::Projects.new(project).ids
-    where(project: project_ids)
-  }
-
   scope :projects, lambda { |projects|
     project_ids = Lookup::Projects.new(projects).ids
     where(project: project_ids).distinct

--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -67,6 +67,13 @@ module Location::Scopes
     scope :regexp, lambda { |phrase|
       where(Location[:name] =~ phrase.to_s.strip.squeeze(" ")).distinct
     }
+    # Locations whose name ends with the given country -- MO location
+    # names are formatted "City, State, Country". Named `in_country`,
+    # not `country`, to avoid colliding with `Location.country`
+    # (parses the country out of a location name string).
+    scope :in_country, lambda { |name|
+      regexp("#{name}$")
+    }
     # https://stackoverflow.com/a/77064711/3357635
     # AR's assumed join condition is
     #   `Location[:id].eq(LocationDescription[:location_id])`
@@ -203,6 +210,10 @@ module Location::Scopes
       regions = hash.delete(:region)
       scope = scope.region(regions) if regions.present?
       scope.joins(:observations).subquery(:Observation, hash)
+    }
+    # Locations of observations attached to the given project(s).
+    scope :projects, lambda { |project_ids|
+      observation_query(projects: project_ids)
     }
 
     scope :show_includes, lambda {

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -460,4 +460,14 @@ class Name < AbstractModel
     Hash[*Observation.group(:name_id).where(name: names).
          pluck(:name_id, Arel.star.count).to_a.flatten]
   end
+
+  # Resolves a name string or id to the ids of its parent taxa.
+  # Called from Query::Observations#validate_name_parents, for the
+  # "related taxa" page linked from a Name's show page. Matching goes
+  # through Lookup::Names, the same name-resolution every other
+  # name-lookup filter in the app uses.
+  def self.parent_ids_for(name_str)
+    Lookup::Names.new(name_str).instances.
+      map { |name| name.approved_name.parents }.flatten.map(&:id).uniq
+  end
 end

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -203,6 +203,45 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       end
       scope.distinct
     }
+    # Observations with the given Name (or a synonym) proposed but not
+    # consensus'd -- the "look-alikes" page linked from a Name's show
+    # page, and (same filter) the "Observations of other taxa where
+    # this taxon was proposed" Name-page tab.
+    scope :look_alikes, lambda { |name_strs|
+      names(lookup: name_strs, include_synonyms: true,
+            include_all_name_proposals: true, exclude_consensus: true)
+    }
+    # Observations of subtaxa of the parent of the given name. The
+    # query_attr resolves the searched name to its parent ids at
+    # validation time (Query::Observations#validate_name_parents), so
+    # this scope receives parent ids directly, not the searched name.
+    scope :related_taxa, lambda { |parent_ids|
+      names(lookup: parent_ids, include_subtaxa: true)
+    }
+    # Observations of this taxon under any name -- the given
+    # text_name/search_name/id or any of its synonyms. Named
+    # `any_name`, not `name` -- a `name` scope would collide with
+    # `Class#name` (Observation.name is Ruby's own class-name reader,
+    # called throughout Rails internals).
+    scope :any_name, lambda { |name_strs|
+      names(lookup: name_strs, include_synonyms: true)
+    }
+    # Observations where this exact Name was proposed (via Namings),
+    # regardless of consensus.
+    scope :name_proposed, lambda { |name_strs|
+      names(lookup: name_strs, include_all_name_proposals: true)
+    }
+    # Observations whose consensus is this Name -- no synonyms, no
+    # proposed-but-not-consensus matches.
+    scope :this_name, lambda { |name_strs|
+      names(lookup: name_strs)
+    }
+    # Observations under other names -- expands to the synonym set,
+    # excluding this Name itself.
+    scope :other_names, lambda { |name_strs|
+      names(lookup: name_strs, include_synonyms: true,
+            exclude_original_names: true)
+    }
     scope :names_like,
           ->(name) { where(name: Name.text_name_has(name)) }
 

--- a/app/views/controllers/names/index.rb
+++ b/app/views/controllers/names/index.rb
@@ -18,11 +18,11 @@ module Views::Controllers::Names
     prop :pagination_data, ::PaginationData
     prop :objects, _Array(::Name)
     prop :user, _Nilable(::User), default: nil
-    # The `needs_description` subaction sets `@help` to a
-    # translation key Symbol; other subactions leave it nil.
+    # A translation key Symbol when the active query filters on
+    # `needs_description`; nil otherwise.
     prop :help, _Nilable(Symbol), default: nil
-    # Set by the `has_descriptions` subaction; per-row descriptions
-    # columns render only when this is true.
+    # True when the active query filters on `has_descriptions`;
+    # per-row descriptions columns render only then.
     prop :has_descriptions, _Boolean, default: false
     # Pattern-search-with-zero-results path: the controller fills
     # this with alternate spellings to suggest.

--- a/app/views/controllers/names/index/row.rb
+++ b/app/views/controllers/names/index/row.rb
@@ -9,8 +9,8 @@
 #     copy-button so users can clipboard the name string)
 #   - the observations count badge (per-name count derived in
 #     bulk by the Index view via `Name.count_observations`)
-#   - on the `has_descriptions` subaction only, three extra
-#     `<span>`s with the description's authors / note status /
+#   - when the active query filters on `has_descriptions`, three
+#     extra `<span>`s with the description's authors / note status /
 #     review status
 class Views::Controllers::Names::Index::Row < Views::Base
   prop :name, ::Name

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -25,6 +25,12 @@ module Views::Layouts
       names: :Names,
       lookup: :Names,
       clade: :Names,
+      look_alikes: :Names,
+      related_taxa: :Names,
+      any_name: :Names,
+      name_proposed: :Names,
+      this_name: :Names,
+      other_names: :Names,
       projects: :Projects,
       project_lists: :ProjectSpeciesLists,
       species_lists: :SpeciesLists,
@@ -47,7 +53,9 @@ module Views::Layouts
     CAPTION_TRUNCATE = 3
     # Lookup keys whose joined string is italicized inside the `<b>`
     # tag (Latin / taxonomic names).
-    ITALICIZE_LOOKUP_KEYS = [:names, :lookup].freeze
+    ITALICIZE_LOOKUP_KEYS = [:names, :lookup, :look_alikes, :related_taxa,
+                             :any_name, :name_proposed, :this_name,
+                             :other_names].freeze
 
     prop :query, ::Query
 

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4348,6 +4348,8 @@
   query_validation_record: "Value for ':[param]' should be id, string or :[type] instance, got: [val]."
   query_validation_id_in_set: "Value for :id_in_set should be an array of ids or :[type] instances, got: [val]."
   query_validation_string: "Value for ':[param]' should be a string or symbol, got a :[class] : [val]."
+  query_validation_invalid_polymorphic_type: "Value for ':[param]' should be a valid type, got: [type]."
+  query_validation_polymorphic_not_found: "Value for ':[param]' refers to a :[type] that does not exist: [id]."
   query_validation_date: "Value for ':[param]' should be a date (YYYY-MM-DD or MM-DD), got: [val]."
   query_validation_time: "Value for ':[param]' should be a UTC time (YYYY-MM-DD-HH-MM-SS), got: :[class] : [val]."
   query_validation_order_by_unsupported: "Query::[models] does not accept order_by: `[key]` — no [model].order_by_[base] scope is defined."
@@ -4442,6 +4444,7 @@
   query_title_has: title has
   query_types: types
   query_url_has: url has
+  query_in_country: country
 
   # in box
   query_in_box: in box
@@ -4469,6 +4472,12 @@
   query_exclude_original_names: exclude original
   query_include_all_name_proposals: all proposed
   query_exclude_consensus: exclude consensus
+  query_look_alikes: look-alikes
+  query_related_taxa: related taxa
+  query_any_name: any name
+  query_name_proposed: name proposed
+  query_this_name: this name
+  query_other_names: other names
 
   # records
   query_external_sites: "[:sites]"

--- a/test/classes/query/comments_test.rb
+++ b/test/classes/query/comments_test.rb
@@ -36,16 +36,49 @@ class Query::CommentsTest < UnitTestCase
                        :Comment, target: { type: :Observation, id: obs.id })
   end
 
-  # Query currently raises on invalid params, so we can't test this yet.
-  # def test_comment_for_invalid_target
-  #   glo = glossary_terms(:convex_glossary_term)
-  #   scope = Comment.target(glo)
-  #   assert_query_scope([], scope,
-  #                      :Comment, target: { type: :GlossaryTerm, id: glo.id })
-  #   scope = Comment.target(type: "GlossaryTerm", id: glo.id)
-  #   assert_query_scope([], scope,
-  #                      :Comment, target: { type: :GlossaryTerm, id: glo.id })
-  # end
+  # An unrecognized `target` type is caught at validation time
+  # (Query::Modules::HashValidation#validate_polymorphic): the query
+  # is invalid, and must still produce zero results rather than an
+  # unfiltered one -- the attr stays present (not skipped as absent)
+  # so `Comment.target`'s own guard turns it into `none`.
+  def test_comment_for_invalid_target
+    glo = glossary_terms(:convex_glossary_term)
+    query = Query.lookup(:Comment, target: { type: "GlossaryTerm",
+                                             id: glo.id })
+
+    assert_not(query.valid)
+    assert_not_empty(query.validation_errors)
+    assert_empty(query.results)
+  end
+
+  # `target:` also accepts a live instance directly, not just the
+  # `{ type:, id: }` hash the URL shortcut sends -- exercises
+  # Query::Modules::HashValidation#validate_polymorphic_instance.
+  def test_comment_for_target_as_instance
+    obs = observations(:minimal_unknown_obs)
+    expects = [comments(:minimal_unknown_obs_comment_2),
+               comments(:minimal_unknown_obs_comment_1)]
+    scope = Comment.order_by_default.target(obs).distinct
+    assert_query_scope(expects, scope, :Comment, target: obs)
+  end
+
+  def test_comment_for_target_as_instance_of_unsupported_type
+    glo = glossary_terms(:convex_glossary_term)
+    query = Query.lookup(:Comment, target: glo)
+
+    assert_not(query.valid)
+    assert_not_empty(query.validation_errors)
+    assert_empty(query.results)
+  end
+
+  def test_comment_for_target_as_unsaved_instance
+    obs = Observation.new
+    query = Query.lookup(:Comment, target: obs)
+
+    assert_not(query.valid)
+    assert_not_empty(query.validation_errors)
+    assert_empty(query.results)
+  end
 
   def test_comment_types
     expects = [comments(:fungi_comment)]

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -378,7 +378,7 @@ class Query::ObservationsTest < UnitTestCase
     name = names(:agaricus)
     params = { lookup: name.id, include_subtaxa: true }
     expects = Observation.names(**params).order_by_default
-    assert_query(expects, :Observation, names: params)
+    assert_query(expects, :Observation, names: params, order_by: :date)
   end
 
   # This test ensures we force empty results when the lookup gets no ids.
@@ -391,17 +391,19 @@ class Query::ObservationsTest < UnitTestCase
                         exclude_original_names: true).order_by_default,
       :Observation, names: { lookup: name.id,
                              include_subtaxa: true,
-                             exclude_original_names: true }
+                             exclude_original_names: true },
+                    order_by: :date
     )
   end
 
   def test_observation_names_with_no_modifiers
     params = { lookup: [names(:fungi).id] }
     scope = Observation.names(**params).order_by_default
-    assert_query(scope, :Observation, names: params)
+    assert_query(scope, :Observation, names: params, order_by: :date)
     assert_query(
       [],
-      :Observation, names: { lookup: [names(:macrolepiota_rachodes).id] }
+      :Observation, names: { lookup: [names(:macrolepiota_rachodes).id] },
+                    order_by: :date
     )
   end
 
@@ -428,7 +430,7 @@ class Query::ObservationsTest < UnitTestCase
     scope = Observation.names(**params).order_by_default
     assert_query_scope(
       [observations(:agaricus_campestris_obs).id], scope,
-      :Observation, names: params
+      :Observation, names: params, order_by: :date
     )
   end
 
@@ -440,7 +442,7 @@ class Query::ObservationsTest < UnitTestCase
                exclude_consensus: true }
     scope = Observation.names(**params).order_by_default
     assert_query_scope(
-      [], scope, :Observation, names: params
+      [], scope, :Observation, names: params, order_by: :date
     )
   end
 
@@ -455,7 +457,7 @@ class Query::ObservationsTest < UnitTestCase
       [observations(:agaricus_campestris_obs).id,
        observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params
+      :Observation, names: params, order_by: :date
     )
   end
 
@@ -469,7 +471,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query_scope(
       [observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params
+      :Observation, names: params, order_by: :date
     )
   end
 
@@ -483,7 +485,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query_scope(
       [observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params
+      :Observation, names: params, order_by: :date
     )
   end
 
@@ -500,7 +502,7 @@ class Query::ObservationsTest < UnitTestCase
        observations(:agaricus_campestrus_obs).id,
        observations(:agaricus_campestris_obs).id],
       scope,
-      :Observation, names: params
+      :Observation, names: params, order_by: :date
     )
   end
 
@@ -515,7 +517,7 @@ class Query::ObservationsTest < UnitTestCase
        observations(:agaricus_campestras_obs).id,
        observations(:agaricus_campestrus_obs).id],
       scope,
-      :Observation, names: params
+      :Observation, names: params, order_by: :date
     )
   end
 
@@ -529,7 +531,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query_scope(
       [],
       scope,
-      :Observation, names: params
+      :Observation, names: params, order_by: :date
     )
   end
 
@@ -547,7 +549,7 @@ class Query::ObservationsTest < UnitTestCase
        observations(:agaricus_campestris_obs).id,
        observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params
+      :Observation, names: params, order_by: :date
     )
   end
 
@@ -561,7 +563,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query_scope(
       [observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params
+      :Observation, names: params, order_by: :date
     )
   end
 
@@ -581,7 +583,7 @@ class Query::ObservationsTest < UnitTestCase
       [observations(:agaricus_campestros_obs).id,
        observations(:agaricus_campestrus_obs).id],
       scope,
-      :Observation, names: params, species_lists: [spl.title]
+      :Observation, names: params, order_by: :date, species_lists: [spl.title]
     )
 
     params = { lookup: agaricus_ssp.map(&:text_name) }
@@ -591,7 +593,7 @@ class Query::ObservationsTest < UnitTestCase
       [observations(:agaricus_campestras_obs).id,
        observations(:agaricus_campestris_obs).id],
       scope,
-      :Observation, names: params, projects: [proj.title]
+      :Observation, names: params, order_by: :date, projects: [proj.title]
     )
   end
 

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -378,7 +378,7 @@ class Query::ObservationsTest < UnitTestCase
     name = names(:agaricus)
     params = { lookup: name.id, include_subtaxa: true }
     expects = Observation.names(**params).order_by_default
-    assert_query(expects, :Observation, names: params, order_by: :date)
+    assert_query(expects, :Observation, names: params)
   end
 
   # This test ensures we force empty results when the lookup gets no ids.
@@ -391,19 +391,17 @@ class Query::ObservationsTest < UnitTestCase
                         exclude_original_names: true).order_by_default,
       :Observation, names: { lookup: name.id,
                              include_subtaxa: true,
-                             exclude_original_names: true },
-                    order_by: :date
+                             exclude_original_names: true }
     )
   end
 
   def test_observation_names_with_no_modifiers
     params = { lookup: [names(:fungi).id] }
     scope = Observation.names(**params).order_by_default
-    assert_query(scope, :Observation, names: params, order_by: :date)
+    assert_query(scope, :Observation, names: params)
     assert_query(
       [],
-      :Observation, names: { lookup: [names(:macrolepiota_rachodes).id] },
-                    order_by: :date
+      :Observation, names: { lookup: [names(:macrolepiota_rachodes).id] }
     )
   end
 
@@ -430,7 +428,7 @@ class Query::ObservationsTest < UnitTestCase
     scope = Observation.names(**params).order_by_default
     assert_query_scope(
       [observations(:agaricus_campestris_obs).id], scope,
-      :Observation, names: params, order_by: :date
+      :Observation, names: params
     )
   end
 
@@ -442,7 +440,7 @@ class Query::ObservationsTest < UnitTestCase
                exclude_consensus: true }
     scope = Observation.names(**params).order_by_default
     assert_query_scope(
-      [], scope, :Observation, names: params, order_by: :date
+      [], scope, :Observation, names: params
     )
   end
 
@@ -457,7 +455,7 @@ class Query::ObservationsTest < UnitTestCase
       [observations(:agaricus_campestris_obs).id,
        observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params, order_by: :date
+      :Observation, names: params
     )
   end
 
@@ -471,7 +469,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query_scope(
       [observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params, order_by: :date
+      :Observation, names: params
     )
   end
 
@@ -485,7 +483,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query_scope(
       [observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params, order_by: :date
+      :Observation, names: params
     )
   end
 
@@ -502,7 +500,7 @@ class Query::ObservationsTest < UnitTestCase
        observations(:agaricus_campestrus_obs).id,
        observations(:agaricus_campestris_obs).id],
       scope,
-      :Observation, names: params, order_by: :date
+      :Observation, names: params
     )
   end
 
@@ -517,7 +515,7 @@ class Query::ObservationsTest < UnitTestCase
        observations(:agaricus_campestras_obs).id,
        observations(:agaricus_campestrus_obs).id],
       scope,
-      :Observation, names: params, order_by: :date
+      :Observation, names: params
     )
   end
 
@@ -531,7 +529,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query_scope(
       [],
       scope,
-      :Observation, names: params, order_by: :date
+      :Observation, names: params
     )
   end
 
@@ -549,7 +547,7 @@ class Query::ObservationsTest < UnitTestCase
        observations(:agaricus_campestris_obs).id,
        observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params, order_by: :date
+      :Observation, names: params
     )
   end
 
@@ -563,7 +561,7 @@ class Query::ObservationsTest < UnitTestCase
     assert_query_scope(
       [observations(:coprinus_comatus_obs).id],
       scope,
-      :Observation, names: params, order_by: :date
+      :Observation, names: params
     )
   end
 
@@ -583,7 +581,7 @@ class Query::ObservationsTest < UnitTestCase
       [observations(:agaricus_campestros_obs).id,
        observations(:agaricus_campestrus_obs).id],
       scope,
-      :Observation, names: params, order_by: :date, species_lists: [spl.title]
+      :Observation, names: params, species_lists: [spl.title]
     )
 
     params = { lookup: agaricus_ssp.map(&:text_name) }
@@ -593,7 +591,7 @@ class Query::ObservationsTest < UnitTestCase
       [observations(:agaricus_campestras_obs).id,
        observations(:agaricus_campestris_obs).id],
       scope,
-      :Observation, names: params, order_by: :date, projects: [proj.title]
+      :Observation, names: params, projects: [proj.title]
     )
   end
 

--- a/test/classes/tab/name/obs_link_test.rb
+++ b/test/classes/tab/name/obs_link_test.rb
@@ -11,8 +11,8 @@ require("test_helper")
 # the names-show controller test — that has a live controller; a
 # unit test here would stub it out and prove little. We pin the
 # title format, the link/no-link predicate, the html_options data
-# attrs, and that each subclass's query has the right `names`
-# subkeys.
+# attrs, and that each subclass's query is built with the right
+# attr.
 class Tab::Name::ObsLinkTest < UnitTestCase
   def setup
     @name = names(:coprinus_comatus)
@@ -71,39 +71,39 @@ class Tab::Name::ObsLinkTest < UnitTestCase
 
   # --- Query shape per subclass --------------------------------
 
+  # Each subclass's flag combination (synonyms, exclude_consensus,
+  # etc.) lives in the same-named Observation scope now, not in
+  # `query.params` -- see obs_link_query_integration_test.rb for the
+  # results-based coverage of that behavior. These just pin which
+  # attr each subclass wires up.
   def test_this_name_query_has_lookup_only
     q = build_tab(Tab::Name::ObsLink::ThisName, count: 1).query
 
-    assert_equal({ lookup: [@name.id] }, q.params[:names])
+    assert_equal([@name.id.to_s], q.params[:this_name])
   end
 
   def test_other_names_query_has_synonyms_and_exclude
     q = build_tab(Tab::Name::ObsLink::OtherNames, count: 1).query
 
-    assert_equal(true, q.params[:names][:include_synonyms])
-    assert_equal(true, q.params[:names][:exclude_original_names])
+    assert_equal([@name.id.to_s], q.params[:other_names])
   end
 
   def test_any_name_query_includes_synonyms_no_exclude
     q = build_tab(Tab::Name::ObsLink::AnyName, count: 1).query
 
-    assert_equal(true, q.params[:names][:include_synonyms])
-    assert_nil(q.params[:names][:exclude_original_names])
+    assert_equal([@name.id.to_s], q.params[:any_name])
   end
 
   def test_taxon_proposed_query_excludes_consensus
     q = build_tab(Tab::Name::ObsLink::TaxonProposed, count: 1).query
 
-    assert_equal(true, q.params[:names][:include_synonyms])
-    assert_equal(true, q.params[:names][:include_all_name_proposals])
-    assert_equal(true, q.params[:names][:exclude_consensus])
+    assert_equal([@name.id.to_s], q.params[:look_alikes])
   end
 
   def test_name_proposed_query_has_all_proposals_no_synonyms
     q = build_tab(Tab::Name::ObsLink::NameProposed, count: 1).query
 
-    assert_equal(true, q.params[:names][:include_all_name_proposals])
-    assert_nil(q.params[:names][:include_synonyms])
+    assert_equal([@name.id.to_s], q.params[:name_proposed])
   end
 
   # --- Query memoization saves once ----------------------------

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -50,8 +50,12 @@ class CommentsControllerTest < FunctionalTestCase
 
     login
     get(:index, params: params)
-    assert_flash(:runtime_invalid, type: '"type"',
-                                   value: params[:type].to_s)
+    assert_flash(
+      [[:runtime_no_matches, { type: :comment }],
+       [:query_validation_invalid_polymorphic_type,
+        { param: "target", type: params[:type] }]]
+    )
+    assert_select("#results tr", count: 0)
   end
 
   def test_index_target_for_non_model
@@ -59,8 +63,26 @@ class CommentsControllerTest < FunctionalTestCase
 
     login
     get(:index, params: params)
-    assert_flash(:runtime_invalid, type: '"type"',
-                                   value: params[:type].to_s)
+    assert_flash(
+      [[:runtime_no_matches, { type: :comment }],
+       [:query_validation_invalid_polymorphic_type,
+        { param: "target", type: params[:type] }]]
+    )
+    assert_select("#results tr", count: 0)
+  end
+
+  def test_index_target_nonexistent_id
+    bad_id = Name.maximum(:id).to_i + 1000
+    params = { type: "Name", target: bad_id }
+
+    login
+    get(:index, params: params)
+    assert_flash(
+      [[:runtime_no_matches, { type: :comment }],
+       [:query_validation_polymorphic_not_found,
+        { param: "target", type: :name, id: bad_id.to_s.inspect }]]
+    )
+    assert_select("#results tr", count: 0)
   end
 
   def test_index_pattern_search_str

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -88,6 +88,19 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
     assert_flash(:runtime_no_matches, type: :herbarium_record)
   end
 
+  # A bad observation id redirects to the observations index. See
+  # redirect_to: in query_attr (app/extensions/class.rb).
+  def test_index_observation_id_bad_id
+    bad_observation_id = Observation.maximum(:id).to_i + 1000
+
+    login
+    get(:index, params: { observation: bad_observation_id })
+
+    assert_flash(:runtime_object_not_found, type: :observation,
+                                            id: bad_observation_id)
+    assert_redirected_to(observations_path)
+  end
+
   ##############################################################################
   # SHOW
   #

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -362,7 +362,7 @@ class LocationsControllerTest < FunctionalTestCase
     get(:index, params: { country: country })
 
     assert_page_title(:locations.ti)
-    assert_displayed_filters("#{:query_regexp.l}: #{country}")
+    assert_displayed_filters("#{:query_in_country.l}: #{country}")
     assert_select(
       "#content a:match('href', ?)", %r{#{locations_path}/\d+},
       { count: matches.count }, "Wrong number of Locations"
@@ -377,7 +377,7 @@ class LocationsControllerTest < FunctionalTestCase
     get(:index, params: { country: country })
 
     assert_page_title(:locations.ti)
-    assert_displayed_filters("#{:query_regexp.l}: #{country}")
+    assert_displayed_filters("#{:query_in_country.l}: #{country}")
     assert_select(
       "#content a:match('href', ?)", /#{location_path(new_mexico)}/,
       true, "USA page should include New Mexico"

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -402,7 +402,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     get(:index, params: { look_alikes: "1", name: name.id })
 
     assert_page_title(:observations.ti)
-    assert_displayed_filters("#{:query_names.l}: #{name.text_name}")
+    assert_displayed_filters("#{:query_look_alikes.l}: #{name.text_name}")
     assert_results(count: look_alikes)
   end
 
@@ -435,7 +435,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     setup_rolfs_index
     get(:index, params: { related_taxa: "1", name: name.text_name })
     assert_page_title(:observations.ti)
-    assert_displayed_filters("#{:query_names.l}: #{parent.text_name}")
+    assert_displayed_filters("#{:query_related_taxa.l}: #{parent.text_name}")
     assert_results(count: obss_of_related_taxa.count)
   end
 
@@ -450,7 +450,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
 
     assert_response(:success)
     assert_page_title(:observations.ti)
-    assert_displayed_filters("#{:query_names.l}: #{name.text_name}")
+    assert_displayed_filters("#{:query_any_name.l}: #{name.text_name}")
     ids.each do |id|
       assert_select(
         "a:match('href', ?)", %r{^/obs/#{id}}, true,

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1504,6 +1504,16 @@ class ObservationTest < UnitTestCase
                         observations(:peltigera_obs))
   end
 
+  # `this_name` backs Tab::Name::ObsLink::ThisName and the observations
+  # index's `name` subaction -- a bare `names(lookup:)` preset, no
+  # synonym/subtaxa expansion.
+  def test_scope_this_name
+    assert_includes(Observation.this_name(names(:peltigera).id),
+                    observations(:peltigera_obs))
+    assert_not_includes(Observation.this_name(names(:fungi).id),
+                        observations(:peltigera_obs))
+  end
+
   def test_scope_clade
     assert_includes(Observation.clade("Agaricales"),
                     observations(:coprinus_comatus_obs))


### PR DESCRIPTION
Completes #5139.

## Summary

Follow-up to #5217 (already merged). Collapses the remaining hand-rolled index subactions across `UsersController`, `FieldSlipsController::Index`, `HerbariumRecordsController`, `SpeciesListsController`, `LocationsController`, `NamesController`, `ObservationsController::Index`, `Observations::IdentifyController`, `CommentsController`, and `SequencesController` down to the generic `create_query_from_url_params` mechanism, so #5140 can eventually collapse the dispatcher itself. Part of #4636.

- New polymorphic-record validation (`Comment#target`) in `Query::Modules::HashValidation#validate_polymorphic`, reusable for any future polymorphic query filter.
- New Observation scopes/`Query::Observations` attrs with a shared `default_order: :confidence`:
  - `look_alikes`
  - `related_taxa`
  - `any_name`
  - `name_proposed`
  - `this_name`
  - `other_names` 
- Adds `Name.parent_ids_for` and a `validate_name_parents` custom Query validator so `related_taxa`'s filter caption shows the resolved parent name, not the raw searched id.
- Fixes a few small bugs found along the way: a dead duplicate `query_attr` on `Query::FieldSlips`, a copy-paste `[Herbarium]` → `[Observation]` accepts-type bug on `Query::HerbariumRecords`, and dead code on `SequencesController#all` (`build_index_with_query` already falls through to `unfiltered_index` on its own, so the dedicated `:all` subaction was a no-op).

## Test plan

- [x] `bundle exec rubocop` clean on every changed file
- [x] Full test files re-run for every touched controller/model/query class (Users, FieldSlips, HerbariumRecords, SpeciesLists, Locations, Names, Observations::Index, Observations::Identify, Comments, RssLogs, Sequences, Tab::Name::ObsLink, Query base + HashValidation, filter_caption)
- [x] `test/classes/localization_files_test.rb` clean (no missing/duplicate translation tags)

<!-- changelog -->
article: no
<!-- /changelog -->
