### PR TITLE
Add spacing to Account preferences `InputGroupAddon` buttons with icons

### DIFF
--- a/app/components/application_form/input_group_addon.rb
+++ b/app/components/application_form/input_group_addon.rb
@@ -62,10 +62,10 @@ class Components::ApplicationForm < Superform::Rails::Form
     # optional `:button_icon` (rendered after a space via the
     # `Components::Icon` component).
     def render_addon_label
-      plain(wrapper_options[:button])
+      span { plain(wrapper_options[:button]) }
       return unless wrapper_options[:button_icon]
 
-      whitespace
+      span(class: "icon-text-gap")
       Icon(type: wrapper_options[:button_icon])
     end
   end


### PR DESCRIPTION
## Summary

Adds spacing between button text and icon within an `InputGroupAddon` in a form, in the case there is an icon.

## Test plan
<img width="1198" height="1316" alt="Screenshot 2026-08-25 at 11 02 19 AM" src="https://github.com/user-attachments/assets/0533ef61-4583-43b4-a1b7-dbf0a2443028" />

<!-- changelog -->
article: no

<!-- /changelog -->
