### PR TITLE
Attach a read field slip onto a companion occurrence

### DIFF
--- a/app/classes/field_slip/attacher.rb
+++ b/app/classes/field_slip/attacher.rb
@@ -34,7 +34,7 @@ class FieldSlip
     # Returns what happened, for the caller's log line.
     def attach
       existing = FieldSlip.find_by(code: @code)
-      return merge_or_refuse(existing) if @observation.occurrence_id
+      return attach_with_occurrence(existing) if @observation.occurrence_id
       return join_or_refuse(existing) if existing&.occurrence
       return :closed_project if barred?(existing)
 
@@ -46,6 +46,38 @@ class FieldSlip
     end
 
     private
+
+    # The observation already belongs to an occurrence. Three shapes:
+    # the code names a slip on a different occurrence (merge), the
+    # occurrence carries no field slip yet -- a reflection's
+    # Edit-companion (adopt the read slip onto that shared occurrence),
+    # or the occurrence already holds a slip and the read code adds
+    # nothing (leave it).
+    def attach_with_occurrence(existing)
+      return merge_or_refuse(existing) if existing&.occurrence
+      unless @join_in_use && @observation.occurrence.field_slip.nil?
+        return :already_linked
+      end
+
+      adopt_into_occurrence(existing)
+    end
+
+    # Set the read slip on the occurrence the observation already sits
+    # in, rather than the fresh occurrence `link` would build -- which
+    # would strand the occurrence's other members (the reflection)
+    # outside the slip.
+    def adopt_into_occurrence(existing)
+      return :closed_project if barred?(existing)
+
+      slip = existing || FieldSlip.find_or_create_by_code(@code, @user)
+      return :invalid unless slip
+
+      @observation.occurrence.update!(field_slip: slip)
+      slip.adopt_user_from(@observation)
+      refresh_occurrence
+      apply_project(slip)
+      :attached
+    end
 
     # An existing slip already in a project the user can neither join
     # nor is a member of: attaching would put the observation in that

--- a/app/classes/form_object/field_slip_review.rb
+++ b/app/classes/form_object/field_slip_review.rb
@@ -82,17 +82,25 @@ class FormObject::FieldSlipReview < FormObject::Base
     end
   end
 
-  # Ticking the read code applies it. That does something in two cases:
-  # the observation has no occurrence (attach the slip), or the code
-  # names a slip on a DIFFERENT occurrence (merge the two -- e.g. a
-  # reflection whose Edit-companion gave it an occurrence, reviewed
-  # against a recorder's slip). It does nothing when the observation's
-  # own occurrence already holds the slip, so no tick is offered then.
+  # Ticking the read code applies it. That does something in three
+  # cases: the observation has no occurrence (attach the slip), its
+  # occurrence carries no field slip -- the state a reflection's
+  # Edit-companion is created in -- (attach onto that shared
+  # occurrence), or the code names a slip on a DIFFERENT occurrence
+  # (merge the two). It does nothing only when the observation's
+  # occurrence already holds the slip, so no tick is offered then.
   def self.code_attachable?(extract, template, observation)
     code = extract.value_for(template.code_field).to_s.strip
     return false if code.blank?
     return true if observation.occurrence_id.nil?
+    return true if observation.occurrence&.field_slip.nil?
 
+    code_on_other_occurrence?(code, observation)
+  end
+
+  # The read code names a slip already sitting on a different
+  # occurrence -- ticking it merges the two.
+  def self.code_on_other_occurrence?(code, observation)
     slip = FieldSlip.find_by(code: code.upcase)
     slip&.occurrence.present? &&
       slip.occurrence.id != observation.occurrence_id

--- a/test/classes/field_slip/attacher_test.rb
+++ b/test/classes/field_slip/attacher_test.rb
@@ -117,6 +117,50 @@ class FieldSlip::AttacherTest < UnitTestCase
                "the primary is a native observation")
   end
 
+  # A reflection's Edit-companion is created in an occurrence with no
+  # field slip. The review's confirmed tick attaches the read slip
+  # onto that shared occurrence -- so the slip reaches the reflection
+  # too -- instead of building a new occurrence that would strand the
+  # reflection outside it.
+  def test_join_in_use_adopts_a_new_slip_onto_a_slipless_occurrence
+    reflection = observations(:minimal_unknown_obs)
+    reflection.update!(occurrence: nil, reflected_at: Time.zone.now)
+    companion = observations(:detailed_unknown_obs)
+    companion.update!(occurrence: nil)
+    shared = Occurrence.create!(user: @obs.user, primary_observation: companion)
+    [reflection, companion].each { |o| o.update!(occurrence: shared) }
+
+    assert_nil(shared.field_slip, "premise: occurrence has no slip")
+    assert_not(FieldSlip.exists?(code: "OPEN-0601"), "premise: new code")
+
+    result = FieldSlip::Attacher.attach(observation: companion.reload,
+                                        code: "OPEN-0601",
+                                        user: @obs.user, join_in_use: true)
+
+    assert_equal(:attached, result)
+    assert_equal("OPEN-0601", companion.reload.field_slip.code)
+    assert_equal(shared.id, companion.occurrence_id,
+                 "the slip lands on the existing occurrence, not a new one")
+    assert_equal(shared.id, reflection.reload.occurrence_id,
+                 "the reflection stays in it, now under the slip")
+    assert_includes(@project.observations.reload, companion,
+                    "the observation files into the prefix project")
+  end
+
+  # Without the confirmed tick (background auto-attach), an observation
+  # that already sits in an occurrence is left alone, even when that
+  # occurrence carries no slip.
+  def test_background_attach_leaves_a_slipless_occurrence_alone
+    companion = observations(:detailed_unknown_obs)
+    companion.update!(occurrence: nil)
+    shared = Occurrence.create!(user: @obs.user, primary_observation: companion)
+    companion.update!(occurrence: shared)
+
+    assert_equal(:already_linked,
+                 attach(obs: companion.reload, code: "OPEN-0601"))
+    assert_nil(shared.reload.field_slip)
+  end
+
   # If the slip's occurrence had a reflection as primary, the merge
   # repoints it to a native member (a reflection is not a primary).
   def test_merge_repoints_a_reflection_primary_to_a_native

--- a/test/classes/form_object/field_slip_review_test.rb
+++ b/test/classes/form_object/field_slip_review_test.rb
@@ -114,9 +114,29 @@ class FormObject::FieldSlipReviewTest < UnitTestCase
     assert(row.default_use?)
   end
 
-  # The read code names the slip already on the observation's own
-  # occurrence -- applying it would do nothing, so no tick is offered.
-  def test_code_row_review_only_when_its_own_occurrence_holds_the_slip
+  # The observation sits in an occurrence that carries no field slip (a
+  # reflection's Edit-companion), and the read code names a slip not
+  # attached anywhere: the code row is savable so the reviewer can
+  # attach it onto that shared occurrence (#4214).
+  def test_code_row_savable_to_attach_onto_a_slipless_occurrence
+    @obs.update!(occurrence: nil)
+    occ = Occurrence.create!(user: @obs.user, primary_observation: @obs)
+    @obs.update!(occurrence: occ)
+
+    assert_nil(occ.field_slip, "premise: occurrence has no slip")
+    assert_not(FieldSlip.exists?(code: "NEMF-10555"), "premise: new code")
+
+    review = build(fields: { "Field Slip Code" => "NEMF-10555" })
+    row = row_for(review, "Field Slip Code")
+
+    assert(row.savable)
+    assert(row.default_use?)
+  end
+
+  # The read code names the slip that the observation's occurrence
+  # already holds -- applying it would do nothing, so no tick is
+  # offered.
+  def test_code_row_review_only_when_the_occurrence_holds_the_slip
     @obs.update!(occurrence: nil)
     slip = FieldSlip.find_or_create_by_code("NEMF-10444", @obs.user)
     @obs.field_slip = slip


### PR DESCRIPTION
## Summary

When a recorder reads a field slip off a photo for the native Edit-companion of an iNat reflection, saving the review dropped the slip. They had to re-enter the code by hand on the observation to attach it. This fixes both places that suppressed the attach.

## What happened (prod, obs 670129 / 670135)

A recorder opened an imported reflection with no field slip and clicked Edit. Edit on a reflection redirects to an editable companion (#5178): `Observation::Companion#create` builds a native companion and, via `Occurrence.create_manual`, puts both observations into a shared occurrence that carries no field slip. He added his field-slip photo, the reader (Gemini) read the code correctly, and he hit "Save to Observation" — but the submit carried no `Field Slip Code` field, so only the data fields saved and no slip attached.

The code row was suppressed because the observation already had that companion occurrence:

- `FormObject::FieldSlipReview.code_attachable?` returned true only when the observation had no occurrence, or the read code named a slip already on a different occurrence (the merge case). An occurrence holding no slip was not covered, so the row rendered as read-only text — no `value[...]` input, no `use[...]` checkbox.
- Even if the tick had been offered, `FieldSlip::Attacher#attach` routes any observation that has an occurrence to `merge_or_refuse`, which returns `:already_linked` and does nothing when the read code names no existing slip.

## The fix

Both now handle the third shape — the observation's occurrence holds no field slip:

- `code_attachable?` offers the tick when `observation.occurrence&.field_slip` is nil.
- `Attacher#attach` adds `attach_with_occurrence`: when the occurrence carries no slip and the tick is the review's confirmed one (`join_in_use`), it creates/finds the slip and sets it on the occurrence the observation already sits in — via `adopt_into_occurrence`, not `link` (which builds a fresh occurrence and would strand the reflection outside the slip). Merge, no-occurrence, and closed-project paths are unchanged. Background auto-attach (`join_in_use: false`) still leaves an observation that has an occurrence alone.

This reproduces the manual `field_code` fix's end-state — slip on the shared occurrence, both observations under it, native primary, project applied — reached now through the recorder review save.

## Test plan

- [x] `bin/rails test test/classes/field_slip/attacher_test.rb test/classes/form_object/field_slip_review_test.rb` (43 tests)
- [x] `bin/rails test test/controllers/images/field_slip_extracts_controller_test.rb test/views/controllers/images/field_slip_extracts/edit_test.rb` (69 tests)
- [x] Reproduced against the prod snapshot: the review save now attaches `2026-NAMA-4367` onto occurrence 7394, both 669800 (reflection) and 670129 (companion) stay in it, native primary, project 407 applied.

Reviewer: import an iNat observation (no slip), Edit it to create the companion, add a field-slip photo, read it, and Save — the slip should attach and appear on both the companion and the reflection.

<!-- changelog -->
article: yes
Attach a Field Slip read from an imported Observation's photo
<!-- /changelog -->
