### PR TITLE
Query params - Revert Observations `project` attr split; move ordering to the Tab link

### DIFF
--- a/app/classes/query/modules/subqueries.rb
+++ b/app/classes/query/modules/subqueries.rb
@@ -109,7 +109,7 @@ module Query::Modules::Subqueries
     # appear as keys here.
     def needs_is_collection_location(target, filter, params)
       target == :Location && filter == :Observation &&
-        (params[:projects] || params[:species_lists]) &&
+        (params[:projects].present? || params[:species_lists].present?) &&
         params[:is_collection_location].blank?
     end
   end

--- a/app/classes/query/modules/subqueries.rb
+++ b/app/classes/query/modules/subqueries.rb
@@ -101,9 +101,15 @@ module Query::Modules::Subqueries
       params.merge(is_collection_location: true)
     end
 
+    # `target`/`filter` are Symbols throughout this module (e.g.
+    # `:Location`), not the model classes. `params` is
+    # `current_query.params` -- already resolved, so this checks the
+    # stored attr names (`projects`/`species_lists`), not their URL
+    # param_alias shortcuts (`project`/`species_list`), which don't
+    # appear as keys here.
     def needs_is_collection_location(target, filter, params)
-      target == Location && filter == :Observation &&
-        (params[:project] || params[:species_list]) &&
+      target == :Location && filter == :Observation &&
+        (params[:projects] || params[:species_lists]) &&
         params[:is_collection_location].blank?
     end
   end

--- a/app/classes/query/observations.rb
+++ b/app/classes/query/observations.rb
@@ -81,11 +81,8 @@ class Query::Observations < Query
 
   query_attr(:herbaria, [Herbarium])
   query_attr(:herbarium_records, [HerbariumRecord])
-  query_attr(:projects, [Project], redirect_to: :model_index)
-  # Separate attr, not aliased to `projects` -- its default_order would
-  # leak into `projects:`-filtered subqueries composed elsewhere.
-  query_attr(:project, Project, redirect_to: :model_index,
-                                default_order: :thumbnail_quality)
+  query_attr(:projects, [Project], param_alias: :project,
+                                   redirect_to: :model_index)
   query_attr(:project_lists, [Project])
   query_attr(:species_lists, [SpeciesList], param_alias: :species_list,
                                             redirect_to: :model_index)

--- a/app/classes/tab/project/observations.rb
+++ b/app/classes/tab/project/observations.rb
@@ -10,8 +10,12 @@ class Tab::Project::Observations < Tab::Base
     "#{@project.visible_observations.count} #{:observations.ti}"
   end
 
+  # `by: "thumbnail_quality"` is explicit here, not a default_order on
+  # the `projects` query_attr -- keeps the ordering choice scoped to
+  # this one link instead of leaking into other `projects:` filters
+  # (e.g. subquery composition; see Query::Observations).
   def path
-    observations_path(project: @project)
+    observations_path(project: @project, by: "thumbnail_quality")
   end
 
   def alt_title

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -191,12 +191,12 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
 
   # Sets @project/@observation-style ivars from a Query's resolved
   # params. Call it from filtered_index_final_hook. No-op when attr is
-  # absent or (for an array-typed attr) holds more than one id.
+  # absent or holds more than one id.
   def derive_ivar_from_query(ivar, query, attr, model_class)
     value = query.params[attr]
-    id = value.is_a?(Array) ? (value.first if value.size == 1) : value
-    return unless id
+    return unless value.is_a?(Array) && value.size == 1
 
+    id = value.first
     instance_variable_set(ivar, resolved_alias_record(attr, id) ||
                                  model_class.safe_find(id))
   end

--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -190,8 +190,9 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
   end
 
   # Sets @project/@observation-style ivars from a Query's resolved
-  # params. Call it from filtered_index_final_hook. No-op when attr is
-  # absent or holds more than one id.
+  # params. Call it from filtered_index_final_hook. `attr` must be
+  # Array-typed -- no-op when its value isn't an Array, or isn't a
+  # 1-element one.
   def derive_ivar_from_query(ivar, query, attr, model_class)
     value = query.params[attr]
     return unless value.is_a?(Array) && value.size == 1

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -172,7 +172,6 @@ class ObservationsController
     def filtered_index_final_hook(query, _display_opts)
       store_query_in_session(query)
       derive_ivar_from_query(:@project, query, :projects, Project)
-      derive_ivar_from_query(:@project, query, :project, Project)
       query
     end
 

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -619,8 +619,6 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       joins(:project_observations).
         where(project_observations: { project: project_ids }).distinct
     }
-    # Separate query_attr from `projects` -- see Query::Observations.
-    scope :project, ->(project) { projects(project) }
     scope :project_lists, lambda { |projects|
       project_ids = Lookup::Projects.new(projects).ids
       joins(species_lists: :project_species_lists).

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -4488,7 +4488,6 @@
   query_locations: "[:locations]"
   query_within_locations: "[:within_locations]"
   query_observations: "[:observations]"
-  query_project: "[:project]"
   query_project_lists: "[:project_lists]"
   query_projects: "[:projects]"
   query_species_lists: "[:species_lists]"

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -1221,6 +1221,41 @@ class QueryTest < UnitTestCase
     assert_equal(1, obs_queries[6].keys.length)
   end
 
+  # An Observation query filtered by project or species_list defaults
+  # its converted Location subquery to is_collection_location: true --
+  # checks the resolved attr names (`projects`/`species_lists`), not
+  # their param_alias shortcuts (`project`/`species_list`), which don't
+  # appear in a Query's stored params. See
+  # Query::Modules::Subqueries#needs_is_collection_location.
+  def test_observation_subquery_of_location_defaults_collection_location
+    project = projects(:bolete_project)
+    species_list = species_lists(:first_species_list)
+
+    by_project = Query.lookup_and_save(:Observation, projects: [project.id])
+    by_species_list = Query.lookup_and_save(
+      :Observation, species_lists: [species_list.id]
+    )
+    unfiltered = Query.lookup_and_save(:Observation, order_by: :id)
+
+    project_location = by_project.subquery_of(:Location)
+    species_list_location = by_species_list.subquery_of(:Location)
+    unfiltered_location = unfiltered.subquery_of(:Location)
+
+    assert_equal(
+      true,
+      project_location.params[:observation_query][:is_collection_location]
+    )
+    assert_equal(
+      true,
+      species_list_location.
+        params[:observation_query][:is_collection_location]
+    )
+    assert_not(
+      unfiltered_location.params[:observation_query].
+        key?(:is_collection_location)
+    )
+  end
+
   def test_observation_subquery_of_name
     burbank = locations(:burbank)
     query_a = []

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -1254,6 +1254,16 @@ class QueryTest < UnitTestCase
       unfiltered_location.params[:observation_query].
         key?(:is_collection_location)
     )
+
+    # An empty array is a present key, not a filter -- .present?, not
+    # truthiness, decides this.
+    empty_projects = Query.lookup_and_save(:Observation, projects: [])
+    empty_projects_location = empty_projects.subquery_of(:Location)
+
+    assert_not(
+      empty_projects_location.params[:observation_query].
+        key?(:is_collection_location)
+    )
   end
 
   def test_observation_subquery_of_name

--- a/test/classes/tab/project/tabs_test.rb
+++ b/test/classes/tab/project/tabs_test.rb
@@ -38,7 +38,10 @@ module Tab::Project
 
       assert_match(/\A\d+ /, tab.title)
       assert_match(/observations/i, tab.title)
-      assert_equal(routes.observations_path(project: @project), tab.path)
+      assert_equal(
+        routes.observations_path(project: @project, by: "thumbnail_quality"),
+        tab.path
+      )
       assert_equal("observations", tab.alt_title)
       assert_equal("observations_link", link_class(tab))
     end

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -724,20 +724,34 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_page_title(:observations.ti)
   end
 
-  # thumbnail_quality is this page's default sort, not a
-  # class-wide default_order on the shared `projects` query_attr
-  # (test_observation_names_in_species_lists_and_projects proves a
-  # bare `projects:` query elsewhere still needs the class default)
-  # -- an explicit `by` must still win.
+  # `project` is a plain param_alias for `projects` -- no attr-level
+  # default_order, so a bare `?project=X` (no `by`) falls through to
+  # the class default (:date). thumbnail_quality only applies via the
+  # explicit `by:` the project header's Observations tab sends (see
+  # Tab::Project::Observations) -- keeping the two orderings separate
+  # is what test_observation_names_in_species_lists_and_projects
+  # already relies on for a bare `projects:` query elsewhere.
+  def test_index_project_bare_url_uses_class_default_order
+    project = projects(:bolete_project)
+
+    login
+    get(:index, params: { project: project.id })
+
+    assert_response(:success)
+    query = @controller.instance_variable_get(:@query)
+    assert_nil(query.params[:order_by])
+    assert_equal(:date, query.default_order)
+  end
+
   def test_index_project_explicit_by_respected
     project = projects(:bolete_project)
 
     login
-    get(:index, params: { project: project.id, by: "date" })
+    get(:index, params: { project: project.id, by: "thumbnail_quality" })
 
     assert_response(:success)
     query = @controller.instance_variable_get(:@query)
-    assert_equal("date", query.params[:order_by])
+    assert_equal("thumbnail_quality", query.params[:order_by])
   end
 
   # A bad project id redirects to the projects index. See redirect_to:
@@ -800,11 +814,8 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     assert_not(query.params.key?(:bogus_param))
   end
 
-  # Query::Observations' `project` attr is record-backed but not an
-  # alias for `projects` (see app/classes/query/observations.rb) --
-  # exercises create_query_from_url_params's `constantize` path with a
-  # directly-matching attr name, not just the lower-level
-  # resolve_query_param_records helper.
+  # `project` is a record-backed param_alias for `projects` -- exercises
+  # create_query_from_url_params's `constantize` path end to end.
   def test_create_query_from_url_params_sets_always_index_for_record_alias
     login
     project = projects(:bolete_project)
@@ -814,7 +825,7 @@ class ObservationsControllerIndexTest < FunctionalTestCase
       :create_query_from_url_params, :Observation, raw_params
     )
 
-    assert_equal(project.id, query.params[:project])
+    assert_equal([project.id], query.params[:projects])
     assert_equal(true, display_opts[:always_index])
   end
 


### PR DESCRIPTION
## Summary

Revisits #5236's `:project`/`:projects` split (a separate `:project` attr carrying a `default_order: :thumbnail_quality`, kept apart from `:projects` to avoid that ordering leaking into subquery composition -- confirmed via `test_image_with_observations_projects` at the time). The split fixed the bug, but the ordering decision didn't belong at the attr level.

- `Query::Observations`'s `:project` goes back to being a plain `param_alias: :project` on `projects`, matching every other singular/plural shortcut in this class (`by_users`/`by_user`, `species_lists`/`species_list`, etc.). No attr-level `default_order:`, so a `projects:`-filtered query anywhere else in the app (including subquery composition) can't pick up an ordering side effect it didn't ask for.
- `Tab::Project::Observations#path` -- the one link this ordering was meant for -- now sends `?project=<id>&by=thumbnail_quality` directly, routing through the existing `:by` -> `order_by` mechanism instead of an attr default. That's already how every other explicit sort on this page works.
- `Observation::Scopes#project` (the delegate scope added for the split) is deleted -- no longer needed once `:project` is a URL-level alias again.
- `derive_ivar_from_query`'s scalar-value handling (added so it could read the singular `:project` attr's bare-id storage) reverts to its array-only form -- no other caller needs it.
- Removed the now-unused `query_project` translation key (`config/locales/en.txt`); the caption falls back to the existing `query_projects` (plural) label, same as before the split.

### Also fixed: `Query::Modules::Subqueries#needs_is_collection_location`

Found while checking whether any code read the old singular-attr storage key directly (part of a skeptical review of the `:project`/`:projects` change). Two bugs in this method, unrelated to this PR's change but surfaced by the same review, meaning the `is_collection_location: true` default has not applied when converting a project- or species-list-filtered Observation query into a Location subquery:

- It checked `params[:project]`/`params[:species_list]` (the URL `param_alias` shortcut names), but `current_query.params` is post-alias-resolution -- `:projects`/`:species_lists` are the keys that appear there, both under this design and under the pre-#5236 one.
- It compared `target == Location` (the model class), but `target` is a Symbol (`:Location`) throughout this module -- a comparison that can't be true.

`git log` on this file shows no history from the `:project`/`:projects` work, confirming both predate it. No existing test exercised this method. Added `test_observation_subquery_of_location_defaults_collection_location` covering the project and species_list cases, plus the unfiltered no-op case.

## Test plan

- [x] `bundle exec rubocop` on every touched file -- no offenses.
- [x] `test/controllers/observations_controller_index_test.rb`, `test/classes/tab/project/tabs_test.rb`, `test/classes/query/observations_test.rb`, `test/classes/query_test.rb` -- all pass.
- [x] Re-ran `test_image_with_observations_projects` (`test/classes/query/images_test.rb`) directly -- the subquery test that caught this bug the first time -- still passes now that `projects` has no `default_order` again.
- [x] Replaced `test_index_project_explicit_by_respected`'s premise (there's no attr-level default left to override) with two tests: a bare `?project=X` now falls through to the class default (`:date`), and an explicit `?project=X&by=thumbnail_quality` still applies.
- [x] `bin/rails lang:update` run after removing `query_project`.
- [x] New `test_observation_subquery_of_location_defaults_collection_location` covers the `needs_is_collection_location` fix directly.

<!-- changelog -->
article: no
<!-- /changelog -->
