### PR TITLE
Query params - Retype `look_alikes`/`related_taxa` as record-backed `Name` attrs

### DIFF
--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -22,16 +22,11 @@ class Query::Observations < Query
                        include_all_name_proposals: :boolean,
                        exclude_consensus: :boolean })
   # Each of these is a named preset of `names:` options, backed by a
-  # same-named Observation scope (Observation::Scopes) -- see there
-  # for what each preset means. `[:string]`, not `:string`, so the
-  # FilterCaption's Lookup-driven rendering (PARAM_LOOKUPS) applies --
-  # it expects an Array, matching every other name-lookup attr.
-  query_attr(:look_alikes, [:string], default_order: :confidence)
-  # `[:name_parents]`, not `[:string]` -- the stored value is the
-  # matched name's parent ids, not the searched name itself, so the
-  # filter caption shows the parent (see `validate_name_parents`
-  # below and Observation::Scopes#related_taxa).
-  query_attr(:related_taxa, [:name_parents], default_order: :confidence)
+  # same-named Observation scope (Observation::Scopes).
+  query_attr(:look_alikes, Name, default_order: :confidence,
+                                 always_index: false)
+  query_attr(:related_taxa, Name, default_order: :confidence,
+                                  always_index: false)
   # param_alias matches the URL shortcut (`?name=`) -- attr itself is
   # `any_name`, not `name`, to avoid colliding with `Observation.name`
   # (see Observation::Scopes#any_name).
@@ -124,17 +119,5 @@ class Query::Observations < Query
 
   def self.default_order
     :date
-  end
-
-  private
-
-  # Custom scalar type for `related_taxa` (a Symbol `accepts`, same
-  # dispatch convention as `validate_string`/`validate_boolean` --
-  # see Query::Modules::Validation#scalar_validate). Resolves the
-  # searched name string/id to its approved name's parent ids at
-  # validation time, so the stored query param is what the filter
-  # caption and `Observation.related_taxa` scope both need.
-  def validate_name_parents(_param, val)
-    Name.parent_ids_for(val)
   end
 end

--- a/app/classes/tab/observation/of_look_alikes.rb
+++ b/app/classes/tab/observation/of_look_alikes.rb
@@ -11,7 +11,7 @@ class Tab::Observation::OfLookAlikes < Tab::Base
   end
 
   def path
-    observations_path(name: @name.id, look_alikes: "1")
+    observations_path(look_alikes: @name.id)
   end
 
   def model

--- a/app/classes/tab/observation/of_related_taxa.rb
+++ b/app/classes/tab/observation/of_related_taxa.rb
@@ -11,7 +11,7 @@ class Tab::Observation::OfRelatedTaxa < Tab::Base
   end
 
   def path
-    observations_path(name: @name.id, related_taxa: "1")
+    observations_path(related_taxa: @name.id)
   end
 
   def model

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -117,22 +117,14 @@ class ObservationsController
     end
 
     # Displays matrix of Observations with the given name proposed, where
-    # that name is not the consensus. `look_alikes` itself is a mode
-    # flag (`?look_alikes=1`); the name comes from the separate `name`
-    # param, same as the `name`/`related_taxa` subactions below.
+    # that name is not the consensus.
     def look_alikes
-      create_query_from_url_params(
-        :Observation,
-        params.merge(look_alikes: [params[:name]]).except(:name)
-      )
+      create_query_from_url_params(:Observation, params)
     end
 
     # Displays matrix of Observations of subtaxa of the parent of given name.
     def related_taxa
-      create_query_from_url_params(
-        :Observation,
-        params.merge(related_taxa: [params[:name]]).except(:name)
-      )
+      create_query_from_url_params(:Observation, params)
     end
 
     # Displays matrix of Observations with the given text_name (or search_name).

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -462,10 +462,10 @@ class Name < AbstractModel
   end
 
   # Resolves a name string or id to the ids of its parent taxa.
-  # Called from Query::Observations#validate_name_parents, for the
-  # "related taxa" page linked from a Name's show page. Matching goes
-  # through Lookup::Names, the same name-resolution every other
-  # name-lookup filter in the app uses.
+  # Called from Observation::Scopes#related_taxa, for the "related
+  # taxa" page linked from a Name's show page. Matching goes through
+  # Lookup::Names, the same name-resolution every other name-lookup
+  # filter in the app uses.
   def self.parent_ids_for(name_str)
     Lookup::Names.new(name_str).instances.
       map { |name| name.approved_name.parents }.flatten.map(&:id).uniq

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -209,16 +209,13 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     # consensus'd -- the "look-alikes" page linked from a Name's show
     # page, and (same filter) the "Observations of other taxa where
     # this taxon was proposed" Name-page tab.
-    scope :look_alikes, lambda { |name_strs|
-      names(lookup: name_strs, include_synonyms: true,
+    scope :look_alikes, lambda { |name_id|
+      names(lookup: name_id, include_synonyms: true,
             include_all_name_proposals: true, exclude_consensus: true)
     }
-    # Observations of subtaxa of the parent of the given name. The
-    # query_attr resolves the searched name to its parent ids at
-    # validation time (Query::Observations#validate_name_parents), so
-    # this scope receives parent ids directly, not the searched name.
-    scope :related_taxa, lambda { |parent_ids|
-      names(lookup: parent_ids, include_subtaxa: true)
+    # Observations of subtaxa of the parent of the given name.
+    scope :related_taxa, lambda { |name_id|
+      names(lookup: Name.parent_ids_for(name_id), include_subtaxa: true)
     }
     # Observations of this taxon under any name -- the given
     # text_name/search_name/id or any of its synonyms. Named

--- a/app/views/layouts/header/index_bar/filter_caption.rb
+++ b/app/views/layouts/header/index_bar/filter_caption.rb
@@ -273,9 +273,12 @@ module Views::Layouts
       string
     end
 
-    # The max number of named items is hardcoded to 3.
+    # The max number of named items is hardcoded to 3. `Array(...)` --
+    # a singular record-backed attr (e.g. look_alikes) stores a bare
+    # id, not a 1-element Array; `.first(n)` below needs an Array
+    # either way.
     def filter_lookup_strings(param, truncate:)
-      ids = @query.params.deep_find(param)
+      ids = Array(@query.params.deep_find(param))
       lookups = truncate ? ids.first(CAPTION_TRUNCATE) : ids
       subclass = PARAM_LOOKUPS[param]
       lookup = "Lookup::#{subclass}".constantize

--- a/test/classes/tab/name/obs_link_test.rb
+++ b/test/classes/tab/name/obs_link_test.rb
@@ -97,7 +97,7 @@ class Tab::Name::ObsLinkTest < UnitTestCase
   def test_taxon_proposed_query_excludes_consensus
     q = build_tab(Tab::Name::ObsLink::TaxonProposed, count: 1).query
 
-    assert_equal([@name.id.to_s], q.params[:look_alikes])
+    assert_equal(@name.id, q.params[:look_alikes])
   end
 
   def test_name_proposed_query_has_all_proposals_no_synonyms

--- a/test/classes/tab/observation/tabs_test.rb
+++ b/test/classes/tab/observation/tabs_test.rb
@@ -102,16 +102,14 @@ module Tab::Observation
     def test_of_look_alikes
       tab = Tab::Observation::OfLookAlikes.new(name: @name)
 
-      assert_equal(routes.observations_path(name: @name.id,
-                                            look_alikes: "1"),
+      assert_equal(routes.observations_path(look_alikes: @name.id),
                    tab.path)
     end
 
     def test_of_related_taxa
       tab = Tab::Observation::OfRelatedTaxa.new(name: @name)
 
-      assert_equal(routes.observations_path(name: @name.id,
-                                            related_taxa: "1"),
+      assert_equal(routes.observations_path(related_taxa: @name.id),
                    tab.path)
     end
 

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -453,6 +453,19 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_results(count: obss_of_related_taxa.count)
   end
 
+  # related_taxa is record-backed (Name) -- a bad id flashes and
+  # redirects, same as look_alikes and any other record-backed
+  # shortcut.
+  def test_index_related_taxa_bad_id
+    bad_id = Name.maximum(:id).to_i + 1
+
+    setup_rolfs_index
+    get(:index, params: { related_taxa: bad_id })
+
+    assert_response(:redirect)
+    assert_flash(:runtime_object_not_found, type: :name, id: bad_id)
+  end
+
   def test_index_name
     name = names(:fungi)
     ids = Observation.where(name: name).map(&:id)

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -401,7 +401,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert(look_alikes > 1, "Test needs different fixture")
 
     setup_rolfs_index
-    get(:index, params: { look_alikes: "1", name: name.id })
+    get(:index, params: { look_alikes: name.id })
 
     assert_page_title(:observations.ti)
     assert_displayed_filters("#{:query_look_alikes.l}: #{name.text_name}")
@@ -417,11 +417,23 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert(look_alikes.zero?, "Test needs different fixture")
 
     setup_rolfs_index
-    get(:index, params: { look_alikes: "1", name: name.id })
+    get(:index, params: { look_alikes: name.id })
 
     assert_response(:success)
     assert_page_title(:observations.ti)
     assert_results(count: look_alikes)
+  end
+
+  # look_alikes is record-backed (Name) -- a bad id flashes and
+  # redirects, same as any other record-backed shortcut.
+  def test_index_look_alikes_bad_id
+    bad_id = Name.maximum(:id).to_i + 1
+
+    setup_rolfs_index
+    get(:index, params: { look_alikes: bad_id })
+
+    assert_response(:redirect)
+    assert_flash(:runtime_object_not_found, type: :name, id: bad_id)
   end
 
   def test_index_related_taxa
@@ -435,9 +447,9 @@ class ObservationsControllerIndexTest < FunctionalTestCase
       )
 
     setup_rolfs_index
-    get(:index, params: { related_taxa: "1", name: name.text_name })
+    get(:index, params: { related_taxa: name.id })
     assert_page_title(:observations.ti)
-    assert_displayed_filters("#{:query_related_taxa.l}: #{parent.text_name}")
+    assert_displayed_filters("#{:query_related_taxa.l}: #{name.text_name}")
     assert_results(count: obss_of_related_taxa.count)
   end
 


### PR DESCRIPTION
These are newly-added query attributes from yesterday - this ensures they have a valid Name id.

## Summary

Prep for issue #5140's dispatch-mechanism collapse. That work makes every recognized `query_attr` a live top-level URL filter param -- but `look_alikes`/`related_taxa` relied on a two-param shape (`?look_alikes=1&name=X`, a mode flag plus a separate name param) that the generic mechanism can't reproduce, since it resolves each recognized key independently.

- `Query::Observations`'s `look_alikes`/`related_taxa` are now plain record-backed `Name` attrs (previously `[:string]`/`[:name_parents]`). Every caller (`Tab::Observation::OfLookAlikes`, `OfRelatedTaxa`, `Tab::Name::ObsLink::TaxonProposed`) sends a Name id, not free text -- checked directly, not assumed. Record-backed typing gets these the same flash+redirect-on-a-bad-id behavior other record-backed shortcuts already have, instead of today's silent "0 results" for a garbled id.
- `related_taxa`'s parent-resolution moves out of a custom Query validator (`validate_name_parents`, deleted) and into `Observation::Scopes#related_taxa` itself, which now takes the searched name's id directly and resolves its parent via `Name.parent_ids_for` before continuing the scope chain. Query goes back to being a thin params-to-scope pass-through for this attr, matching every other name-lookup preset.
- The filter caption for `related_taxa` now shows the searched name, not its resolved parent -- a deliberate behavior change, since the stored param is now the searched name's id, not the parent's.
- `Tab::Observation::OfLookAlikes`/`OfRelatedTaxa#path` collapse to a single `?look_alikes=<id>` / `?related_taxa=<id>`, not the mode-flag-plus-name-param shape. `ObservationsController::Index#look_alikes`/`#related_taxa` become bare `create_query_from_url_params(:Observation, params)` calls.
- Fixes a latent `FilterCaption` gap found along the way: `filter_lookup_strings` called `.first(n)` on the stored param unconditionally, which assumes an Array -- true for every existing `PARAM_LOOKUPS`-keyed attr so far, but not for a singular record-backed one like the new `look_alikes`. Wrapped in `Array(...)`, a no-op for attrs that are already Array-typed.

## Test plan

- [x] `bundle exec rubocop` on every touched file -- no offenses.
- [x] `test/controllers/observations_controller_index_test.rb`, `test/classes/tab/observation/tabs_test.rb`, `test/classes/tab/name/obs_link_test.rb`, `test/classes/query/observations_test.rb`, `test/views/layouts/header/index_bar/filter_caption_test.rb` -- all pass.
- [x] Added `test_index_look_alikes_bad_id`, covering the new flash+redirect-on-bad-id behavior.
- [x] Skeptical pass: confirmed no other caller of the `Observation.related_taxa`/`look_alikes` scopes exists outside the Tab classes (the scope signature change is safe), confirmed an old array-bracket URL (`?look_alikes[]=1`) is silently dropped by strong params rather than erroring, and confirmed `always_index: false` reproduces the pre-change no-force behavior.

<!-- changelog -->
article: no
<!-- /changelog -->
