### PR TITLE
Adopt a field slip onto a slip-less occurrence in `Observation#field_slip=`

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -223,20 +223,16 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   end
 
   # Backward-compatible writer: creates/reuses an occurrence to
-  # link this observation to the given field slip.
+  # link this observation to the given field slip. Detaching is done
+  # by clearing the occurrence, so nil is a no-op here.
   def field_slip=(slip)
-    if slip.nil?
-      # Detach: handled by clearing occurrence
-      return
-    end
+    return if slip.nil?
 
-    occ = slip.occurrence
-    occ ||= Occurrence.create!(
-      user: user || current_user,
-      primary_observation: self,
-      field_slip: slip
-    )
-    self.occurrence = occ
+    self.occurrence = slip.occurrence ||
+                      adopt_slip_onto_occurrence(slip) ||
+                      Occurrence.create!(user: user || current_user,
+                                         primary_observation: self,
+                                         field_slip: slip)
   end
 
   has_many :observation_herbarium_records, dependent: :destroy
@@ -1291,6 +1287,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     return unless old_id && new_id
 
     cleanup_old_occurrence_after_move(old_id)
+    reset_thumbnail_left_behind
     occurrence&.recompute_has_specimen!
   end
 
@@ -1301,9 +1298,39 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
     reassign_occurrence_primary(old_occ) if old_occ.primary_observation_id == id
     return if old_occ.destroyed?
 
+    old_occ.reassign_thumbnails_from(self)
     old_occ.reload
     old_occ.destroy_if_incomplete!
     old_occ.recompute_has_specimen! unless old_occ.destroyed?
+  end
+
+  # A thumbnail borrowed from a sibling in the old occurrence is not
+  # reachable from the new one. update_columns: an after_update
+  # callback must not re-enter the save callbacks.
+  def reset_thumbnail_left_behind
+    return if thumb_image_id.nil? || thumb_image_reachable?
+
+    update_columns(thumb_image_id: next_thumb_image&.id,
+                   updated_at: Time.zone.now)
+  end
+
+  def thumb_image_reachable?
+    return true if image_ids.include?(thumb_image_id)
+    return false unless occurrence
+
+    ObservationImage.exists?(image_id: thumb_image_id,
+                             observation_id: occurrence.observation_ids)
+  end
+
+  # An occurrence this observation already sits in that carries no
+  # slip -- a reflection's Edit-companion occurrence -- takes the slip,
+  # so its other members stay under it instead of being stranded when
+  # a fresh occurrence is built around this observation alone.
+  def adopt_slip_onto_occurrence(slip)
+    return nil unless occurrence && occurrence.field_slip_id.nil?
+
+    occurrence.update!(field_slip: slip)
+    occurrence
   end
 
   def reassign_occurrence_primary(occ)

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1329,6 +1329,10 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   def adopt_slip_onto_occurrence(slip)
     return nil unless occurrence && occurrence.field_slip_id.nil?
 
+    # update! on purpose: the validations that can fail here (slip on
+    # another occurrence, primary not a member, over the member cap)
+    # mean the occurrence is already inconsistent, and a slip must not
+    # be written onto it silently.
     occurrence.update!(field_slip: slip)
     occurrence
   end

--- a/test/controllers/observations/field_slips_controller_test.rb
+++ b/test/controllers/observations/field_slips_controller_test.rb
@@ -55,6 +55,32 @@ module Observations
       assert_equal(slip.id, obs.reload.field_slip&.id)
     end
 
+    # A reflection's Edit-companion shares a slip-less occurrence with
+    # the reflection. Attaching a code from the companion's page puts
+    # the slip on that occurrence; the reflection stays in it.
+    def test_attach_onto_slipless_companion_occurrence
+      companion = observations(:coprinus_comatus_obs)
+      reflection = observations(:minimal_unknown_obs)
+      [companion, reflection].each do |o|
+        o.update_column(:occurrence_id, nil)
+      end
+      reflection.update!(reflected_at: Time.zone.now)
+      shared = Occurrence.create!(user: companion.user,
+                                  primary_observation: companion)
+      [companion, reflection].each { |o| o.update!(occurrence: shared) }
+      code = "EOL-9998"
+      assert_not(FieldSlip.exists?(code: code))
+
+      login("rolf")
+      put(:update, params: { id: companion.id, field_code: code })
+
+      assert_redirected_to(permanent_observation_path(companion.id))
+      assert_equal(code, shared.reload.field_slip&.code)
+      assert_equal(shared.id, companion.reload.occurrence_id)
+      assert_equal(shared.id, reflection.reload.occurrence_id,
+                   "the reflection is not stranded outside the slip")
+    end
+
     def test_attach_invalid_field_slip_code
       obs = observations(:coprinus_comatus_obs)
       login("rolf")

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -2243,6 +2243,49 @@ class ObservationTest < UnitTestCase
                  "Setting field_slip to nil should not alter occurrence")
   end
 
+  # A reflection's Edit-companion sits in an occurrence with no slip.
+  # A new slip lands on that occurrence, so the reflection stays under
+  # it, instead of a second occurrence being built around the
+  # companion alone (which dissolved the shared one -- obs 670589).
+  def test_field_slip_setter_adopts_slipless_occurrence
+    companion = observations(:coprinus_comatus_obs)
+    reflection = observations(:minimal_unknown_obs)
+    [companion, reflection].each { |o| o.update_column(:occurrence_id, nil) }
+    shared = Occurrence.create!(user: companion.user,
+                                primary_observation: companion)
+    [companion, reflection].each { |o| o.update!(occurrence: shared) }
+    slip = field_slips(:field_slip_no_obs)
+    assert_nil(slip.occurrence, "premise: slip has no occurrence")
+
+    companion.field_slip = slip
+    companion.save!
+
+    assert_equal(shared.id, companion.reload.occurrence_id)
+    assert_equal(slip.id, shared.reload.field_slip_id)
+    assert_equal(shared.id, reflection.reload.occurrence_id)
+  end
+
+  # An occurrence that already carries a slip keeps it: a different
+  # new slip still moves the observation into a separate occurrence.
+  def test_field_slip_setter_leaves_occurrence_that_has_a_slip
+    obs = observations(:coprinus_comatus_obs)
+    other = observations(:minimal_unknown_obs)
+    [obs, other].each { |o| o.update_column(:occurrence_id, nil) }
+    old_slip = FieldSlip.find_or_create_by_code("EOL-7777", obs.user)
+    taken = Occurrence.create!(user: obs.user, primary_observation: other,
+                               field_slip: old_slip)
+    [obs, other].each { |o| o.update!(occurrence: taken) }
+    slip = field_slips(:field_slip_no_obs)
+
+    obs.field_slip = slip
+    obs.save!
+
+    assert_not_equal(taken.id, obs.reload.occurrence_id)
+    assert_equal(slip.id, obs.occurrence.field_slip_id)
+    assert_equal(old_slip.id, taken.reload.field_slip_id)
+    assert_equal(taken.id, other.reload.occurrence_id)
+  end
+
   # destroy_orphaned_collection_numbers wipes any collection_number
   # that was attached to only this obs (line 312). Called directly
   # rather than via obs.destroy because the dependent: :destroy on

--- a/test/models/occurrence_test.rb
+++ b/test/models/occurrence_test.rb
@@ -178,6 +178,39 @@ class OccurrenceTest < UnitTestCase
     assert_nil(@obs2.reload.occurrence_id)
   end
 
+  # A thumbnail borrowed from a sibling stops being reachable once the
+  # borrower leaves that sibling's occurrence.
+  def test_move_to_other_occurrence_resets_borrowed_thumbnail
+    borrowed = images(:in_situ_image)
+    assert_includes(@obs3.image_ids, borrowed.id, "premise: obs3's image")
+    assert_empty(@obs1.image_ids, "premise: obs1 has no images")
+    create_occurrence(@obs3, @obs1, @obs2)
+    occ_b = create_occurrence(@obs4)
+    @obs1.update!(thumb_image: borrowed)
+
+    @obs1.update!(occurrence: occ_b)
+
+    assert_empty(occ_b.observations.flat_map(&:image_ids),
+                 "premise: nothing to borrow in the new occurrence")
+    assert_nil(@obs1.reload.thumb_image_id,
+               "the borrowed thumbnail is dropped, not left dangling")
+  end
+
+  def test_move_to_other_occurrence_resets_siblings_borrowed_thumbnail
+    borrowed = images(:in_situ_image)
+    assert_includes(@obs3.image_ids, borrowed.id, "premise: obs3's image")
+    occ_a = create_occurrence(@obs1, @obs2, @obs3)
+    occ_b = create_occurrence(@obs4)
+    @obs2.update!(thumb_image: borrowed)
+
+    @obs3.update!(occurrence: occ_b)
+
+    assert(Occurrence.exists?(occ_a.id), "two members remain")
+    assert_equal(images(:connected_coprinus_comatus_image).id,
+                 @obs2.reload.thumb_image_id,
+                 "the sibling falls back to a photo it owns")
+  end
+
   def test_single_obs_occurrence_not_destroyed
     fs = field_slips(:field_slip_no_obs)
     @obs1.update!(field_slip: fs)


### PR DESCRIPTION
## Summary

Reported by Andy 2026-08-29 (Adele, `ammehta`): after reading a field slip onto an iNat reflection's Edit-companion, "the image disappeared." Production log trace:

1. `GET /observations/669537/edit` created Edit-companion 670589 in a shared occurrence with the reflection, thumbnail pointed at the reflection's photo 2083865 (`Observation::Companion` — the companion owns no images; the occurrence pools them).
2. `PATCH /observations/670589/field_slip` (code `2026-NAMA-7499`, the standalone attach page) → `assign_field_slip` → `Observation#field_slip=`. The slip was new, so `field_slip=` built a fresh occurrence (7568) around 670589 alone and moved it there. `cleanup_abandoned_occurrence` then found the old occurrence holding only the reflection with no slip and dissolved it. 670589 was already out of that occurrence when `reset_cross_observation_thumbnails` ran, so its `thumb_image_id` stayed at 2083865 — a photo it no longer shares an occurrence with. The show page renders no image.

This is the stranding #5266 fixed this morning for the review-tick path (`FieldSlip::Attacher#adopt_into_occurrence`); the manual paths — `Observations::FieldSlipsController#update` and the observation edit form's field code — still went through `field_slip=`.

## Changes

- `Observation#field_slip=`: when the slip has no occurrence and the observation already sits in one that carries no slip, set the slip on that occurrence (`adopt_slip_onto_occurrence`) instead of creating a new one. An occurrence that already has a slip is left alone — a different slip still moves the observation out, as before.
- `cleanup_abandoned_occurrence` (observation moves occurrence): reset the mover's thumbnail when it borrowed a sibling's photo that the new occurrence can't reach (`reset_thumbnail_left_behind`, via `update_columns` so the after_update callback doesn't re-enter save), and reset any old-occurrence sibling whose thumbnail pointed at the mover's photos (`old_occ.reassign_thumbnails_from(self)`).

## Data repair

670589 / 669537 in production still need the reflection put back under occurrence 7568 — a runner script is prepared outside the repo (`projects/field-slip-repair/repair_obs_670589.rb`, dry-run by default).

## Test plan

Reviewer: as a project admin, open an iNat reflection in a field-slip-prefix project and click Edit (that creates the companion). On the companion's show page, use the "attach a field slip" link and enter an unused code. Expected: the companion keeps its photo, the reflection's show page lists the slip too, and the slip's page shows both observations.

<!-- changelog -->
article: yes
Fix a Field Slip attach losing a synced Observation's photo
<!-- /changelog -->

