### PR TITLE
Query params - Make `needs_naming` a viewer-bound presence flag, not a User id

### DIFF
--- a/app/classes/query/modules/initialization.rb
+++ b/app/classes/query/modules/initialization.rb
@@ -109,9 +109,16 @@ module Query::Modules::Initialization
 
   # `:order_by` gets `viewer:` forwarded - it decides postal/scientific
   # location-name sort order, see AbstractModel::OrderingScopes.
+  # `:needs_naming` treats `val` as a presence flag, not an id -- `false`
+  # skips the scope (skippable_values doesn't skip `false` generally, so
+  # this has to check explicitly), `true` sends `viewer` instead of
+  # `val`. The URL can only mean "my queue", not an arbitrary user's --
+  # see Observation::Scopes#needs_naming.
   def apply_scope_param(param, val)
     if param == :order_by
       @scopes.send(param, val, viewer: viewer)
+    elsif param == :needs_naming
+      val ? @scopes.send(param, viewer) : @scopes
     elsif val.is_a?(Hash)
       @scopes.send(param, **val)
     else

--- a/app/classes/query/modules/validation.rb
+++ b/app/classes/query/modules/validation.rb
@@ -175,6 +175,16 @@ module Query::Modules::Validation
   end
   # rubocop:enable Lint/BooleanSymbol
 
+  # Permissive sibling of `validate_boolean`, with no error branch --
+  # an old stored value whose identity no longer matters (e.g. a
+  # legacy `needs_naming: <user_id>` bookmark, see
+  # Query::Observations) stays a working "flag on" instead of failing
+  # validation. Same FALSE_VALUES Rails already uses to cast a param
+  # string to boolean.
+  def validate_truthy(_param, val)
+    ActiveRecord::Type::Boolean.new.cast(val)
+  end
+
   # We don't currently have params for integers, but this would enable them.
   # def validate_integer(param, val)
   #   if val.is_a?(Integer) || val.is_a?(String) && val.match(/^-?\d+$/)

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -43,9 +43,11 @@ class Query::Observations < Query
   query_attr(:confidence, [:float])
   # A presence flag, not a User id -- Query::Modules::Initialization's
   # apply_scope_param sends `viewer` to the scope, ignoring this value's
-  # identity, so the URL can only mean "my queue". default_order matches
-  # the identify page's default (Observations::IdentifyController).
-  query_attr(:needs_naming, :boolean, default_order: :rss_log)
+  # identity, so the URL can only mean "my queue". `:truthy`, not
+  # `:boolean`, so an old `needs_naming: <user_id>` bookmark still
+  # resolves to "flag on" instead of failing validation. default_order
+  # matches the identify page's default (Observations::IdentifyController).
+  query_attr(:needs_naming, :truthy, default_order: :rss_log)
   # query_attr(:clade, :string) # content filter
   # query_attr(:lichen, :boolean) # content filter
   # The identify page's clade/region autocompleter -- see

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -41,7 +41,11 @@ class Query::Observations < Query
   query_attr(:this_name, [:string], default_order: :confidence)
   query_attr(:other_names, [:string], default_order: :confidence)
   query_attr(:confidence, [:float])
-  query_attr(:needs_naming, User)
+  # A presence flag, not a User id -- Query::Modules::Initialization's
+  # apply_scope_param sends `viewer` to the scope, ignoring this value's
+  # identity, so the URL can only mean "my queue". default_order matches
+  # the identify page's default (Observations::IdentifyController).
+  query_attr(:needs_naming, :boolean, default_order: :rss_log)
   # query_attr(:clade, :string) # content filter
   # query_attr(:lichen, :boolean) # content filter
   # The identify page's clade/region autocompleter -- see

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -355,12 +355,12 @@ class Components::Form::Search < Components::ApplicationForm
 
   # NOTE: `SearchFieldUI` returns `:single_value_autocompleter` for
   # Class-typed `query_attr` definitions (e.g.
-  # `query_attr(:needs_naming, User)`). No current search-form
+  # `query_attr(:editable_by_user, User)`). No current search-form
   # `FIELD_COLUMNS` exposes such a field, and the few existing
-  # Class-typed attrs' names (`needs_naming`, `for_user`,
-  # `by_author`, `editable_by_user`) don't map to a supported
-  # autocompleter `type` via `AutocompleterPrefill#autocompleter_type`
-  # either. The dispatcher in `render_search_field` would raise
+  # Class-typed attrs' names (`for_user`, `by_author`,
+  # `editable_by_user`) don't map to a supported autocompleter `type`
+  # via `AutocompleterPrefill#autocompleter_type` either. The
+  # dispatcher in `render_search_field` would raise
   # `NoMethodError` if a future FIELD_COLUMNS added one — loud and
   # actionable. Add `render_single_value_autocompleter` back here
   # when that day comes.

--- a/app/controllers/observations/identify_controller.rb
+++ b/app/controllers/observations/identify_controller.rb
@@ -35,7 +35,7 @@ module Observations
 
     # override the default? maybe no longer necessary
     def unfiltered_index_opts
-      super.merge(query_args: { needs_naming: @user, order_by: :rss_log })
+      super.merge(query_args: { needs_naming: true, order_by: :rss_log })
     end
 
     def default_sort_order
@@ -49,12 +49,12 @@ module Observations
     # Dispatches to Observation.identify_filter (Observation::Scopes),
     # which picks clade or region based on identify_filter[type] --
     # the single swappable autocompleter submits both under one field
-    # pair. `needs_naming` is always this page's current user,
-    # regardless of the optional clade/region sub-filter, so it's
-    # merged in here rather than coming from the URL.
+    # pair. `needs_naming` always applies on this page regardless of
+    # the optional clade/region sub-filter, so it's merged in here
+    # rather than coming from the URL.
     def identify_filter
       create_query_from_url_params(
-        :Observation, params.merge(needs_naming: @user&.id)
+        :Observation, params.merge(needs_naming: true)
       )
     end
 

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -40,12 +40,11 @@ module Views::Layouts
       by_editor: :Users,
       collectors: :Users,
       members: :Users,
-      # Both User-typed too — without these the caption fell
-      # through to the raw-value path and printed the user id
+      # User-typed too — without this the caption fell through to
+      # the raw-value path and printed the user id
       # ("editable_by_user: 1") instead of the proper title
       # ("editable_by_user: Nathan Wilson (nathan)").
-      editable_by_user: :Users,
-      needs_naming: :Users
+      editable_by_user: :Users
     }.freeze
     # The captions with these sub-params make more sense without keys:
     CAPTION_IGNORE_KEYS = [:lookup, :id].freeze

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4426,7 +4426,7 @@
   query_misspellings: misspellings
   query_name_has: name has
   query_needs_description: needs description
-  query_needs_naming: needing identification, user
+  query_needs_naming: needing identification
   query_nonpersonal: nonpersonal
   query_notes_has: notes has
   query_number_has: number has

--- a/test/classes/query/observations_test.rb
+++ b/test/classes/query/observations_test.rb
@@ -887,4 +887,50 @@ class Query::ObservationsTest < UnitTestCase
     # 3 raw matches, but obs2 collapses into obs1 → 2 results
     assert_equal(2, query.num_results)
   end
+
+  def test_observation_needs_naming_true_filters_by_viewer
+    mary = users(:mary)
+    expected = Observation.needs_naming(mary)
+
+    query = Query.lookup_and_save(:Observation, needs_naming: true)
+    query.viewer = mary
+
+    assert_equal(expected.count, query.num_results)
+  end
+
+  # `false` is a presence flag turned off, not "show only reviewed" --
+  # the scope stays out of the chain entirely.
+  def test_observation_needs_naming_false_applies_no_filter
+    query = Query.lookup_and_save(:Observation, needs_naming: false)
+    query.viewer = users(:mary)
+
+    assert_equal(Observation.count, query.num_results)
+  end
+
+  # No login (e.g. a stray `?needs_naming=1` on an anonymous session) --
+  # `viewer` is nil. `Observation.needs_naming(nil)` still applies
+  # (the `needs_naming` DB column half of the scope doesn't depend on
+  # viewer), so the correct comparison is the scope itself, not an
+  # unfiltered count.
+  def test_observation_needs_naming_without_viewer_does_not_raise
+    expected = Observation.needs_naming(nil)
+
+    query = Query.lookup_and_save(:Observation, needs_naming: true)
+
+    assert_equal(expected.count, query.num_results)
+  end
+
+  # A legacy bookmark stored `needs_naming: <user_id>` (record-backed,
+  # pre-#5246) -- :truthy must keep resolving that as "flag on" rather
+  # than failing validation, since the value's identity is ignored
+  # regardless (see apply_scope_param).
+  def test_observation_needs_naming_accepts_legacy_stored_id
+    mary = users(:mary)
+    expected = Observation.needs_naming(mary)
+
+    query = Query.lookup_and_save(:Observation, needs_naming: 999_999)
+    query.viewer = mary
+
+    assert_equal(expected.count, query.num_results)
+  end
 end

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -326,7 +326,7 @@ class QueryTest < UnitTestCase
     # Scalar attrs (and the :by alias) are bare symbols.
     assert_includes(filters, :order_by)
     assert_includes(filters, :by)
-    assert_includes(filters, :needs_naming) # scalar Class (User)
+    assert_includes(filters, :needs_naming) # scalar :boolean
     # An "enum" hash (`{ boolean: [true] }`/`{ string: [...] }`) is a
     # bare scalar from the URL's perspective, not a nested hash --
     # permitting it as `attr: {}` would strip a request's scalar

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -326,7 +326,7 @@ class QueryTest < UnitTestCase
     # Scalar attrs (and the :by alias) are bare symbols.
     assert_includes(filters, :order_by)
     assert_includes(filters, :by)
-    assert_includes(filters, :needs_naming) # scalar :boolean
+    assert_includes(filters, :needs_naming) # scalar :truthy
     # An "enum" hash (`{ boolean: [true] }`/`{ string: [...] }`) is a
     # bare scalar from the URL's perspective, not a nested hash --
     # permitting it as `attr: {}` would strip a request's scalar

--- a/test/controllers/observations/identify_controller_test.rb
+++ b/test/controllers/observations/identify_controller_test.rb
@@ -14,7 +14,8 @@ module Observations
       obs_count = obs.count
       mary.update(layout_count: obs_count + 1)
 
-      query = Query.lookup_and_save(:Observation, needs_naming: mary)
+      query = Query.lookup_and_save(:Observation, needs_naming: true)
+      query.viewer = mary
       assert_equal(query.num_results, obs_count)
 
       get(:index)
@@ -27,8 +28,9 @@ module Observations
       # make a query, and test that the query results match obs scope
       aga_obs = Observation.needs_naming(mary).clade("Agaricales")
       query = Query.lookup_and_save(
-        :Observation, needs_naming: mary, clade: "Agaricales"
+        :Observation, needs_naming: true, clade: "Agaricales"
       )
+      query.viewer = mary
 
       # q = @controller.q_param(QueryRecord.last.query)
       # get(:index, params: { q: })
@@ -40,8 +42,9 @@ module Observations
 
       bol_obs = Observation.needs_naming(mary).clade("Boletus")
       query = Query.lookup_and_save(
-        :Observation, needs_naming: mary, clade: "Boletus"
+        :Observation, needs_naming: true, clade: "Boletus"
       )
+      query.viewer = mary
       assert_equal(query.num_results, bol_obs.count)
 
       # REGION
@@ -49,16 +52,18 @@ module Observations
       # start with continent
       sam_obs = Observation.needs_naming(mary).region("South America")
       query = Query.lookup_and_save(
-        :Observation, needs_naming: mary, region: "South America"
+        :Observation, needs_naming: true, region: "South America"
       )
+      query.viewer = mary
       assert_equal(query.num_results, sam_obs.count)
 
       cal_obs = Observation.needs_naming(mary).region("California, USA")
       # remember the original count, will change
       cal_obs_count = cal_obs.count
       query = Query.lookup_and_save(
-        :Observation, needs_naming: mary, region: "California, USA"
+        :Observation, needs_naming: true, region: "California, USA"
       )
+      query.viewer = mary
       assert_equal(query.num_results, cal_obs_count)
 
       get(:index,

--- a/test/views/layouts/header/index_bar/filter_caption_test.rb
+++ b/test/views/layouts/header/index_bar/filter_caption_test.rb
@@ -109,11 +109,10 @@ module Views::Layouts
       assert_no_html(html, "#caption-truncated .small b i")
     end
 
-    # Both `editable_by_user` (SpeciesLists) and `needs_naming`
-    # (Observations) are User-typed query attrs. Before this PR
-    # they weren't in PARAM_LOOKUPS, so the caption fell through
-    # to the raw-value formatter and printed the user id
-    # ("editable_by_user: 1") instead of the user's title.
+    # `editable_by_user` is a User-typed query attr -- without it in
+    # PARAM_LOOKUPS, the caption falls through to the raw-value
+    # formatter and prints the user id ("editable_by_user: 1") instead
+    # of the user's title.
     def test_editable_by_user_renders_user_title_not_id
       user = users(:rolf)
       query = Query.lookup_and_save(:SpeciesList, editable_by_user: user.id)
@@ -124,14 +123,15 @@ module Views::Layouts
                   text: user.unique_text_name)
     end
 
-    def test_needs_naming_renders_user_title_not_id
-      user = users(:rolf)
-      query = Query.lookup_and_save(:Observation, needs_naming: user.id)
+    # `needs_naming` is a presence flag, not a User id -- it renders
+    # as a bare label, not a lookup.
+    def test_needs_naming_renders_bare_label
+      query = Query.lookup_and_save(:Observation, needs_naming: true)
 
       html = render_for(query)
 
-      assert_html(html, "#caption-truncated .small b",
-                  text: user.unique_text_name)
+      assert_html(html, "#caption-truncated .small span",
+                  text: :query_needs_naming.l)
     end
 
     def test_project_lookup_does_not_italicize


### PR DESCRIPTION
`Observation.needs_naming` - change the query_attr/scope from the `current_user_id` to `truthy` (a new Query validation type). Query intercepts the boolean flag and sets the current_user_id from the controller. Makes identify queue bookmarks generic so they don't leak between users. Accepts old bookmarked `?needs_naming=<user_id>` as truthy, ignoring the value.

## Summary

Prep for issue #5140's dispatch-mechanism collapse. That work makes every recognized `query_attr` a live top-level URL filter param, including `needs_naming` (`Query::Observations`). Today `needs_naming` is typed `User` -- record-backed, resolved by id -- so exposing it generically would let a URL pick an arbitrary user's identify queue (`?needs_naming=<any_user_id>`), not just the signed-in one.

`Query#viewer` already exists for this "who's looking" concept, deliberately kept out of query matching (see its doc comment). `Query::Modules::Initialization#apply_scope_param` already special-cases `:order_by` to forward `viewer` instead of the submitted value. This PR extends that mechanism to `:needs_naming`:

- `needs_naming` is now `query_attr(:needs_naming, :truthy, default_order: :rss_log)` -- the URL value is a presence flag (`?needs_naming=1`), not an id.
- `apply_scope_param` sends `viewer` to the scope when the flag is true, and skips the scope when false -- the submitted value's identity has no bearing on which user gets used.
- New `Query::Modules::Validation#validate_truthy` -- a permissive sibling of `validate_boolean` (same FALSE_VALUES Rails uses to cast a param string to boolean, no error branch). Needed because a legacy stored query with `needs_naming: <user_id>` would otherwise fail `validate_boolean`'s strict allowlist and degrade to no-filter-plus-flash-warning -- `:truthy` keeps that bookmark working as "flag on" instead, since the value's identity is ignored either way.
- `Observations::IdentifyController`'s `unfiltered_index_opts` and `identify_filter` both merge `needs_naming: true` now instead of `needs_naming: @user`/`@user&.id`.
- `FilterCaption::PARAM_LOOKUPS` drops `needs_naming: :Users` (no longer a user lookup) -- it renders as a bare label (`val == true` branch), so the `query_needs_naming` translation drops its now-meaningless ", user" suffix.
- Updated the direct `Query.lookup_and_save(needs_naming: mary)` calls in `identify_controller_test.rb` to `needs_naming: true` + `query.viewer = mary` -- these test-only calls bypass the controller's `create_query` helper, which is the only place `viewer` normally gets set.

No behavior change for a live request -- the identify page's filtering is unchanged; this only closes the spoofing gap for when the attr becomes exposed as a bare top-level param in a later PR, and keeps a legacy bookmarked query working under the new type.

## Test plan

- [x] `bundle exec rubocop` on every touched file -- no offenses.
- [x] `test/classes/query_test.rb`, `test/classes/query/observations_test.rb`, `test/controllers/observations/identify_controller_test.rb`, `test/views/layouts/header/index_bar/filter_caption_test.rb` -- all pass.
- [x] Added direct `Query::Observations` unit tests for the `needs_naming: false` no-op case, the no-`viewer` case, and the legacy-stored-id backward-compat case -- a skeptical pass over the first commit found none of these were covered.
- [x] `bin/rails lang:update` run after the `query_needs_naming` translation edit.

<!-- changelog -->
article: no
<!-- /changelog -->
