### PR TITLE
`Projects::ViolationsController#index`- no discarded query, paginate directly

### DIFF
--- a/app/components/paginated_results.rb
+++ b/app/components/paginated_results.rb
@@ -11,9 +11,7 @@ class Components::PaginatedResults < Components::Base
   prop :html_id, String, default: "results"
 
   def view_template(&block)
-    encoded_q = URI.parse(observations_path(q: q_param)).query
-
-    div(id: @html_id, data: { q: encoded_q }) do
+    div(id: @html_id) do
       trusted_html(content_for(:index_pagination_top)) if
         content_for?(:index_pagination_top)
       yield

--- a/app/controllers/projects/violations_controller.rb
+++ b/app/controllers/projects/violations_controller.rb
@@ -13,38 +13,26 @@ module Projects
     # Cannot figure out the eager loading here.
     around_action :skip_bullet, if: -> { defined?(Bullet) }, only: [:index]
 
-    # build_index_with_query's query and display_opts are discarded --
-    # render_index_view below renders @violations, not @objects.
-    # controller_model_name ("Project") only decides which Query
-    # class's params are live top-level filters here, not what gets
-    # listed. See #5250 for known side-effect bugs from calling this
-    # on a page whose query result is unused.
+    # @violations is a plain Ruby Array (Project#violations), not a
+    # Query/AR relation, so it's paginated directly with
+    # PaginationData rather than through build_index_with_query's
+    # Query-driven machinery -- see the class doc on PaginationData
+    # for this exact "without Query" usage.
     def index
       return unless find_project!
 
       @violations = @project.violations
-      build_index_with_query
+      @pagination_data = number_pagination_data
+      @pagination_data.num_total = @violations.length
+      @violations = @violations[@pagination_data.from_to] || []
+      render_index_view
     end
 
-    # Overrides `ApplicationController::Indexes#render_index_view` so
-    # `show_index_of_objects` renders the Phlex `Violations::Index`
-    # class instead of `projects/violations/index.html.erb` (deleted).
     def render_index_view
       render(Views::Controllers::Projects::Violations::Index.new(
-               project: @project, violations: @violations, user: @user
+               project: @project, violations: @violations,
+               pagination_data: @pagination_data, user: @user
              ))
-    end
-
-    # The discarded query's display_opts still control
-    # show_index_of_objects's single-result auto-redirect --
-    # Query::Projects' `member` filter opts out of always_index (see
-    # query/projects.rb), so without forcing it here, a `member:`
-    # filter that narrows to one project site-wide would redirect
-    # this page away to that other project's show page instead of
-    # rendering the violations list -- @violations plays no part in
-    # that decision.
-    def index_display_opts(opts, _query)
-      opts.merge(always_index: true)
     end
 
     # GET-only turbo-stream endpoint that renders the Add-Target-Location

--- a/app/views/controllers/projects/violations/index.rb
+++ b/app/views/controllers/projects/violations/index.rb
@@ -10,6 +10,7 @@ module Views::Controllers::Projects::Violations
   class Index < Views::FullPageBase
     prop :project, ::Project
     prop :violations, _Array(::Project::Violation)
+    prop :pagination_data, ::PaginationData
     # Non-nilable: this view forwards `user` to `Violations::Form`,
     # whose `prop :user` is non-nilable, and the controller's
     # `login_required` guarantees `@user` is present.
@@ -18,10 +19,13 @@ module Views::Controllers::Projects::Violations
     def view_template
       add_project_banner(@project)
       container_class(:wide)
+      add_pagination(@pagination_data)
 
-      render(Views::Controllers::Projects::Violations::Form.new(
-               project: @project, violations: @violations, user: @user
-             ))
+      PaginatedResults do
+        render(Views::Controllers::Projects::Violations::Form.new(
+                 project: @project, violations: @violations, user: @user
+               ))
+      end
     end
   end
 end

--- a/test/components/paginated_results_test.rb
+++ b/test/components/paginated_results_test.rb
@@ -3,14 +3,6 @@
 require("test_helper")
 
 class PaginatedResultsTest < ComponentTestCase
-  def setup
-    super
-    controller.define_singleton_method(:q_param) { nil }
-    controller.define_singleton_method(:observations_path) do |**|
-      "/observations"
-    end
-  end
-
   def test_wraps_block_in_results_div
     html = render_it
 
@@ -28,13 +20,6 @@ class PaginatedResultsTest < ComponentTestCase
     html = render_it
 
     assert_html(html, "div#results", text: "content")
-  end
-
-  def test_data_q_encodes_q_param
-    controller.define_singleton_method(:q_param) { "42" }
-    html = render_it
-
-    assert_html(html, "div#results[data-q='q=42']")
   end
 
   def test_weaves_pagination_strips_when_present

--- a/test/controllers/projects/violations_controller_test.rb
+++ b/test/controllers/projects/violations_controller_test.rb
@@ -29,6 +29,15 @@ module Projects
       end
     end
 
+    # Overrides the `controller_name.classify` default (which would
+    # derive "Violation", not a model). Nothing else exercises this:
+    # TopNav's create-button label and Sorter's sort-link name both
+    # call it, but neither renders on this controller's pages (no
+    # `new` action, no sortable Query).
+    def test_controller_model_name
+      assert_equal("Project", @controller.controller_model_name)
+    end
+
     def test_index_no_violations
       project = projects(:eol_project)
       assert_empty(project.violations,

--- a/test/controllers/projects/violations_controller_test.rb
+++ b/test/controllers/projects/violations_controller_test.rb
@@ -41,50 +41,44 @@ module Projects
       assert_select("p", { text: /#{:form_violations_no_violations.l}/ })
     end
 
-    # This controller shares Query::Projects with ProjectsController
-    # (see `controller_model_name`), so every param Query::Projects
-    # recognizes -- not just `:by`/`:q`/`:id` (`:id` here is the
-    # route's project id, always present) -- is a live top-level
-    # filter here too, through the generic dispatch in
-    # ApplicationController::Indexes#build_index_with_query. The page
-    # ignores the built query's results (renders `@violations`
-    # directly), so this only needs to confirm the dispatch itself is
-    # harmless: a recognized filter still renders, and a bad
-    # record-backed id degrades to a redirect back to this same page,
-    # not a crash.
-    def test_index_recognizes_projects_query_filter_param
+    # @pagination_data.num_total must reflect the full violation
+    # count, not just the first page's worth (#5250).
+    def test_index_pagination_data_matches_full_violation_count
       project = projects(:falmouth_2023_09_project)
       login(project.user.login)
-      get(:index, params: { id: project.id, member: project.user.id })
+      get(:index, params: { id: project.id })
 
       assert_response(:success)
+      pagination_data = @controller.instance_variable_get(:@pagination_data)
+      assert_equal(project.violations.size, pagination_data.num_total)
     end
 
-    def test_index_bad_member_id_redirects_instead_of_crashing
+    # #5250: build_index_with_query used to run here for its query,
+    # whose result was discarded -- but update_stored_query still
+    # overwrote session[:query_record] with it, clobbering whatever
+    # unrelated query the user had active elsewhere.
+    def test_index_does_not_clobber_session_query_record
       project = projects(:falmouth_2023_09_project)
       login(project.user.login)
-      get(:index, params: { id: project.id, member: 999_999_999 })
+      other_query = Query.lookup_and_save(:Project, by_users: project.user.id)
+      session[:query_record] = other_query.id
 
-      assert_redirected_to(project_violations_path(project))
+      get(:index, params: { id: project.id })
+
+      assert_response(:success)
+      assert_equal(other_query.id, session[:query_record],
+                   "Visiting the violations page should not overwrite an " \
+                   "unrelated stored query")
     end
 
-    # `Query::Projects`' `members`/`member` opts out of `always_index`
-    # (see query/projects.rb) -- without index_display_opts forcing
-    # it back on, `filtered_index` would take its single-result
-    # shortcut (`show_index_of_objects`) whenever a `member:` filter
-    # narrows to one project site-wide, regardless of which project's
-    # violations page it was submitted on, since the query built here
-    # isn't scoped to @project. Confirms a member of only one project
-    # (`lone_wolf`, sole member of "Lone Wolf Project") still renders
-    # this page instead of redirecting away to their project's show
-    # page.
-    def test_index_member_filter_matching_one_project_does_not_redirect
-      viewed_project = projects(:falmouth_2023_09_project)
-      sole_member = users(:lone_wolf)
-      login(viewed_project.user.login)
-
-      get(:index, params: { id: viewed_project.id,
-                            member: sole_member.id })
+    # #5250: redirect_past_last_page? used to clamp/redirect based on
+    # the discarded query's (unrelated) page count. No query is built
+    # here anymore, so an out-of-range page just renders empty,
+    # instead of redirecting.
+    def test_index_large_page_number_does_not_redirect
+      project = projects(:falmouth_2023_09_project)
+      login(project.user.login)
+      get(:index, params: { id: project.id, page: 999 })
 
       assert_response(:success)
     end

--- a/test/controllers/projects/violations_controller_test.rb
+++ b/test/controllers/projects/violations_controller_test.rb
@@ -42,7 +42,7 @@ module Projects
     end
 
     # @pagination_data.num_total must reflect the full violation
-    # count, not just the first page's worth (#5250).
+    # count, not just the first page's worth.
     def test_index_pagination_data_matches_full_violation_count
       project = projects(:falmouth_2023_09_project)
       login(project.user.login)
@@ -53,10 +53,9 @@ module Projects
       assert_equal(project.violations.size, pagination_data.num_total)
     end
 
-    # #5250: build_index_with_query used to run here for its query,
-    # whose result was discarded -- but update_stored_query still
-    # overwrote session[:query_record] with it, clobbering whatever
-    # unrelated query the user had active elsewhere.
+    # This page builds no Query, so it must not touch
+    # session[:query_record] -- an unrelated query stored elsewhere
+    # should survive a visit here untouched.
     def test_index_does_not_clobber_session_query_record
       project = projects(:falmouth_2023_09_project)
       login(project.user.login)
@@ -71,10 +70,9 @@ module Projects
                    "unrelated stored query")
     end
 
-    # #5250: redirect_past_last_page? used to clamp/redirect based on
-    # the discarded query's (unrelated) page count. No query is built
-    # here anymore, so an out-of-range page just renders empty,
-    # instead of redirecting.
+    # This page builds no Query, so an out-of-range page has no
+    # page-clamp mechanism to trigger -- it renders empty instead of
+    # redirecting.
     def test_index_large_page_number_does_not_redirect
       project = projects(:falmouth_2023_09_project)
       login(project.user.login)


### PR DESCRIPTION
## Summary

Closes #5250.

`Projects::ViolationsController#index` called `build_index_with_query`, which ran a full `Query::Projects` query purely for side effects — `render_index_view` has always rendered `@violations`, not the query's `@objects`. Some of those side effects were wrong:

1. `update_stored_query` clobbered whatever unrelated query the user had active in session (e.g. a filtered `/projects?region=X` search).
2. `redirect_past_last_page?` could clamp or redirect based on that discarded query's page count, not anything tied to `@violations`.
3. The page had no pagination, silently rendering every violation on one page regardless of project size.

`Project#violations` returns a plain Ruby `Array` (built by iterating observations and checking constraints in Ruby), not a `Query`/AR relation, so it's paginated directly with `PaginationData` — this is the documented "without Query" use case on `PaginationData` itself (see the class doc's `custom_index` example). `build_index_with_query` and the `index_display_opts` override it needed (added earlier to guard against a since-removed redirect risk) are both gone — nothing on this page calls into the `Query` system anymore.

## Changes

- `Projects::ViolationsController#index` builds `@pagination_data` via `number_pagination_data`, sets `num_total` to the full violation count, and slices `@violations` to the current page before rendering.
- `Views::Controllers::Projects::Violations::Index` takes a `pagination_data:` prop, calls `add_pagination`, and wraps the violations form in `PaginatedResults` — the same pattern every other index page uses.
- Removed 3 tests that covered the now-gone `build_index_with_query`/`member:`-filter/`always_index` mechanism (that Query surface no longer exists on this page); added 3 covering the fixes: `num_total` reflects the full count, an unrelated stored query isn't clobbered, and an out-of-range `?page=` renders instead of redirecting.

## Test plan

- [x] `bin/rails test test/controllers/projects/violations_controller_test.rb`
- [x] `bundle exec rubocop` on every touched file

<!-- changelog -->
article: no
<!-- /changelog -->
