### PR TITLE
Query params - Send `target` as a polymorphic hash for the comments index filter

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -74,10 +74,7 @@ class CommentsController < ApplicationController
   # with the bookmarked `q[target][...]` query path. It flashes on an
   # unrecognized type or nonexistent id.
   def target
-    create_query_from_url_params(
-      :Comment, params.merge(target: { type: params[:type],
-                                       id: params[:target] })
-    )
+    create_query_from_url_params(:Comment, params)
   end
 
   def index_display_opts(opts, query)

--- a/app/views/controllers/comments/comments_for_object.rb
+++ b/app/views/controllers/comments/comments_for_object.rb
@@ -84,8 +84,9 @@ module Views::Controllers::Comments
 
     def render_and_more_link
       Link(type: :get, name: :show_comments_and_more.t(num: and_more),
-           target: comments_path(target: @object.id,
-                                 type: @object.class.name),
+           target: comments_path(
+             target: { type: @object.class.name, id: @object.id }
+           ),
            class: "float-right")
     end
 

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -25,7 +25,7 @@ class CommentsControllerTest < FunctionalTestCase
 
   def test_index_target_has_comments
     target = observations(:minimal_unknown_obs)
-    params = { type: target.class.name, target: target.id }
+    params = { target: { type: target.class.name, id: target.id } }
     comments = Comment.where(target_type: target.class.name, target: target)
 
     login
@@ -37,7 +37,7 @@ class CommentsControllerTest < FunctionalTestCase
 
   def test_index_target_valid_target_without_comments
     target = names(:conocybe_filaris)
-    params = { type: target.class.name, target: target.id }
+    params = { target: { type: target.class.name, id: target.id } }
 
     login
     get(:index, params: params)
@@ -46,34 +46,34 @@ class CommentsControllerTest < FunctionalTestCase
 
   def test_index_target_invalid_target_type
     target = api_keys(:rolfs_api_key)
-    params = { type: target.class.name, target: target.id }
+    params = { target: { type: target.class.name, id: target.id } }
 
     login
     get(:index, params: params)
     assert_flash(
       [[:runtime_no_matches, { type: :comment }],
        [:query_validation_invalid_polymorphic_type,
-        { param: "target", type: params[:type] }]]
+        { param: "target", type: params[:target][:type] }]]
     )
     assert_select("#results tr", count: 0)
   end
 
   def test_index_target_for_non_model
-    params = { type: "Hacker", target: 666 }
+    params = { target: { type: "Hacker", id: 666 } }
 
     login
     get(:index, params: params)
     assert_flash(
       [[:runtime_no_matches, { type: :comment }],
        [:query_validation_invalid_polymorphic_type,
-        { param: "target", type: params[:type] }]]
+        { param: "target", type: params[:target][:type] }]]
     )
     assert_select("#results tr", count: 0)
   end
 
   def test_index_target_nonexistent_id
     bad_id = Name.maximum(:id).to_i + 1000
-    params = { type: "Name", target: bad_id }
+    params = { target: { type: "Name", id: bad_id } }
 
     login
     get(:index, params: params)

--- a/test/views/controllers/comments/comments_for_object_test.rb
+++ b/test/views/controllers/comments/comments_for_object_test.rb
@@ -102,7 +102,7 @@ module Views::Controllers::Comments
       # full comments index for this target.
       assert_html(html, "#comments .list-group-item.comment", count: 1)
       assert_html(html, "a[href='#{routes.comments_path(
-        target: @observation.id, type: @observation.class.name
+        target: { type: @observation.class.name, id: @observation.id }
       )}']", text: :show_comments_and_more.t(num: and_more).as_displayed)
     end
 


### PR DESCRIPTION
## Summary

- `CommentsController#target` was the only `index_active_params` dispatch method left that wasn't a thin `create_query_from_url_params(:Model, params)` wrapper — it manually combined two separate top-level params (`:type`, `:target`) into the `{ type:, id: }` hash `Query::Comments`'s `target:` attr already accepts natively via `query_attr(:target, { polymorphic: Comment::ALL_TYPES })`.
- Switched the one caller reaching `#index` this way — the "and N more" footer link in `comments_for_object.rb` — to send `target[type]`/`target[id]` directly, so the controller method collapses to the same one-liner every other dispatch method already has.
- `comments/form.rb`'s `form_action` builds a similar-looking `comments_path(target:, type:)` call, but it submits by POST, routing to `#create`, not `#index` — a separate code path with its own flat-param contract (`load_target`). Left untouched; changing it would break comment creation, not fix anything. Confirmed by reading `#create`/`#new`'s param reads directly.

## Test plan

- [x] `bundle exec rubocop` clean on every touched file.
- [x] `test/controllers/comments_controller_test.rb` — updated the 5 index-target tests to the nested shape; full file green (45 tests), including the untouched `#new`/`#create` tests (confirms `form.rb` staying alone was correct).
- [x] `test/views/controllers/comments/comments_for_object_test.rb` — updated the "and N more" link assertion; green.
- [x] Grepped the whole app for `comments_path(` — confirmed only 3 callers exist, only one of which is in scope.
- [x] 100% local coverage on both touched source files.

Fixes #5230

<!-- changelog -->
article: no
<!-- /changelog -->
