### PR TITLE
Gate the observation-list panel on editable lists; redirect to the observation

### DIFF
--- a/app/controllers/observations/species_lists_controller.rb
+++ b/app/controllers/observations/species_lists_controller.rb
@@ -28,7 +28,7 @@ module Observations
                     (@observation = find_observation!)
 
       unless permission!(@species_list)
-        return redirect_to(species_list_path(@species_list.id))
+        return redirect_with_query(permanent_observation_path(@observation.id))
       end
 
       set_list_ivars
@@ -92,7 +92,7 @@ module Observations
       species_list.add_observation(observation)
       flash_notice(:runtime_species_list_add_observation_success.
         t(name: species_list.unique_format_name, id: observation.id))
-      redirect_to(species_list_path(id: species_list.id))
+      redirect_with_query(permanent_observation_path(observation.id))
     end
 
     # Used by manage_species_lists.
@@ -100,7 +100,7 @@ module Observations
       species_list.remove_observation(observation)
       flash_notice(:runtime_species_list_remove_observation_success.
         t(name: species_list.unique_format_name, id: observation.id))
-      redirect_to(species_list_path(id: species_list.id))
+      redirect_with_query(permanent_observation_path(observation.id))
     end
   end
 end

--- a/app/views/controllers/observations/show/species_lists_panel.rb
+++ b/app/views/controllers/observations/show/species_lists_panel.rb
@@ -3,13 +3,16 @@
 # "Species lists" panel on the observation show page. When the
 # observation already belongs to species lists, the heading is the
 # bare "Observation Lists" title with an icon-only "manage lists"
-# link flush right (for users who own any species lists), and the
+# link flush right (for users who can edit any species list), and the
 # body lists every species_list this observation is part of, with
 # an inline `[REMOVE]` button for any list the user has permission
 # to edit. When the observation belongs to no lists yet, the whole
 # heading is an icon+text "Add to an Observation List" link — shown
-# only if the user owns a list to add it to; otherwise the panel
-# doesn't render at all.
+# only if the user can edit a list to add it to; otherwise the panel
+# does not render.
+#
+# The link is gated on editable lists, not owned ones, so a foray
+# recorder who can edit a project list (but owns none) can still add.
 #
 class Views::Controllers::Observations::Show::SpeciesListsPanel < Views::Base
   prop :obs, ::Observation
@@ -36,7 +39,7 @@ class Views::Controllers::Observations::Show::SpeciesListsPanel < Views::Base
   end
 
   def manage_link?
-    @user&.species_list_ids&.any?
+    @user&.all_editable_species_lists&.any?
   end
 
   def manage_link

--- a/test/controllers/observations/species_lists_controller_test.rb
+++ b/test/controllers/observations/species_lists_controller_test.rb
@@ -75,7 +75,7 @@ module Observations
       assert_not(spl.observations.member?(obs))
       params = { id: obs.id, species_list_id: spl.id, commit: "add" }
       requires_login(:update, params)
-      assert_redirected_to(species_list_path(spl.id))
+      assert_redirected_to(permanent_observation_path(obs.id))
       assert(spl.reload.observations.member?(obs))
     end
 
@@ -86,7 +86,7 @@ module Observations
       params = { id: obs.id, species_list_id: spl.id, commit: "add" }
       login("dick")
       put(:update, params: params)
-      assert_redirected_to(species_list_path(spl.id))
+      assert_redirected_to(permanent_observation_path(obs.id))
       assert_not(spl.reload.observations.member?(obs))
     end
 
@@ -111,14 +111,14 @@ module Observations
       assert_not_equal("rolf", owner)
 
       # Try with non-owner (can't use requires_user since failure is a redirect)
-      # effectively fails and gets redirected to show_species_list
+      # effectively fails and gets redirected to the observation
       requires_login(:update, params)
-      assert_redirected_to(species_list_path(spl.id))
+      assert_redirected_to(permanent_observation_path(obs.id))
       assert(spl.reload.observations.member?(obs))
 
       login(owner)
       put(:update, params: params)
-      assert_redirected_to(species_list_path(spl.id))
+      assert_redirected_to(permanent_observation_path(obs.id))
       assert_not(spl.reload.observations.member?(obs))
     end
 
@@ -203,7 +203,7 @@ module Observations
 
       put(:update,
           params: { id: obs2.id, species_list_id: spl1.id, commit: "add" })
-      assert_redirected_to(species_list_path(spl1.id))
+      assert_redirected_to(permanent_observation_path(obs2.id))
       get(:edit, params: { id: obs2.id })
       assert_select("form[action=?]",
                     observation_species_list_path(id: obs2.id,
@@ -215,7 +215,7 @@ module Observations
 
       put(:update,
           params: { id: obs2.id, species_list_id: spl1.id, commit: "remove" })
-      assert_redirected_to(species_list_path(spl1.id))
+      assert_redirected_to(permanent_observation_path(obs2.id))
       get(:edit, params: { id: obs2.id })
       assert_select("form[action=?]",
                     observation_species_list_path(id: obs2.id,

--- a/test/views/controllers/observations/show/species_lists_panel_test.rb
+++ b/test/views/controllers/observations/show/species_lists_panel_test.rb
@@ -21,17 +21,37 @@ class Views::Controllers::Observations::Show::SpeciesListsPanelTest <
                    "Expected no list when obs has no species_lists")
   end
 
-  def test_no_species_lists_and_no_owned_lists_renders_nothing
+  def test_no_species_lists_and_no_editable_lists_renders_nothing
     obs = observations(:imageless_unvouchered_obs)
     user = users(:dick)
     assert(obs.species_lists.none?,
            "Need obs fixture obs without species lists")
+
+    html = user.stub(:all_editable_species_lists, []) do
+      render(panel_with(obs, user))
+    end
+
+    assert_equal("", html)
+  end
+
+  # A recorder who owns no lists but can edit one (a project list) still
+  # gets the "add to a list" link -- the gate is editable, not owned.
+  def test_no_species_lists_but_can_edit_a_list_renders_add_link
+    obs = observations(:imageless_unvouchered_obs)
+    user = users(:dick)
     assert(user.species_list_ids.none?,
-           "Need user fixture who owns no species lists")
+           "premise: dick owns no species lists")
+    assert(user.all_editable_species_lists.any?,
+           "premise: dick can edit at least one species list")
 
     html = render(panel_with(obs, user))
 
-    assert_equal("", html)
+    assert_html(
+      html,
+      "a[href='#{routes.edit_observation_species_lists_path(obs.id)}']",
+      text: :show_observation_add_to_species_list.l
+    )
+    assert_no_html(html, "ul")
   end
 
   def test_no_species_lists_but_user_owns_lists_renders_add_link


### PR DESCRIPTION
## Summary

Two fixes to the "Observation Lists" (species-list) panel on the observation show page.

**The add/manage link now follows editable lists, not just the ones a user created.** `SpeciesListsPanel#manage_link?` gated on `@user.species_list_ids` (the lists the user created), so the "Add to an Observation List" link came and went depending on whether a recorder happened to have created a personal list. A foray recorder who can edit a project/foray list but created none saw no link and could not add through the panel. It now gates on `@user.all_editable_species_lists`, the same set the edit page (`Query.lookup(:SpeciesList, editable_by_user:)`) and the `permission!` check on `update` already use -- so a recorder can add any observation to any list they can edit.

**Add/remove now returns to the observation, not the species list.** `add_observation_to_species_list`, `remove_observation_from_species_list`, and the permission-denied path all redirected to `species_list_path`. From the panel button and the `observations/:id/species_lists/edit` page the user is working in the observation's context, so they now `redirect_with_query(permanent_observation_path(...))` back to the observation show page, preserving the pager query.

## Notes

- The permission to add an observation to a list keys on editing the *list* (`permission!(@species_list)`), not the observation -- so this does not let anyone touch an observation they could not already, it just surfaces the link for lists they can curate.
- Panel test updated: the "renders nothing" case now stubs an empty editable set, and a new test covers a recorder with no personal list who can edit one. Controller test redirects updated to the observation.

## Test plan

- [x] `bin/rails test test/controllers/observations/species_lists_controller_test.rb test/views/controllers/observations/show/species_lists_panel_test.rb`
- Reviewer: as a project member who can edit the project's species list but created none, open an observation and confirm the "Add to an Observation List" link shows and lands you back on the observation after adding.

<!-- changelog -->
article: yes
Add Observations to any Species List you can edit
<!-- /changelog -->
