### PR TITLE
Query params – eliminate remaining controller exceptions

### DIFF
--- a/app/classes/query/herbaria.rb
+++ b/app/classes/query/herbaria.rb
@@ -11,6 +11,7 @@ class Query::Herbaria < Query
   query_attr(:mailing_address_has, :string)
   query_attr(:pattern, :string)
   query_attr(:nonpersonal, { boolean: [true] },
+             param_alias: :nonpersonal, always_index: true,
              default_order: :code_then_name)
 
   def alphabetical_by

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -75,8 +75,11 @@ class Query::Observations < Query
 
   query_attr(:herbaria, [Herbarium])
   query_attr(:herbarium_records, [HerbariumRecord])
-  query_attr(:projects, [Project], param_alias: :project,
-                                   redirect_to: :model_index)
+  query_attr(:projects, [Project], redirect_to: :model_index)
+  # Separate attr, not aliased to `projects` -- its default_order would
+  # leak into `projects:`-filtered subqueries composed elsewhere.
+  query_attr(:project, Project, redirect_to: :model_index,
+                                default_order: :thumbnail_quality)
   query_attr(:project_lists, [Project])
   query_attr(:species_lists, [SpeciesList], param_alias: :species_list,
                                             redirect_to: :model_index)

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -102,7 +102,7 @@ class Query::Observations < Query
 
   # ObservationsController::Index's `where` shortcut aliases to this
   # attr -- redeclared (after the loop above) with the alias.
-  query_attr(:search_where, :string, param_alias: :where)
+  query_attr(:search_where, :string, param_alias: :where, always_index: true)
 
   def alphabetical_by
     @alphabetical_by ||= case params[:order_by].to_s

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -190,14 +190,15 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
   end
 
   # Sets @project/@observation-style ivars from a Query's resolved
-  # params. Call it from filtered_index_final_hook. No-op when attr
-  # is absent or holds more than one id.
+  # params. Call it from filtered_index_final_hook. No-op when attr is
+  # absent or (for an array-typed attr) holds more than one id.
   def derive_ivar_from_query(ivar, query, attr, model_class)
-    ids = query.params[attr]
-    return unless ids.is_a?(Array) && ids.size == 1
+    value = query.params[attr]
+    id = value.is_a?(Array) ? (value.first if value.size == 1) : value
+    return unless id
 
-    instance_variable_set(ivar, resolved_alias_record(attr, ids.first) ||
-                                 model_class.safe_find(ids.first))
+    instance_variable_set(ivar, resolved_alias_record(attr, id) ||
+                                 model_class.safe_find(id))
   end
 
   # Reuses the record already fetched for this attr, instead of

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -10,37 +10,32 @@ module ApplicationController::QueryParamAliases
   # any of the target Query's registered `param_alias:` params (e.g.
   # `?project=123`) into their query_attr (`projects: [123]`) before
   # creating the query. Permits only params the Query subclass
-  # recognizes (its query_attr names plus their param_alias names) -- the
-  # generic replacement for a controller's own `index_active_params`
+  # recognizes (its query_attr names plus their param_alias names) --
+  # the generic replacement for a controller's `index_active_params`
   # allowlist.
   #
-  # A param_alias'd id that doesn't resolve to an existing record flashes
-  # and redirects -- to the calling controller's own index by default,
-  # or to the looked-up model's own index when the attr declares
+  # A record-backed value that doesn't resolve to an existing record
+  # flashes and redirects -- to the calling controller's index by
+  # default, or to the looked-up model's index when the attr declares
   # `redirect_to: :model_index` (matching `find_or_goto_index`) -- see
-  # `resolve_record_backed_alias`. Returns nil in that case, so check
-  # the return value the same way you would any other
-  # index-redirecting lookup.
+  # `resolve_record_backed_value`. Returns nil in that case, so check
+  # the return value the same way you would any other index-redirecting
+  # lookup.
   #
-  # `always_index: true` is set automatically whenever a resolved alias's
-  # attr declares it (default true -- see `query_attr`), whether the attr
-  # is record-backed (e.g. `project`) or scalar (e.g. `nonpersonal`),
-  # matching every hand-written index filter param's existing
-  # `always_index: true` (an aliased single-result index should show the
-  # list, not auto-redirect to the one result). A sort-order change has
-  # no such single-result-redirect concern, so `by` alone doesn't trigger
-  # it.
+  # `always_index: true` is set automatically whenever a resolved attr
+  # declares it (default true -- see `query_attr`), matching every
+  # hand-written index filter param's existing `always_index: true` (a
+  # single-result index should show the list, not auto-redirect to the
+  # one result). A sort-order change has no such single-result-redirect
+  # concern, so `by` alone doesn't trigger it.
   #
-  # Returns `[query, display_opts]`, or nil if a param_alias'd id failed to
-  # resolve.
+  # Returns `[query, display_opts]`, or nil if a record-backed value
+  # failed to resolve.
   def create_query_from_url_params(model_symbol, raw_params)
     klass = "Query::#{model_symbol.to_s.pluralize}".constantize
     permitted = raw_params.permit(*klass.permit_filters).
                 to_h.symbolize_keys
-    aliased_keys = klass.param_aliases.keys & permitted.keys
-    resolved, force_index = resolve_param_alias_records(
-      klass, permitted, aliased_keys
-    )
+    resolved, force_index = resolve_query_param_records(klass, permitted)
     return nil unless resolved
 
     query = create_query(model_symbol, resolved)
@@ -49,17 +44,23 @@ module ApplicationController::QueryParamAliases
 
   private
 
-  # Resolves each `aliased_keys` entry to its target query_attr value,
-  # looking up record-backed attrs (e.g. `projects: [Project]`) via
-  # `resolve_record_backed_alias` -- which flashes and redirects on a bad
-  # id. Returns `[nil, false]` (redirect already performed) the moment
-  # one fails to resolve; otherwise `[resolved_params, force_index?]`,
-  # where `force_index?` is true iff at least one resolved alias's attr
-  # declares `always_index: true` (record-backed or scalar).
-  def resolve_param_alias_records(klass, permitted, aliased_keys)
+  # Resolves every permitted param -- whether it arrived under its attr
+  # name or a `param_alias:` shortcut -- looking up record-backed attrs
+  # (e.g. `projects: [Project]`) via `resolve_record_backed_value`,
+  # which flashes and redirects on a bad id. Returns `[nil, false]`
+  # (redirect already performed) the moment one fails to resolve;
+  # otherwise `[resolved_params, force_index?]`, where `force_index?` is
+  # true iff at least one resolved attr declares `always_index: true`
+  # (record-backed or scalar).
+  def resolve_query_param_records(klass, permitted)
     force_index = false
-    aliased_keys.each do |alias_key|
-      outcome = resolve_one_param_alias(klass, permitted, alias_key)
+    # `keys` snapshots into a plain Array first -- resolving a param may
+    # add a new key to `permitted` (e.g. renaming an alias), and
+    # iterating the live Hash during that (`each_key`) raises.
+    keys = permitted.keys
+    keys.each do |key|
+      attr = klass.param_aliases[key] || key
+      outcome = resolve_one_query_param(klass, permitted, key, attr)
       return [nil, false] if outcome == :not_found
 
       force_index ||= outcome == :forces_index
@@ -67,25 +68,27 @@ module ApplicationController::QueryParamAliases
     [permitted, force_index]
   end
 
-  # Resolves a single `alias_key` in place on `permitted` (mutating it),
+  # Resolves a single `key` in place on `permitted` (mutating it),
   # returning :forces_index, :no_force, or :not_found -- see
-  # `resolve_param_alias_records`. The alias wins over an already-present
-  # value under the target attr name (see Query.resolve_param_aliases for
-  # why), so it resolves and overwrites unconditionally.
-  def resolve_one_param_alias(klass, permitted, alias_key)
-    attr = klass.param_aliases[alias_key]
-    raw_value = permitted.delete(alias_key)
+  # `resolve_query_param_records`. When `key` is an alias (`key != attr`),
+  # it wins over an already-present value under the target attr name
+  # (see Query.resolve_param_aliases for why), so it resolves and
+  # overwrites unconditionally.
+  def resolve_one_query_param(klass, permitted, key, attr)
+    raw_value = permitted[key]
+    permitted.delete(key) if key != attr
     model_class = alias_record_class(klass, attr)
     unless model_class
       permitted[attr] = wrap_if_array_attr(klass, attr, raw_value)
       # Scalar: opposite polarity from the record-backed branch below --
       # forces only when explicitly declared (`nil` doesn't force). Most
-      # scalar aliases (e.g. `by`) have no opinion on this.
+      # scalar attrs (e.g. `by`) have no opinion on this.
       always_index = klass.attribute_types[attr].always_index
       return always_index ? :forces_index : :no_force
     end
 
-    resolve_record_backed_alias(klass, permitted, attr, model_class, raw_value)
+    resolve_record_backed_value(klass, permitted, attr, model_class,
+                                raw_value)
   end
 
   # Looks up `raw_value` as `model_class`, flashing and redirecting on a
@@ -96,7 +99,7 @@ module ApplicationController::QueryParamAliases
   # `always_index: false`, in which case :no_force. The record-lookup/
   # flash/redirect-on-bad-id behavior above is unconditional either way --
   # only whether a *found* record forces always_index changes.
-  def resolve_record_backed_alias(klass, permitted, attr, model_class,
+  def resolve_record_backed_value(klass, permitted, attr, model_class,
                                   raw_value)
     type = klass.attribute_types[attr]
     record = if type.redirect_to == :model_index

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -78,17 +78,35 @@ module ApplicationController::QueryParamAliases
     raw_value = permitted[key]
     permitted.delete(key) if key != attr
     model_class = alias_record_class(klass, attr)
-    unless model_class
-      permitted[attr] = wrap_if_array_attr(klass, attr, raw_value)
-      # Scalar: opposite polarity from the record-backed branch below --
-      # forces only when explicitly declared (`nil` doesn't force). Most
-      # scalar attrs (e.g. `by`) have no opinion on this.
-      always_index = klass.attribute_types[attr].always_index
-      return always_index ? :forces_index : :no_force
+    return resolve_scalar_query_param(klass, permitted, attr, raw_value) unless
+      model_class
+
+    if raw_value.is_a?(Array) && raw_value.size > 1
+      return resolve_multi_id_query_param(permitted, attr, raw_value)
     end
 
+    raw_value = raw_value.first if raw_value.is_a?(Array)
     resolve_record_backed_value(klass, permitted, attr, model_class,
                                 raw_value)
+  end
+
+  # Scalar: opposite polarity from the record-backed branch -- forces
+  # only when explicitly declared (`nil` doesn't force). Most scalar
+  # attrs (e.g. `by`) have no opinion on this.
+  def resolve_scalar_query_param(klass, permitted, attr, raw_value)
+    permitted[attr] = wrap_if_array_attr(klass, attr, raw_value)
+    always_index = klass.attribute_types[attr].always_index
+    always_index ? :forces_index : :no_force
+  end
+
+  # Multiple ids (e.g. `q[projects][]=1&q[projects][]=2`) skip
+  # single-record lookup/validation -- `find_by(id: [...])` returns only
+  # the first match, which would silently drop the rest. Pass the list
+  # through as-is; the underlying scope (e.g. Lookup::Projects) already
+  # resolves a list of ids/titles/instances.
+  def resolve_multi_id_query_param(permitted, attr, raw_value)
+    permitted[attr] = raw_value
+    :no_force
   end
 
   # Looks up `raw_value` as `model_class`, flashing and redirecting on a

--- a/app/controllers/application_controller/query_param_aliases.rb
+++ b/app/controllers/application_controller/query_param_aliases.rb
@@ -22,9 +22,10 @@ module ApplicationController::QueryParamAliases
   # the return value the same way you would any other
   # index-redirecting lookup.
   #
-  # `always_index: true` is set automatically whenever a record-backed
-  # param_alias resolved a param (e.g. `project`, not the scalar `by`
-  # sort alias), matching every hand-written index filter param's existing
+  # `always_index: true` is set automatically whenever a resolved alias's
+  # attr declares it (default true -- see `query_attr`), whether the attr
+  # is record-backed (e.g. `project`) or scalar (e.g. `nonpersonal`),
+  # matching every hand-written index filter param's existing
   # `always_index: true` (an aliased single-result index should show the
   # list, not auto-redirect to the one result). A sort-order change has
   # no such single-result-redirect concern, so `by` alone doesn't trigger
@@ -37,13 +38,13 @@ module ApplicationController::QueryParamAliases
     permitted = raw_params.permit(*klass.permit_filters).
                 to_h.symbolize_keys
     aliased_keys = klass.param_aliases.keys & permitted.keys
-    resolved, record_backed = resolve_param_alias_records(
+    resolved, force_index = resolve_param_alias_records(
       klass, permitted, aliased_keys
     )
     return nil unless resolved
 
     query = create_query(model_symbol, resolved)
-    [query, { always_index: record_backed }]
+    [query, { always_index: force_index }]
   end
 
   private
@@ -52,49 +53,49 @@ module ApplicationController::QueryParamAliases
   # looking up record-backed attrs (e.g. `projects: [Project]`) via
   # `resolve_record_backed_alias` -- which flashes and redirects on a bad
   # id. Returns `[nil, false]` (redirect already performed) the moment
-  # one fails to resolve; otherwise `[resolved_params, record_backed?]`,
-  # where `record_backed?` is true iff at least one resolved alias was
-  # record-backed.
+  # one fails to resolve; otherwise `[resolved_params, force_index?]`,
+  # where `force_index?` is true iff at least one resolved alias's attr
+  # declares `always_index: true` (record-backed or scalar).
   def resolve_param_alias_records(klass, permitted, aliased_keys)
-    record_backed = false
+    force_index = false
     aliased_keys.each do |alias_key|
       outcome = resolve_one_param_alias(klass, permitted, alias_key)
       return [nil, false] if outcome == :not_found
 
-      record_backed ||= outcome == :record_backed
+      force_index ||= outcome == :forces_index
     end
-    [permitted, record_backed]
+    [permitted, force_index]
   end
 
   # Resolves a single `alias_key` in place on `permitted` (mutating it),
-  # returning :scalar, :record_backed, or :not_found -- see
+  # returning :forces_index, :no_force, or :not_found -- see
   # `resolve_param_alias_records`. The alias wins over an already-present
   # value under the target attr name (see Query.resolve_param_aliases for
   # why), so it resolves and overwrites unconditionally.
-  #
-  # A found record still returns :scalar (not forcing always_index) when
-  # the attr declares `always_index: false` -- the record-lookup/flash/
-  # redirect-on-bad-id behavior below is unconditional either way, only
-  # whether a *found* record forces always_index changes.
   def resolve_one_param_alias(klass, permitted, alias_key)
     attr = klass.param_aliases[alias_key]
     raw_value = permitted.delete(alias_key)
     model_class = alias_record_class(klass, attr)
     unless model_class
       permitted[attr] = wrap_if_array_attr(klass, attr, raw_value)
-      return :scalar
+      # Scalar: opposite polarity from the record-backed branch below --
+      # forces only when explicitly declared (`nil` doesn't force). Most
+      # scalar aliases (e.g. `by`) have no opinion on this.
+      always_index = klass.attribute_types[attr].always_index
+      return always_index ? :forces_index : :no_force
     end
 
     resolve_record_backed_alias(klass, permitted, attr, model_class, raw_value)
   end
 
   # Looks up `raw_value` as `model_class`, flashing and redirecting on a
-  # bad id -- to the calling controller's own index by default, or to
-  # `model_class`'s own index when the attr declares
+  # bad id -- to the calling controller's index by default, or to
+  # `model_class`'s index when the attr declares
   # `redirect_to: :model_index` (see `query_attr`). :not_found on
-  # failure; otherwise :record_backed, unless the attr opts out via
-  # `always_index: false` (see `resolve_one_param_alias`), in which case
-  # :scalar.
+  # failure; otherwise :forces_index, unless the attr opts out via
+  # `always_index: false`, in which case :no_force. The record-lookup/
+  # flash/redirect-on-bad-id behavior above is unconditional either way --
+  # only whether a *found* record forces always_index changes.
   def resolve_record_backed_alias(klass, permitted, attr, model_class,
                                   raw_value)
     type = klass.attribute_types[attr]
@@ -109,7 +110,10 @@ module ApplicationController::QueryParamAliases
     # instead of fetching it again.
     cache_resolved_alias_record(attr, record)
     permitted[attr] = type.accepts.is_a?(Array) ? [record.id] : record.id
-    type.always_index ? :record_backed : :scalar
+    # Record-backed: forces unless explicitly opted out (`always_index`
+    # undeclared/nil still forces -- matches every hand-written index
+    # filter param's existing behavior before this attr had one).
+    type.always_index == false ? :no_force : :forces_index
   end
 
   def cache_resolved_alias_record(attr, record)

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -213,11 +213,7 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
   end
 
   def nonpersonal
-    store_location
-    query, = create_query_from_url_params(:Herbarium, params)
-    return unless query
-
-    [query, { always_index: true }]
+    create_query_from_url_params(:Herbarium, params)
   end
 
   def index_display_opts(opts, _query)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -51,10 +51,6 @@ class LocationsController < ApplicationController
     ::Query::Locations.default_order # :name
   end
 
-  def unfiltered_index_opts
-    super.merge(display_opts: { link_all_sorts: true })
-  end
-
   # ApplicationController uses this to dispatch #index to a private method
   def index_active_params
     [:pattern, :country, :project, :by_user, :by_editor,
@@ -63,57 +59,48 @@ class LocationsController < ApplicationController
 
   # Displays a list of all locations whose country matches the param.
   def country
-    query, = create_query_from_url_params(:Location, params)
-    return unless query
-
-    [query, { link_all_sorts: true }]
+    create_query_from_url_params(:Location, params)
   end
 
   # Displays a list of locations of obs whose project matches the param.
   def project
-    query, = create_query_from_url_params(:Location, params)
-    return unless query
-
-    [query, { link_all_sorts: true }]
+    create_query_from_url_params(:Location, params)
   end
 
   # Display list of locations that a given user created.
   def by_user
-    query, = create_query_from_url_params(:Location, params)
-    return unless query
-
-    [query, { link_all_sorts: true }]
+    create_query_from_url_params(:Location, params)
   end
 
   # Display list of locations that a given user is editor on.
   def by_editor
-    query, = create_query_from_url_params(:Location, params)
-    return unless query
-
-    [query, {}]
+    create_query_from_url_params(:Location, params)
   end
 
   # Hook runs before template displayed. Must return query.
-  def filtered_index_final_hook(query, display_opts)
+  def filtered_index_final_hook(query, _display_opts)
     # Matching undefined locations is meaningless in a box.
     # (Undefined locations don't have a box!)
     return query if query.params[:in_box].present?
 
-    # Get matching *undefined* locations.
-    set_matching_undefined_location_ivars(query, display_opts)
+    # "By name"/"by frequency" subtitles apply to every filter except
+    # by_editor -- computed from the resolved query, not which subaction
+    # fired, so this covers the unfiltered index too.
+    set_matching_undefined_location_ivars(
+      query, link_all_sorts: !query.params.key?(:by_editor)
+    )
     query
   end
 
   # Paginate the defined locations using the usual helper.
   #
   # always_index always comes from @undef_pages here, regardless of
-  # what a subaction's own create_query_from_url_params call
-  # resolved -- country/project/by_user/by_editor above all discard
-  # that value and pass a fixed opts hash instead. Single-match
-  # auto-redirect for this index depends on @undef_pages's
-  # letter-pagination total, not the Query layer's opinion.
+  # what the query resolved -- single-match auto-redirect for this
+  # index depends on @undef_pages's letter-pagination total, not the
+  # Query layer's opinion. Merged last so it wins over any :always_index
+  # a generic create_query_from_url_params call put in `opts`.
   def index_display_opts(opts, _query)
-    { always_index: @undef_pages&.num_total&.positive? }.merge(opts)
+    opts.merge(always_index: @undef_pages&.num_total&.positive?)
   end
 
   def set_matching_undefined_location_ivars(query, display_opts)

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -159,19 +159,8 @@ class ObservationsController
     end
 
     # Display matrix of Observations attached to a given project.
-    #
-    # `by: :thumbnail_quality` is this page's default sort, not
-    # Query::Observations' class-wide one. This can't move onto the
-    # `projects` query_attr's `default_order:` -- that scope has a
-    # join/where side effect (see order_by_thumbnail_quality), which
-    # leaks into any subquery composition of `projects:` (e.g.
-    # Query::Images' `observation_query: {projects: ...}`) even though
-    # `AbstractModel::Scopes#subquery` reorders the merged relation away;
-    # reorder clears the ORDER BY clause, not a join/where a scope added
-    # as a side effect of computing it.
     def project
-      create_query_from_url_params(:Observation,
-                                   params.reverse_merge(by: :thumbnail_quality))
+      create_query_from_url_params(:Observation, params)
     end
 
     # Display matrix of Observations attached to a given species_list.
@@ -183,6 +172,7 @@ class ObservationsController
     def filtered_index_final_hook(query, _display_opts)
       store_query_in_session(query)
       derive_ivar_from_query(:@project, query, :projects, Project)
+      derive_ivar_from_query(:@project, query, :project, Project)
       query
     end
 

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -155,29 +155,23 @@ class ObservationsController
     # AbstractModel's scope `search_where`, which searches two tables
     # (obs and loc) for the fuzzy match.
     def where
-      query, = create_query_from_url_params(:Observation, params)
-      return unless query
-
-      [query, { always_index: true }]
+      create_query_from_url_params(:Observation, params)
     end
 
     # Display matrix of Observations attached to a given project.
     #
     # `by: :thumbnail_quality` is this page's default sort, not
-    # Query::Observations' class-wide one -- a bare `projects:` filter
-    # elsewhere (e.g. a raw Query.lookup) still gets the class
-    # default, so the override is threaded through the raw params
-    # here rather than a shared `default_order:` on the `projects`
-    # attr. An explicit `by` still wins.
+    # Query::Observations' class-wide one. This can't move onto the
+    # `projects` query_attr's `default_order:` -- that scope has a
+    # join/where side effect (see order_by_thumbnail_quality), which
+    # leaks into any subquery composition of `projects:` (e.g.
+    # Query::Images' `observation_query: {projects: ...}`) even though
+    # `AbstractModel::Scopes#subquery` reorders the merged relation away;
+    # reorder clears the ORDER BY clause, not a join/where a scope added
+    # as a side effect of computing it.
     def project
-      raw_params = if params[:by].present?
-                     params
-                   else
-                     params.merge(
-                       by: :thumbnail_quality
-                     )
-                   end
-      create_query_from_url_params(:Observation, raw_params)
+      create_query_from_url_params(:Observation,
+                                   params.reverse_merge(by: :thumbnail_quality))
     end
 
     # Display matrix of Observations attached to a given species_list.

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -619,6 +619,8 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       joins(:project_observations).
         where(project_observations: { project: project_ids }).distinct
     }
+    # Separate query_attr from `projects` -- see Query::Observations.
+    scope :project, ->(project) { projects(project) }
     scope :project_lists, lambda { |projects|
       project_ids = Lookup::Projects.new(projects).ids
       joins(species_lists: :project_species_lists).

--- a/app/types/query_param_type.rb
+++ b/app/types/query_param_type.rb
@@ -42,8 +42,13 @@ class QueryParamType < ActiveModel::Type::Value
   # Add our custom args :accepts, :param_alias, :default_order,
   # :always_index, :redirect_to to the default args -- see `query_attr`
   # in app/extensions/class.rb.
+  #
+  # `always_index` defaults to nil (not `true`) so a consumer can tell
+  # an undeclared attr apart from an explicit value -- record-backed and
+  # scalar aliases interpret nil with opposite polarity (see
+  # ApplicationController::QueryParamAliases).
   def initialize(accepts: nil, param_alias: nil, default_order: nil,
-                 always_index: true, redirect_to: :own_index)
+                 always_index: nil, redirect_to: :own_index)
     @accepts = accepts
     @param_alias = param_alias
     @default_order = default_order

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4488,6 +4488,7 @@
   query_locations: "[:locations]"
   query_within_locations: "[:within_locations]"
   query_observations: "[:observations]"
+  query_project: "[:project]"
   query_project_lists: "[:project_lists]"
   query_projects: "[:projects]"
   query_species_lists: "[:species_lists]"

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -834,6 +834,29 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_equal(true, force_index)
   end
 
+  # Multiple ids submitted directly under the attr's name (not via a
+  # param_alias) must not collapse to a single record --
+  # find_by(id: [...]) only returns the first match, so this attr
+  # skips single-record lookup entirely instead of silently dropping
+  # every id but one.
+  def test_resolve_query_param_records_preserves_multiple_ids
+    login
+    project1 = projects(:bolete_project)
+    project2 = projects(:empty_project)
+    klass = Class.new(Query::Observations) do
+      query_attr(:projects, [Project])
+    end
+
+    resolved, force_index = @controller.send(
+      :resolve_query_param_records, klass,
+      { projects: [project1.id.to_s, project2.id.to_s] }
+    )
+
+    assert_equal({ projects: [project1.id.to_s, project2.id.to_s] },
+                 resolved)
+    assert_equal(false, force_index)
+  end
+
   # Non-record-backed Array-typed attrs (e.g. [:time]) need the same
   # scalar-to-array wrapping a record-backed alias already gets --
   # confirmed missing by Copilot review on PR #5142.

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -801,10 +801,11 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_not(query.params.key?(:bogus_param))
   end
 
-  # Query::Observations's `projects` attr already declares a
-  # record-backed param_alias (see app/classes/query/observations.rb)
-  # -- exercises create_query_from_url_params's `constantize` path,
-  # not just the lower-level resolve_param_alias_records helper.
+  # Query::Observations' `project` attr is record-backed but not an
+  # alias for `projects` (see app/classes/query/observations.rb) --
+  # exercises create_query_from_url_params's `constantize` path with a
+  # directly-matching attr name, not just the lower-level
+  # resolve_query_param_records helper.
   def test_create_query_from_url_params_sets_always_index_for_record_alias
     login
     project = projects(:bolete_project)
@@ -814,52 +815,50 @@ class ObservationsControllerIndexTest < FunctionalTestCase
       :create_query_from_url_params, :Observation, raw_params
     )
 
-    assert_equal([project.id], query.params[:projects])
+    assert_equal(project.id, query.params[:project])
     assert_equal(true, display_opts[:always_index])
   end
 
-  def test_resolve_param_alias_records_looks_up_record_and_wraps_array
+  def test_resolve_query_param_records_looks_up_record_and_wraps_array
     login
     project = projects(:bolete_project)
     klass = Class.new(Query::Observations) do
       query_attr(:projects, [Project], param_alias: :project)
     end
 
-    resolved, record_backed = @controller.send(
-      :resolve_param_alias_records, klass,
-      { project: project.id.to_s }, [:project]
+    resolved, force_index = @controller.send(
+      :resolve_query_param_records, klass, { project: project.id.to_s }
     )
 
     assert_equal({ projects: [project.id] }, resolved)
-    assert_equal(true, record_backed)
+    assert_equal(true, force_index)
   end
 
   # Non-record-backed Array-typed attrs (e.g. [:time]) need the same
   # scalar-to-array wrapping a record-backed alias already gets --
   # confirmed missing by Copilot review on PR #5142.
-  def test_resolve_param_alias_records_wraps_non_record_backed_array_attr
+  def test_resolve_query_param_records_wraps_non_record_backed_array_attr
     login
     klass = Class.new(Query::Observations) do
       query_attr(:test_dates, [:time], param_alias: :test_date)
     end
 
-    resolved, record_backed = @controller.send(
-      :resolve_param_alias_records, klass,
-      { test_date: "2024-01-01" }, [:test_date]
+    resolved, force_index = @controller.send(
+      :resolve_query_param_records, klass, { test_date: "2024-01-01" }
     )
 
     assert_equal({ test_dates: ["2024-01-01"] }, resolved)
-    assert_equal(false, record_backed)
+    assert_equal(false, force_index)
   end
 
   # find_alias_record_or_goto_own_index's flash+redirect-on-bad-id
   # behavior is already covered by
   # test_index_project_with_unknown_id_redirects (a dispatched request
   # through the existing `project` shortcut) -- this test isolates
-  # what resolve_param_alias_records itself does with a not-found
+  # what resolve_query_param_records itself does with a not-found
   # result, stubbing find_alias_record_or_goto_own_index so a bare
   # @controller.send doesn't trip Rails' one-redirect-per-action guard.
-  def test_resolve_param_alias_records_returns_nil_when_lookup_fails
+  def test_resolve_query_param_records_returns_nil_when_lookup_fails
     login
     klass = Class.new(Query::Observations) do
       query_attr(:projects, [Project], param_alias: :project)
@@ -868,13 +867,12 @@ class ObservationsControllerIndexTest < FunctionalTestCase
       :find_alias_record_or_goto_own_index
     ) { |*| nil }
 
-    resolved, record_backed = @controller.send(
-      :resolve_param_alias_records, klass,
-      { project: "999999999" }, [:project]
+    resolved, force_index = @controller.send(
+      :resolve_query_param_records, klass, { project: "999999999" }
     )
 
     assert_nil(resolved)
-    assert_equal(false, record_backed)
+    assert_equal(false, force_index)
   end
 
   def test_index_species_list


### PR DESCRIPTION
Eliminates last remaining "special case" overrides for index params.
As the last PR was supposed to do, but the intern...

## Summary

Prep for issue #5140 ("collapse `build_index_with_query`'s subaction dispatch; delete `index_active_params`") -- fixing special cases first, so the dispatch redesign (a separate, later PR) doesn't need to bake exceptions into the new mechanism. An inventory of every non-`:pattern` subaction across 15 controllers found ~27 of ~33 already reduce to a bare `create_query_from_url_params(model, params)` call; this PR closes the gap on the rest.

### 1. `always_index` gap for scalar/direct-name attrs

`create_query_from_url_params`'s `always_index` determination only consulted record-backed param aliases -- a scalar alias (or an attr with no alias) didn't reach the check. Fixed by giving `QueryParamType#always_index` a `nil` default instead of `true`, so a consumer can distinguish "undeclared" from an explicit value: record-backed keeps its existing polarity (`nil`/`true` forces, only explicit `false` opts out, matching every attr that relies on the implicit old default), scalar gets the opposite (only explicit `true` forces, so `by` and every other existing scalar alias is unaffected). `HerbariaController#nonpersonal` and `ObservationsController::Index#where` both existed only to force `always_index` by hand; both collapse to bare generic calls now.

### 2. Locations' 4 subactions collapse to zero

`country`/`project`/`by_user`/`by_editor` each hand-returned a `link_all_sorts` display flag, asymmetric across 3-of-4 (`by_editor` is the exception -- confirmed `link_all_sorts: true` is the default, since the unfiltered index sets it too). Moved into `filtered_index_final_hook`, computed from the resolved query's params instead of which subaction fired -- this also covers the unfiltered-index path, which previously set the same flag through a separate route (`unfiltered_index_opts`, now deleted). `index_display_opts`'s merge order also had to flip so the undefined-locations panel's `always_index` computation can't be silently overridden by whatever a generic call resolves.

### 3. Observations' `:project` collapses to zero too, via a dedicated attr

Moving `by: :thumbnail_quality` onto `Query::Observations`' `projects` attr as a `default_order:` doesn't work -- `order_by_thumbnail_quality` isn't order-only; it adds a `LEFT OUTER JOIN` + `WHERE` clause as a side effect. `AbstractModel::Scopes#subquery` reorders a merged relation away (`.reorder("")`) before composing it into a parent query, but that only clears the `ORDER BY` clause, not a join/where a scope introduced computing it -- caught by `test_image_with_observations_projects` (via `Query::Images`' `observation_query: {projects: ...}` subquery composition) silently dropping a row. Fixed by giving `:project` a separate `query_attr` from `projects`, so the `default_order:` can't leak into a `projects:`-filtered subquery composed elsewhere. `Observation.project` is a thin delegate to `Observation.projects`.

### 4. Record validation generalized to any attr, not just aliased ones

Giving `:project` a dedicated attr surfaced a question worth asking: why should a param need a `param_alias:` to get flash+redirect-on-bad-id, `always_index`, and ivar-caching? It shouldn't -- that coupling was accidental. `resolve_one_param_alias` only ran for keys present in `klass.param_aliases`; a record-backed attr reached by its plain name skipped all of that. Rewrote the pipeline (`resolve_query_param_records`, renamed from `resolve_param_alias_records`) to resolve every permitted key uniformly, whether it arrived under its attr name directly or a `param_alias:` shortcut. This is what makes `:project` fully generic with no self-referential alias needed. Also extended `derive_ivar_from_query` to accept a scalar id (not just a 1-element array), so `@project` still gets set when the singular `:project` attr resolves the query.

## Test plan

- [x] `bundle exec rubocop` on every touched file -- no offenses.
- [x] Full test suites for all 15 controllers this line of work eventually touches (Images, Herbaria, CollectionNumbers, Locations, Comments, HerbariumRecords, RssLogs, Projects, Names, SpeciesLists, Names::Descriptions, Locations::Descriptions, Observations, Observations::Identify, FieldSlips, Users) plus `search_controller_test.rb` -- all pass, confirming the shared resolution-pipeline rewrite doesn't regress any existing record-backed or scalar alias.
- [x] Every corresponding `test/classes/query/<model>_test.rb` -- all pass.
- [x] Caught and fixed two bugs mid-implementation: `test_image_with_observations_projects` failed (missing row, not just reordering) after the first `default_order:` attempt for `:project` on the shared `projects` attr -- confirmed it passes on `main`, root-caused to the join/where leak described above. Separately, RuboCop's autocorrect turned an intentional snapshot iteration (`permitted.keys.each`) into `permitted.each_key`, which iterates the live Hash and raises when resolution adds a new key mid-loop -- fixed by routing through a local variable so the cop can't rewrite it back.
- [x] `bin/rails lang:update` run after adding the `query_project` translation key (needed for the filter-caption display now that `:project` is a distinct attr).

<!-- changelog -->
article: no
<!-- /changelog -->

