### PR TITLE
Add `script/dedup_namings.rb`, missing from #5186

### DIFF
--- a/db/migrate/20260825021326_add_unique_index_to_namings.rb
+++ b/db/migrate/20260825021326_add_unique_index_to_namings.rb
@@ -4,8 +4,8 @@
 # (#5186). Duplicate namings arose from name merges repointing without
 # folding, an import that re-created rather than reused, and web-form
 # double-submits; the code paths are fixed (#5204) and the existing
-# duplicates are collapsed by projects/5186/dedup_namings.rb, which must
-# run before this migration -- a leftover duplicate makes add_index fail.
+# duplicates are collapsed by script/dedup_namings.rb, which must run
+# before this migration -- a leftover duplicate makes add_index fail.
 #
 # Occurrence members keep their own copies: each is a distinct
 # Observation, so (observation_id, user_id, name_id) still differs.

--- a/script/dedup_namings.rb
+++ b/script/dedup_namings.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# One-time cleanup for #5186: deletes duplicate Namings (same
+# observation_id, user_id, name_id), keeping the oldest of each group,
+# so db/migrate/20260825021326_add_unique_index_to_namings.rb's unique
+# index can be added. Referenced by that migration's comment. Namings
+# with a NULL observation_id are excluded -- they don't collide in the
+# unique index either.
+#
+# Recalculates consensus for every affected observation afterward,
+# since deleting a naming cascades to its votes but doesn't otherwise
+# touch the observation's cached consensus.
+#
+#   bin/rails runner script/dedup_namings.rb          # dry run
+#   bin/rails runner script/dedup_namings.rb --apply   # write
+
+apply = !ARGV.delete("--apply").nil?
+abort("Unknown argument(s): #{ARGV.join(", ")}") unless ARGV.empty?
+
+duplicate_keys = Naming.where.not(observation_id: nil).
+                 group(:observation_id, :user_id, :name_id).
+                 count.
+                 select { |_key, count| count > 1 }.
+                 keys
+
+if duplicate_keys.empty?
+  warn("No duplicate namings found. Nothing to do.")
+  exit
+end
+
+affected_observation_ids = Set.new
+
+duplicate_keys.each do |observation_id, user_id, name_id|
+  namings = Naming.where(observation_id:, user_id:, name_id:).order(:id).to_a
+  survivor = namings.shift
+  namings.each do |dup|
+    warn("obs=#{observation_id} user=#{user_id} name=#{name_id}: " \
+         "deleting naming ##{dup.id}, keeping ##{survivor.id} " \
+         "#{apply ? "(applying)" : "(dry run)"}")
+    next unless apply
+
+    dup.destroy!
+    affected_observation_ids << observation_id
+  end
+end
+
+if apply
+  affected_observation_ids.each do |obs_id|
+    obs = Observation.naming_includes.find(obs_id)
+    Observation::NamingConsensus.new(obs).calc_consensus
+  end
+  warn("APPLIED. Recalculated consensus for " \
+       "#{affected_observation_ids.size} observation(s).")
+else
+  warn("Dry run - nothing written. To apply: " \
+       "bin/rails runner script/dedup_namings.rb --apply")
+end


### PR DESCRIPTION
## Summary

- `db/migrate/20260825021326_add_unique_index_to_namings.rb` (#5186) adds a unique index on `namings(observation_id, user_id, name_id)`. Its own comment says a dedup script must run first to collapse pre-existing duplicates, but that script (`projects/5186/dedup_namings.rb`) was missing from the repo — any dev DB with duplicate namings hits `Trilogy::ProtocolError: 1062: Duplicate entry` and can't migrate.
- Adds `script/dedup_namings.rb`: for each duplicate group (same `observation_id`/`user_id`/`name_id`), deletes every naming but the oldest, then recalculates consensus for each affected observation (deleting cascades to votes, which would otherwise leave a stale cached consensus). Follows the repo's dry-run/`--apply` convention.
- Fixes the migration's own comment, which pointed at `projects/5186/dedup_namings.rb` — that path did not exist in this repo; `script/` is where one-off scripts live.
- Verified against the local dev DB: found 194 duplicate groups (220 namings), including the exact row from the blocking error (`obs=266428 user=9613 name=31`), applied cleanly, migration then ran, and a second dry-run pass confirmed 0 remaining duplicates.

## Test plan

- [x] `bundle exec rubocop` clean on both files.
- [x] Ran dry run, then `--apply`, against local dev DB — 220 duplicates removed, 220 observations' consensus recalculated.
- [x] `bin/rails db:migrate` succeeded afterward.
- [x] Re-ran the script — confirmed idempotent (reports no duplicates).

<!-- changelog -->
article: no
<!-- /changelog -->
