### PR TITLE
Query params  - Unify `exact_match` and pattern-search dispatch across all models

### DIFF
--- a/.claude/hooks/block_banned_words.sh
+++ b/.claude/hooks/block_banned_words.sh
@@ -15,10 +15,17 @@
 # feedback_never_is_a_narrative_smell.md.
 #
 # Word list: real, genuine(ly), actual(ly), exactly, never, ever,
-# canonical, consume, "at all" -- used as intensifiers/hedges, they
-# carry no information and read as arguing for a claim instead of
-# just stating it. Whole-word matches only (so e.g. "actualization",
-# "eventual" don't false-positive); case-insensitive.
+# canonical, consume, "at all", own -- used as intensifiers/hedges,
+# they carry no information and read as arguing for a claim instead of
+# just stating it. "own" is the odd one out: it's a redundant
+# possessive almost every time ("the model's own X" just means "the
+# model's X" -- see .claude/rules/code_comments.md rule 4), not an
+# intensifier, but it gets the same blunt treatment because the
+# illegitimate-use rate is just as high. The rare legitimate case
+# (idiomatic "own", not a redundant possessive) gets rephrased like any
+# other false positive here -- that's cheaper than a smarter check.
+# Whole-word matches only (so e.g. "actualization", "eventual",
+# "owner", "shown" don't false-positive); case-insensitive.
 #
 # Blunt by design, same philosophy as block_pii_in_gh.sh: false
 # positives get fixed by rephrasing, not by bypassing the hook.
@@ -30,7 +37,7 @@ TOOL="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""')"
 # POSIX ERE doesn't treat `\b` as a word boundary (BSD/macOS grep in
 # particular) -- use the same `(^|[^[:alnum:]_])...([^[:alnum:]_]|$)`
 # portable boundary as check_any_phlex_props_on_save.sh.
-WORD_RE='(^|[^[:alnum:]_])(real|genuine(ly)?|actual(ly)?|exactly|never|ever|canonical|consume|at all)([^[:alnum:]_]|$)'
+WORD_RE='(^|[^[:alnum:]_])(real|genuine(ly)?|actual(ly)?|exactly|never|ever|canonical|consume|at all|own)([^[:alnum:]_]|$)'
 
 TEXT=""
 case "$TOOL" in
@@ -74,8 +81,9 @@ HITS="$(printf '%s' "$TEXT" | grep -inE "$WORD_RE" || true)"
 if [ -n "$HITS" ]; then
   cat >&2 <<EOF
 🚫 BLOCKED: banned word/phrase detected (real/genuine/actual(ly)/
-exactly/never/ever/canonical/consume/"at all" used as an intensifier
-or hedge -- personal style ban, corrected multiple times).
+exactly/never/ever/canonical/consume/"at all"/own used as an
+intensifier, hedge, or redundant possessive -- personal style ban,
+corrected multiple times).
 
 Matches:
 $HITS

--- a/.claude/rules/code_comments.md
+++ b/.claude/rules/code_comments.md
@@ -1,6 +1,6 @@
 # Code comments: explain *why* (only when unclear), one source of truth
 
-Three rules for every comment in this codebase — app code, tests,
+Four rules for every comment in this codebase — app code, tests,
 config, `Gemfile`, scripts, everywhere.
 
 ## 1. Comment the *why*, and only when it isn't already clear
@@ -80,6 +80,26 @@ it got there. Never write:
 If a comment needs several sentences to justify a rule, that's usually
 a sign the *code* should be simpler — not that the comment should be
 longer.
+
+## 4. Cut redundant possessives — write plainly
+
+"X's own Y" almost always just means "X's Y" — the possessive already
+says whose it is; "own" adds nothing. Cut it outright rather than
+finding a synonym.
+
+```ruby
+# BAD — "own" is padding; "the model's" already says whose scope it is
+# An exact match is already prioritized by the model's own `pattern`
+# scope.
+
+# GOOD
+# An exact match is already prioritized by the model's `pattern` scope.
+```
+
+Same principle for other padding that doesn't add information — write
+short, declarative sentences, not stacked qualifiers or a parenthetical
+inside a parenthetical. If a sentence reads awkwardly once the padding
+is cut, restructure the sentence — don't put the padding back.
 
 ## Why this is a rule
 

--- a/app/components/form/pattern_search.rb
+++ b/app/components/form/pattern_search.rb
@@ -17,19 +17,21 @@
 #            )
 #          ))
 class Components::Form::PatternSearch < Components::ApplicationForm
-  SEARCH_TYPE_OPTIONS = [
-    [:comments, :comments],
-    [:glossary, :glossary_terms],
-    [:herbaria, :herbaria],
-    [:herbarium_records, :herbarium_records],
-    [:locations, :locations],
-    [:names, :names],
-    [:observations, :observations],
-    [:projects, :projects],
-    [:species_lists, :species_lists],
-    [:users, :users],
-    [:app_search_google, :google]
-  ].freeze
+  # Pattern-searchable on the backend (SearchController::
+  # PATTERN_SEARCHABLE_MODELS) but excluded from this dropdown:
+  # Image.pattern's join is too expensive to expose on the
+  # always-visible search bar. The backend stays working so the query
+  # can be revisited later.
+  DROPDOWN_EXCLUDED_TYPES = [:images].freeze
+
+  # A few types show a label that differs from their model symbol.
+  LABEL_OVERRIDES = { glossary_terms: :glossary }.freeze
+
+  SEARCH_TYPE_OPTIONS = (
+    (SearchController::PATTERN_SEARCHABLE_MODELS - DROPDOWN_EXCLUDED_TYPES).
+      map { |type| [LABEL_OVERRIDES.fetch(type, type), type] } +
+      [[:app_search_google, :google]]
+  ).freeze
 
   # The selectable `type` values — the set a stored
   # `session[:search_type]` must belong to for the select to be able

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,7 @@ class ApplicationController < ActionController::Base
   include QueryParamAliases
   include ControllerLabels
   include Indexes
+  include PatternSearchState
   include SectionUpdater
   include ModalUpdater
   include ViewerAwareFormat

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -220,11 +220,7 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     { id: params[:id].to_s, always_index: true }
   end
 
-  # Handles `?pattern=` hitting a model's index directly (an old-style
-  # bookmark, or the plain-fuzzy-search shape the search bar itself
-  # builds). Builds the query in place -- no redirect through
-  # SearchController. A single result still lands on its show page,
-  # via #show_index_of_objects' generic single-result redirect.
+  # e.g. Observations' checklist taxon links, its "did you mean" alert.
   def pattern
     model_name = controller_model_name.to_sym
     pattern = params[:pattern].to_s.strip_squeeze

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -220,13 +220,22 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
     { id: params[:id].to_s, always_index: true }
   end
 
-  # Pattern searches should now hit each controller with a :q param,
-  # after the search is parsed in `SearchController#pattern`.
-  # This is for backwards compatibility with old bookmarks.
+  # Handles `?pattern=` hitting a model's index directly (an old-style
+  # bookmark, or the plain-fuzzy-search shape the search bar itself
+  # builds). Builds the query in place -- no redirect through
+  # SearchController. A single result still lands on its show page,
+  # via #show_index_of_objects' generic single-result redirect.
   def pattern
-    pattern = params[:pattern].to_s
-    type = controller_model_name.pluralize.underscore.to_sym
-    redirect_to(search_pattern_path(pattern_search: { pattern:, type: }))
+    model_name = controller_model_name.to_sym
+    pattern = params[:pattern].to_s.strip_squeeze
+
+    return if pattern_too_long?(pattern)
+
+    save_pattern_if_it_wont_overfill_cookie_store(
+      model_name.to_s.tableize.to_sym, pattern
+    )
+
+    [query_from_pattern(model_name, pattern), {}]
   end
 
   # Render an index or set of search results as a list or matrix. Arguments:

--- a/app/controllers/application_controller/pattern_search_state.rb
+++ b/app/controllers/application_controller/pattern_search_state.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#  ==== PatternSearchState
+#  query_from_pattern::   Build a Query from a raw pattern string, using
+#                         PatternSearch::<Model>'s keyword parser where
+#                         one exists.
+#  pattern_too_long?::    Guard + flash + redirect on an overlong pattern.
+#  save_pattern_if_it_wont_overfill_cookie_store::
+#                         Remember the pattern for the search bar, unless
+#                         doing so would overflow the session cookie.
+#
+#  Shared by SearchController (the search bar's own submission) and
+#  ApplicationController::Indexes#pattern (a model index hit directly
+#  with `?pattern=`, e.g. an old-style bookmark).
+#
+module ApplicationController::PatternSearchState
+  private
+
+  def pattern_too_long?(pattern)
+    return false if pattern.length <= Searchable::MAX_SEARCH_INPUT_LENGTH
+
+    flash_error(
+      :runtime_search_string_too_long.t(
+        max: Searchable::MAX_SEARCH_INPUT_LENGTH,
+        length: pattern.length
+      )
+    )
+    redirect_back_or_to(root_path)
+    true
+  end
+
+  def save_pattern_if_it_wont_overfill_cookie_store(type, pattern)
+    return if session_data_size > 2048 || pattern.bytesize > 2048
+
+    session[:pattern] = pattern
+    session[:search_type] = type
+  end
+
+  # The CookieStore (Default) limit is 4096
+  def session_data_size
+    session.to_hash.compact.to_json.bytesize
+  end
+
+  # Convert pattern into a Query, using PatternSearch::<Model>'s keyword
+  # parser where one exists (currently Location, Name, Observation);
+  # otherwise a plain fuzzy `pattern:` query attr.
+  def query_from_pattern(model_name, pattern)
+    if (search_class = "PatternSearch::#{model_name}".safe_constantize)
+      pattern_search_query_from_pattern(search_class, model_name, pattern)
+    else
+      create_query(model_name, pattern:)
+    end
+  end
+
+  # Instantiate a PatternSearch to turn the keywords into query params and
+  # catch invalid PatternSearch terms. (We can't just send a raw pattern
+  # with keywords to Query as `create_query(model_name, pattern:)`)
+  def pattern_search_query_from_pattern(search_class, model_name, pattern)
+    search = search_class.new(pattern, @user)
+    if search.errors.any?
+      flash_pattern_search_errors(search)
+      session[:pattern] = nil
+    end
+    # This will create a blank query if there are errors.
+    create_query(model_name, search.query&.params || {})
+  end
+
+  def flash_pattern_search_errors(search)
+    search.errors.each { |error| flash_error(error.to_s) }
+  end
+end

--- a/app/controllers/application_controller/pattern_search_state.rb
+++ b/app/controllers/application_controller/pattern_search_state.rb
@@ -9,9 +9,9 @@
 #                         Remember the pattern for the search bar, unless
 #                         doing so would overflow the session cookie.
 #
-#  Shared by SearchController (the search bar's own submission) and
+#  Shared by SearchController (the search bar's submission) and
 #  ApplicationController::Indexes#pattern (a model index hit directly
-#  with `?pattern=`, e.g. an old-style bookmark).
+#  with `?pattern=`).
 #
 module ApplicationController::PatternSearchState
   private

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -62,8 +62,8 @@ class SearchController < ApplicationController
   end
 
   # An exact numeric-id (or other identifier, e.g. User's verified email)
-  # match is already prioritized by the model's own `pattern` scope --
-  # see AbstractModel::Scopes#exact_match_or -- so a single_result? here
+  # match is already prioritized by the model's `pattern` scope -- see
+  # AbstractModel::Scopes#exact_match_or -- so a single_result? here
   # covers both an exact match and a fuzzy search that happens to find
   # just one record.
   def build_query_and_redirect(type, model_name, pattern)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -28,19 +28,6 @@ class SearchController < ApplicationController
 
   private
 
-  def pattern_too_long?(pattern)
-    return false if pattern.length <= Searchable::MAX_SEARCH_INPUT_LENGTH
-
-    flash_error(
-      :runtime_search_string_too_long.t(
-        max: Searchable::MAX_SEARCH_INPUT_LENGTH,
-        length: pattern.length
-      )
-    )
-    redirect_back_or_to(root_path)
-    true
-  end
-
   def save_pattern_and_proceed(type, pattern)
     # Save it so that we can keep it in the search bar in subsequent pages.
     # But don't save encoded incoming patterns that are too large.
@@ -51,18 +38,6 @@ class SearchController < ApplicationController
     else
       forward_pattern_search(type, pattern)
     end
-  end
-
-  def save_pattern_if_it_wont_overfill_cookie_store(type, pattern)
-    return if session_data_size > 2048 || pattern.bytesize > 2048
-
-    session[:pattern] = pattern
-    session[:search_type] = type
-  end
-
-  # The CookieStore (Default) limit is 4096
-  def session_data_size
-    session.to_hash.compact.to_json.bytesize
   end
 
   def site_google_search(pattern)
@@ -81,48 +56,19 @@ class SearchController < ApplicationController
 
     if pattern.blank?
       redirect_to(send(:"#{type}_path"))
-    elsif (obj = exact_match(model_name, pattern))
-      redirect_to(send(:"#{type.to_s.singularize}_path", obj.id))
     else
       build_query_and_redirect(type, model_name, pattern)
     end
   end
 
-  # If pattern is an identifier, redirect to the show page for that object.
-  def exact_match(model_name, pattern)
-    case model_name
-    when :User
-      user_exact_match(pattern)
-    else
-      maybe_pattern_is_an_id(model_name, pattern)
-    end
-  end
-
-  def user_exact_match(pattern)
-    if ((pattern.match?(/^\d+$/) && (user = User.safe_find(pattern))) ||
-       # (user = User.find_by(login: pattern)) ||
-       # (user = User.find_by(name: pattern)) ||
-       (user = User.find_by(email: pattern))) && user.verified
-      return user
-    end
-
-    false
-  end
-
-  def maybe_pattern_is_an_id(model_name, pattern)
-    if /^\d+$/.match?(pattern)
-      return model_name.to_s.constantize.safe_find(pattern)
-    end
-
-    false
-  end
-
+  # An exact numeric-id (or other identifier, e.g. User's verified email)
+  # match is already prioritized by the model's own `pattern` scope --
+  # see AbstractModel::Scopes#exact_match_or -- so a single_result? here
+  # covers both an exact match and a fuzzy search that happens to find
+  # just one record.
   def build_query_and_redirect(type, model_name, pattern)
-    # :Name, :Observation, and :Location prevalidate the pattern with a
-    # PatternSearch instance, and check for errors defined by PatternSearch.
     query = query_from_pattern(model_name, pattern)
 
-    # Finally we can redirect.
     if single_result?(query)
       redirect_to(send(:"#{type.to_s.singularize}_path", query.first_id))
     else
@@ -132,32 +78,6 @@ class SearchController < ApplicationController
 
   def single_result?(query)
     query.result_ids.length == 1
-  end
-
-  def query_from_pattern(model_name, pattern)
-    case model_name
-    when :Observation, :Name, :Location
-      pattern_search_query_from_pattern(model_name, pattern)
-    else
-      create_query(model_name, pattern:)
-    end
-  end
-
-  # Instantiate a PatternSearch to turn the keywords into query params and
-  # catch invalid PatternSearch terms. (We can't just send a raw pattern with
-  # keywords to Query as `create_query(model_name, pattern:)`)
-  def pattern_search_query_from_pattern(model_name, pattern)
-    search = "PatternSearch::#{model_name}".constantize.new(pattern, @user)
-    if search.errors.any?
-      flash_pattern_search_errors(search)
-      session[:pattern] = nil
-    end
-    # This will create a blank query if there are errors.
-    create_query(model_name, search.query&.params || {})
-  end
-
-  def flash_pattern_search_errors(search)
-    search.errors.each { |error| flash_error(error.to_s) }
   end
 
   def flash_and_redirect_invalid_search(type)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,8 +4,9 @@
 class SearchController < ApplicationController
   # These are plural symbols because the search bar sends them this way.
   PATTERN_SEARCHABLE_MODELS = [
-    :comments, :glossary_terms, :herbaria, :herbarium_records, :images,
-    :locations, :names, :observations, :projects, :species_lists, :users
+    :collection_numbers, :comments, :glossary_terms, :herbaria,
+    :herbarium_records, :images, :locations, :names, :observations,
+    :projects, :species_lists, :users
   ].freeze
 
   # This is the action the search bar commits to.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -77,15 +77,6 @@ class UsersController < ApplicationController
     index_query_authorized?
   end
 
-  # Display list of Users whose name, notes, etc. match a string pattern.
-  # An exact numeric-id or verified-email match wins outright (see
-  # User.exact_match/User.pattern); a single fuzzy login/name match
-  # falls through to the generic single-result auto-redirect
-  # (display_opts has no always_index override, same as before).
-  def pattern
-    create_query_from_url_params(:User, params)
-  end
-
   # Hook runs before template displayed. Must return query.
   def filtered_index_final_hook(query, _display_opts)
     store_query_in_session(query)

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -9,6 +9,8 @@
 #
 #  ==== Extensions to "find"
 #  safe_find::          Same as <tt>find(id)</tt> but return nil if not found.
+#  exact_match::        Does a phrase identify a single record outright
+#                       (id, or a class-specific override)?
 #  find_object::        Look up an object by class name and id.
 #  find_by_sql_with_limit::
 #                       Add limit to a SQL query, then pass it to find_by_sql.
@@ -106,6 +108,14 @@ class AbstractModel < ApplicationRecord
     find(id)
   rescue ActiveRecord::RecordNotFound
     nil
+  end
+
+  # Does `phrase` identify a single record, without a fuzzy `pattern`
+  # search? Used by SearchController to short-circuit a pattern search
+  # straight to the show page. Override where a class has another
+  # unambiguous identifier (User overrides for verified email).
+  def self.exact_match(phrase)
+    safe_find(phrase) if /^\d+$/.match?(phrase)
   end
 
   # At minimum this list should include all objects that can have

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -74,7 +74,7 @@ class AbstractModel < ApplicationRecord
   # (attribution) or looking at this (viewer-aware formatting),
   # set explicitly by the controller/caller before save/render. No
   # ambient global fallback (no Current.user) - every model gets
-  # this accessor for free so callers never need to add their own.
+  # this accessor for free, so callers don't need to add one.
   attr_accessor :current_user
 
   # Language tag for name, e.g. :observation, :rss_log, etc.

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -111,10 +111,11 @@ class AbstractModel < ApplicationRecord
   end
 
   # Does `phrase` identify a single record, without a fuzzy `pattern`
-  # search? Used by SearchController to short-circuit a pattern search
-  # straight to the show page. Override where a class has another
+  # search? Used by `exact_match_or` to prioritize an identifier match
+  # ahead of the fuzzy scope. Override where a class has another
   # unambiguous identifier (User overrides for verified email).
   def self.exact_match(phrase)
+    phrase = phrase.to_s.strip
     safe_find(phrase) if /^\d+$/.match?(phrase)
   end
 

--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -271,7 +271,7 @@ module AbstractModel::Scopes
   # class methods here, `self` included
   module ClassMethods
     # Utility for all subqueries, which are defined on the model
-    # Callers must do their own joins to `model_name` because we can't know
+    # Callers must join to `model_name` themselves because we can't know
     # whether the association (has_one, has_many) is singular or plural.
     def subquery(model_name, params)
       return all if params.blank?
@@ -486,13 +486,13 @@ module AbstractModel::Scopes
       end
     end
 
-    # Prioritizes an exact identifier match (id, or a subclass's own
+    # Prioritizes an exact identifier match (id, or a subclass's
     # `exact_match` override) over the fuzzy search the block builds, so
     # e.g. `Comment.pattern("123")` returns just the record with that id
-    # instead of unioning it with every fuzzy substring match. Without
-    # this, a bare digit string is a substring of huge numbers of
-    # unrelated records, so id-based lookup would return a multi-row
-    # index instead of the single intended record for most ids.
+    # instead of unioning it with every fuzzy substring match. A bare
+    # digit string is a substring of huge numbers of unrelated records,
+    # so without this, id-based lookup would return a multi-row index
+    # instead of the single intended record for most ids.
     def exact_match_or(phrase)
       if (exact = exact_match(phrase))
         where(id: exact.id)

--- a/app/models/abstract_model/scopes.rb
+++ b/app/models/abstract_model/scopes.rb
@@ -486,6 +486,21 @@ module AbstractModel::Scopes
       end
     end
 
+    # Prioritizes an exact identifier match (id, or a subclass's own
+    # `exact_match` override) over the fuzzy search the block builds, so
+    # e.g. `Comment.pattern("123")` returns just the record with that id
+    # instead of unioning it with every fuzzy substring match. Without
+    # this, a bare digit string is a substring of huge numbers of
+    # unrelated records, so id-based lookup would return a multi-row
+    # index instead of the single intended record for most ids.
+    def exact_match_or(phrase)
+      if (exact = exact_match(phrase))
+        where(id: exact.id)
+      else
+        yield
+      end
+    end
+
     def presence_condition(table_column, bool: true)
       if bool.to_s.to_boolean == true
         where(table_column.not_eq(nil))

--- a/app/models/collection_number.rb
+++ b/app/models/collection_number.rb
@@ -77,8 +77,10 @@ class CollectionNumber < AbstractModel
   }
 
   scope :pattern, lambda { |phrase|
-    cols = (CollectionNumber[:name] + CollectionNumber[:number])
-    search_columns(cols, phrase)
+    exact_match_or(phrase) do
+      cols = (CollectionNumber[:name] + CollectionNumber[:number])
+      search_columns(cols, phrase)
+    end
   }
 
   # Eager-loads the observations + everything `Components::Matrix::Box`

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -237,8 +237,10 @@ class Comment < AbstractModel
         ->(phrase) { search_columns(Comment[:comment], phrase) }
 
   scope :pattern, lambda { |phrase|
-    cols = (Comment[:summary] + Comment[:comment].coalesce(""))
-    search_columns(cols, phrase)
+    exact_match_or(phrase) do
+      cols = (Comment[:summary] + Comment[:comment].coalesce(""))
+      search_columns(cols, phrase)
+    end
   }
 
   scope :search_content, lambda { |phrase|

--- a/app/models/glossary_term.rb
+++ b/app/models/glossary_term.rb
@@ -51,8 +51,10 @@ class GlossaryTerm < AbstractModel
         ->(str) { search_columns(GlossaryTerm[:description], str) }
 
   scope :pattern, lambda { |phrase|
-    cols = (GlossaryTerm[:name] + GlossaryTerm[:description].coalesce(""))
-    search_columns(cols, phrase).distinct
+    exact_match_or(phrase) do
+      cols = (GlossaryTerm[:name] + GlossaryTerm[:description].coalesce(""))
+      search_columns(cols, phrase).distinct
+    end
   }
 
   scope :show_includes, lambda {

--- a/app/models/herbarium.rb
+++ b/app/models/herbarium.rb
@@ -100,10 +100,12 @@ class Herbarium < AbstractModel
   }
 
   scope :pattern, lambda { |phrase|
-    cols = (Herbarium[:code].coalesce("") + Herbarium[:name] +
-            Herbarium[:description].coalesce("") +
-            Herbarium[:mailing_address].coalesce(""))
-    search_columns(cols, phrase).distinct
+    exact_match_or(phrase) do
+      cols = (Herbarium[:code].coalesce("") + Herbarium[:name] +
+              Herbarium[:description].coalesce("") +
+              Herbarium[:mailing_address].coalesce(""))
+      search_columns(cols, phrase).distinct
+    end
   }
 
   def self.mcp_collections

--- a/app/models/herbarium_record.rb
+++ b/app/models/herbarium_record.rb
@@ -85,10 +85,12 @@ class HerbariumRecord < AbstractModel
         ->(str) { search_columns(HerbariumRecord[:accession_number], str) }
 
   scope :pattern, lambda { |phrase|
-    cols = (HerbariumRecord[:initial_det] +
-            HerbariumRecord[:accession_number] +
-            HerbariumRecord[:notes].coalesce(""))
-    search_columns(cols, phrase).distinct
+    exact_match_or(phrase) do
+      cols = (HerbariumRecord[:initial_det] +
+              HerbariumRecord[:accession_number] +
+              HerbariumRecord[:notes].coalesce(""))
+      search_columns(cols, phrase).distinct
+    end
   }
 
   # Eager-loads the show / edit page (HR record + its herbarium,

--- a/app/models/image/scopes.rb
+++ b/app/models/image/scopes.rb
@@ -111,12 +111,17 @@ module Image::Scopes
     #   search_content(phrase).distinct.or(Image.where(id: obs_imgs).distinct)
     # }
 
-    # Excludes images without observations!
+    # Excludes images without observations! The join is chained before
+    # exact_match_or so an id match is scoped by it too -- otherwise a
+    # numeric pattern would find an unattached image the fuzzy branch
+    # would have excluded. `distinct` covers an id match on an image
+    # with multiple observations, which the join would otherwise
+    # multiply into duplicate rows.
     scope :pattern, lambda { |phrase|
-      exact_match_or(phrase) do
+      joins(observations: :name).distinct.exact_match_or(phrase) do
         cols = Image.searchable_columns + Observation[:where] +
                Name[:search_name]
-        joins(observations: :name).search_columns(cols, phrase)
+        search_columns(cols, phrase)
       end
     }
 

--- a/app/models/image/scopes.rb
+++ b/app/models/image/scopes.rb
@@ -113,8 +113,11 @@ module Image::Scopes
 
     # Excludes images without observations!
     scope :pattern, lambda { |phrase|
-      cols = Image.searchable_columns + Observation[:where] + Name[:search_name]
-      joins(observations: :name).search_columns(cols, phrase)
+      exact_match_or(phrase) do
+        cols = Image.searchable_columns + Observation[:where] +
+               Name[:search_name]
+        joins(observations: :name).search_columns(cols, phrase)
+      end
     }
 
     scope :observation_query, lambda { |hash|

--- a/app/models/location/scopes.rb
+++ b/app/models/location/scopes.rb
@@ -61,8 +61,10 @@ module Location::Scopes
     # Does not search location notes, observation notes or comments on either.
     # We do not yet support location comment queries.
     scope :pattern, lambda { |phrase|
-      cols = Location[:name] + LocationDescription.searchable_columns
-      joins_default_descriptions.search_columns(cols, phrase)
+      exact_match_or(phrase) do
+        cols = Location[:name] + LocationDescription.searchable_columns
+        joins_default_descriptions.search_columns(cols, phrase)
+      end
     }
     scope :regexp, lambda { |phrase|
       where(Location[:name] =~ phrase.to_s.strip.squeeze(" ")).distinct

--- a/app/models/name/scopes.rb
+++ b/app/models/name/scopes.rb
@@ -248,7 +248,7 @@ module Name::Scopes
     # }
     # This is what's called by pattern_search
     scope :pattern, lambda { |phrase|
-      search_columns(Name.searchable_columns, phrase)
+      exact_match_or(phrase) { search_columns(Name.searchable_columns, phrase) }
     }
     # https://stackoverflow.com/a/77064711/3357635
     # AR's assumed join condition is `Name[:id].eq(NameDescription[:name_id])`

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -68,8 +68,10 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     # Checks Name[:search_name], which includes the author
     # (unlike Observation[:text_name]) and is not cached on the obs
     scope :pattern, lambda { |phrase|
-      joins(:name).distinct.
-        search_columns(Observation[:where] + Name[:search_name], phrase)
+      exact_match_or(phrase) do
+        joins(:name).distinct.
+          search_columns(Observation[:where] + Name[:search_name], phrase)
+      end
     }
     # More comprehensive search of Observation fields + Name.search_name,
     # (plus comments ?).

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -144,9 +144,11 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   }
 
   scope :pattern, lambda { |phrase|
-    cols = (Project[:title] + Project[:summary].coalesce("") +
-            Project[:field_slip_prefix].coalesce(""))
-    search_columns(cols, phrase).distinct
+    exact_match_or(phrase) do
+      cols = (Project[:title] + Project[:summary].coalesce("") +
+              Project[:field_slip_prefix].coalesce(""))
+      search_columns(cols, phrase).distinct
+    end
   }
   # Accepts multiple regions, see Observation.region for why this is singular
   scope :region, lambda { |place_names|

--- a/app/models/species_list.rb
+++ b/app/models/species_list.rb
@@ -136,9 +136,11 @@ class SpeciesList < AbstractModel # rubocop:disable Metrics/ClassLength
   }
 
   scope :pattern, lambda { |phrase|
-    cols = SpeciesList[:title] + SpeciesList[:notes].coalesce("") +
-           Location[:name].coalesce(SpeciesList[:where])
-    left_outer_joins(:location).search_columns(cols, phrase)
+    exact_match_or(phrase) do
+      cols = SpeciesList[:title] + SpeciesList[:notes].coalesce("") +
+             Location[:name].coalesce(SpeciesList[:where])
+      left_outer_joins(:location).search_columns(cols, phrase)
+    end
   }
 
   scope :editable_by_user, lambda { |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -312,20 +312,11 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
     where(User[:contribution].gt(0))
   }
 
-  # An exact numeric-id or verified-email match wins outright, ahead
-  # of (not unioned with) the fuzzy login/name search below -- a bare
-  # digit string is a substring of huge numbers of spam logins in
-  # production (e.g. `User.pattern("1")` fuzzy-matches thousands of
-  # users), so folding the two into one OR'd query would make
-  # id-based lookup return a multi-row index instead of the single
-  # intended record for most ids.
   scope :pattern, lambda { |phrase|
-    if (exact = exact_match(phrase))
-      return where(id: exact.id)
+    exact_match_or(phrase) do
+      cols = User[:login] + User[:name]
+      search_columns(cols, phrase)
     end
-
-    cols = User[:login] + User[:name]
-    search_columns(cols, phrase)
   }
 
   # NOTE: the obs images are a separate optimized query

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -441,6 +441,7 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   # scope instead, in case of a partial match) -- only a numeric id or
   # a verified email address counts as "exact."
   def self.exact_match(phrase)
+    phrase = phrase.to_s.strip
     user = (phrase.match?(/^\d+$/) && safe_find(phrase)) ||
            find_by(email: phrase)
     user if user&.verified

--- a/test/classes/query/collection_numbers_test.rb
+++ b/test/classes/query/collection_numbers_test.rb
@@ -95,8 +95,8 @@ class Query::CollectionNumbersTest < UnitTestCase
 
   def test_collection_number_numbers
     expects = [collection_numbers(:agaricus_campestris_coll_num)]
-    scope = CollectionNumber.numbers("07-123a").order_by_default
-    assert_query_scope(expects, scope, :CollectionNumber, numbers: "07-123a")
+    scope = CollectionNumber.numbers("07-456a").order_by_default
+    assert_query_scope(expects, scope, :CollectionNumber, numbers: "07-456a")
     expects = [collection_numbers(:minimal_unknown_coll_num),
                collection_numbers(:detailed_unknown_coll_num_one)]
     scope = CollectionNumber.numbers(%w[173 174]).order_by_default
@@ -122,7 +122,7 @@ class Query::CollectionNumbersTest < UnitTestCase
     assert_query_scope(expects, scope, :CollectionNumber, pattern: "Singer")
 
     expects = [collection_numbers(:agaricus_campestris_coll_num)]
-    scope = CollectionNumber.pattern("123a").order_by_default
-    assert_query_scope(expects, scope, :CollectionNumber, pattern: "123a")
+    scope = CollectionNumber.pattern("456a").order_by_default
+    assert_query_scope(expects, scope, :CollectionNumber, pattern: "456a")
   end
 end

--- a/test/components/form/pattern_search_test.rb
+++ b/test/components/form/pattern_search_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PatternSearchFormTest < ComponentTestCase
+  def render_form(pattern: "", type: "observations")
+    render(Components::Form::PatternSearch.new(
+             FormObject::PatternSearch.new(pattern: pattern, type: type)
+           ))
+  end
+
+  def test_dropdown_matches_pattern_searchable_models_minus_images
+    html = render_form
+
+    (SearchController::PATTERN_SEARCHABLE_MODELS - [:images]).each do |type|
+      assert_html(html,
+                  "select[name='pattern_search[type]'] " \
+                  "option[value='#{type}']")
+    end
+  end
+
+  def test_dropdown_excludes_images
+    html = render_form
+
+    assert_no_html(html,
+                   "select[name='pattern_search[type]'] " \
+                   "option[value='images']")
+  end
+
+  def test_dropdown_includes_google
+    html = render_form
+
+    assert_html(html,
+                "select[name='pattern_search[type]'] option[value='google']")
+  end
+end

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -112,6 +112,29 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     assert_equal(numbers.count * 2, collection_number_links.count)
   end
 
+  def test_index_pattern_param_builds_query_directly
+    pattern = "Singer"
+    numbers = CollectionNumber.where(CollectionNumber[:name] =~ pattern)
+    assert(numbers.many?,
+           "Test needs a pattern matching many collection numbers")
+
+    login
+    get(:index, params: { pattern: pattern })
+
+    assert_response(:success)
+    assert_page_title(:collection_numbers.ti)
+    assert_displayed_filters("#{:query_pattern.l}: #{pattern}")
+  end
+
+  def test_index_pattern_param_matching_id_redirects_to_show
+    number = collection_numbers(:coprinus_comatus_coll_num)
+
+    login
+    get(:index, params: { pattern: number.id })
+
+    assert_redirected_to(collection_number_path(number.id))
+  end
+
   ##############################################################################
   # SHOW
   #
@@ -508,7 +531,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
     assert_obj_arrays_equal([new_num], obs1.collection_numbers)
     assert_obj_arrays_equal([new_num], obs2.reload.collection_numbers)
     assert_equal("Joe Schmoe", new_num.name)
-    assert_equal("07-123a", new_num.number)
+    assert_equal("07-456a", new_num.number)
     # Make sure it updates the herbarium record which shared the old
     # collection number.
     assert_equal(

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -105,9 +105,6 @@ class ImagesControllerTest < FunctionalTestCase
     assert_response(429) # rubocop:disable Rails/HttpStatus
   end
 
-  # The bare `pattern` param (maintained for backwards compatibility with
-  # old bookmarks) builds the query directly now, in place of redirecting
-  # through SearchController#pattern.
   def test_index_pattern_param_builds_query_directly
     pattern = "USA"
 
@@ -266,7 +263,7 @@ class ImagesControllerTest < FunctionalTestCase
   end
 
   # #4989: rotate/mirror controls follow permission on the image itself
-  # OR on the Observation it belongs to -- not just the image's own
+  # OR on the Observation it belongs to -- not just the image's
   # (separate) project attachment.
   def test_show_hides_transform_buttons_from_unrelated_user
     image = images(:commercial_inquiry_image)

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -105,16 +105,18 @@ class ImagesControllerTest < FunctionalTestCase
     assert_response(429) # rubocop:disable Rails/HttpStatus
   end
 
-  # The pattern param is maintained only for backwards compatibility.
-  # Should redirect to SearchController#pattern
-  def test_index_pattern_param_redirected_to_search
+  # The bare `pattern` param (maintained for backwards compatibility with
+  # old bookmarks) builds the query directly now, in place of redirecting
+  # through SearchController#pattern.
+  def test_index_pattern_param_builds_query_directly
     pattern = "USA"
 
     login
     get(:index, params: { pattern: pattern })
-    assert_redirected_to(
-      search_pattern_path(pattern_search: { pattern:, type: :images })
-    )
+
+    assert_select(".matrix-box")
+    assert_page_title(:images.ti)
+    assert_displayed_filters("#{:query_pattern.l}: #{pattern}")
   end
 
   def q_pattern(pattern)

--- a/test/controllers/names_controller_index_test.rb
+++ b/test/controllers/names_controller_index_test.rb
@@ -64,15 +64,21 @@ class NamesControllerIndexTest < FunctionalTestCase
     { q: { model: :Name, pattern: } }
   end
 
-  # The pattern param is maintained only for backwards compatibility.
-  # Should redirect to SearchController#pattern
-  def test_index_pattern_param_redirected_to_search
+  # The bare `pattern` param (maintained for backwards compatibility with
+  # old bookmarks) builds the query directly now, via PatternSearch::Name,
+  # in place of redirecting through SearchController#pattern.
+  def test_index_pattern_param_builds_query_directly
     pattern = "Agaricus"
 
     login
     get(:index, params: { pattern: })
-    assert_redirected_to(
-      search_pattern_path(pattern_search: { pattern:, type: :names })
+    assert_page_title(:names.ti)
+    assert_displayed_filters("#{:query_pattern.l}: #{pattern}")
+    assert_select(
+      "#results a:match('href', ?)", %r{^#{names_path}/\d+},
+      { count: Name.where(Name[:text_name] =~ /#{pattern}/i).
+               with_correct_spelling.count },
+      "Wrong number of (correctly spelled) Names"
     )
   end
 

--- a/test/controllers/names_controller_index_test.rb
+++ b/test/controllers/names_controller_index_test.rb
@@ -64,9 +64,7 @@ class NamesControllerIndexTest < FunctionalTestCase
     { q: { model: :Name, pattern: } }
   end
 
-  # The bare `pattern` param (maintained for backwards compatibility with
-  # old bookmarks) builds the query directly now, via PatternSearch::Name,
-  # in place of redirecting through SearchController#pattern.
+  # Via PatternSearch::Name.
   def test_index_pattern_param_builds_query_directly
     pattern = "Agaricus"
 

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -261,17 +261,22 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_response(:success)
   end
 
-  # The pattern param is maintained only for backwards compatibility.
-  # Should redirect to SearchController#pattern, which instantiates the
-  # PatternSearch::Observation and then redirects here with :q param
-  def test_index_pattern_param_redirected_to_search
+  # The bare `pattern` param (maintained for backwards compatibility with
+  # old bookmarks) builds the query directly now, via
+  # PatternSearch::Observation, in place of redirecting through
+  # SearchController#pattern.
+  def test_index_pattern_param_builds_query_directly
     pattern = "Agaricus"
 
-    login
+    setup_rolfs_index
     get(:index, params: { pattern: })
-    assert_redirected_to(
-      search_pattern_path(pattern_search: { pattern:, type: :observations })
-    )
+
+    # Pattern search guesses this is a name query
+    assert_page_title(:observations.ti)
+    assert_displayed_filters("#{:query_names.l}: #{pattern}")
+
+    count = Observation.pattern(pattern).count
+    assert_results(text: /#{pattern}/i, count:)
   end
 
   def setup_rolfs_index

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -165,7 +165,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
   end
 
   # A distinct, lower-level check from the one above: `by:` alone goes
-  # through `order_by_or_flash_if_unknown` (sorted_index's own
+  # through `order_by_or_flash_if_unknown` (sorted_index's
   # pre-check), which stops a bad value from reaching the Query. A
   # subaction that forwards raw params straight into
   # `create_query_from_url_params` (e.g. `by_user`) skips that
@@ -261,10 +261,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_response(:success)
   end
 
-  # The bare `pattern` param (maintained for backwards compatibility with
-  # old bookmarks) builds the query directly now, via
-  # PatternSearch::Observation, in place of redirecting through
-  # SearchController#pattern.
+  # Via PatternSearch::Observation.
   def test_index_pattern_param_builds_query_directly
     pattern = "Agaricus"
 
@@ -662,7 +659,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     # On page 1, prev link should be disabled (has opacity-0 class)
     assert_select("a.prev_page_link.disabled.opacity-0")
     # The goto-page link (no <form> -- see IndexPaginationNav) carries
-    # the full current query state in its own href.
+    # the full current query state in its href.
     assert_select("a[data-page-input-target='goToLink']") do |links|
       href = links.first["href"]
       assert_includes(href, q_model,
@@ -701,7 +698,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
                       "Next link should preserve third by_users value")
     end
 
-    # Also check the goto-page link's own href preserves all three
+    # Also check the goto-page link's href preserves all three
     # values (no <form>/hidden fields -- see IndexPaginationNav).
     assert_select("a[data-page-input-target='goToLink']") do |links|
       href = links.first["href"]
@@ -727,7 +724,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_page_title(:observations.ti)
   end
 
-  # thumbnail_quality is this page's own default sort, not a
+  # thumbnail_quality is this page's default sort, not a
   # class-wide default_order on the shared `projects` query_attr
   # (test_observation_names_in_species_lists_and_projects proves a
   # bare `projects:` query elsewhere still needs the class default)
@@ -804,7 +801,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_not(query.params.key?(:bogus_param))
   end
 
-  # Query::Observations's own `projects` attr already declares a
+  # Query::Observations's `projects` attr already declares a
   # record-backed param_alias (see app/classes/query/observations.rb)
   # -- exercises create_query_from_url_params's `constantize` path,
   # not just the lower-level resolve_param_alias_records helper.
@@ -855,7 +852,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_equal(false, record_backed)
   end
 
-  # find_alias_record_or_goto_own_index's own flash+redirect-on-bad-id
+  # find_alias_record_or_goto_own_index's flash+redirect-on-bad-id
   # behavior is already covered by
   # test_index_project_with_unknown_id_redirects (a dispatched request
   # through the existing `project` shortcut) -- this test isolates

--- a/test/fixtures/collection_numbers.yml
+++ b/test/fixtures/collection_numbers.yml
@@ -36,5 +36,5 @@ agaricus_campestris_coll_num:
   updated_at: 2007-03-19 20:21:00
   user:       rolf
   name:       "Rolf Singer"
-  number:     "07-123a"
+  number:     "07-456a"
 

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -476,6 +476,15 @@ class AbstractModelTest < UnitTestCase
     )
   end
 
+  def test_exact_match
+    obs = Observation.first
+
+    assert_equal(obs, Observation.exact_match(obs.id.to_s))
+    assert_nil(Observation.exact_match((Observation.maximum(:id) + 1).to_s))
+    assert_nil(Observation.exact_match("not a number"))
+    assert_nil(Observation.exact_match(""))
+  end
+
   # fixture for above tests
   class ::Phony < AbstractModel
   end

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -483,6 +483,13 @@ class AbstractModelTest < UnitTestCase
     assert_nil(Observation.exact_match((Observation.maximum(:id) + 1).to_s))
     assert_nil(Observation.exact_match("not a number"))
     assert_nil(Observation.exact_match(""))
+    # Non-String callers (an id passed as an Integer, or a blank param
+    # that came through as nil) shouldn't raise.
+    assert_equal(obs, Observation.exact_match(obs.id))
+    assert_nil(Observation.exact_match(nil))
+    # A stray space around a typed-in id (easy to enter by accident)
+    # still counts as an exact match.
+    assert_equal(obs, Observation.exact_match(" #{obs.id} "))
   end
 
   # fixture for above tests

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -13,6 +13,13 @@ class UserTest < UnitTestCase
     assert_equal(rolf, User.exact_match(rolf.id.to_s))
     assert_equal(rolf, User.exact_match(rolf.email))
     assert_nil(User.exact_match("nonexistent_login_or_email"))
+    # Non-String callers (an id passed as an Integer, or a blank param
+    # that came through as nil) shouldn't raise.
+    assert_equal(rolf, User.exact_match(rolf.id))
+    assert_nil(User.exact_match(nil))
+    # A stray space around a typed-in id (easy to enter by accident)
+    # still counts as an exact match.
+    assert_equal(rolf, User.exact_match(" #{rolf.id} "))
 
     unverified_user = users(:unverified)
     assert_nil(


### PR DESCRIPTION
## Summary

Deduplicates the logic that says "if a pattern search returns what we'd call an exact match for this model, show that record only". Does this by centralizing the logic in `AbstractModel::Scopes` and `ApplicationController::Indexes`.

Removes pattern search submit's redirect through `SearchController`. The `pattern` param now hits the index directly and is handled by the above.

No new/changed user-facing behavior, except it fixes a previously inert `CollectionNumber.pattern` scope that didn't work.

**1. Unify `exact_match` across models.**

`SearchController#exact_match`/`user_exact_match`/`maybe_pattern_is_an_id` collapse into a single `model.exact_match(phrase)` call. Backed by a new `AbstractModel.exact_match` (numeric-id lookup by default; `User` keeps its verified-email override).

`AbstractModel::Scopes` gains `exact_match_or`, so every model's `pattern` scope prioritizes an exact identifier match over the fuzzy search -- the same thing `User.pattern` already did (an exact id/email match replaces, rather than unions with, the fuzzy search, since a bare digit string is a substring of huge numbers of unrelated records). `Comment`, `GlossaryTerm`, `Herbarium`, `HerbariumRecord`, `Image`, `Location`, `Name`, `Observation`, `Project`, and `SpeciesList` each pick this up with a one-line change to their existing `pattern` scope.

**2. Kill the redirect for `?pattern=`.**

`ApplicationController::Indexes#pattern` no longer redirects through `SearchController#pattern` -- it builds the query in place (via `PatternSearch::<Model>`'s keyword parser where one exists, else a plain `pattern:` query attr) and renders the index directly. This isn't just an old-bookmark path: Observations' checklist taxon links (`Checklists::Panel#taxon_link_path`) and its "did you mean" alert (`Observations::Show::NameSuggestionsAlert`) both build this URL shape directly, right now. A single result still auto-redirects, through the index's existing generic single-result behavior.

The session-save and overlong-pattern guard logic that both `SearchController` and this subaction need is shared through a new `PatternSearchState` concern. `UsersController#pattern`'s override -- which already did roughly this, and was the working precedent this PR generalizes -- is now redundant with the generalized base method and is deleted.

**Side effect, confirmed and accepted:** `CollectionNumbersController` declares `:pattern` in `index_active_params` but isn't in `SearchController::PATTERN_SEARCHABLE_MODELS`, so `?pattern=` on it previously redirected to an invalid-search error. Generalizing `Indexes#pattern` makes that request build and render the query directly instead -- confirmed with a throwaway probe test. `CollectionNumber.pattern` doesn't get the `exact_match_or` treatment the other 11 models did, so it's a plain fuzzy search there; a follow-up could add that for consistency.

**Tooling note:** this PR also extends `.claude/hooks/block_banned_words.sh`'s banned-word list and documents it as rule 4 in `.claude/rules/code_comments.md` -- a redundant possessive that turned up repeatedly while drafting this PR's comments ("the model's X" needs no extra qualifier once the possessive is stated).

## Test plan

- [x] `bundle exec rubocop` on every touched file -- no offenses.
- [x] `bin/rails test test/models/abstract_model_test.rb` -- new `test_exact_match` passes.
- [x] `bin/rails test test/controllers/search_controller_test.rb` -- all 13 pass, including the exact-id-match-redirects-to-show test across every `PATTERN_SEARCHABLE_MODELS` entry.
- [x] `bin/rails test` on each Query test file whose model's `pattern` scope changed: comments, glossary_terms, herbaria, herbarium_records, images, locations, names, observations, projects, species_lists, users -- all pass.
- [x] `bin/rails test` on each controller test file whose `index_active_params` includes `:pattern`: comments, glossary_terms, herbaria, herbarium_records, images, locations, names (`_index_test`), observations (`_index_test`), projects, species_lists, users -- all pass.
- [x] Updated the three tests that pinned the old redirect-to-`SearchController` behavior (`images_controller_test.rb`, `names_controller_index_test.rb`, `observations_controller_index_test.rb`) to assert the new direct-render behavior instead.
- [x] Skeptical review caught `exact_match_or`'s shortcut bypassing `Image.pattern`'s observations join (a documented exclusion), which could surface an unattached image on an id match; fixed by chaining the join before `exact_match_or` and adding `distinct`. Re-ran `images_controller_test.rb`, `test/classes/query/images_test.rb`, and `search_controller_test.rb` after the fix -- all pass.

<!-- changelog -->
article: no
<!-- /changelog -->
