### PR TITLE
Let an image's uploader scan and review its field slip extract

### DIFF
--- a/app/controllers/images/field_slip_extracts_controller.rb
+++ b/app/controllers/images/field_slip_extracts_controller.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 module Images
-  # Machine-reads a field slip photo and lets a site admin review the
-  # result before any of it reaches the observation (see
-  # FieldSlip::Extractor).
+  # Machine-reads a field slip photo and lets the collector -- or a
+  # reviewer -- check the result before any of it reaches the
+  # observation (see FieldSlip::Extractor).
   #
-  # Open to site admins and to admins of a project the image's
-  # observations belong to (see `FieldSlipExtract.permitted?`), not to
-  # everyone: each call costs money and roughly a third of fields need
-  # correcting, so this wants people who know what a slip should say.
-  # `create` always re-reads -- extraction changes over time and a fresh
-  # read is the point of pressing the button again.
+  # Open to the image's owner (their photo, their record), to
+  # admins of a project the image's observations belong to, and to
+  # site admins (see `FieldSlipExtract.permitted?`) -- not to everyone,
+  # since each call costs money and writes to a record. `create` always
+  # re-reads -- extraction changes over time and a fresh read is the
+  # point of pressing the button again.
   class FieldSlipExtractsController < ApplicationController
     before_action :login_required
     before_action :find_image!
@@ -74,29 +74,15 @@ module Images
 
     # No return value: a `before_action` halts the chain when it
     # redirects, so signalling with true/false would be decoration.
-    # Runs after `find_image!` because the permission depends on the
-    # image's observations, not just on the user.
+    # Runs after `find_image!` because the permission needs the image
+    # (ownership and its observations' projects), not just the user.
     def permission_required
       return unless @image
       return if FieldSlipExtract.permitted?(image: @image, user: @user,
                                             site_admin: in_admin_mode?)
-      return if awaiting_own_upload?
 
       flash_error(:permission_denied.t)
       redirect_to(image_path(@image.id))
-    end
-
-    # The observation-create redirect can land here BEFORE the QR jobs
-    # have filed the observation into its project -- at which point
-    # `permitted?` has no project to check against. Waiting on your own
-    # freshly uploaded photo shows nothing but a status panel, so it
-    # only needs ownership; the review form itself stays behind
-    # `permitted?`, which holds by the time the extract completes.
-    def awaiting_own_upload?
-      return false unless request.get?
-      return false if FieldSlipExtract.find_by(image_id: @image.id)&.complete?
-
-      @image.observations.any? { |obs| obs.user_id == @user.id }
     end
 
     def find_image!

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -18,18 +18,24 @@ class FieldSlipExtract < AbstractModel
   validates :model, presence: true
   validates :image_id, uniqueness: true
 
-  # Who may read a slip and review the result: site admins, and the
-  # admins of any project the image's observations belong to. A foray's
-  # own organizers are exactly the people who can tell whether a slip
-  # was transcribed correctly, and they are already trusted with that
-  # project's data -- gating on site admin alone would put every foray's
-  # transcription through the same few people.
+  # Who may read a slip and review the result:
   #
-  # Still not open to everyone: each read costs an API call, and a
-  # careless one writes to observations the reviewer may not own.
+  # - The image's owner: it is their photo, so the read costs them an
+  #   API call and the review finalizes their upload. This is also how
+  #   a collector scans their image and reviews it, even
+  #   before the observation has joined any project.
+  # - Admins of any project the image's observations belong to: a
+  #   foray's organizers can tell whether a slip was transcribed
+  #   correctly and are already trusted with that project's data.
+  # - Site admins.
+  #
+  # Still not open to everyone: for someone who is none of these, the
+  # read costs an API call and the review would write to a record they
+  # do not own.
   def self.permitted?(image:, user:, site_admin: false)
     return false unless user
     return true if site_admin
+    return true if image.user_id == user.id
 
     image.observations.any? do |obs|
       obs.projects.any? { |project| project.is_admin?(user) }

--- a/app/models/field_slip_extract.rb
+++ b/app/models/field_slip_extract.rb
@@ -18,28 +18,19 @@ class FieldSlipExtract < AbstractModel
   validates :model, presence: true
   validates :image_id, uniqueness: true
 
-  # Who may read a slip and review the result:
-  #
-  # - The image's owner: it is their photo, so the read costs them an
-  #   API call and the review finalizes their upload. This is also how
-  #   a collector scans their image and reviews it, even
-  #   before the observation has joined any project.
-  # - Admins of any project the image's observations belong to: a
-  #   foray's organizers can tell whether a slip was transcribed
-  #   correctly and are already trusted with that project's data.
-  # - Site admins.
-  #
-  # Still not open to everyone: for someone who is none of these, the
-  # read costs an API call and the review would write to a record they
-  # do not own.
+  # Who may read a slip and review the result: site admins, and anyone
+  # who can edit an observation the image is on. The review writes the
+  # transcribed values straight onto that observation (see
+  # Applier#apply), so the permission to review is the permission to
+  # edit -- the collector, and the project admins the collector has
+  # trusted with editing (Observation#can_edit?), no wider. An image
+  # owner whose photo hangs on somebody else's observation cannot
+  # review a slip into a record they could not otherwise touch.
   def self.permitted?(image:, user:, site_admin: false)
     return false unless user
     return true if site_admin
-    return true if image.user_id == user.id
 
-    image.observations.any? do |obs|
-      obs.projects.any? { |project| project.is_admin?(user) }
-    end
+    image.observations.any? { |obs| obs.can_edit?(user) }
   end
 
   # An extraction has a lifecycle now that it runs in the background:

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -67,9 +67,10 @@ module Images
     # slip was transcribed right.
     def test_edit_allowed_for_a_project_admin
       record_extract(fields: { "Collector" => "A" })
-      join_project_as_admin(mary)
+      join_project_as_admin(rolf)
 
-      assert(@project.is_admin?(mary), "premise: mary administers it")
+      assert(@project.is_admin?(rolf), "premise: rolf administers it")
+      assert_not_equal(rolf, @image.user, "premise: not the image owner")
       get(:edit, params: { image_id: @image.id })
 
       assert_response(:success)
@@ -167,18 +168,16 @@ module Images
       assert_response(:success)
     end
 
-    # ...and can land before the observation is even in its project,
-    # when `permitted?` has nothing to check against. Waiting on your
-    # own upload needs only ownership; the review form still needs
-    # project admin-ship.
-    def test_owner_may_wait_on_their_own_upload_before_project_filing
+    # The image's owner may watch their upload's read progress even
+    # before the observation has joined any project -- permission comes
+    # from owning the photo, not from the observation's project
+    # membership.
+    def test_owner_sees_their_pending_read
       owner = @obs.user
       login(owner.login)
 
-      assert_not(
-        FieldSlipExtract.permitted?(image: @image.reload, user: owner),
-        "premise: ownership alone, no project admin-ship"
-      )
+      assert_equal(owner, @image.reload.user, "premise: owner owns the image")
+      assert(FieldSlipExtract.permitted?(image: @image, user: owner))
 
       FieldSlipExtract.start!(image: @image, user: owner)
 
@@ -188,21 +187,21 @@ module Images
       assert_select("[data-controller='reload-poll']")
     end
 
-    def test_owner_alone_may_not_review_a_completed_extract
+    # The fix for the field-scanner lockout: a constraint-violating
+    # location kept the observation out of its project, and the old
+    # policy then denied the collector the review. The owner now reviews
+    # their completed read.
+    def test_owner_may_review_their_completed_extract
       owner = @obs.user
       login(owner.login)
 
-      assert_not(
-        FieldSlipExtract.permitted?(image: @image.reload, user: owner),
-        "premise: ownership alone, no project admin-ship"
-      )
-
-      record_extract(fields: { "Collector" => "A" })
+      assert_equal(owner, @image.reload.user, "premise: owner owns the image")
+      record_extract(fields: { "Collector" => "Scott Shapiro" })
 
       get(:edit, params: { image_id: @image.id })
 
-      assert_redirected_to(image_path(@image.id))
-      assert_flash_error
+      assert_response(:success)
+      assert_select("input[name='value[Collector]'][value='Scott Shapiro']")
     end
 
     def test_edit_renders_the_rows_and_the_name_section

--- a/test/controllers/images/field_slip_extracts_controller_test.rb
+++ b/test/controllers/images/field_slip_extracts_controller_test.rb
@@ -69,7 +69,7 @@ module Images
       record_extract(fields: { "Collector" => "A" })
       join_project_as_admin(rolf)
 
-      assert(@project.is_admin?(rolf), "premise: rolf administers it")
+      assert(@obs.reload.can_edit?(rolf), "premise: rolf can edit the obs")
       assert_not_equal(rolf, @image.user, "premise: not the image owner")
       get(:edit, params: { image_id: @image.id })
 
@@ -168,15 +168,14 @@ module Images
       assert_response(:success)
     end
 
-    # The image's owner may watch their upload's read progress even
-    # before the observation has joined any project -- permission comes
-    # from owning the photo, not from the observation's project
-    # membership.
+    # The collector may watch their read progress even before the
+    # observation has joined any project -- permission is edit rights
+    # on the observation, not the observation's project membership.
     def test_owner_sees_their_pending_read
       owner = @obs.user
       login(owner.login)
 
-      assert_equal(owner, @image.reload.user, "premise: owner owns the image")
+      assert(@obs.can_edit?(owner), "premise: owner can edit the observation")
       assert(FieldSlipExtract.permitted?(image: @image, user: owner))
 
       FieldSlipExtract.start!(image: @image, user: owner)
@@ -195,7 +194,7 @@ module Images
       owner = @obs.user
       login(owner.login)
 
-      assert_equal(owner, @image.reload.user, "premise: owner owns the image")
+      assert(@obs.can_edit?(owner), "premise: owner can edit the observation")
       record_extract(fields: { "Collector" => "Scott Shapiro" })
 
       get(:edit, params: { image_id: @image.id })

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -380,6 +380,17 @@ class FieldSlipExtractTest < UnitTestCase
     assert(FieldSlipExtract.permitted?(image: @image.reload, user: rolf))
   end
 
+  # The collector reviews -- and can rescan -- the slip on their photo,
+  # even when the observation is in no project. Exactly the
+  # field-scanner case a constraint-violating location produced: the
+  # slip's observation was left out of its project, which used to lock
+  # the owner out of the review.
+  def test_permitted_for_the_image_owner
+    assert_equal(mary, @image.user, "fixture premise: mary owns the image")
+
+    assert(FieldSlipExtract.permitted?(image: @image, user: mary))
+  end
+
   def test_not_permitted_for_a_plain_member
     project = projects(:eol_project)
     project.observations << @obs unless project.observations.include?(@obs)

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -370,25 +370,43 @@ class FieldSlipExtractTest < UnitTestCase
                                        site_admin: true))
   end
 
-  # A foray's own organizers are the people who can tell whether a slip
-  # was transcribed right, so project admins get in too.
+  # A foray's organizers get in -- but through edit rights on the
+  # observation, so the collector must have trusted the project with
+  # editing (Observation#can_edit?, via Project.user_admin_via_project?).
   def test_permitted_for_admin_of_the_observations_project
     project = projects(:eol_project)
     project.observations << @obs unless project.observations.include?(@obs)
 
-    assert(project.is_admin?(rolf), "fixture must have rolf as admin")
+    assert(@obs.reload.can_edit?(rolf), "premise: rolf can edit the obs")
     assert(FieldSlipExtract.permitted?(image: @image.reload, user: rolf))
   end
 
-  # The collector reviews -- and can rescan -- the slip on their photo,
-  # even when the observation is in no project. Exactly the
-  # field-scanner case a constraint-violating location produced: the
-  # slip's observation was left out of its project, which used to lock
-  # the owner out of the review.
-  def test_permitted_for_the_image_owner
-    assert_equal(mary, @image.user, "fixture premise: mary owns the image")
+  # The collector reviews -- and can rescan -- the slip on their own
+  # observation, even when it is in no project. The field-scanner case
+  # a constraint-violating location produced: the slip's observation
+  # was left out of its project, which used to lock the collector out
+  # of the review. Permission is edit rights on the observation, not
+  # ownership of the photo.
+  def test_permitted_for_the_observation_owner
+    assert_equal(mary, @obs.user, "premise: mary owns the observation")
+    assert(@obs.can_edit?(mary))
 
     assert(FieldSlipExtract.permitted?(image: @image, user: mary))
+  end
+
+  # Owning the photo is not enough: the review writes the transcribed
+  # values onto the observation, so a user who cannot edit it is
+  # refused even on an image they uploaded (Copilot + Nathan review,
+  # PR #5240). Here katrina's photo hangs on mary's observation, which
+  # katrina cannot edit.
+  def test_not_permitted_for_an_image_owner_who_cannot_edit_the_obs
+    image = images(:amateur_image)
+    @obs.images << image unless @obs.images.include?(image)
+
+    assert_equal(katrina, image.user, "premise: katrina owns the image")
+    assert_not(@obs.can_edit?(katrina), "premise: katrina cannot edit it")
+    assert_not(FieldSlipExtract.permitted?(image: image.reload,
+                                           user: katrina))
   end
 
   def test_not_permitted_for_a_plain_member
@@ -424,7 +442,7 @@ class FieldSlipExtractTest < UnitTestCase
     other = @image.observations.find { |obs| obs.id != @obs.id }
 
     assert(other, "premise: the image carries a second observation")
-    assert(other.projects.any? { |project| project.is_admin?(dick) })
+    assert(other.can_edit?(dick), "premise: dick can edit the other obs")
     assert(FieldSlipExtract.permitted?(image: @image, user: dick))
   end
 


### PR DESCRIPTION
## Summary

An image's uploader can now request a field-slip read of their photo and review/save the result — the same review that was open only to site admins and project admins.

This clears a field-scanner lockout hit during the 2026 NAMA Yoop foray. A collector (a project admin, at that) created an observation through the field-scanner flow, but its location came through as the placeholder "Earth" box, which fails the project's Michigan location constraint. `FieldSlip::Attacher#apply_project` therefore sent the attached slip spare and left the observation in no project. The review page (`Images::FieldSlipExtractsController#edit`) is gated by `FieldSlipExtract.permitted?`, which keys on "is the user an admin of a project the image's observations belong to" — with the observation in no project, that returned false, so the moment the background read completed the collector was redirected to the plain image page: the review bypassed, access denied. A site admin bypasses the gate, which is why saving it in admin mode landed correctly.

The observation's creator, reviewing the slip on a photo they uploaded, does not hit the concern the gate exists for (a careless review writing to observations the reviewer has no claim to). So `FieldSlipExtract.permitted?` now returns true for `image.user_id == user.id`, alongside site admins and project admins.

## What changed

- `FieldSlipExtract.permitted?` admits the image's uploader.
- One predicate gates all three surfaces, so they move together: the review page (`edit`/`update`), the scan request (`create`), and the "Read Field Slip" button + status on the image show page.
- Removed `awaiting_own_upload?` — a time-boxed grace that let the uploader watch only the *pending* read and then bounced them when it completed. Uploader access now holds in every extract state, so the grace is redundant.

## Not included (separate follow-up)

`apply_project` still tests the constraint against the observation's provisional location at attach time — before the read's stated location (the "Days River Trailhead" project alias) is known — so a slip whose observation names a valid in-project location via the slip still goes spare until the review reconciles it. This PR makes that review reachable by the uploader, who then applies the location and rejoins the project. Deferring the attach-time spare decision until the read lands is a separate change.

## Test plan

- [x] `bin/rails test test/models/field_slip_extract_test.rb test/controllers/images/field_slip_extracts_controller_test.rb` (81 tests, 0 failures)
- Reviewer: as a non-admin user, upload a photo of a field slip on a new observation, tap "Read Field Slip" on the image page, and confirm you reach the review, can edit the fields, and save — with the observation in no project.

<!-- changelog -->
article: yes
Read and review the Field Slip on a photo you uploaded
<!-- /changelog -->
