### PR TITLE
Make `Project#violations` build a single query, eliminating N+1s

### DIFF
--- a/app/controllers/projects/violations_controller.rb
+++ b/app/controllers/projects/violations_controller.rb
@@ -10,21 +10,23 @@
 module Projects
   class ViolationsController < ApplicationController
     before_action :login_required
-    # Cannot figure out the eager loading here.
-    around_action :skip_bullet, if: -> { defined?(Bullet) }, only: [:index]
 
-    # @violations is a plain Ruby Array (Project#violations), not a
-    # Query/AR relation, so it's paginated directly with
-    # PaginationData rather than through build_index_with_query's
-    # Query-driven machinery -- see the class doc on PaginationData
-    # for this exact "without Query" usage.
+    # `@project.violating_observations` is an AR relation (not a
+    # Query), so it's paginated directly with PaginationData rather
+    # than through build_index_with_query's Query-driven machinery --
+    # see the class doc on PaginationData for this "without Query"
+    # usage. Unlike the array-slicing shown there, the current page
+    # is fetched with LIMIT/OFFSET, so only one page of observations
+    # gets its violation kinds computed.
     def index
       return unless find_project!
 
-      @violations = @project.violations
+      observations = @project.violating_observations
       @pagination_data = number_pagination_data
-      @pagination_data.num_total = @violations.length
-      @violations = @violations[@pagination_data.from_to] || []
+      @pagination_data.num_total = observations.count
+      page = observations.offset(@pagination_data.from).
+             limit(@pagination_data.num_per_page)
+      @violations = @project.violations_for(page)
       render_index_view
     end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -305,7 +305,6 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   def found_here?(obs)
-    return true if obs.location == self
     return contains?(obs.lat, obs.lng) if obs.lat && obs.lng
 
     loc = obs.location

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -817,16 +817,11 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         or(base.where(Observation[:when].lt(start_date)))
     end
 
-    # Location#found_here? checks obs.location == self first, before
-    # geoloc or location-bbox logic. The three branches below don't
-    # each repeat that exclusion; it's ANDed onto the combined result
-    # once instead, via not_project_location_condition.
     def project_violating_by_bbox(project, base)
       location = project.location
       return unless location
 
-      branches = bbox_violation_branches(base, location)
-      branches.reduce(:or).where(not_project_location_condition(location))
+      bbox_violation_branches(base, location).reduce(:or)
     end
 
     def bbox_violation_branches(base, location)
@@ -836,15 +831,6 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         merge(Location.not_in_box(**location.bounding_box))
       no_geoloc_no_location = base.where(lat: nil, location_id: nil)
       [has_geoloc, no_geoloc_has_location, no_geoloc_no_location]
-    end
-
-    # `location_id != X` is false in SQL for rows where location_id
-    # IS NULL, so a plain where.not(location_id: location.id) would
-    # drop no-location rows from the combined result. Comparing
-    # against nil explicitly keeps them in.
-    def not_project_location_condition(location)
-      Observation[:location_id].not_eq(location.id).
-        or(Observation[:location_id].eq(nil))
     end
 
     def project_violating_by_target_name(project, base)

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -623,22 +623,19 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     }
     # Every observation violating at least one of the given project's
     # configured constraints (date range, bbox, target names, target
-    # locations). See the project_violating_by_* class methods below
+    # locations). See the project_*_violation_ids class methods below
     # for the per-kind logic.
     scope :project_violations, lambda { |project|
       project = Project.find(project) unless project.is_a?(Project)
       return none unless project.constraints?
 
-      base = project_violation_base(project)
-      relations = [
-        project_violating_by_date(project, base),
-        project_violating_by_bbox(project, base),
-        project_violating_by_target_name(project, base),
-        project_violating_by_target_location(project, base)
-      ].compact
+      ids = Set.new
+      ids.merge(project_date_violation_ids(project))
+      ids.merge(project_bbox_violation_ids(project))
+      ids.merge(project_target_name_violation_ids(project))
+      ids.merge(project_target_location_violation_ids(project))
 
-      relations.reduce(:or).distinct.includes(:name, :location).
-        order_by(:name)
+      where(id: ids).includes(:name, :location).order_by(:name)
     }
     scope :species_lists, lambda { |species_lists|
       spl_ids = Lookup::SpeciesLists.new(species_lists).ids
@@ -801,15 +798,27 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     end
 
     # ----- helpers for the project_violations scope -----
+    #
+    # Each helper runs a separate query plucking the ids of
+    # observations violating one constraint kind. project_violations
+    # merges the four id sets in Ruby and wraps the result in a single
+    # where(id: ...), rather than combining four relations into one
+    # query with Relation#or. Relation#or dedups the two sides' where
+    # clauses by comparing Arel nodes with ==, and for two predicates
+    # that are structurally similar but semantically different (see
+    # project_target_location_violation_ids) that == is wrong, so
+    # Relation#or can silently drop one of them.
 
-    def project_violation_base(project)
-      project.visible_observations.left_joins(:name, :location)
-    end
-
-    def project_violating_by_date(project, base)
+    def project_date_violation_ids(project)
       start_date = project.start_date
       end_date = project.end_date
-      return unless start_date || end_date
+      return [] unless start_date || end_date
+
+      project_date_violations(project.visible_observations,
+                              start_date, end_date).ids
+    end
+
+    def project_date_violations(base, start_date, end_date)
       return base.where(Observation[:when].gt(end_date)) unless start_date
       return base.where(Observation[:when].lt(start_date)) unless end_date
 
@@ -817,43 +826,51 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         or(base.where(Observation[:when].lt(start_date)))
     end
 
-    def project_violating_by_bbox(project, base)
+    def project_bbox_violation_ids(project)
       location = project.location
-      return unless location
+      return [] unless location
 
-      bbox_violation_branches(base, location).reduce(:or)
+      base = project.visible_observations
+      geoloc_outside_bbox_ids(base, location) +
+        location_outside_bbox_ids(base, location) +
+        no_geoloc_no_location_ids(base)
     end
 
-    def bbox_violation_branches(base, location)
-      has_geoloc = base.where.not(lat: nil).not_in_box(**location.bounding_box)
-      no_geoloc_has_location =
-        base.where(lat: nil).where.not(location_id: nil).
-        merge(Location.not_in_box(**location.bounding_box))
-      no_geoloc_no_location = base.where(lat: nil, location_id: nil)
-      [has_geoloc, no_geoloc_has_location, no_geoloc_no_location]
+    def geoloc_outside_bbox_ids(base, location)
+      base.where.not(lat: nil).not_in_box(**location.bounding_box).ids
     end
 
-    def project_violating_by_target_name(project, base)
-      return unless project.target_names.any?
-
-      base.where.not(name_id: project.expanded_target_name_id_set.to_a)
+    def location_outside_bbox_ids(base, location)
+      base.where(lat: nil).where.not(location_id: nil).
+        left_joins(:location).
+        merge(Location.not_in_box(**location.bounding_box)).ids
     end
 
-    # Builds the combined predicate with Arel's `.or` directly
-    # instead of `Relation#or` -- `Relation#or` diffs the two sides'
-    # where clauses using Arel node `==`, which considers
-    # location_suffix_conditions and where_suffix_conditions equal
-    # (same LIKE-or-equals shape, different columns) even though
-    # their `hash`es differ, and silently drops one of the two.
-    def project_violating_by_target_location(project, base)
-      return unless project.target_locations.any?
+    def no_geoloc_no_location_ids(base)
+      base.where(lat: nil, location_id: nil).ids
+    end
 
-      has_loc = Observation[:location_id].not_eq(nil).
-                and(project.location_suffix_conditions)
-      no_loc = Observation[:location_id].eq(nil).
-               and(project.where_suffix_conditions)
-      passing = base.where(has_loc.or(no_loc))
-      base.where.not(id: passing.select(:id))
+    def project_target_name_violation_ids(project)
+      return [] unless project.target_names_present?
+
+      project.visible_observations.
+        where.not(name_id: project.expanded_target_name_id_set.to_a).ids
+    end
+
+    # An observation passes the target-location check if its
+    # Location's name matches a target location's name, or, lacking a
+    # Location, its where text matches. A name-suffix match, not a
+    # bounding box -- project_bbox_violation_ids covers that check.
+    # Violation ids are every other visible observation.
+    def project_target_location_violation_ids(project)
+      return [] unless project.target_locations_present?
+
+      base = project.visible_observations
+      passing_ids = base.where.not(location_id: nil).left_joins(:location).
+                    where(project.location_suffix_conditions).ids
+      passing_ids += base.where(location_id: nil).
+                     where(project.where_suffix_conditions).ids
+      base.where.not(id: passing_ids).ids
     end
   end
 end

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -843,18 +843,29 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
         no_geoloc_no_location_ids(base)
     end
 
+    # Location#found_here? only trusts GPS when both lat and lng are
+    # present -- match that here rather than keying off lat alone, so
+    # a row with one of the two set (blocked at the model layer by
+    # Observation#check_latitude/#check_longitude, but not something
+    # the DB itself forbids) can't fall through every branch below
+    # unclassified.
+    def incomplete_or_missing_geoloc
+      Observation[:lat].eq(nil).or(Observation[:lng].eq(nil))
+    end
+
     def geoloc_outside_bbox_ids(base, location)
-      base.where.not(lat: nil).not_in_box(**location.bounding_box).ids
+      base.where.not(incomplete_or_missing_geoloc).
+        not_in_box(**location.bounding_box).ids
     end
 
     def location_outside_bbox_ids(base, location)
-      base.where(lat: nil).where.not(location_id: nil).
+      base.where(incomplete_or_missing_geoloc).where.not(location_id: nil).
         left_joins(:location).
         merge(Location.not_in_box(**location.bounding_box)).ids
     end
 
     def no_geoloc_no_location_ids(base)
-      base.where(lat: nil, location_id: nil).ids
+      base.where(incomplete_or_missing_geoloc).where(location_id: nil).ids
     end
 
     def project_target_name_violation_ids(project)

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -861,16 +861,26 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     # Location's name matches a target location's name, or, lacking a
     # Location, its where text matches. A name-suffix match, not a
     # bounding box -- project_bbox_violation_ids covers that check.
-    # Violation ids are every other visible observation.
+    # An observation with a Location violates when that name doesn't
+    # match; one without a Location violates when its where text
+    # doesn't match. The two branches partition on location_id, so
+    # concatenating their ids needs no dedup.
     def project_target_location_violation_ids(project)
       return [] unless project.target_locations_present?
 
       base = project.visible_observations
-      passing_ids = base.where.not(location_id: nil).left_joins(:location).
-                    where(project.location_suffix_conditions).ids
-      passing_ids += base.where(location_id: nil).
-                     where(project.where_suffix_conditions).ids
-      base.where.not(id: passing_ids).ids
+      with_location_violation_ids(base, project) +
+        no_location_violation_ids(base, project)
+    end
+
+    def with_location_violation_ids(base, project)
+      base.where.not(location_id: nil).left_joins(:location).
+        where.not(project.location_suffix_conditions).ids
+    end
+
+    def no_location_violation_ids(base, project)
+      base.where(location_id: nil).
+        where.not(project.where_suffix_conditions).ids
     end
   end
 end

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -629,13 +629,8 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       project = Project.find(project) unless project.is_a?(Project)
       return none unless project.constraints?
 
-      ids = Set.new
-      ids.merge(project_date_violation_ids(project))
-      ids.merge(project_bbox_violation_ids(project))
-      ids.merge(project_target_name_violation_ids(project))
-      ids.merge(project_target_location_violation_ids(project))
-
-      where(id: ids).includes(:name, :location).order_by(:name)
+      where(id: project_violation_ids(project)).includes(:name, :location).
+        order_by(:name)
     }
     scope :species_lists, lambda { |species_lists|
       spl_ids = Lookup::SpeciesLists.new(species_lists).ids
@@ -800,14 +795,26 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
     # ----- helpers for the project_violations scope -----
     #
     # Each helper runs a separate query plucking the ids of
-    # observations violating one constraint kind. project_violations
-    # merges the four id sets in Ruby and wraps the result in a single
-    # where(id: ...), rather than combining four relations into one
-    # query with Relation#or. Relation#or dedups the two sides' where
-    # clauses by comparing Arel nodes with ==, and for two predicates
-    # that are structurally similar but semantically different (see
-    # project_target_location_violation_ids) that == is wrong, so
-    # Relation#or can silently drop one of them.
+    # observations violating one constraint kind. project_violation_ids
+    # merges the four id sets in Ruby, rather than combining four
+    # relations into one query with Relation#or. Relation#or dedups
+    # the two sides' where clauses by comparing Arel nodes with ==,
+    # and for two predicates that are structurally similar but
+    # semantically different (see project_target_location_violation_ids)
+    # that == is wrong, so Relation#or can silently drop one of them.
+    #
+    # Public so Project#count_violations can take just the Set's size,
+    # skipping the includes/order_by/distinct project_violations adds
+    # for display -- a count doesn't need the observations sorted or
+    # their name/location eager-loaded.
+    def project_violation_ids(project)
+      ids = Set.new
+      ids.merge(project_date_violation_ids(project))
+      ids.merge(project_bbox_violation_ids(project))
+      ids.merge(project_target_name_violation_ids(project))
+      ids.merge(project_target_location_violation_ids(project))
+      ids
+    end
 
     def project_date_violation_ids(project)
       start_date = project.start_date

--- a/app/models/observation/scopes.rb
+++ b/app/models/observation/scopes.rb
@@ -621,6 +621,25 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
       joins(species_lists: :project_species_lists).
         where(project_species_lists: { project: project_ids }).distinct
     }
+    # Every observation violating at least one of the given project's
+    # configured constraints (date range, bbox, target names, target
+    # locations). See the project_violating_by_* class methods below
+    # for the per-kind logic.
+    scope :project_violations, lambda { |project|
+      project = Project.find(project) unless project.is_a?(Project)
+      return none unless project.constraints?
+
+      base = project_violation_base(project)
+      relations = [
+        project_violating_by_date(project, base),
+        project_violating_by_bbox(project, base),
+        project_violating_by_target_name(project, base),
+        project_violating_by_target_location(project, base)
+      ].compact
+
+      relations.reduce(:or).distinct.includes(:name, :location).
+        order_by(:name)
+    }
     scope :species_lists, lambda { |species_lists|
       spl_ids = Lookup::SpeciesLists.new(species_lists).ids
       joins(:species_list_observations).
@@ -779,6 +798,76 @@ module Observation::Scopes # rubocop:disable Metrics/ModuleLength
                       (value + 1.0)
         Observation[:vote_cache].lt(next_higher)
       end
+    end
+
+    # ----- helpers for the project_violations scope -----
+
+    def project_violation_base(project)
+      project.visible_observations.left_joins(:name, :location)
+    end
+
+    def project_violating_by_date(project, base)
+      start_date = project.start_date
+      end_date = project.end_date
+      return unless start_date || end_date
+      return base.where(Observation[:when].gt(end_date)) unless start_date
+      return base.where(Observation[:when].lt(start_date)) unless end_date
+
+      base.where(Observation[:when].gt(end_date)).
+        or(base.where(Observation[:when].lt(start_date)))
+    end
+
+    # Location#found_here? checks obs.location == self first, before
+    # geoloc or location-bbox logic. The three branches below don't
+    # each repeat that exclusion; it's ANDed onto the combined result
+    # once instead, via not_project_location_condition.
+    def project_violating_by_bbox(project, base)
+      location = project.location
+      return unless location
+
+      branches = bbox_violation_branches(base, location)
+      branches.reduce(:or).where(not_project_location_condition(location))
+    end
+
+    def bbox_violation_branches(base, location)
+      has_geoloc = base.where.not(lat: nil).not_in_box(**location.bounding_box)
+      no_geoloc_has_location =
+        base.where(lat: nil).where.not(location_id: nil).
+        merge(Location.not_in_box(**location.bounding_box))
+      no_geoloc_no_location = base.where(lat: nil, location_id: nil)
+      [has_geoloc, no_geoloc_has_location, no_geoloc_no_location]
+    end
+
+    # `location_id != X` is false in SQL for rows where location_id
+    # IS NULL, so a plain where.not(location_id: location.id) would
+    # drop no-location rows from the combined result. Comparing
+    # against nil explicitly keeps them in.
+    def not_project_location_condition(location)
+      Observation[:location_id].not_eq(location.id).
+        or(Observation[:location_id].eq(nil))
+    end
+
+    def project_violating_by_target_name(project, base)
+      return unless project.target_names.any?
+
+      base.where.not(name_id: project.expanded_target_name_id_set.to_a)
+    end
+
+    # Builds the combined predicate with Arel's `.or` directly
+    # instead of `Relation#or` -- `Relation#or` diffs the two sides'
+    # where clauses using Arel node `==`, which considers
+    # location_suffix_conditions and where_suffix_conditions equal
+    # (same LIKE-or-equals shape, different columns) even though
+    # their `hash`es differ, and silently drops one of the two.
+    def project_violating_by_target_location(project, base)
+      return unless project.target_locations.any?
+
+      has_loc = Observation[:location_id].not_eq(nil).
+                and(project.location_suffix_conditions)
+      no_loc = Observation[:location_id].eq(nil).
+               and(project.where_suffix_conditions)
+      passing = base.where(has_loc.or(no_loc))
+      base.where.not(id: passing.select(:id))
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -320,8 +320,14 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # Called from the project show page's render_violations_button, so
   # any per-project work multiplies by the number of projects
   # rendered.
+  # Counts via the same per-kind id helpers project_violations uses,
+  # not violating_observations.count -- that relation carries
+  # includes/order_by/distinct for display, none of which a count
+  # needs, and .count would otherwise re-run all of it as a query.
   def count_violations
-    violating_observations.count
+    return 0 unless constraints?
+
+    Observation.project_violation_ids(self).size
   end
 
   def constraints?
@@ -745,10 +751,10 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # target_location violation check).
   def location_suffix_conditions
     tbl = Location.arel_table
-    target_locations.map do |tl|
-      escaped = self.class.sanitize_sql_like(tl.name)
+    target_location_names.map do |name|
+      escaped = self.class.sanitize_sql_like(name)
       tbl[:name].matches("%, #{escaped}").
-        or(tbl[:name].eq(tl.name))
+        or(tbl[:name].eq(name))
     end.reduce(:or)
   end
 
@@ -756,10 +762,10 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # `observations.where` (used when an obs has no location_id).
   def where_suffix_conditions
     tbl = Observation.arel_table
-    target_locations.map do |tl|
-      escaped = self.class.sanitize_sql_like(tl.name)
+    target_location_names.map do |name|
+      escaped = self.class.sanitize_sql_like(name)
       tbl[:where].matches("%, #{escaped}").
-        or(tbl[:where].eq(tl.name))
+        or(tbl[:where].eq(name))
     end.reduce(:or)
   end
 
@@ -1041,8 +1047,8 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
            end
     return false if name.blank?
 
-    target_locations.any? do |tl|
-      name == tl.name || name.end_with?(", #{tl.name}")
+    target_location_names.any? do |tl_name|
+      name == tl_name || name.end_with?(", #{tl_name}")
     end
   end
 
@@ -1069,6 +1075,17 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   def invalidate_expanded_target_name_id_set!
     remove_instance_variable(:@expanded_target_name_id_set) if
       defined?(@expanded_target_name_id_set)
+  end
+
+  # Same reasoning as expanded_target_name_id_set above: reads via
+  # project_target_locations, not the target_locations association,
+  # so add_target_location/remove_target_location updating the join
+  # table directly doesn't leave a caller's already-loaded
+  # target_locations stale. location_suffix_conditions/
+  # where_suffix_conditions always see the current list, with no
+  # invalidation call needed on the mutator side.
+  def target_location_names
+    project_target_locations.joins(:location).pluck(Location[:name])
   end
 
   def trackers

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -934,7 +934,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
       violating_by_target_location(base)
     ].compact
 
-    relations.reduce(:or).distinct.order_by(:name)
+    relations.reduce(:or).distinct.includes(:name, :location).order_by(:name)
   end
 
   # Builds `Violation` structs (obs + kinds) for a collection of

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -800,13 +800,20 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     base.where.not(name_id: expanded_target_name_id_set.to_a)
   end
 
+  # Builds the combined predicate with Arel's `.or` directly instead
+  # of `Relation#or` -- `Relation#or` diffs the two sides' where
+  # clauses using Arel node `==`, which considers
+  # location_suffix_conditions and where_suffix_conditions equal
+  # (same LIKE-or-equals shape, different columns) even though their
+  # `hash`es differ, and silently drops one of the two.
   def violating_by_target_location(base)
     return unless target_locations.any?
 
-    with_loc = base.where.not(location_id: nil).
-               where(location_suffix_conditions)
-    without_loc = base.where(location_id: nil).where(where_suffix_conditions)
-    base.where.not(id: with_loc.or(without_loc).select(:id))
+    has_loc = Observation[:location_id].not_eq(nil).
+              and(location_suffix_conditions)
+    no_loc = Observation[:location_id].eq(nil).and(where_suffix_conditions)
+    passing = base.where(has_loc.or(no_loc))
+    base.where.not(id: passing.select(:id))
   end
 
   public

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -609,10 +609,12 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # Add target name to this project if not already present.
   def add_target_name(name)
     project_target_names.find_or_create_by!(name: name)
-    @target_names_present = true
     touch
   rescue ActiveRecord::RecordNotUnique
-    # Already exists, no-op
+    # Already exists, no-op -- a concurrent insert raced this one, but
+    # the target name exists either way.
+  ensure
+    @target_names_present = true
   end
 
   # Remove target name from this project. Also removes observations
@@ -632,10 +634,12 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # Add target location to this project if not already present.
   def add_target_location(location)
     project_target_locations.find_or_create_by!(location: location)
-    @target_locations_present = true
     touch
   rescue ActiveRecord::RecordNotUnique
-    # Already exists, no-op
+    # Already exists, no-op -- a concurrent insert raced this one, but
+    # the target location exists either way.
+  ensure
+    @target_locations_present = true
   end
 
   # Remove target location from this project.
@@ -679,9 +683,8 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   # GPS-inside-bbox OR (no GPS AND obs.location bbox is fully
-  # contained in project bbox). Mirrors out_of_area_observations'
-  # inverse so candidate_observations and the bbox violation kind
-  # agree on what "in" means.
+  # contained in project bbox). Agrees with the bbox violation kind
+  # in Observation.project_violations on what "in" means.
   def constrain_to_project_bbox(scope)
     return scope if location.nil?
 
@@ -987,15 +990,6 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
-  # Obs lat/lon is outside Project.location exor
-  # Obs location is not a subset of Project.location
-  def out_of_area_observations
-    return [] if location.nil?
-
-    obs_geoloc_outside_project_location +
-      obs_without_geoloc_location_not_contained_in_location
-  end
-
   def violates_constraints?(observation)
     violation_kinds_for(observation).any?
   end
@@ -1152,27 +1146,5 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
       transform_values do |aliases|
         aliases.map { |project_alias| [project_alias.name, project_alias.id] }
       end
-  end
-
-  # Mirrors Location#found_here?'s first branch (`return true if
-  # obs.location == self`) -- an obs assigned to the project's
-  # location is compliant regardless of GPS precision, so it's
-  # excluded here even when its lat/lng falls outside the location's
-  # bbox.
-  def obs_geoloc_outside_project_location
-    visible_observations.
-      where.not(observations: { lat: nil }).
-      where.not(location_id: location.id).
-      not_in_box(**location.bounding_box)
-  end
-
-  def obs_without_geoloc_location_not_contained_in_location
-    visible_observations.where(lat: nil).
-      where.not(location_id: location.id).
-      joins(:location).
-      merge(
-        # invert_where is safe (doesn't invert observations.where(lat: nil))
-        Location.not_in_box(**location.bounding_box)
-      )
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -326,7 +326,26 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
   def constraints?
     start_date || end_date || location ||
-      target_names.any? || target_locations.any?
+      target_names_present? || target_locations_present?
+  end
+
+  # Memoized: violation_kinds_for calls violates_target_name?/
+  # violates_target_location? once per observation, and neither
+  # target_names.any? nor target_locations.any? caches its result on
+  # an unloaded association -- without this, checking violations for
+  # a page of observations re-queries "does this project have any
+  # target names/locations" once per observation instead of once per
+  # request.
+  def target_names_present?
+    return @target_names_present if defined?(@target_names_present)
+
+    @target_names_present = target_names.any?
+  end
+
+  def target_locations_present?
+    return @target_locations_present if defined?(@target_locations_present)
+
+    @target_locations_present = target_locations.any?
   end
 
   # Check if user has permission to edit a given object.
@@ -590,6 +609,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # Add target name to this project if not already present.
   def add_target_name(name)
     project_target_names.find_or_create_by!(name: name)
+    @target_names_present = true
     touch
   rescue ActiveRecord::RecordNotUnique
     # Already exists, no-op
@@ -604,12 +624,15 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
     record.destroy
     purge_observations_matching_name(name)
+    remove_instance_variable(:@target_names_present) if
+      defined?(@target_names_present)
     touch
   end
 
   # Add target location to this project if not already present.
   def add_target_location(location)
     project_target_locations.find_or_create_by!(location: location)
+    @target_locations_present = true
     touch
   rescue ActiveRecord::RecordNotUnique
     # Already exists, no-op
@@ -621,6 +644,8 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     return unless record
 
     record.destroy
+    remove_instance_variable(:@target_locations_present) if
+      defined?(@target_locations_present)
     touch
   end
 
@@ -1060,7 +1085,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # AND the observation's name (with synonyms and sub-taxa expansion,
   # matching candidate_observations) is not in it.
   def violates_target_name?(observation)
-    return false unless target_names.any?
+    return false unless target_names_present?
 
     expanded_target_name_id_set.exclude?(observation.name_id)
   end
@@ -1070,7 +1095,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # the obs's location name (or `where`, when there's no location).
   # GPS overlap with a target_location does NOT satisfy the rule.
   def violates_target_location?(observation)
-    return false unless target_locations.any?
+    return false unless target_locations_present?
 
     !target_location_suffix_match?(observation)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -644,11 +644,13 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   def add_target_location(location)
     project_target_locations.find_or_create_by!(location: location)
     @target_locations_present = true
+    invalidate_target_location_names!
     touch
   rescue ActiveRecord::RecordNotUnique
     # Already exists, no-op -- a concurrent insert raced this one, but
     # the target location exists either way.
     @target_locations_present = true
+    invalidate_target_location_names!
   end
 
   # Remove target location from this project.
@@ -659,6 +661,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     record.destroy
     remove_instance_variable(:@target_locations_present) if
       defined?(@target_locations_present)
+    invalidate_target_location_names!
     touch
   end
 
@@ -1085,7 +1088,17 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # where_suffix_conditions always see the current list, with no
   # invalidation call needed on the mutator side.
   def target_location_names
-    project_target_locations.joins(:location).pluck(Location[:name])
+    @target_location_names ||=
+      project_target_locations.joins(:location).pluck(Location[:name])
+  end
+
+  # add_target_location/remove_target_location call this so a
+  # Project instance that already memoized the name list doesn't
+  # keep using a stale one after the target_locations it's built
+  # from changed.
+  def invalidate_target_location_names!
+    remove_instance_variable(:@target_location_names) if
+      defined?(@target_location_names)
   end
 
   def trackers

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1049,21 +1049,24 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # Memoized: project's target_names with synonyms + sub-taxa expanded
   # into a Set of name_ids, matching the candidate_observations rule.
   # Used by violates_target_name? as a per-obs membership test.
+  # Reads name ids via project_target_names.pluck, not the
+  # target_names association -- target_names may already be loaded
+  # (callers like TargetNamesController#add_names check it before
+  # add_target_name/remove_target_name run) on a strict_loading
+  # Project, and resetting or reloading it here to pick up the change
+  # would make a later access of that same association raise
+  # ActiveRecord::StrictLoadingViolationError instead of reusing its
+  # existing load. pluck queries project_target_names directly and
+  # doesn't touch target_names' loaded state.
   def expanded_target_name_id_set
     @expanded_target_name_id_set ||=
-      expanded_target_name_ids(target_name_ids).to_set
+      expanded_target_name_ids(project_target_names.pluck(:name_id)).to_set
   end
 
   # add_target_name/remove_target_name call this so a Project
   # instance that already memoized the expanded set doesn't keep
   # using a stale one after the target_names it's built from changed.
   def invalidate_expanded_target_name_id_set!
-    # target_names is a has_many :through the project_target_names
-    # join table add/remove_target_name just mutated directly, so
-    # Rails' association cache doesn't know to invalidate it -- reset
-    # it too, or target_name_ids below would still return the
-    # pre-change list.
-    target_names.reset
     remove_instance_variable(:@expanded_target_name_id_set) if
       defined?(@expanded_target_name_id_set)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -317,12 +317,11 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     member?(user)
   end
 
-  # Called from the project show page's `render_violations_button`
-  # (inlined from the former `Tabs::ProjectsHelper#violations_button`),
-  # so any per-project work multiplies by the number of projects
+  # Called from the project show page's render_violations_button, so
+  # any per-project work multiplies by the number of projects
   # rendered.
   def count_violations
-    violating_observation_ids.size
+    violating_observations.count
   end
 
   def constraints?
@@ -731,58 +730,58 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
   # ----- helpers for SQL-based violation detection -----
 
-  # Set of ids of every observation violating at least one configured
-  # constraint. Shared building block for `count_violations` (just
-  # the size) and `violating_observations` (the AR relation built
-  # from these ids).
-  def violating_observation_ids
-    return Set.new unless constraints?
-
-    ids = Set.new
-    collect_date_violation_ids(ids)
-    collect_bbox_violation_ids(ids)
-    collect_target_name_violation_ids(ids)
-    collect_target_location_violation_ids(ids)
-    ids
+  # Each constraint kind builds a relation off the same base, so all
+  # of them can combine with Relation#or into one query. A kind
+  # returns nil when the project doesn't have that constraint set;
+  # violating_observations drops the nils before combining.
+  def violation_detection_base
+    visible_observations.left_joins(:name, :location)
   end
 
-  def collect_date_violation_ids(ids)
+  def violating_by_date(base)
     return unless start_date || end_date
+    return base.where(Observation[:when].gt(end_date)) unless start_date
+    return base.where(Observation[:when].lt(start_date)) unless end_date
 
-    ids.merge(out_of_range_observations.ids)
+    base.where(Observation[:when].gt(end_date)).
+      or(base.where(Observation[:when].lt(start_date)))
   end
 
-  def collect_bbox_violation_ids(ids)
+  # found_here? checks obs.location == self first, before geoloc or
+  # location-bbox logic. The three branches below don't each repeat
+  # that exclusion; it's ANDed onto the combined result once instead.
+  def violating_by_bbox(base)
     return unless location
 
-    ids.merge(obs_geoloc_outside_project_location.ids)
-    ids.merge(obs_without_geoloc_location_not_contained_in_location.ids)
-    ids.merge(obs_missing_geoloc_and_location.ids)
+    has_geoloc = base.where.not(lat: nil).not_in_box(**location.bounding_box)
+    no_geoloc_has_location = base.where(lat: nil).where.not(location_id: nil).
+                             merge(Location.not_in_box(**location.bounding_box))
+    no_geoloc_no_location = base.where(lat: nil, location_id: nil)
+
+    # `location_id != X` is false in SQL for rows where location_id
+    # IS NULL, so a plain where.not(location_id: location.id) would
+    # drop the no_geoloc_no_location branch's rows from the combined
+    # result. Comparing against nil explicitly keeps them in.
+    not_project_location = Observation[:location_id].not_eq(location.id).
+                           or(Observation[:location_id].eq(nil))
+
+    has_geoloc.or(no_geoloc_has_location).or(no_geoloc_no_location).
+      where(not_project_location)
   end
 
-  def collect_target_name_violation_ids(ids)
+  def violating_by_target_name(base)
     return unless target_names.any?
 
-    ids.merge(
-      visible_observations.
-        where.not(name_id: expanded_target_name_id_set.to_a).ids
-    )
+    base.where.not(name_id: expanded_target_name_id_set.to_a)
   end
 
-  def collect_target_location_violation_ids(ids)
+  def violating_by_target_location(base)
     return unless target_locations.any?
 
-    passing = passing_target_location_ids
-    ids.merge(visible_observations.where.not(id: passing).ids)
-  end
-
-  def passing_target_location_ids
-    with_loc = visible_observations.joins(:location).
-               where(location_suffix_conditions).
-               pluck("observations.id")
-    without_loc = visible_observations.where(location_id: nil).
-                  where(where_suffix_conditions).pluck(:id)
-    (with_loc + without_loc).uniq
+    with_loc = base.where.not(location_id: nil).
+               where(location_suffix_conditions)
+    without_loc = base.where(location_id: nil).where(where_suffix_conditions)
+    base.where.not(id: with_loc.or(without_loc).select(:id))
   end
 
   public
@@ -921,15 +920,21 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   # Ordered relation of every observation violating at least one
-  # configured constraint. Unpaginated -- a caller that only needs
-  # one page (`Projects::ViolationsController#index`) should
-  # paginate this directly rather than loading every violation into
-  # Ruby first.
+  # configured constraint. Unpaginated. A caller that only needs one
+  # page should paginate this directly instead of loading every
+  # violation into Ruby first.
   def violating_observations
     return Observation.none unless constraints?
 
-    Observation.where(id: violating_observation_ids).
-      includes(:name, :location).order_by(:name)
+    base = violation_detection_base
+    relations = [
+      violating_by_date(base),
+      violating_by_bbox(base),
+      violating_by_target_name(base),
+      violating_by_target_location(base)
+    ].compact
+
+    relations.reduce(:or).distinct.order_by(:name)
   end
 
   # Builds `Violation` structs (obs + kinds) for a collection of
@@ -1208,14 +1213,5 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
         # invert_where is safe (doesn't invert observations.where(lat: nil))
         Location.not_in_box(**location.bounding_box)
       )
-  end
-
-  # Mirrors Location#found_here?'s last branch (`return false unless
-  # loc`) -- an obs with neither GPS nor an assigned Location can't
-  # be confirmed inside the project's area, so it violates. Neither
-  # of the two scopes above matches this case: one requires lat
-  # present, the other requires a location to join against.
-  def obs_missing_geoloc_and_location
-    visible_observations.where(lat: nil, location_id: nil)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -317,23 +317,12 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     member?(user)
   end
 
-  # SQL-based count over the four violation kinds (#4136). Each branch
-  # plucks ids of OFFENDING observations and merges them into a Set
-  # for dedup; total cost is O(violations) rather than the
-  # O(visible_observations) cost of the full Ruby iteration in
-  # `#violations`. Called from the project show page's
-  # `render_violations_button` (inlined from the former
-  # `Tabs::ProjectsHelper#violations_button`), so any per-project
-  # work multiplies by the number of projects rendered.
+  # Called from the project show page's `render_violations_button`
+  # (inlined from the former `Tabs::ProjectsHelper#violations_button`),
+  # so any per-project work multiplies by the number of projects
+  # rendered.
   def count_violations
-    return 0 unless constraints?
-
-    ids = Set.new
-    collect_date_violation_ids(ids)
-    collect_bbox_violation_ids(ids)
-    collect_target_name_violation_ids(ids)
-    collect_target_location_violation_ids(ids)
-    ids.size
+    violating_observation_ids.size
   end
 
   def constraints?
@@ -740,7 +729,22 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     end.reduce(:or)
   end
 
-  # ----- helpers for SQL-based count_violations (#4136) -----
+  # ----- helpers for SQL-based violation detection -----
+
+  # Set of ids of every observation violating at least one configured
+  # constraint. Shared building block for `count_violations` (just
+  # the size) and `violating_observations` (the AR relation built
+  # from these ids).
+  def violating_observation_ids
+    return Set.new unless constraints?
+
+    ids = Set.new
+    collect_date_violation_ids(ids)
+    collect_bbox_violation_ids(ids)
+    collect_target_name_violation_ids(ids)
+    collect_target_location_violation_ids(ids)
+    ids
+  end
 
   def collect_date_violation_ids(ids)
     return unless start_date || end_date
@@ -912,16 +916,32 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   Violation = Struct.new(:obs, :kinds)
 
   def violations
-    return [] unless constraints?
+    violations_for(violating_observations)
+  end
 
-    rows = visible_observations.includes(:name, :location).
-           filter_map do |obs|
+  # Ordered relation of every observation violating at least one
+  # configured constraint. Unpaginated -- a caller that only needs
+  # one page (`Projects::ViolationsController#index`) should
+  # paginate this directly rather than loading every violation into
+  # Ruby first.
+  def violating_observations
+    return Observation.none unless constraints?
+
+    Observation.where(id: violating_observation_ids).
+      includes(:name, :location).order_by(:name)
+  end
+
+  # Builds `Violation` structs (obs + kinds) for a collection of
+  # observations already known to violate a constraint, e.g. a page
+  # of `violating_observations`. Skips any observation
+  # `violation_kinds_for` doesn't agree is a violation.
+  def violations_for(observations)
+    observations.filter_map do |obs|
       kinds = violation_kinds_for(obs)
       next if kinds.empty?
 
       Violation.new(obs, kinds)
     end
-    rows.sort_by { |v| v.obs.name&.sort_name.to_s.downcase }
   end
 
   # Returns the kinds of violation that apply to the given observation

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -609,12 +609,14 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # Add target name to this project if not already present.
   def add_target_name(name)
     project_target_names.find_or_create_by!(name: name)
+    @target_names_present = true
+    invalidate_expanded_target_name_id_set!
     touch
   rescue ActiveRecord::RecordNotUnique
     # Already exists, no-op -- a concurrent insert raced this one, but
     # the target name exists either way.
-  ensure
     @target_names_present = true
+    invalidate_expanded_target_name_id_set!
   end
 
   # Remove target name from this project. Also removes observations
@@ -628,17 +630,18 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     purge_observations_matching_name(name)
     remove_instance_variable(:@target_names_present) if
       defined?(@target_names_present)
+    invalidate_expanded_target_name_id_set!
     touch
   end
 
   # Add target location to this project if not already present.
   def add_target_location(location)
     project_target_locations.find_or_create_by!(location: location)
+    @target_locations_present = true
     touch
   rescue ActiveRecord::RecordNotUnique
     # Already exists, no-op -- a concurrent insert raced this one, but
     # the target location exists either way.
-  ensure
     @target_locations_present = true
   end
 
@@ -1049,6 +1052,20 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   def expanded_target_name_id_set
     @expanded_target_name_id_set ||=
       expanded_target_name_ids(target_name_ids).to_set
+  end
+
+  # add_target_name/remove_target_name call this so a Project
+  # instance that already memoized the expanded set doesn't keep
+  # using a stale one after the target_names it's built from changed.
+  def invalidate_expanded_target_name_id_set!
+    # target_names is a has_many :through the project_target_names
+    # join table add/remove_target_name just mutated directly, so
+    # Rails' association cache doesn't know to invalidate it -- reset
+    # it too, or target_name_ids below would still return the
+    # pre-change list.
+    target_names.reset
+    remove_instance_variable(:@expanded_target_name_id_set) if
+      defined?(@expanded_target_name_id_set)
   end
 
   def trackers

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -757,6 +757,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
 
     ids.merge(obs_geoloc_outside_project_location.ids)
     ids.merge(obs_without_geoloc_location_not_contained_in_location.ids)
+    ids.merge(obs_missing_geoloc_and_location.ids)
   end
 
   def collect_target_name_violation_ids(ids)
@@ -1187,16 +1188,34 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
       end
   end
 
+  # Mirrors Location#found_here?'s first branch (`return true if
+  # obs.location == self`) -- an obs assigned to the project's
+  # location is compliant regardless of GPS precision, so it's
+  # excluded here even when its lat/lng falls outside the location's
+  # bbox.
   def obs_geoloc_outside_project_location
     visible_observations.
-      where.not(observations: { lat: nil }).not_in_box(**location.bounding_box)
+      where.not(observations: { lat: nil }).
+      where.not(location_id: location.id).
+      not_in_box(**location.bounding_box)
   end
 
   def obs_without_geoloc_location_not_contained_in_location
-    visible_observations.where(lat: nil).joins(:location).
+    visible_observations.where(lat: nil).
+      where.not(location_id: location.id).
+      joins(:location).
       merge(
         # invert_where is safe (doesn't invert observations.where(lat: nil))
         Location.not_in_box(**location.bounding_box)
       )
+  end
+
+  # Mirrors Location#found_here?'s last branch (`return false unless
+  # loc`) -- an obs with neither GPS nor an assigned Location can't
+  # be confirmed inside the project's area, so it violates. Neither
+  # of the two scopes above matches this case: one requires lat
+  # present, the other requires a location to join against.
+  def obs_missing_geoloc_and_location
+    visible_observations.where(lat: nil, location_id: nil)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -732,7 +732,11 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
     scope.select("observations.id")
   end
 
+  public
+
   # OR clause: location.name LIKE '%, <target>' OR = '<target>'
+  # Public: also called from Observation.project_violations (the
+  # target_location violation check).
   def location_suffix_conditions
     tbl = Location.arel_table
     target_locations.map do |tl|
@@ -752,71 +756,6 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
         or(tbl[:where].eq(tl.name))
     end.reduce(:or)
   end
-
-  # ----- helpers for SQL-based violation detection -----
-
-  # Each constraint kind builds a relation off the same base, so all
-  # of them can combine with Relation#or into one query. A kind
-  # returns nil when the project doesn't have that constraint set;
-  # violating_observations drops the nils before combining.
-  def violation_detection_base
-    visible_observations.left_joins(:name, :location)
-  end
-
-  def violating_by_date(base)
-    return unless start_date || end_date
-    return base.where(Observation[:when].gt(end_date)) unless start_date
-    return base.where(Observation[:when].lt(start_date)) unless end_date
-
-    base.where(Observation[:when].gt(end_date)).
-      or(base.where(Observation[:when].lt(start_date)))
-  end
-
-  # found_here? checks obs.location == self first, before geoloc or
-  # location-bbox logic. The three branches below don't each repeat
-  # that exclusion; it's ANDed onto the combined result once instead.
-  def violating_by_bbox(base)
-    return unless location
-
-    has_geoloc = base.where.not(lat: nil).not_in_box(**location.bounding_box)
-    no_geoloc_has_location = base.where(lat: nil).where.not(location_id: nil).
-                             merge(Location.not_in_box(**location.bounding_box))
-    no_geoloc_no_location = base.where(lat: nil, location_id: nil)
-
-    # `location_id != X` is false in SQL for rows where location_id
-    # IS NULL, so a plain where.not(location_id: location.id) would
-    # drop the no_geoloc_no_location branch's rows from the combined
-    # result. Comparing against nil explicitly keeps them in.
-    not_project_location = Observation[:location_id].not_eq(location.id).
-                           or(Observation[:location_id].eq(nil))
-
-    has_geoloc.or(no_geoloc_has_location).or(no_geoloc_no_location).
-      where(not_project_location)
-  end
-
-  def violating_by_target_name(base)
-    return unless target_names.any?
-
-    base.where.not(name_id: expanded_target_name_id_set.to_a)
-  end
-
-  # Builds the combined predicate with Arel's `.or` directly instead
-  # of `Relation#or` -- `Relation#or` diffs the two sides' where
-  # clauses using Arel node `==`, which considers
-  # location_suffix_conditions and where_suffix_conditions equal
-  # (same LIKE-or-equals shape, different columns) even though their
-  # `hash`es differ, and silently drops one of the two.
-  def violating_by_target_location(base)
-    return unless target_locations.any?
-
-    has_loc = Observation[:location_id].not_eq(nil).
-              and(location_suffix_conditions)
-    no_loc = Observation[:location_id].eq(nil).and(where_suffix_conditions)
-    passing = base.where(has_loc.or(no_loc))
-    base.where.not(id: passing.select(:id))
-  end
-
-  public
 
   delegate :count, to: :candidate_observations, prefix: true
 
@@ -956,17 +895,7 @@ class Project < AbstractModel # rubocop:disable Metrics/ClassLength
   # page should paginate this directly instead of loading every
   # violation into Ruby first.
   def violating_observations
-    return Observation.none unless constraints?
-
-    base = violation_detection_base
-    relations = [
-      violating_by_date(base),
-      violating_by_bbox(base),
-      violating_by_target_name(base),
-      violating_by_target_location(base)
-    ].compact
-
-    relations.reduce(:or).distinct.includes(:name, :location).order_by(:name)
+    Observation.project_violations(self)
   end
 
   # Builds `Violation` structs (obs + kinds) for a collection of

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -622,6 +622,42 @@ class ProjectTest < UnitTestCase
                  "violating_observations should match violations, in order")
   end
 
+  # violation_kinds_for's bbox check (Location#found_here?) has two
+  # branches the four SQL id-collecting scopes must also cover, or
+  # count_violations/violating_observations would disagree with
+  # violates_location? for these obs.
+  def test_bbox_violation_matches_found_here_with_no_geoloc_or_location
+    proj = Project.create!(title: "Bbox Missing Info #{SecureRandom.hex(4)}",
+                           user: users(:rolf), location: locations(:burbank))
+    obs = Observation.create!(user: users(:rolf), when: Date.current,
+                              name: names(:agaricus), location_id: nil,
+                              lat: nil, lng: nil, where: "Nowhere specific")
+    proj.add_observation(obs)
+
+    assert(proj.violates_location?(obs),
+           "Test needs an obs with neither geoloc nor location")
+    assert_includes(proj.send(:violating_observation_ids), obs.id,
+                    "Obs with no geoloc and no location should violate " \
+                    "the project's location constraint")
+  end
+
+  def test_bbox_violation_matches_found_here_when_location_matches_project
+    proj = Project.create!(title: "Bbox Matching Loc #{SecureRandom.hex(4)}",
+                           user: users(:rolf), location: locations(:burbank))
+    outside_burbank = proj.location.north + 5.0
+    obs = Observation.create!(user: users(:rolf), when: Date.current,
+                              name: names(:agaricus), location: proj.location,
+                              lat: outside_burbank, lng: proj.location.east)
+    proj.add_observation(obs)
+
+    assert_not(proj.violates_location?(obs),
+               "Test needs an obs whose location matches the project's, " \
+               "with geoloc outside that location's bbox")
+    assert_not_includes(proj.send(:violating_observation_ids), obs.id,
+                        "Obs assigned to the project's location should be " \
+                        "compliant regardless of geoloc precision")
+  end
+
   # violating_observations is a relation, so a caller can paginate it
   # with LIMIT/OFFSET instead of loading every violation into Ruby.
   # Uses 3 target_name violations (not a fixture count, so this

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -258,6 +258,42 @@ class ProjectTest < UnitTestCase
            "RecordNotUnique race")
   end
 
+  # violates_target_name? memoizes expanded_target_name_id_set on the
+  # Project instance -- add/remove_target_name must invalidate it so a
+  # check made before the change doesn't leak into one made after.
+  def test_add_target_name_invalidates_stale_expanded_set
+    proj = projects(:rare_fungi_project)
+    peltigera_obs = observations(:peltigera_obs)
+
+    assert(proj.violates_target_name?(peltigera_obs),
+           "Test needs an obs whose name is not yet a target")
+
+    proj.add_target_name(names(:peltigera))
+
+    assert_not(
+      proj.violates_target_name?(peltigera_obs),
+      "violates_target_name? used a stale expanded_target_name_id_set " \
+      "memoized before the target name was added"
+    )
+  end
+
+  def test_remove_target_name_invalidates_stale_expanded_set
+    proj = projects(:rare_fungi_project)
+    peltigera_obs = observations(:peltigera_obs)
+    proj.add_target_name(names(:peltigera))
+
+    assert_not(proj.violates_target_name?(peltigera_obs),
+               "Test needs peltigera added as a target first")
+
+    proj.remove_target_name(names(:peltigera))
+
+    assert(
+      proj.violates_target_name?(peltigera_obs),
+      "violates_target_name? used a stale expanded_target_name_id_set " \
+      "memoized before the target name was removed"
+    )
+  end
+
   def test_candidate_observations
     proj = projects(:rare_fungi_project)
     # Project has both target names and target locations, so

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -614,6 +614,48 @@ class ProjectTest < UnitTestCase
     assert_equal(proj.violations.size, proj.count_violations)
   end
 
+  def test_violating_observations_matches_violations
+    proj = projects(:falmouth_2023_09_project)
+
+    assert_equal(proj.violations.map { |v| v.obs.id },
+                 proj.violating_observations.map(&:id),
+                 "violating_observations should match violations, in order")
+  end
+
+  # violating_observations is a relation, so a caller can paginate it
+  # with LIMIT/OFFSET instead of loading every violation into Ruby.
+  # Uses 3 target_name violations (not a fixture count, so this
+  # doesn't depend on fixture data staying in sync) to prove
+  # offset/limit slices the query.
+  def test_violating_observations_is_paginable_with_offset_and_limit
+    proj = Project.create!(title: "Paginable #{SecureRandom.hex(4)}",
+                           user: users(:rolf))
+    proj.add_target_name(names(:agaricus))
+    off_target = [observations(:peltigera_obs),
+                  observations(:california_obs),
+                  observations(:minimal_unknown_obs)]
+    off_target.each { |obs| proj.add_observation(obs) }
+
+    ordered_ids = proj.violations.map { |v| v.obs.id }
+    assert_equal(3, ordered_ids.size, "Test needs exactly 3 violations")
+
+    page = proj.violating_observations.offset(1).limit(1)
+    assert_equal([ordered_ids[1]], page.map(&:id),
+                 "offset(1).limit(1) should return only the 2nd violation")
+  end
+
+  def test_violations_for_skips_observations_that_are_not_violations
+    proj = projects(:falmouth_2023_09_project)
+    violating_obs = proj.violations.first.obs
+    visible = proj.visible_observations.to_a - [violating_obs]
+    passing_obs = visible.find { |obs| proj.violation_kinds_for(obs).empty? }
+    assert(passing_obs, "Test needs a visible obs that is not a violation")
+
+    result = proj.violations_for([violating_obs, passing_obs])
+
+    assert_equal([violating_obs.id], result.map { |v| v.obs.id })
+  end
+
   def test_candidate_observations_respects_date_range
     proj = build_target_name_project_with_dates
     in_range = observations(:agaricus_campestris_obs)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -622,9 +622,10 @@ class ProjectTest < UnitTestCase
                  "violating_observations should match violations, in order")
   end
 
-  # violation_kinds_for's bbox check (Location#found_here?) has two
-  # branches Observation.project_violating_by_bbox must also cover,
-  # or count_violations/violating_observations would disagree with
+  # violation_kinds_for's bbox check (Location#found_here?) falls
+  # back to "violates" when an obs has neither geoloc nor a Location.
+  # Observation.project_violating_by_bbox must also cover this, or
+  # count_violations/violating_observations would disagree with
   # violates_location? for these obs.
   def test_bbox_violation_matches_found_here_with_no_geoloc_or_location
     proj = Project.create!(title: "Bbox Missing Info #{SecureRandom.hex(4)}",
@@ -641,7 +642,11 @@ class ProjectTest < UnitTestCase
                     "the project's location constraint")
   end
 
-  def test_bbox_violation_matches_found_here_when_location_matches_project
+  # Devs' verdict (2026-08-28): flagged as a violation, even though
+  # the obs is assigned to the project's Location -- violations are
+  # review flags, not a binding state, and imprecise GPS is worth a
+  # look regardless of the assigned Location name.
+  def test_bbox_violation_flags_imprecise_geoloc_even_when_location_matches
     proj = Project.create!(title: "Bbox Matching Loc #{SecureRandom.hex(4)}",
                            user: users(:rolf), location: locations(:burbank))
     outside_burbank = proj.location.north + 5.0
@@ -650,12 +655,12 @@ class ProjectTest < UnitTestCase
                               lat: outside_burbank, lng: proj.location.east)
     proj.add_observation(obs)
 
-    assert_not(proj.violates_location?(obs),
-               "Test needs an obs whose location matches the project's, " \
-               "with geoloc outside that location's bbox")
-    assert_not_includes(proj.violating_observations.pluck(:id), obs.id,
-                        "Obs assigned to the project's location should be " \
-                        "compliant regardless of geoloc precision")
+    assert(proj.violates_location?(obs),
+           "Test needs an obs whose location matches the project's, " \
+           "with geoloc outside that location's bbox")
+    assert_includes(proj.violating_observations.pluck(:id), obs.id,
+                    "Obs with geoloc outside the bbox should violate " \
+                    "even when its Location matches the project's")
   end
 
   # violating_observations is a relation, so a caller can paginate it

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -623,7 +623,7 @@ class ProjectTest < UnitTestCase
   end
 
   # violation_kinds_for's bbox check (Location#found_here?) has two
-  # branches the four SQL id-collecting scopes must also cover, or
+  # branches violating_by_bbox must also cover, or
   # count_violations/violating_observations would disagree with
   # violates_location? for these obs.
   def test_bbox_violation_matches_found_here_with_no_geoloc_or_location
@@ -636,7 +636,7 @@ class ProjectTest < UnitTestCase
 
     assert(proj.violates_location?(obs),
            "Test needs an obs with neither geoloc nor location")
-    assert_includes(proj.send(:violating_observation_ids), obs.id,
+    assert_includes(proj.violating_observations.pluck(:id), obs.id,
                     "Obs with no geoloc and no location should violate " \
                     "the project's location constraint")
   end
@@ -653,7 +653,7 @@ class ProjectTest < UnitTestCase
     assert_not(proj.violates_location?(obs),
                "Test needs an obs whose location matches the project's, " \
                "with geoloc outside that location's bbox")
-    assert_not_includes(proj.send(:violating_observation_ids), obs.id,
+    assert_not_includes(proj.violating_observations.pluck(:id), obs.id,
                         "Obs assigned to the project's location should be " \
                         "compliant regardless of geoloc precision")
   end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -294,6 +294,50 @@ class ProjectTest < UnitTestCase
     )
   end
 
+  # location_suffix_conditions/where_suffix_conditions read location
+  # names via project_target_locations, not the target_locations
+  # association, precisely so a caller that already loaded
+  # target_locations (as Projects::TargetLocationsController does)
+  # still sees an add/remove take effect immediately.
+  def test_add_target_location_reflects_even_if_association_preloaded
+    proj = projects(:rare_fungi_project)
+    albion = locations(:albion)
+    obs = Observation.create!(user: users(:rolf), when: Date.current,
+                              name: names(:agaricus), location: albion)
+    proj.target_locations.load
+
+    assert(proj.violates_target_location?(obs),
+           "Test needs an obs whose Location is not yet a target")
+
+    proj.add_target_location(albion)
+
+    assert_not(
+      proj.violates_target_location?(obs),
+      "violates_target_location? must reflect the new target location " \
+      "even when target_locations was already loaded"
+    )
+  end
+
+  def test_remove_target_location_reflects_even_if_association_preloaded
+    proj = projects(:rare_fungi_project)
+    albion = locations(:albion)
+    obs = Observation.create!(user: users(:rolf), when: Date.current,
+                              name: names(:agaricus), location: albion)
+    proj.add_target_location(albion)
+    proj.target_locations.load
+
+    assert_not(proj.violates_target_location?(obs),
+               "Test needs albion added as a target location first")
+
+    proj.remove_target_location(albion)
+
+    assert(
+      proj.violates_target_location?(obs),
+      "violates_target_location? must reflect the removed target " \
+      "location even when target_locations was already loaded"
+    )
+  end
+
   def test_candidate_observations
     proj = projects(:rare_fungi_project)
     # Project has both target names and target locations, so

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -623,8 +623,8 @@ class ProjectTest < UnitTestCase
   end
 
   # violation_kinds_for's bbox check (Location#found_here?) has two
-  # branches violating_by_bbox must also cover, or
-  # count_violations/violating_observations would disagree with
+  # branches Observation.project_violating_by_bbox must also cover,
+  # or count_violations/violating_observations would disagree with
   # violates_location? for these obs.
   def test_bbox_violation_matches_found_here_with_no_geoloc_or_location
     proj = Project.create!(title: "Bbox Missing Info #{SecureRandom.hex(4)}",

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -151,13 +151,6 @@ class ProjectTest < UnitTestCase
     assert_equal(expect, project.in_range_observations.count)
   end
 
-  def test_out_of_area_observations
-    project = projects(:falmouth_2023_09_project)
-    assert_equal(2, project.out_of_area_observations.size)
-
-    assert_empty(projects(:unlimited_project).out_of_area_observations)
-  end
-
   def test_place_name
     proj = projects(:eol_project)
     loc = locations(:albion)
@@ -171,48 +164,6 @@ class ProjectTest < UnitTestCase
     loc = locations(:albion)
     proj.place_name = loc.display_name(roy)
     assert_equal(proj.location, loc)
-  end
-
-  def test_location_violations
-    proj = Project.create(
-      location: locations(:burbank),
-      title: "With Location Violations",
-      open_membership: true
-    )
-    geoloc_in_burbank = observations(:unknown_with_lat_lng)
-    geoloc_outside_burbank =
-      observations(:trusted_hidden) # lat/lon in Falmouth
-    geoloc_nil_burbank_contains_loc =
-      observations(:minimal_unknown_obs)
-    geoloc_nil_outside_burbank = observations(:reused_observation)
-
-    proj.observations = [
-      geoloc_in_burbank,
-      geoloc_nil_burbank_contains_loc,
-      geoloc_outside_burbank,
-      geoloc_nil_outside_burbank
-    ]
-
-    location_violations = proj.out_of_area_observations
-
-    assert_includes(
-      location_violations, geoloc_outside_burbank,
-      "Noncompliant Obss missing Obs with geoloc outside Proj location"
-    )
-    assert_includes(
-      location_violations, geoloc_nil_outside_burbank,
-      "Noncompliant Obss missing Obs w/o geoloc " \
-      "whose Loc is not contained in Proj location"
-    )
-    assert_not_includes(
-      location_violations, geoloc_in_burbank,
-      "Noncompliant Obss wrongly includes Obs with geoloc inside Proj location"
-    )
-    assert_not_includes(
-      location_violations, geoloc_nil_burbank_contains_loc,
-      "Noncompliant Obss wrongly includes Obs w/o geoloc " \
-      "whose Loc is contained in Proj location"
-    )
   end
 
   def test_add_and_remove_target_names
@@ -271,6 +222,40 @@ class ProjectTest < UnitTestCase
 
     empty = projects(:empty_project)
     assert_not(empty.has_targets?)
+  end
+
+  # A concurrent insert of the same target name/location can make
+  # find_or_create_by! raise RecordNotUnique instead of returning the
+  # existing record, skipping the line that would otherwise memoize
+  # target_names_present?/target_locations_present? as true.
+  def test_add_target_name_after_record_not_unique_race
+    proj = projects(:empty_project)
+    assert_not(proj.target_names_present?)
+
+    proj.project_target_names.stub(
+      :find_or_create_by!, ->(*) { raise(ActiveRecord::RecordNotUnique) }
+    ) do
+      proj.add_target_name(names(:agaricus))
+    end
+
+    assert(proj.target_names_present?,
+           "target_names_present? must not stay stale after a " \
+           "RecordNotUnique race")
+  end
+
+  def test_add_target_location_after_record_not_unique_race
+    proj = projects(:empty_project)
+    assert_not(proj.target_locations_present?)
+
+    proj.project_target_locations.stub(
+      :find_or_create_by!, ->(*) { raise(ActiveRecord::RecordNotUnique) }
+    ) do
+      proj.add_target_location(locations(:burbank))
+    end
+
+    assert(proj.target_locations_present?,
+           "target_locations_present? must not stay stale after a " \
+           "RecordNotUnique race")
   end
 
   def test_candidate_observations


### PR DESCRIPTION
## Summary

Closes #5256. Supersedes #5263.

`Project#violations` scanned every visible observation in Ruby, then sorted and paginated in Ruby. This PR replaces it with `Observation.project_violations`: four independent queries, one per constraint kind (date, bbox, target name, target location), each plucking violating ids into a Set, wrapped in one `where(id: ...)` fetch. `Project#violating_observations` delegates to it. `Projects::ViolationsController#index` paginates with LIMIT/OFFSET, so per-observation kind computation only runs on the current page.

## Front-end behavior

Same list as `main`, except one case, resolved with the team (see PR comments): an observation whose Location matches the project's Location but whose GPS falls outside its bounding box is now flagged too. Previously exempted.

The count badge now always matches the list -- both come from the same query.

## Benchmark

Same process, two implementations, `Project` fetched fresh per measurement.

**Every dev-DB project with a current violation** (main reproduced against the same data):

| Project | Violations | main | this PR |
|---|---|---|---|
| Northeast Rare Fungi Challenge | 1 | 14 queries, 0.122s | 20 queries, 0.020s |
| North Falmouth Fungi | 2 | 9 queries, 0.015s | 13 queries, 0.016s |
| Field Slip Testing | 4 | 8 queries, 0.005s | 9 queries, 0.006s |
| 2025 NAMA New England | 2 | 8 queries, 0.032s | 9 queries, 0.025s |
| 2025 NEMF | 18 | 8 queries, 0.063s | 10 queries, 0.016s |
| FunDiS West Coast Rare Fungi Challenge | 3 | 14 queries, 0.104s | 20 queries, 0.013s |
| Caloboletus test project | 10 | 13 queries, 0.091s | 15 queries, 0.009s |
| 2026 NEMF | 7 | 9 queries, 0.061s | 14 queries, 0.059s |

Not a query-count win at today's sizes -- four independent queries can cost more round trips than one Ruby scan over a few hundred observations. It is a consistent wall-time win, 2-6x faster on every project above, and cost stops scaling with total observation count.

Synthetic project, 2000 observations, one constraint kind:

| Scenario | main | this PR |
|---|---|---|
| Page 1 | 2012 queries, 1.44s | 15 queries, 0.34s |
| Page 20 (offset 950) | 2012 queries, 1.02s | 15 queries, 0.22s |

`main` is O(visible observations); this PR is O(page size + constraint kinds). No dev-DB project is near 2000 observations today -- the query-count collapse is a hedge for growth, not a fix for a problem happening now.

## Bugs found and fixed along the way

Two bbox-check drifts from `Location#found_here?`, confirmed by direct reproduction, resolved with the team:

- No GPS, no Location -- now flagged. Previously missed.
- Location matches the project's Location, GPS outside its bbox -- now flagged. Previously exempted.

A pre-existing N+1: `violates_target_name?`/`violates_target_location?` each re-query `.any?` per observation. Memoized as `Project#target_names_present?`/`#target_locations_present?`, reused by the SQL helpers below.

An earlier version of this PR combined all four checks into one query with `ActiveRecord::Relation#or`, which surfaced a NULL-comparison bug and a broken Arel `Or`-node `==` that silently dropped a predicate. Both were fixed, and that version worked. But the combined-relation code was harder to follow than four separate queries, so it was reverted in favor of the current design. Fewer queries on large projects wasn't worth the harder-to-read code, especially given the Benchmark below.

## Changes

- `Observation.project_violations` plus per-kind class methods in `Observation::Scopes`. `Project#violating_observations` delegates to it.
- `Project#target_names_present?`/`#target_locations_present?`, memoized with explicit invalidation on the four target mutators.
- `Project#location_suffix_conditions`/`#where_suffix_conditions` made public.
- Removed the old id-collection machinery and the now-orphaned `obs_missing_geoloc_and_location`.
- `Projects::ViolationsController#index` paginates via LIMIT/OFFSET; dropped the now-unneeded `skip_bullet` override.

## Verification

- Parity script: `Observation.project_violations` vs `violation_kinds_for`, every dev-DB project (241), 0 mismatches.
- Direct-reproduction scripts for each bug above.
- `bin/rails test test/models/project_test.rb` -- pass.

## Test plan

- [x] `bin/rails test test/models/project_test.rb`
- [x] `bundle exec rubocop` on every touched file

<!-- changelog -->
article: no
<!-- /changelog -->
