### PR TITLE
Revert accidental direct push to `main`

### DIFF
--- a/app/controllers/account/preferences_controller.rb
+++ b/app/controllers/account/preferences_controller.rb
@@ -12,14 +12,13 @@ module Account
     def update
       load_user_licenses
 
-      normalize_rss_type_list_param
       update_password
       update_prefs_from_form
-      success = prefs_changed_successfully
 
-      respond_to do |format|
-        format.turbo_stream { render(turbo_stream: turbo_stream_flash_update) }
-        format.html { render_update_response(success) }
+      if prefs_changed_successfully
+        redirect_to(action: :edit)
+      else
+        render_edit_view_invalid # render to get the errors to display
       end
     end
 
@@ -67,26 +66,6 @@ module Account
 
     private
 
-    def render_update_response(success)
-      if success
-        redirect_to(action: :edit)
-      else
-        render_edit_view_invalid # render to get the errors to display
-      end
-    end
-
-    # "Save these as my defaults" on the RSS-logs filter form submits
-    # the same q[types][] checkboxes the Apply button uses, not
-    # user[default_rss_type] directly. Translate before the generic
-    # prefs loop runs.
-    def normalize_rss_type_list_param
-      types = params.dig(:q, :types)
-      return if types.blank?
-
-      params[:user] ||= {}
-      params[:user][:default_rss_type] = Array(types).join(" ")
-    end
-
     def render_edit_view(status: :ok, **render_opts)
       render(Views::Controllers::Account::Preferences::Edit.new(
                user: @user, licenses: @licenses,
@@ -116,19 +95,14 @@ module Account
 
     def update_prefs_from_form
       prefs_types.each do |pref, type|
-        next unless params[:user].key?(pref)
-
-        apply_pref(pref, type, params[:user][pref])
-      end
-    end
-
-    def apply_pref(pref, type, val)
-      case type
-      when :string  then update_pref(pref, val.to_s.strip)
-      when :integer then update_pref(pref, val.to_i)
-      when :boolean then update_pref(pref, val == "1")
-      when :enum    then update_pref(pref, val)
-      when :content_filter then update_content_filter(pref, val)
+        val = params[:user][pref]
+        case type
+        when :string  then update_pref(pref, val.to_s.strip)
+        when :integer then update_pref(pref, val.to_i)
+        when :boolean then update_pref(pref, val == "1")
+        when :enum    then update_pref(pref, val)
+        when :content_filter then update_content_filter(pref, val)
+        end
       end
     end
 
@@ -167,7 +141,6 @@ module Account
     # Used by update_prefs_from_form
     def prefs_types # rubocop:disable Metrics/MethodLength
       [
-        [:default_rss_type, :string],
         [:email_comments_owner, :boolean],
         [:email_comments_response, :boolean],
         [:email_general_commercial, :boolean],

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -75,6 +75,13 @@ class RssLogsController < ApplicationController
     update_stored_query(query) # also stores query in session
     tags = RssLog.normalize_type_tags(query.params[:types])
     @types = tags.empty? ? ["none"] : tags.sort
+
+    # Let the user make this their default and fine tune.
+    if @user && params[:make_default] == "1"
+      @user.default_rss_type = @types.join(" ")
+      @user.save_without_our_callbacks
+    end
+
     query
   end
 

--- a/app/views/controllers/rss_logs/type_filters.rb
+++ b/app/views/controllers/rss_logs/type_filters.rb
@@ -7,7 +7,6 @@ module Views::Controllers::RssLogs
   class TypeFilters < Views::Base
     prop :query, _Nilable(::Query)
     prop :types, _Array(::String)
-    prop :user, _Nilable(::User), default: nil
 
     # Not a Superform -- a multi-select checkbox filter, not a
     # single-model-bound field set. Submitting the combined state of
@@ -49,7 +48,6 @@ module Views::Controllers::RssLogs
           render_everything_button
           render_type_buttons
           render_submit_button
-          render_save_default_button
         end
       end
     end
@@ -85,21 +83,6 @@ module Views::Controllers::RssLogs
     # stands out as the commit action.
     def render_submit_button
       Button(type: :submit, name: :apply.ti, size: :sm)
-    end
-
-    # A second submit button on the same form as "Apply," targeting a
-    # different action via `formaction`/`formmethod` -- whatever's
-    # checked at the moment of click is what gets saved, the same
-    # values "Apply" would filter by. `data-turbo="true"` opts just
-    # this button into Turbo, overriding the form's own
-    # `data-turbo="false"`, so the response is a flash-only
-    # confirmation with no page navigation.
-    def render_save_default_button
-      return unless show_make_default?
-
-      Button(type: :submit, name: :rss_make_default.t, variant: :outline,
-             size: :sm, formaction: account_preferences_path,
-             formmethod: "post", data: { turbo: "true" })
     end
 
     # Individual type checkbox styled as a Bootstrap button. Routes
@@ -146,10 +129,6 @@ module Views::Controllers::RssLogs
 
     def type_checked?(type)
       @types.include?(type) || @types == ["all"]
-    end
-
-    def show_make_default?
-      @user && @user.default_rss_type.to_s.split.sort != @types
     end
 
     def query_params_except_types


### PR DESCRIPTION
## Summary

- `main` got a stray commit (`ec805136d2`, message "initial commit") pushed directly to it via GitHub Desktop, bypassing review.
- Root cause: `nimmo-5224-rss-log-default-turbo`'s local branch tracking config had `branch.*.merge` pointing at `refs/heads/main` instead of its own branch name — a mistracked upstream from however that branch was originally created (most likely `git checkout -b <name> origin/main`, which sets tracking to `origin/main` under git's default `autoSetupMerge` behavior). GitHub Desktop's push follows the branch's configured upstream, not its display name, so the push landed on `main`.
- The work itself is unaffected — it's on `origin/nimmo-5224-rss-log-default-turbo`, a fresh branch created after fixing the tracking config, ready for its own PR.
- This PR reverts the stray commit so `main` matches its state before the accidental push.
- Local tracking was fixed on all 4 branches that had the same corrupted config, and `branch.autoSetupMerge` was set to `false` in this local repo to prevent a repeat, regardless of which tool creates the next branch.

## Test plan

- [x] `bundle exec rubocop` clean on all 3 reverted files.
- [x] Confirmed `git diff` reverses `ec805136d2`'s changes and nothing else.

<!-- changelog -->
article: no
<!-- /changelog -->
