### PR TITLE
Fix show Yoop Locations crash

### DIFF
--- a/app/controllers/concerns/projects/location_grouping.rb
+++ b/app/controllers/concerns/projects/location_grouping.rb
@@ -9,7 +9,7 @@ module Projects
     def build_grouped_locations(project)
       obs_locs = project.locations.distinct.to_a
       targets = sorted_targets(project)
-      sorted_obs = obs_locs.sort_by(&:scientific_name)
+      sorted_obs = obs_locs.sort_by { |loc| sort_key(loc) }
       return [[], sorted_obs] if targets.empty?
 
       groups = build_groups(obs_locs, targets)
@@ -18,6 +18,13 @@ module Projects
         grouped_ids.include?(l.id)
       end
       [groups, ungrouped]
+    end
+
+    # `scientific_name` isn't guaranteed on legacy Location rows -- fall
+    # back to `name` so a nil doesn't blow up `sort_by`'s comparison
+    # against other locations' non-nil scientific names.
+    def sort_key(loc)
+      loc.scientific_name || loc.name
     end
 
     def sorted_targets(project)
@@ -29,7 +36,7 @@ module Projects
       assignments = assign_to_targets(obs_locs, targets)
       targets.map do |target|
         subs = (assignments[target.id] || []).
-               sort_by(&:scientific_name)
+               sort_by { |loc| sort_key(loc) }
         { target: target, sub_locations: subs }
       end
     end

--- a/test/controllers/projects/locations_controller_test.rb
+++ b/test/controllers/projects/locations_controller_test.rb
@@ -84,5 +84,34 @@ module Projects
       assert_select("a", { text: nybg.display_name, minimum: 1 },
                     "NYBG should appear ungrouped")
     end
+
+    # Regression test: `scientific_name` isn't guaranteed on legacy
+    # Location rows (no presence validation, see Location#display_name).
+    # `build_grouped_locations` sorts locations by `scientific_name` in
+    # Ruby, which raises `ArgumentError: comparison of NilClass with
+    # String failed` if any location in the mix has a nil value.
+    def test_index_with_nil_scientific_name
+      project = projects(:rare_fungi_project)
+      albion = locations(:albion)
+      nybg = locations(:nybg_location)
+      albion.update_column(:scientific_name, nil)
+
+      [albion, nybg].each do |loc|
+        obs = Observation.create!(
+          name: names(:fungi), user: users(:rolf),
+          location: loc, when: Time.zone.now
+        )
+        project.observations << obs
+      end
+
+      login
+      get(:index, params: { project_id: project.id })
+
+      assert_response(
+        :success,
+        "Index should not error when a project location has a nil " \
+        "scientific_name"
+      )
+    end
   end
 end


### PR DESCRIPTION
## Summary

<!-- What this PR changes and why. -->

## Test plan

<!-- How a reviewer can verify the change. -->

<!--
The changelog block below feeds the automated changelogs (issue #5155).
- `article: yes` + a one-line, plain-English sentence written for site
  users (no code names; 60 characters or fewer, e.g. "Fix map cluster
  Show All for shared-location observations") => the change appears in
  the user-facing MO Article changelog with that sentence.
- `article: no` (and no sentence) => technical-only change; it still
  appears in CHANGELOG.md automatically.
Pick one — leaving `yes|no` unedited counts as "no block" and gets
flagged at deploy for manual review. Reviewers: feel free to edit the
verdict or reword the sentence. Details: .claude/rules/changelog.md
-->
<!-- changelog -->
article: yes
Fix Project Location crash when scientific name is nil

<!-- /changelog -->
