### PR TITLE
Make `Project#violations` build an AR relation, paginate with SQL

### DIFF
--- a/app/controllers/projects/violations_controller.rb
+++ b/app/controllers/projects/violations_controller.rb
@@ -10,21 +10,23 @@
 module Projects
   class ViolationsController < ApplicationController
     before_action :login_required
-    # Cannot figure out the eager loading here.
-    around_action :skip_bullet, if: -> { defined?(Bullet) }, only: [:index]
 
-    # @violations is a plain Ruby Array (Project#violations), not a
-    # Query/AR relation, so it's paginated directly with
-    # PaginationData rather than through build_index_with_query's
-    # Query-driven machinery -- see the class doc on PaginationData
-    # for this exact "without Query" usage.
+    # `@project.violating_observations` is an AR relation (not a
+    # Query), so it's paginated directly with PaginationData rather
+    # than through build_index_with_query's Query-driven machinery --
+    # see the class doc on PaginationData for this "without Query"
+    # usage. Unlike the array-slicing shown there, the current page
+    # is fetched with LIMIT/OFFSET, so only one page of observations
+    # gets its violation kinds computed.
     def index
       return unless find_project!
 
-      @violations = @project.violations
+      observations = @project.violating_observations
       @pagination_data = number_pagination_data
-      @pagination_data.num_total = @violations.length
-      @violations = @violations[@pagination_data.from_to] || []
+      @pagination_data.num_total = observations.count
+      page = observations.offset(@pagination_data.from).
+             limit(@pagination_data.num_per_page)
+      @violations = @project.violations_for(page)
       render_index_view
     end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -317,23 +317,12 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     member?(user)
   end
 
-  # SQL-based count over the four violation kinds (#4136). Each branch
-  # plucks ids of OFFENDING observations and merges them into a Set
-  # for dedup; total cost is O(violations) rather than the
-  # O(visible_observations) cost of the full Ruby iteration in
-  # `#violations`. Called from the project show page's
-  # `render_violations_button` (inlined from the former
-  # `Tabs::ProjectsHelper#violations_button`), so any per-project
-  # work multiplies by the number of projects rendered.
+  # Called from the project show page's `render_violations_button`
+  # (inlined from the former `Tabs::ProjectsHelper#violations_button`),
+  # so any per-project work multiplies by the number of projects
+  # rendered.
   def count_violations
-    return 0 unless constraints?
-
-    ids = Set.new
-    collect_date_violation_ids(ids)
-    collect_bbox_violation_ids(ids)
-    collect_target_name_violation_ids(ids)
-    collect_target_location_violation_ids(ids)
-    ids.size
+    violating_observation_ids.size
   end
 
   def constraints?
@@ -740,7 +729,22 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     end.reduce(:or)
   end
 
-  # ----- helpers for SQL-based count_violations (#4136) -----
+  # ----- helpers for SQL-based violation detection -----
+
+  # Set of ids of every observation violating at least one configured
+  # constraint. Shared building block for `count_violations` (just
+  # the size) and `violating_observations` (the AR relation built
+  # from these ids).
+  def violating_observation_ids
+    return Set.new unless constraints?
+
+    ids = Set.new
+    collect_date_violation_ids(ids)
+    collect_bbox_violation_ids(ids)
+    collect_target_name_violation_ids(ids)
+    collect_target_location_violation_ids(ids)
+    ids
+  end
 
   def collect_date_violation_ids(ids)
     return unless start_date || end_date
@@ -912,16 +916,32 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   Violation = Struct.new(:obs, :kinds)
 
   def violations
-    return [] unless constraints?
+    violations_for(violating_observations)
+  end
 
-    rows = visible_observations.includes(:name, :location).
-           filter_map do |obs|
+  # Ordered relation of every observation violating at least one
+  # configured constraint. Unpaginated -- a caller that only needs
+  # one page (`Projects::ViolationsController#index`) should
+  # paginate this directly rather than loading every violation into
+  # Ruby first.
+  def violating_observations
+    return Observation.none unless constraints?
+
+    Observation.where(id: violating_observation_ids).
+      includes(:name, :location).order_by(:name)
+  end
+
+  # Builds `Violation` structs (obs + kinds) for a collection of
+  # observations already known to violate a constraint, e.g. a page
+  # of `violating_observations`. Skips any observation
+  # `violation_kinds_for` doesn't agree is a violation.
+  def violations_for(observations)
+    observations.filter_map do |obs|
       kinds = violation_kinds_for(obs)
       next if kinds.empty?
 
       Violation.new(obs, kinds)
     end
-    rows.sort_by { |v| v.obs.name&.sort_name.to_s.downcase }
   end
 
   # Returns the kinds of violation that apply to the given observation

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -757,6 +757,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
     ids.merge(obs_geoloc_outside_project_location.ids)
     ids.merge(obs_without_geoloc_location_not_contained_in_location.ids)
+    ids.merge(obs_missing_geoloc_and_location.ids)
   end
 
   def collect_target_name_violation_ids(ids)
@@ -1187,16 +1188,34 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
       end
   end
 
+  # Mirrors Location#found_here?'s first branch (`return true if
+  # obs.location == self`) -- an obs assigned to the project's
+  # location is compliant regardless of GPS precision, so it's
+  # excluded here even when its lat/lng falls outside the location's
+  # bbox.
   def obs_geoloc_outside_project_location
     visible_observations.
-      where.not(observations: { lat: nil }).not_in_box(**location.bounding_box)
+      where.not(observations: { lat: nil }).
+      where.not(location_id: location.id).
+      not_in_box(**location.bounding_box)
   end
 
   def obs_without_geoloc_location_not_contained_in_location
-    visible_observations.where(lat: nil).joins(:location).
+    visible_observations.where(lat: nil).
+      where.not(location_id: location.id).
+      joins(:location).
       merge(
         # invert_where is safe (doesn't invert observations.where(lat: nil))
         Location.not_in_box(**location.bounding_box)
       )
+  end
+
+  # Mirrors Location#found_here?'s last branch (`return false unless
+  # loc`) -- an obs with neither GPS nor an assigned Location can't
+  # be confirmed inside the project's area, so it violates. Neither
+  # of the two scopes above matches this case: one requires lat
+  # present, the other requires a location to join against.
+  def obs_missing_geoloc_and_location
+    visible_observations.where(lat: nil, location_id: nil)
   end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -622,6 +622,42 @@ class ProjectTest < UnitTestCase
                  "violating_observations should match violations, in order")
   end
 
+  # violation_kinds_for's bbox check (Location#found_here?) has two
+  # branches the four SQL id-collecting scopes must also cover, or
+  # count_violations/violating_observations would disagree with
+  # violates_location? for these obs.
+  def test_bbox_violation_matches_found_here_with_no_geoloc_or_location
+    proj = Project.create!(title: "Bbox Missing Info #{SecureRandom.hex(4)}",
+                           user: users(:rolf), location: locations(:burbank))
+    obs = Observation.create!(user: users(:rolf), when: Date.current,
+                              name: names(:agaricus), location_id: nil,
+                              lat: nil, lng: nil, where: "Nowhere specific")
+    proj.add_observation(obs)
+
+    assert(proj.violates_location?(obs),
+           "Test needs an obs with neither geoloc nor location")
+    assert_includes(proj.send(:violating_observation_ids), obs.id,
+                    "Obs with no geoloc and no location should violate " \
+                    "the project's location constraint")
+  end
+
+  def test_bbox_violation_matches_found_here_when_location_matches_project
+    proj = Project.create!(title: "Bbox Matching Loc #{SecureRandom.hex(4)}",
+                           user: users(:rolf), location: locations(:burbank))
+    outside_burbank = proj.location.north + 5.0
+    obs = Observation.create!(user: users(:rolf), when: Date.current,
+                              name: names(:agaricus), location: proj.location,
+                              lat: outside_burbank, lng: proj.location.east)
+    proj.add_observation(obs)
+
+    assert_not(proj.violates_location?(obs),
+               "Test needs an obs whose location matches the project's, " \
+               "with geoloc outside that location's bbox")
+    assert_not_includes(proj.send(:violating_observation_ids), obs.id,
+                        "Obs assigned to the project's location should be " \
+                        "compliant regardless of geoloc precision")
+  end
+
   # violating_observations is a relation, so a caller can paginate it
   # with LIMIT/OFFSET instead of loading every violation into Ruby.
   # Uses 3 target_name violations (not a fixture count, so this

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -614,6 +614,48 @@ class ProjectTest < UnitTestCase
     assert_equal(proj.violations.size, proj.count_violations)
   end
 
+  def test_violating_observations_matches_violations
+    proj = projects(:falmouth_2023_09_project)
+
+    assert_equal(proj.violations.map { |v| v.obs.id },
+                 proj.violating_observations.map(&:id),
+                 "violating_observations should match violations, in order")
+  end
+
+  # violating_observations is a relation, so a caller can paginate it
+  # with LIMIT/OFFSET instead of loading every violation into Ruby.
+  # Uses 3 target_name violations (not a fixture count, so this
+  # doesn't depend on fixture data staying in sync) to prove
+  # offset/limit slices the query.
+  def test_violating_observations_is_paginable_with_offset_and_limit
+    proj = Project.create!(title: "Paginable #{SecureRandom.hex(4)}",
+                           user: users(:rolf))
+    proj.add_target_name(names(:agaricus))
+    off_target = [observations(:peltigera_obs),
+                  observations(:california_obs),
+                  observations(:minimal_unknown_obs)]
+    off_target.each { |obs| proj.add_observation(obs) }
+
+    ordered_ids = proj.violations.map { |v| v.obs.id }
+    assert_equal(3, ordered_ids.size, "Test needs exactly 3 violations")
+
+    page = proj.violating_observations.offset(1).limit(1)
+    assert_equal([ordered_ids[1]], page.map(&:id),
+                 "offset(1).limit(1) should return only the 2nd violation")
+  end
+
+  def test_violations_for_skips_observations_that_are_not_violations
+    proj = projects(:falmouth_2023_09_project)
+    violating_obs = proj.violations.first.obs
+    visible = proj.visible_observations.to_a - [violating_obs]
+    passing_obs = visible.find { |obs| proj.violation_kinds_for(obs).empty? }
+    assert(passing_obs, "Test needs a visible obs that is not a violation")
+
+    result = proj.violations_for([violating_obs, passing_obs])
+
+    assert_equal([violating_obs.id], result.map { |v| v.obs.id })
+  end
+
   def test_candidate_observations_respects_date_range
     proj = build_target_name_project_with_dates
     in_range = observations(:agaricus_campestris_obs)


### PR DESCRIPTION
## Front-end behavior changes

- Some projects will show a **new** violation: an observation with neither GPS nor an assigned Location, in a project with a location constraint, now correctly appears (previously invisible).
- Some projects will show **one fewer** violation: an observation whose Location is the project's constrained Location, but whose GPS falls outside that Location's bounding box, is now correctly excluded (previously a false positive).
- Both affect the violations page's row list and the count badge on the project's page, since both now share the same id set.
- Pagination page size/boundaries are unchanged for unaffected projects — only the slicing mechanism changed (SQL LIMIT/OFFSET instead of Ruby array indexing).

## Summary

Closes #5256.

`Project#violations` iterated every visible observation in Ruby and sorted the full result, even though the violations page only displays one page at a time. `Project#count_violations` already proved the existence check is SQL-expressible via four `collect_*_violation_ids` scopes merged into a Set — extracted that merge into `violating_observation_ids`, shared by `count_violations` and the new `violating_observations` (an ordered AR relation built from those ids).

`Projects::ViolationsController#index` now paginates `violating_observations` with LIMIT/OFFSET and only computes violation kinds for the current page's observations, via the new `violations_for`. Removed the `skip_bullet` override — the eager loading needed for it turned out to be sufficient, confirmed by the controller/view tests passing without it.

## Bug found and fixed along the way

Unifying `count_violations` and `#violations` onto one SQL id set surfaced two pre-existing drifts between the SQL bbox scopes and `Location#found_here?` (the Ruby check `violation_kinds_for` uses), confirmed by direct reproduction against a rolled-back transaction:

- An obs with neither GPS nor an assigned Location was invisible to the SQL scopes (one requires lat present, the other requires a location to join against), but `found_here?` flags it as a violation. Added `obs_missing_geoloc_and_location` to cover it.
- An obs whose Location is the project's Location was wrongly flagged when its GPS fell outside that Location's bbox — `found_here?`'s first branch (`obs.location == self`) exempts this regardless of GPS precision, but the SQL scopes had no equivalent exemption. Added the missing `location_id` exclusion to both existing scopes.

These drifts predate this PR (they were already live in `count_violations`'s badge count), but this PR extends their reach to the violations list, so fixing them here keeps the new unified path correct instead of inheriting a known gap.

## Changes

- `Project#violating_observation_ids` — shared Set-building method (the merge `count_violations` already did), now also used by `violating_observations`.
- `Project#violating_observations` — ordered, unpaginated AR relation of every violating observation.
- `Project#violations_for(observations)` — builds `Violation` structs for a given collection (a page, or the full set for `#violations`).
- `Project#violations` — now `violations_for(violating_observations)`, same public contract (`Array<Violation>`), used by existing tests.
- Two bbox scopes fixed to match `Location#found_here?`; one new scope added for the missing case.
- `Projects::ViolationsController#index` paginates via LIMIT/OFFSET instead of Ruby array slicing; `skip_bullet` removed.
- New tests: `violating_observations` matches `violations`, LIMIT/OFFSET pagination slices correctly, `violations_for` skips non-violations, and the two bbox parity fixes.

## Test plan

- [x] `bin/rails test test/models/project_test.rb`
- [x] `bundle exec rubocop` on every touched file

<!-- changelog -->
article: no
<!-- /changelog -->
