### PR TITLE
Query params - Collapse `default_sort_order` to `controller_query_class.default_order`

### DIFF
--- a/app/controllers/application_controller/indexes.rb
+++ b/app/controllers/application_controller/indexes.rb
@@ -97,14 +97,11 @@ module ApplicationController::Indexes # rubocop:disable Metrics/ModuleLength
            status: :forbidden)
   end
 
-  # Currently some controller tests expect nil: Even though the sort order
-  # resulting from `nil` is the default, passing no explicit :by param
-  # means the index is titled "____ Index", rather than "____ by ____".
-  # NOTE: Could be standardized.
+  # `CollectionNumbersController` overrides this to `nil` -- passing no
+  # explicit :by param there keeps the index titled "____ Index" rather
+  # than "____ by ____ and ____".
   def default_sort_order
-    # query_base = "::Query::#{controller_model_name.pluralize}".constantize
-    # query_base.send(:default_order) || nil
-    nil
+    controller_query_class.default_order
   end
 
   # Generally this is the default index action, no params given.

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -41,10 +41,6 @@ class ArticlesController < ApplicationController
 
   private
 
-  def default_sort_order
-    ::Query::Articles.default_order # :created_at
-  end
-
   def index_display_opts(opts, _query)
     { letters: true,
       num_per_page: 50,

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -37,8 +37,11 @@ class CollectionNumbersController < ApplicationController
 
   private
 
+  # `Query::CollectionNumbers.default_order` is :name_and_number, but
+  # nil keeps this index titled "Collection Numbers Index" rather than
+  # "... by Name and Number" -- see the base class's doc.
   def default_sort_order
-    nil # Query::CollectionNumbers.default_order
+    nil
   end
 
   # Hook runs before template displayed. Must return query.

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -47,10 +47,6 @@ class CommentsController < ApplicationController
 
   private
 
-  def default_sort_order
-    ::Query::Comments.default_order # :created_at
-  end
-
   def index_display_opts(opts, query)
     # `:include` falls back to `Comment.index_includes_tree` via
     # `default_index_includes_for_model`. (Re: the historical

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -40,10 +40,6 @@ class ContributorsController < ApplicationController
            ))
   end
 
-  def default_sort_order
-    :contribution # ::Query::Users.default_order is :name
-  end
-
   def unfiltered_index_opts
     super.merge(query_args: { has_contribution: true })
   end

--- a/app/controllers/field_slips_controller/index.rb
+++ b/app/controllers/field_slips_controller/index.rb
@@ -19,10 +19,6 @@ module FieldSlipsController::Index
 
   private
 
-  def default_sort_order
-    ::Query::FieldSlips.default_order # :date
-  end
-
   # Hook runs before template displayed. Must return query.
   def filtered_index_final_hook(query, _display_opts)
     derive_ivar_from_query(:@project, query, :projects, Project)

--- a/app/controllers/glossary_terms_controller.rb
+++ b/app/controllers/glossary_terms_controller.rb
@@ -22,10 +22,6 @@ class GlossaryTermsController < ApplicationController
            ))
   end
 
-  def default_sort_order
-    ::Query::GlossaryTerms.default_order # :name
-  end
-
   def index_display_opts(opts, _query)
     { letters: true,
       num_per_page: 50,

--- a/app/controllers/herbaria_controller.rb
+++ b/app/controllers/herbaria_controller.rb
@@ -204,10 +204,6 @@ class HerbariaController < ApplicationController # rubocop:disable Metrics/Class
     @merge = Herbarium.safe_find(params[:merge])
   end
 
-  def default_sort_order
-    ::Query::Herbaria.default_order # :records
-  end
-
   def index_display_opts(opts, _query)
     { letters: true,
       num_per_page: 100,

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -39,10 +39,6 @@ class HerbariumRecordsController < ApplicationController
 
   private
 
-  def default_sort_order
-    ::Query::Herbaria.default_order # :name
-  end
-
   # Hook runs before template displayed. Must return query.
   def filtered_index_final_hook(query, _display_opts)
     derive_ivar_from_query(:@observation, query, :observations, Observation)

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -44,10 +44,6 @@ class ImagesController < ApplicationController
     ].freeze
   end
 
-  def default_sort_order
-    ::Query::Images.default_order # :created_at
-  end
-
   private
 
   # Don't show the index if they're asking too much.

--- a/app/controllers/locations/descriptions_controller.rb
+++ b/app/controllers/locations/descriptions_controller.rb
@@ -46,11 +46,6 @@ module Locations
 
     private
 
-    # Is :name
-    def default_sort_order
-      ::Query::LocationDescriptions.default_order # :name
-    end
-
     # Hook runs before template displayed. Must return query.
     def filtered_index_final_hook(query, _display_opts)
       store_query_in_session(query)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -47,10 +47,6 @@ class LocationsController < ApplicationController
 
   private
 
-  def default_sort_order
-    ::Query::Locations.default_order # :name
-  end
-
   # Hook runs before template displayed. Must return query.
   def filtered_index_final_hook(query, _display_opts)
     # Matching undefined locations is meaningless in a box.

--- a/app/controllers/names/descriptions_controller.rb
+++ b/app/controllers/names/descriptions_controller.rb
@@ -58,10 +58,6 @@ module Names
 
     private
 
-    def default_sort_order
-      ::Query::NameDescriptions.default_order # :name
-    end
-
     # Hook runs before template displayed. Must return query.
     def filtered_index_final_hook(query, _display_opts)
       store_query_in_session(query)

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -47,10 +47,6 @@ class NamesController < ApplicationController
 
   private
 
-  def default_sort_order
-    ::Query::Names.default_order # :name
-  end
-
   def make_name_suggestions
     return unless @objects.empty? &&
                   params[:q].is_a?(ActionController::Parameters) &&

--- a/app/controllers/observations_controller/index.rb
+++ b/app/controllers/observations_controller/index.rb
@@ -82,14 +82,6 @@ class ObservationsController
       ].freeze
     end
 
-    # Default on home is :rss_log (:log_updated_at), not :date.
-    # Maybe other filters should explicitly specify :date?
-    # Then we could use default_sort_order above.
-    # Or, set an "unfiltered sort order" method that defaults to this.
-    def default_sort_order
-      ::Query::Observations.default_order # :date
-    end
-
     # Note all other filters of the obs index are sorted by date.
     def unfiltered_index_opts
       super.merge(query_args: { order_by: :rss_log })

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -38,10 +38,6 @@ class ProjectsController < ApplicationController
 
   private
 
-  def default_sort_order
-    ::Query::Projects.default_order # :updated_at
-  end
-
   def index_display_opts(opts, _query)
     { letters: true,
       num_per_page: 50,

--- a/app/controllers/rss_logs_controller.rb
+++ b/app/controllers/rss_logs_controller.rb
@@ -21,10 +21,6 @@ class RssLogsController < ApplicationController
 
   private
 
-  def default_sort_order
-    ::Query::RssLogs.default_order # :updated_at
-  end
-
   def unfiltered_index_opts
     super.merge(query_args: { types: index_type_default })
   end

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -60,10 +60,6 @@ class SequencesController < ApplicationController
 
   private
 
-  def default_sort_order
-    ::Query::Sequences.default_order # :created_at
-  end
-
   def index_display_opts(opts, _query)
     { letters: true,
       include: [{ observation: :name }, :user],

--- a/app/controllers/species_lists_controller.rb
+++ b/app/controllers/species_lists_controller.rb
@@ -59,11 +59,6 @@ class SpeciesListsController < ApplicationController # rubocop:disable Metrics/C
 
   private
 
-  # unused now. should be :date, maybe - AN
-  def default_sort_order
-    ::Query::SpeciesLists.default_order # :date
-  end
-
   def unfiltered_index_opts
     super.merge(query_args: { order_by: :date })
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -64,10 +64,6 @@ class UsersController < ApplicationController
     false
   end
 
-  def default_sort_order
-    ::Query::Users.default_order # :name
-  end
-
   def sorted_index_permitted?
     index_query_authorized?
   end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -245,14 +245,6 @@ class ApplicationControllerTest < FunctionalTestCase
     IpStats.reset!
   end
 
-  # `ApplicationController::Indexes#default_sort_order`'s base
-  # implementation returns nil -- every controller with an index
-  # overrides it, so InfoController (no index action) is the only
-  # way to reach the base method itself.
-  def test_default_sort_order_base_implementation_is_nil
-    assert_nil(@controller.send(:default_sort_order))
-  end
-
   # `ApplicationController::Indexes#index_display_opts`'s base
   # implementation merges into an empty hash -- every controller with
   # an index overrides it, so InfoController (no index action) is the

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -41,7 +41,8 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
 
     assert_response(:success)
     query = @controller.instance_variable_get(:@query)
-    assert_equal("herbarium_label", query.params[:order_by])
+    assert_equal(Query::HerbariumRecords.default_order.to_s,
+                 query.params[:order_by])
   end
 
   def test_index_pattern_with_multiple_matching_records

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -34,6 +34,16 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
                   "Wrong number of Herbarium Records")
   end
 
+  # Unfiltered index sorts by Query::HerbariumRecords.default_order.
+  def test_index_default_sort_order
+    login
+    get(:index)
+
+    assert_response(:success)
+    query = @controller.instance_variable_get(:@query)
+    assert_equal("herbarium_label", query.params[:order_by])
+  end
+
   def test_index_pattern_with_multiple_matching_records
     # Two herbarium_records match this pattern.
     pattern = "Coprinus comatus"


### PR DESCRIPTION
## Summary

Follow-up to the `index_active_params` removal (#5140): `ApplicationController::Indexes#default_sort_order` still hardcoded `nil`, and 18 controllers overrode it with nothing but `::Query::<Model>.default_order` — the same class `controller_query_class` already resolves generically from `controller_model_name`. Collapsed the base default to `controller_query_class.default_order` and deleted all 18 now-redundant overrides.

`CollectionNumbersController` keeps its override — deliberately `nil` so the index stays titled "Collection Numbers Index" rather than "... by Name and Number" (matches the base class's documented rationale for the old blanket `nil`).

## Bug found and fixed along the way

`HerbariumRecordsController#default_sort_order` referenced `::Query::Herbaria.default_order` (`:records`) instead of `::Query::HerbariumRecords.default_order` (`:herbarium_label`). `order_by_records` is guarded to `Herbarium` only (`return all unless self == Herbarium`), so on `HerbariumRecord` it silently no-ops — the unfiltered `/herbarium_records` index has been rendering with no defined sort order. Deleting the override in favor of the generic (correctly-resolving) default fixes this. Added `test_index_default_sort_order` to lock in the fix.

## Changes

- `ApplicationController::Indexes#default_sort_order` now returns `controller_query_class.default_order` instead of a hardcoded `nil`.
- Deleted the redundant override in: Articles, Comments, Contributors, FieldSlips, GlossaryTerms, Herbaria, HerbariumRecords, Images, Locations, Locations::Descriptions, Names, Names::Descriptions, Observations::Index, Projects, RssLogs, Sequences, SpeciesLists, Users.
- Kept and re-commented `CollectionNumbersController`'s override (its old comment was stale/misleading).
- Added a regression test for the HerbariumRecords sort-order fix.

## Test plan

- [x] `bin/rails test test/controllers/herbarium_records_controller_test.rb`
- [x] `bundle exec rubocop` on every touched file

<!-- changelog -->
article: no
<!-- /changelog -->
