### PR TITLE
Render field slip name-approval radios inside the review form

### DIFF
--- a/app/views/controllers/images/field_slip_extracts/edit.rb
+++ b/app/views/controllers/images/field_slip_extracts/edit.rb
@@ -18,7 +18,6 @@ module Views::Controllers::Images::FieldSlipExtracts
       container_class(:full)
 
       render_flags
-      render_name_feedback if @name_feedback.present?
       Row do
         Column(xs: 12, md: 5) { render_slip_photo }
         Column(xs: 12, md: 7) { render_form }
@@ -91,22 +90,6 @@ module Views::Controllers::Images::FieldSlipExtracts
            target: new_project_alias_path(project_id: project.id))
     end
 
-    # The resolver's own feedback UI -- "create this name?", the
-    # ambiguous-author list, the deprecated-name alternatives -- reused
-    # rather than restated, so approving here behaves as it does on the
-    # observation form.
-    def render_name_feedback
-      render(Components::Form::NameFeedback.new(
-               button_name: :field_slip_extract_save.l,
-               given_name: @given_name.to_s,
-               names: @name_feedback[:names],
-               valid_names: @name_feedback[:valid_names],
-               suggest_corrections:
-                 @name_feedback[:suggest_corrections].present?,
-               parent_deprecated: @name_feedback[:parent_deprecated].presence
-             ))
-    end
-
     def render_slip_photo
       InteractiveImage(image: @extract.image, user: @user, votes: false)
     end
@@ -114,6 +97,7 @@ module Views::Controllers::Images::FieldSlipExtracts
     def render_form
       render(Form.new(image: @extract.image, extract: @extract,
                       approved_name: (@given_name if @name_feedback.present?),
+                      name_feedback: @name_feedback,
                       review: FormObject::FieldSlipReview.build(
                         extract: @extract, observation: @observation,
                         user: @user

--- a/app/views/controllers/images/field_slip_extracts/form.rb
+++ b/app/views/controllers/images/field_slip_extracts/form.rb
@@ -13,6 +13,12 @@ module Views::Controllers::Images::FieldSlipExtracts
     # back on the form action is what turns the resubmit into approval.
     prop :approved_name, _Nilable(String), default: nil
 
+    # The resolver's feedback for an unrecognized or ambiguous ID, set
+    # on the confirmation round-trip. Rendered inside this form (beside
+    # the ID field) so a radio choice submits with the Save button --
+    # rendered outside the form, the choice is dropped on submit.
+    prop :name_feedback, _Nilable(Hash), default: nil
+
     # Superform wants the form's data object as the first positional
     # arg; the review IS that object, so it goes to `super` rather than
     # being held as a separate prop -- `model` reaches it everywhere
@@ -203,11 +209,26 @@ module Views::Controllers::Images::FieldSlipExtracts
       Panel(panel_id: "field_slip_extract_name") do |p|
         p.with_body do
           render_name_field(row)
+          render_name_feedback if @name_feedback.present?
           render_name_use(row)
           render_vote_field
           Help(content: :field_slip_extract_id_help.l)
         end
       end
+    end
+
+    # The resolver's create/disambiguate UI, rendered inside the form so
+    # a radio choice (chosen_name) submits with the Save button.
+    def render_name_feedback
+      render(Components::Form::NameFeedback.new(
+               button_name: :field_slip_extract_save.l,
+               given_name: @approved_name.to_s,
+               names: @name_feedback[:names],
+               valid_names: @name_feedback[:valid_names],
+               suggest_corrections:
+                 @name_feedback[:suggest_corrections].present?,
+               parent_deprecated: @name_feedback[:parent_deprecated].presence
+             ))
     end
 
     def render_name_field(row)

--- a/test/views/controllers/images/field_slip_extracts/edit_test.rb
+++ b/test/views/controllers/images/field_slip_extracts/edit_test.rb
@@ -339,6 +339,22 @@ module Views::Controllers::Images::FieldSlipExtracts
                   "input[name='value[Location]'][value='Behind the barn']")
     end
 
+    # The ambiguous-name radio choice has to submit with the Save
+    # button so the resolver can pick the chosen Name. When the radios
+    # sat outside the form, the choice was dropped and the round-trip
+    # looped on the ambiguous name.
+    def test_ambiguous_name_feedback_radios_render_inside_the_form
+      options = [names(:coprinus_comatus), names(:agaricus_campestris)]
+      html = render(Edit.new(
+                      extract: extract_with(fields: { "ID" => "Mycena" }),
+                      observation: @obs, user: @user, given_name: "Mycena",
+                      name_feedback: { names: options }
+                    ))
+
+      assert_html(html,
+                  "form input[type='radio'][name='chosen_name[name_id]']")
+    end
+
     private
 
     # Puts a second observation in the project at a known location, so


### PR DESCRIPTION
## Summary

Fixes a broken Save on the field-slip review page when the reviewed ID is ambiguous or unrecognized.

When the model reads an ID like "Mycena" that matches several Names, `Naming::NameResolver` asks for a confirmation round-trip and the review re-renders with `Components::Form::NameFeedback` — the radio choices among the matching Names. But the Edit view rendered that feedback in the page `view_template`, **above and outside** the review `<form>` (`render_form`). The radios set `chosen_name`, but the Save button lives inside the form, so the choice was dropped on submit; the resolver re-ran on the still-ambiguous name and looped. To the reviewer, picking an option and clicking Save did nothing.

## Fix

Move the `NameFeedback` render into the form itself (`Views::Controllers::Images::FieldSlipExtracts::Form`), beside the ID field — the same pattern `Views::Controllers::Observations::Namings::Form` already uses. Now the radio is a descendant of the `<form>`, so `chosen_name[name_id]` submits with Save and the resolver resolves to the chosen Name.

`name_feedback` rides to the form as a declared prop (through `**attrs`), so the form's parameter list is unchanged.

## Test plan

- [x] `bin/rails test test/controllers/images/field_slip_extracts_controller_test.rb test/views/controllers/images/field_slip_extracts/edit_test.rb` (70 tests)
- New regression test asserts the radio renders as a descendant of the form (`form input[type='radio'][name='chosen_name[name_id]']`) — it fails when the feedback is rendered outside the form.
- Reviewer: review a field slip whose ID is an ambiguous genus (e.g. "Mycena"), pick one of the radio options, and confirm Save proposes that Name and returns to the observation.

<!-- changelog -->
article: yes
Fix saving a Field Slip review with an ambiguous name
<!-- /changelog -->
