### PR TITLE
Delete dead `SearchController#coming_from_obs_needing_ids?` redirect

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -123,17 +123,11 @@ class SearchController < ApplicationController
     query = query_from_pattern(model_name, pattern)
 
     # Finally we can redirect.
-    if coming_from_obs_needing_ids?(model_name)
-      redirect_to(identify_observations_path(q: query.q_param))
-    elsif single_result?(query)
+    if single_result?(query)
       redirect_to(send(:"#{type.to_s.singularize}_path", query.first_id))
     else
       redirect_to(send(:"#{type}_path", params: { q: query.q_param }))
     end
-  end
-
-  def coming_from_obs_needing_ids?(model_name)
-    model_name == :Observation && params[:needs_naming]
   end
 
   def single_result?(query)

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -158,53 +158,6 @@ class SearchControllerTest < FunctionalTestCase
     )
   end
 
-  def test_pattern_search_from_needs_naming
-    pattern = "Briceland"
-    params = { pattern_search: { pattern:, type: :observations },
-               needs_naming: rolf }
-
-    login
-    get(:pattern, params:)
-
-    assert_redirected_to(
-      identify_observations_path(q: { model: :Observation, pattern: }),
-      "Pattern in search from obs_needing_ids should render " \
-      "obs_needing_ids"
-    )
-  end
-
-  def test_pattern_search_from_needs_naming_blank_pattern
-    login
-    get(:pattern,
-        params: { pattern_search: { pattern: "", type: :observations },
-                  needs_naming: rolf })
-
-    assert_redirected_to(
-      observations_path,
-      "Blank pattern from obs_needing_ids should render blank obs index"
-    )
-  end
-
-  def test_pattern_search_from_needs_naming_bad_pattern
-    login
-    get(:pattern,
-        params: { pattern_search: { pattern: "help:me",
-                                    type: :observations },
-                  needs_naming: rolf })
-
-    assert_redirected_to(
-      identify_observations_path(q: { model: :Observation }),
-      "Bad pattern from obs_needing_ids should render " \
-      "obs_needing_ids with query"
-    )
-    assert_flash_error(
-      :pattern_search_bad_term_error,
-      type: :observation,
-      term: '"help"',
-      help: :pattern_search_terms_short_help.l
-    )
-  end
-
   def test_pattern_search_redirects_to_google
     login
     stub_request(:any, /google.com/)


### PR DESCRIPTION
Deletes dead code that now has a more direct alternative path.

## Summary

Deletes `SearchController#coming_from_obs_needing_ids?` and its call site in `build_query_and_redirect`, plus the three tests that exercised it. This redirected a pattern search to `identify_observations_path` when `params[:needs_naming]` was set, instead of the normal `observations_path`.

While researching issue #5140's `:pattern` handling, no live path was found that still sets `params[:needs_naming]` on a request into `SearchController`:

- The top-nav search bar (`Components::Form::PatternSearch`, `Views::Layouts::TopNav::SearchBar`) has no `needs_naming` field or logic.
- `Identify::FormFilter` -- the identify page's filter form -- submits directly (`method: :get`) to `Observations::IdentifyController#index`, bypassing `SearchController` entirely. That controller's own dispatch unconditionally injects `needs_naming: @user`, so the identify page already stays on itself by construction. Covered by the existing, passing `test/controllers/observations/identify_controller_test.rb`.
- No commit that has touched the search bar's files references `needs_naming`.
- No JS/Stimulus controller sets it either.

This is prep work carved out of the larger #5140-prep effort so that work doesn't need to design around a case that turns out not to exist.

## Test plan

- [x] `bundle exec rubocop app/controllers/search_controller.rb test/controllers/search_controller_test.rb` -- no offenses.
- [x] `bin/rails test test/controllers/search_controller_test.rb` -- 13 tests, 0 failures.
- [x] Grepped the whole repo for `needs_naming`/`coming_from_obs_needing_ids` post-deletion -- only legitimate references remain (the `Query::Observations` query attr, `Observation` model/scopes, `Observations::IdentifyController`'s own dispatch, `filter_caption.rb`'s caption-formatting entry for that attr).

<!-- changelog -->
article: no
<!-- /changelog -->
