### PR TITLE
Read a field slip when zbar decodes a QR but not its slip code

### DIFF
--- a/app/classes/field_slip/extractor/gemini.rb
+++ b/app/classes/field_slip/extractor/gemini.rb
@@ -22,6 +22,18 @@ class FieldSlip
       IMAGE_SIZE = :huge
       TIMEOUT = 60
 
+      # Pass-1 prompt of the QR-miss fallback: just the printed slip
+      # code, no template -- the full field read comes later, with the
+      # right one (see #read_slip_code).
+      CODE_PROMPT =
+        "This photo may show a mushroom field slip: a printed form " \
+        "carrying a code like \"2026-NAMA-0205\" or \"NEMF-10222\" " \
+        "(letters and digits, often beside a QR code). Return JSON " \
+        "{\"slip_present\": true|false, \"code\": \"<the printed " \
+        "slip code, or null>\"}. If no field slip is visible, " \
+        "slip_present is false and code is null. Read only what is " \
+        "printed; do not invent a code."
+
       # The model that will be asked for, credentials override first --
       # also what a pending/failed extract stamps as provenance before
       # any response reports the concrete model that answered.
@@ -43,6 +55,19 @@ class FieldSlip
 
         raw = post(Prompt.new(context).to_s, image_data(image))
         build_result(raw, parse(raw), context)
+      end
+
+      # Pass 1 of the QR-miss fallback (ResolveFieldSlipCodeJob): read
+      # only the printed slip code, template-free. Its prefix names the
+      # project, which picks the template for the full read. Returns
+      # the code, or nil when the model reports no slip / no code.
+      def read_slip_code(image)
+        raise(MissingKey) if @api_key.blank?
+
+        payload = parse(post(CODE_PROMPT, image_data(image)))
+        return nil unless payload["slip_present"]
+
+        payload["code"].to_s.strip.presence
       end
 
       class MissingKey < StandardError

--- a/app/classes/field_slip/qr_decoder.rb
+++ b/app/classes/field_slip/qr_decoder.rb
@@ -49,10 +49,25 @@ class FieldSlip
                                             err: File::NULL) || false
     end
 
+    # One zbar read, yielding both signals a caller needs: the slip
+    # code a QR names (nil when none does), and whether any QR decoded
+    # at all. A non-slip QR -- a DNA-sticker code, a product label --
+    # still means the photo holds something worth a model read (the
+    # QR-miss fallback, see ResolveFieldSlipCodeJob).
+    Reading = Data.define(:slip_code, :qr_present)
+
+    def self.reading(image)
+      codes = raw_codes(image)
+      Reading.new(
+        slip_code: codes.filter_map { |text| slip_code_from(text) }.first,
+        qr_present: codes.any?
+      )
+    end
+
     # The slip code in the image's QR code, or nil: no local file, no
     # QR, or QR content that isn't a slip code.
     def self.slip_code_in(image)
-      raw_codes(image).filter_map { |text| slip_code_from(text) }.first
+      reading(image).slip_code
     end
 
     # A bare code is only believed when its prefix names a project --

--- a/app/jobs/detect_field_slip_qr_job.rb
+++ b/app/jobs/detect_field_slip_qr_job.rb
@@ -20,9 +20,20 @@ class DetectFieldSlipQRJob < ApplicationJob
     return unless observation && image && observation.occurrence_id.nil?
     return unless FieldSlip::QRDecoder.available?
 
-    code = FieldSlip::QRDecoder.slip_code_in(image)
-    return unless code
+    reading = FieldSlip::QRDecoder.reading(image)
+    if reading.slip_code
+      attach_and_read(observation, image, reading.slip_code)
+    elsif reading.qr_present
+      # zbar decoded a QR but not a slip code (a DNA-sticker code, say):
+      # the photo still holds a slip it could not read, so hand off to
+      # the model-based read (see ResolveFieldSlipCodeJob).
+      escalate(observation, image)
+    end
+  end
 
+  private
+
+  def attach_and_read(observation, image, code)
     result = FieldSlip::Attacher.attach(observation: observation,
                                         code: code, user: observation.user)
     Rails.logger.info(
@@ -38,5 +49,10 @@ class DetectFieldSlipQRJob < ApplicationJob
     # linked observation never re-reads a slip somebody may have
     # reviewed (those runs exit above on the occurrence check).
     ExtractFieldSlipJob.request(image: image, user: observation.user)
+  end
+
+  def escalate(observation, image)
+    ResolveFieldSlipCodeJob.perform_later(observation.id, image.id,
+                                          observation.user_id)
   end
 end

--- a/app/jobs/resolve_field_slip_code_job.rb
+++ b/app/jobs/resolve_field_slip_code_job.rb
@@ -23,13 +23,18 @@ class ResolveFieldSlipCodeJob < ApplicationJob
   rescue StandardError => e
     # Logged, not re-raised: a provider hiccup here should not wedge the
     # job. The collector can still scan the slip by hand.
-    Rails.logger.error(
-      "ResolveFieldSlipCodeJob failed on image #{image_id}: " \
-      "#{e.class}: #{e.message}"
-    )
+    log_failure(image_id, e)
   end
 
   private
+
+  def log_failure(image_id, error)
+    Rails.logger.error(
+      "ResolveFieldSlipCodeJob failed on image #{image_id}: " \
+      "#{error.class}: #{error.message}\n" \
+      "#{error.backtrace&.first(10)&.join("\n")}"
+    )
+  end
 
   def resolve(observation, image, user)
     code = FieldSlip::Extractor.default.read_slip_code(image)

--- a/app/jobs/resolve_field_slip_code_job.rb
+++ b/app/jobs/resolve_field_slip_code_job.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Pass one of the QR-miss fallback. When DetectFieldSlipQRJob decoded a
+# QR but not a slip code -- a DNA-sticker code, say -- the photo still
+# holds a slip zbar could not read. This reads the printed code off it
+# with the model (FieldSlip::Extractor#read_slip_code, a small,
+# template-free call), attaches the slip that code names, and hands off
+# to ExtractFieldSlipJob for the full, correctly-templated read. Two
+# model calls, but only on photos that already showed a QR, so the
+# volume stays small.
+class ResolveFieldSlipCodeJob < ApplicationJob
+  queue_as :default
+
+  def perform(observation_id, image_id, user_id)
+    observation = Observation.find_by(id: observation_id)
+    image = Image.find_by(id: image_id)
+    user = User.find_by(id: user_id)
+    return unless observation && image && user
+    return unless observation.occurrence_id.nil?
+    return if FieldSlipExtract.exists?(image_id: image.id)
+
+    resolve(observation, image, user)
+  rescue StandardError => e
+    # Logged, not re-raised: a provider hiccup here should not wedge the
+    # job. The collector can still scan the slip by hand.
+    Rails.logger.error(
+      "ResolveFieldSlipCodeJob failed on image #{image_id}: " \
+      "#{e.class}: #{e.message}"
+    )
+  end
+
+  private
+
+  def resolve(observation, image, user)
+    code = FieldSlip::Extractor.default.read_slip_code(image)
+    return if code.blank?
+
+    result = FieldSlip::Attacher.attach(observation: observation,
+                                        code: code, user: user)
+    Rails.logger.info(
+      "ResolveFieldSlipCodeJob: read code #{code} -> #{result} " \
+      "(observation #{observation.id}, image #{image.id})"
+    )
+    return unless result == :attached
+
+    ExtractFieldSlipJob.request(image: image, user: user)
+  end
+end

--- a/test/classes/field_slip/extractor/gemini_test.rb
+++ b/test/classes/field_slip/extractor/gemini_test.rb
@@ -311,6 +311,38 @@ class FieldSlip::Extractor::GeminiTest < UnitTestCase
                     "models/gemini-from-credentials:generateContent")
   end
 
+  # ---------- read_slip_code: the pass-1 code-only read ----------
+
+  def read_slip_code(api_key: KEY)
+    FieldSlip::Extractor::Gemini.new(api_key: api_key).read_slip_code(@image)
+  end
+
+  def test_read_slip_code_returns_the_printed_code
+    stub_gemini({ slip_present: true, code: "2026-NAMA-0205" }.to_json)
+
+    assert_equal("2026-NAMA-0205", read_slip_code)
+  end
+
+  def test_read_slip_code_is_nil_when_no_slip_is_present
+    stub_gemini({ slip_present: false, code: nil }.to_json)
+
+    assert_nil(read_slip_code)
+  end
+
+  def test_read_slip_code_is_nil_when_the_code_is_blank
+    stub_gemini({ slip_present: true, code: "" }.to_json)
+
+    assert_nil(read_slip_code)
+  end
+
+  def test_read_slip_code_raises_without_a_key
+    with_gemini_credentials(nil) do
+      assert_raises(FieldSlip::Extractor::Gemini::MissingKey) do
+        FieldSlip::Extractor::Gemini.new.read_slip_code(@image)
+      end
+    end
+  end
+
   private
 
   # Which bytes reached the provider, read off THIS test's captured

--- a/test/classes/field_slip/qr_decoder_test.rb
+++ b/test/classes/field_slip/qr_decoder_test.rb
@@ -233,4 +233,40 @@ class FieldSlip::QRDecoderTest < UnitTestCase
     assert_not(FieldSlip::QRDecoder.available?)
     assert_includes([true, false], FieldSlip::QRDecoder.zbarimg?)
   end
+
+  # ---------- reading: slip code + QR presence ----------
+
+  def stub_reading(codes)
+    FieldSlip::QRDecoder.stub(:available?, true) do
+      Image::LocalFile.stub(:path, "/tmp/fake.jpg") do
+        FieldSlip::QRDecoder.stub(:scan, codes) do
+          FieldSlip::QRDecoder.reading(images(:in_situ_image))
+        end
+      end
+    end
+  end
+
+  def test_reading_returns_the_slip_code_and_qr_presence
+    read = stub_reading(["https://example.com", "OPEN-0219"])
+
+    assert_equal("OPEN-0219", read.slip_code)
+    assert(read.qr_present)
+  end
+
+  # A QR whose payload is not a slip code (a DNA-sticker code, a
+  # product label): no slip code, but a QR is present -- the signal
+  # that drives the model-read fallback.
+  def test_reading_flags_a_qr_that_is_not_a_slip_code
+    read = stub_reading(["2099-XYZ-0001"])
+
+    assert_nil(read.slip_code)
+    assert(read.qr_present)
+  end
+
+  def test_reading_reports_no_qr_when_nothing_decodes
+    read = stub_reading([])
+
+    assert_nil(read.slip_code)
+    assert_not(read.qr_present)
+  end
 end

--- a/test/jobs/detect_field_slip_qr_job_test.rb
+++ b/test/jobs/detect_field_slip_qr_job_test.rb
@@ -11,8 +11,15 @@ class DetectFieldSlipQRJobTest < ActiveJob::TestCase
   end
 
   def perform_with_code(code)
+    perform_with_reading(slip_code: code, qr_present: code.present?)
+  end
+
+  def perform_with_reading(slip_code:, qr_present: false)
+    reading = FieldSlip::QRDecoder::Reading.new(
+      slip_code: slip_code, qr_present: qr_present
+    )
     FieldSlip::QRDecoder.stub(:available?, true) do
-      FieldSlip::QRDecoder.stub(:slip_code_in, code) do
+      FieldSlip::QRDecoder.stub(:reading, reading) do
         DetectFieldSlipQRJob.perform_now(@obs.id, @image.id)
       end
     end
@@ -79,5 +86,24 @@ class DetectFieldSlipQRJobTest < ActiveJob::TestCase
     DetectFieldSlipQRJob.perform_now(@obs.id, -1)
 
     assert_nil(@obs.reload.occurrence)
+  end
+
+  # zbar decoded a QR (a DNA-sticker code, say) but not a slip code:
+  # the photo still holds a slip it could not read, so the model-based
+  # read (ResolveFieldSlipCodeJob) takes over. The QR job itself
+  # attaches nothing in this branch.
+  def test_escalates_when_a_qr_is_present_but_not_a_slip_code
+    assert_enqueued_with(job: ResolveFieldSlipCodeJob,
+                         args: [@obs.id, @image.id, @obs.user_id]) do
+      perform_with_reading(slip_code: nil, qr_present: true)
+    end
+
+    assert_nil(@obs.reload.occurrence)
+  end
+
+  def test_no_escalation_when_no_qr_was_decoded
+    assert_no_enqueued_jobs(only: ResolveFieldSlipCodeJob) do
+      perform_with_reading(slip_code: nil, qr_present: false)
+    end
   end
 end

--- a/test/jobs/resolve_field_slip_code_job_test.rb
+++ b/test/jobs/resolve_field_slip_code_job_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class ResolveFieldSlipCodeJobTest < ActiveJob::TestCase
+  def setup
+    @obs = observations(:minimal_unknown_obs)
+    @obs.update!(occurrence: nil)
+    @image = images(:in_situ_image)
+    @obs.images << @image unless @obs.images.include?(@image)
+    @user = @obs.user
+  end
+
+  def fake_reader(code)
+    reader = Object.new
+    reader.define_singleton_method(:read_slip_code) { |_image| code }
+    reader
+  end
+
+  def perform_reading(code)
+    FieldSlip::Extractor.stub(:default, fake_reader(code)) do
+      ResolveFieldSlipCodeJob.perform_now(@obs.id, @image.id, @user.id)
+    end
+  end
+
+  # The model reads the printed code off a slip zbar could not, the
+  # slip attaches, and the full, correctly-templated extraction is
+  # chained.
+  def test_reads_the_code_attaches_and_chains_the_extraction
+    assert_enqueued_with(job: ExtractFieldSlipJob,
+                         args: [@image.id, @user.id]) do
+      perform_reading("OPEN-0219")
+    end
+
+    assert_equal("OPEN-0219", @obs.reload.field_slip.code)
+    assert(FieldSlipExtract.find_by(image_id: @image.id).pending?)
+  end
+
+  # No slip in the photo (the QR was a stray sticker): nothing attaches
+  # and no extraction runs.
+  def test_no_code_read_leaves_the_observation_alone
+    assert_no_enqueued_jobs(only: ExtractFieldSlipJob) do
+      perform_reading(nil)
+    end
+
+    assert_nil(@obs.reload.occurrence)
+  end
+
+  # The code named a slip already in use elsewhere, so nothing attached
+  # here -- no read is chained.
+  def test_no_chain_when_the_slip_does_not_attach
+    FieldSlip::Extractor.stub(:default, fake_reader("OPEN-0219")) do
+      FieldSlip::Attacher.stub(:attach, :in_use) do
+        assert_no_enqueued_jobs(only: ExtractFieldSlipJob) do
+          ResolveFieldSlipCodeJob.perform_now(@obs.id, @image.id, @user.id)
+        end
+      end
+    end
+  end
+
+  # An observation that already carries a slip is left untouched: the
+  # occurrence guard returns before any read.
+  def test_noop_when_the_observation_already_has_a_slip
+    slip = FieldSlip.find_or_create_by_code("OPEN-0800", @user)
+    @obs.field_slip = slip
+    @obs.save!
+
+    perform_reading("OPEN-0219")
+
+    assert_equal("OPEN-0800", @obs.reload.field_slip.code)
+  end
+
+  # Does not re-read an image somebody may already have reviewed: an
+  # existing extract short-circuits before the model is called.
+  def test_skips_when_an_extract_already_exists
+    FieldSlipExtract.start!(image: @image, user: @user)
+
+    assert_no_enqueued_jobs(only: ExtractFieldSlipJob) do
+      perform_reading("OPEN-0219")
+    end
+
+    assert_nil(@obs.reload.occurrence)
+  end
+
+  # A provider failure is logged, not raised, so the job does not wedge
+  # -- the collector can still scan by hand.
+  def test_logs_and_swallows_a_provider_failure
+    reader = Object.new
+    reader.define_singleton_method(:read_slip_code) do |_image|
+      raise(FieldSlip::Extractor::Gemini::BadResponse.new("boom"))
+    end
+
+    FieldSlip::Extractor.stub(:default, reader) do
+      Rails.logger.stub(:error, nil) do
+        ResolveFieldSlipCodeJob.perform_now(@obs.id, @image.id, @user.id)
+      end
+    end
+
+    assert_nil(@obs.reload.occurrence)
+  end
+
+  def test_survives_vanished_records
+    ResolveFieldSlipCodeJob.perform_now(-1, @image.id, @user.id)
+    ResolveFieldSlipCodeJob.perform_now(@obs.id, -1, @user.id)
+    ResolveFieldSlipCodeJob.perform_now(@obs.id, @image.id, -1)
+
+    assert_nil(@obs.reload.occurrence)
+  end
+end


### PR DESCRIPTION
## Summary

When a field-slip photo's QR can't be decoded into a slip code, MO now reads the printed code with a small model call and completes the scan automatically, instead of leaving the collector to do it by hand.

Diagnosed from a 2026 NAMA Yoop foray photo (obs 667630, image 2079157). The photo carries three QR codes -- one is a DNA sticker (`76-G1`) that zbar decodes instantly; the field slip's QR is the light-gray NAMA 2026 template, which zbar reads as blank paper even after contrast enhancement (confirmed against the image with `zbarimg`). So zbar returns a QR, but not a slip code, and the old code discarded that -- `slip_code_in` collapsed "decoded a non-slip QR" and "decoded nothing" into the same nil, and the collector got a "no field slip detected" flash.

## What changed

- **`QRDecoder.reading(image)`** returns both the slip code (nil if none) and whether any QR decoded. `slip_code_in` now delegates to it, so its callers are unchanged.
- **`DetectFieldSlipQRJob`** keeps its happy path (slip-code QR -> `Attacher.attach` -> `ExtractFieldSlipJob`). On the new branch -- a QR decoded but not a slip code -- it hands off to `ResolveFieldSlipCodeJob`.
- **`ResolveFieldSlipCodeJob`** (new, pass 1): reads the printed slip code with a small, template-free model call (`Gemini#read_slip_code`), attaches the slip that code names, and chains `ExtractFieldSlipJob` (pass 2 -- the existing extractor, unchanged).

## Why two passes, not one

The extraction prompt/template is chosen by `Context#project` from the slip's prefix, so pass 2 needs the code first. We can't take the template from the observation's project: at create time that is just the recorder's last-used project, wrong when they switch projects, file a first observation, or (the earlier "Earth" case) get excluded from the project by a constraint. Reading the code in pass 1 and attaching the slip sets `Context#project` from the slip itself, so pass 2 uses the right template regardless of what the observation was in.

## Cost

Pass 1 is a small code-only call; pass 2 is the full extraction we would run anyway. Both fire only on photos where zbar decoded a QR, so the volume stays with voucher slips. A multi-photo observation whose photos each carry a sticker QR can enqueue one pass-1 per photo, but the occurrence guard makes all but the first no-op once the slip attaches.

## Not included (follow-ups)

- The create redirect still lands on the observation page with the "no field slip detected" flash for this case; taking the collector to the review await page (so they watch the two-pass finish) is a separate UX change.
- That warning is shown only to field-slip-project admins; surfacing a QR-present hint to the uploader too is worth doing (relates to #5240).

## Test plan

- [x] `bin/rails test test/jobs/detect_field_slip_qr_job_test.rb test/jobs/resolve_field_slip_code_job_test.rb test/classes/field_slip/qr_decoder_test.rb test/classes/field_slip/extractor/gemini_test.rb` (68 tests, 0 failures)
- Reviewer: on the foray, photograph a slip whose QR will not scan but which carries a DNA-sticker QR, create the observation, and confirm the slip attaches and the review fills in without a manual scan.

<!-- changelog -->
article: yes
Read a Field Slip even when its QR code won't scan
<!-- /changelog -->
