### PR TITLE
Convert `Tab::Name::ObsLink::*` to plain route-helper paths

### DIFF
--- a/app/classes/tab/name/obs_link.rb
+++ b/app/classes/tab/name/obs_link.rb
@@ -14,10 +14,10 @@
 # Query::Observations to filter by, and the pre-computed count of
 # matching observations (carried by `Name::Observations` -- one
 # query total for all 5 counts, computed before any of these Tabs
-# are built). Building the path here is plain string formatting;
-# it does not query the database. Title format is `"#{label.t}
-# (#{count})"`. When `count.zero?`, `linked?` returns false and the
-# view renders a plain "(0)" placeholder instead of a link.
+# are built). Building the path here uses a route helper and does not
+# query the database. Title format is "#{label.t} (#{count})". When
+# `count.zero?`, `linked?` returns false and the view renders a plain
+# "(0)" placeholder instead of a link.
 #
 # Subclasses MUST implement:
 #   #label_key      — Symbol for the link label (e.g. `:obss_of_this_name`)

--- a/app/classes/tab/name/obs_link.rb
+++ b/app/classes/tab/name/obs_link.rb
@@ -10,23 +10,26 @@
 #   - `Tab::Name::ObsLink::TaxonProposed`
 #   - `Tab::Name::ObsLink::NameProposed`
 #
-# Each Tab knows: a translation key for its label, a Query of
-# Observations to point at, and the pre-computed count of matching
-# observations (carried by `Name::Observations`). Title format is
-# `"#{label.t} (#{count})"`. When `count.zero?`, `linked?` returns
-# false and the view renders a plain "(0)" placeholder instead of
-# a link.
+# Each Tab knows: a translation key for its label, a query_attr on
+# Query::Observations to filter by, and the pre-computed count of
+# matching observations (carried by `Name::Observations` -- one
+# query total for all 5 counts, computed before any of these Tabs
+# are built). Building the path here is plain string formatting;
+# it does not query the database. Title format is `"#{label.t}
+# (#{count})"`. When `count.zero?`, `linked?` returns false and the
+# view renders a plain "(0)" placeholder instead of a link.
 #
 # Subclasses MUST implement:
 #   #label_key      — Symbol for the link label (e.g. `:obss_of_this_name`)
 #   #filter_attr    — Query::Observations attr for this Tab's preset
 #                      (e.g. `:this_name`, `:any_name`)
 #
-# The base inherits `Tab::QueryLink`'s memoized `#query` and
-# `#path` (via `controller.add_q_param(observations_path, query)`).
-class Tab::Name::ObsLink < Tab::QueryLink
-  def initialize(name:, count:, controller:)
-    super(controller: controller)
+# `Tab::Name::ObsLink::Subtaxa` is a separate case, not a subclass
+# of this base -- it wraps a Query the controller already built for
+# other page chrome, so it inherits `Tab::QueryLink` instead.
+class Tab::Name::ObsLink < Tab::Base
+  def initialize(name:, count:)
+    super()
     @name = name
     @count = count
   end
@@ -43,31 +46,16 @@ class Tab::Name::ObsLink < Tab::QueryLink
   end
 
   # When false, the panel renders `"#{title}"` as plain text
-  # without an anchor — no need to build / save the query.
+  # without an anchor.
   def linked?
     @count.positive?
   end
 
-  # Data attrs read by the `filter-caption` Stimulus controller on
-  # the observations index. Empty when the tab isn't linked (the
-  # view doesn't render an `<a>` in that case).
-  def html_options
-    return {} unless linked?
-
-    { data: {
-      query_params: query.params.deep_compact_blank.to_json,
-      query_record: query.record.id,
-      query_alph: query.record.id.alphabetize
-    } }
+  def path
+    observations_path(filter_attr => @name.id)
   end
 
   private
-
-  def build_query
-    q = Query.create_query(:Observation, filter_attr => @name.id)
-    q.save
-    q
-  end
 
   def label_key
     raise(NotImplementedError.new("#{self.class}#label_key"))
@@ -75,9 +63,5 @@ class Tab::Name::ObsLink < Tab::QueryLink
 
   def filter_attr
     raise(NotImplementedError.new("#{self.class}#filter_attr"))
-  end
-
-  def target_params
-    observations_path
   end
 end

--- a/app/classes/tab/name/obs_link/all.rb
+++ b/app/classes/tab/name/obs_link/all.rb
@@ -37,8 +37,7 @@ class Tab::Name::ObsLink::All < Tab::Collection
 
   def standard_tabs
     SPECS.map do |klass, count_method|
-      klass.new(name: @name, count: @obss.send(count_method).size,
-                controller: @controller)
+      klass.new(name: @name, count: @obss.send(count_method).size)
     end
   end
 

--- a/app/classes/tab/name/obs_link/subtaxa.rb
+++ b/app/classes/tab/name/obs_link/subtaxa.rb
@@ -11,11 +11,27 @@
 # is supplied by the controller rather than built locally — the
 # observations-subtaxa query is also used elsewhere on the page
 # (header pager scope), so duplicating the construction would be
-# wasteful.
-class Tab::Name::ObsLink::Subtaxa < Tab::Name::ObsLink
+# wasteful. Inherits `Tab::QueryLink` directly rather than
+# `Tab::Name::ObsLink` -- the other 5 build a plain route-helper
+# path with no Query, so they no longer share a base with this one.
+class Tab::Name::ObsLink::Subtaxa < Tab::QueryLink
   def initialize(name:, count:, controller:, query:)
+    super(controller: controller)
+    @name = name
+    @count = count
     @injected_query = query
-    super(name: name, count: count, controller: controller)
+  end
+
+  def title
+    "#{label_key.t} (#{@count})"
+  end
+
+  def alt_title
+    label_key.to_s
+  end
+
+  def linked?
+    @count.positive?
   end
 
   private
@@ -26,5 +42,9 @@ class Tab::Name::ObsLink::Subtaxa < Tab::Name::ObsLink
 
   def build_query
     @injected_query
+  end
+
+  def target_params
+    observations_path
   end
 end

--- a/app/classes/tab/query_link.rb
+++ b/app/classes/tab/query_link.rb
@@ -8,17 +8,16 @@
 #
 #   - Multiple Tab families share this "save a query, build an
 #     `add_q_param(target, query)` URL" pattern — `Tab::RelatedQuery`
-#     (cross-model "related index" links) and the obs-counting Tabs
-#     under `Tab::Name::ObsLink::*`. Centralizing the boilerplate
-#     here means new query-link Tabs only declare their `#query` and
+#     (cross-model "related index" links) and
+#     `Tab::Name::ObsLink::Subtaxa` (a subtaxa-observations link
+#     wrapping a query the controller already built for other page
+#     chrome). Centralizing the boilerplate here means new
+#     query-link Tabs only declare their `#build_query` and
 #     `#target_params`.
-#   - `#query` is memoized in the base. Subclasses that have save
-#     side-effects (the obs-link Tabs call `query.save` in
-#     `#build_query` so the `q` param can carry a stable record id)
-#     must not be called twice — the view typically asks for both
-#     `#path` and `#html_options[:data]`, each of which reads
-#     `query`. Without memoization the same query would be saved
-#     twice, creating two `QueryRecord` rows.
+#   - `#query` is memoized in the base. A subclass whose
+#     `#build_query` saves a new record (`query.save`) must not do
+#     that twice if `#path` is read more than once — without
+#     memoization, a second read would re-save unnecessarily.
 #
 # Subclasses MUST implement:
 #

--- a/test/classes/tab/name/obs_link_query_integration_test.rb
+++ b/test/classes/tab/name/obs_link_query_integration_test.rb
@@ -2,11 +2,14 @@
 
 require("test_helper")
 
-# Integration test for the `Query::Observations` instances that
-# the 5 `Tab::Name::ObsLink::*` subclasses build. Constructs the
-# 2-name synonymized x 3-consensus-arrangement fixture grid (6
-# observations, 6 namings) and asserts that each Tab's query
-# returns exactly the right rows. Migrated from
+# Integration test for the `Query::Observations` attrs the 5
+# `Tab::Name::ObsLink::*` subclasses link to (`any_name`,
+# `other_names`, `look_alikes`, `name_proposed`). The Tabs
+# themselves build a plain route-helper path now, not a Query, so
+# this asserts each attr's query directly via `Query.lookup`.
+# Constructs the 2-name synonymized x 3-consensus-arrangement
+# fixture grid (6 observations, 6 namings) and asserts each query's
+# rows against it. Migrated from
 # `NamesHelperTest#test_observations_of_queries` after the
 # observation-link helpers moved into the Tab POROs.
 class Tab::Name::ObsLinkQueryIntegrationTest < UnitTestCase
@@ -95,27 +98,27 @@ class Tab::Name::ObsLinkQueryIntegrationTest < UnitTestCase
     obs
   end
 
-  def query_for(klass, name)
-    klass.new(name: name, count: 1, controller: nil).query
+  def query_for(attr, name)
+    Query.lookup(:Observation, attr => name.id)
   end
 
   def assert_any_name_query(name, includes:, excludes:)
-    results = query_for(Tab::Name::ObsLink::AnyName, name).results
+    results = query_for(:any_name, name).results
     assert_query_returns(results, includes: includes, excludes: excludes)
   end
 
   def assert_other_names_query(name, includes:, excludes:)
-    results = query_for(Tab::Name::ObsLink::OtherNames, name).results
+    results = query_for(:other_names, name).results
     assert_query_returns(results, includes: includes, excludes: excludes)
   end
 
   def assert_taxon_proposed_query(name, includes:, excludes:)
-    results = query_for(Tab::Name::ObsLink::TaxonProposed, name).results
+    results = query_for(:look_alikes, name).results
     assert_query_returns(results, includes: includes, excludes: excludes)
   end
 
   def assert_name_proposed_query(name, includes:, excludes:)
-    results = query_for(Tab::Name::ObsLink::NameProposed, name).results
+    results = query_for(:name_proposed, name).results
     assert_query_returns(results, includes: includes, excludes: excludes)
   end
 

--- a/test/classes/tab/name/obs_link_test.rb
+++ b/test/classes/tab/name/obs_link_test.rb
@@ -3,17 +3,14 @@
 require("test_helper")
 
 # Contract tests for the `Tab::Name::ObsLink::*` family. Each Tab
-# encapsulates a label, a saved `Query::Observations`, and a
+# encapsulates a label, a `Query::Observations` filter attr, and a
 # count. The view uses `#linked?` to decide whether to render an
 # `<a>` (count > 0) or a plain "(0)" placeholder.
-#
-# Path construction (`controller.add_q_param`) is exercised via
-# the names-show controller test — that has a live controller; a
-# unit test here would stub it out and prove little. We pin the
-# title format, the link/no-link predicate, the html_options data
-# attrs, and that each subclass's query is built with the right
-# attr.
 class Tab::Name::ObsLinkTest < UnitTestCase
+  def routes
+    Rails.application.routes.url_helpers
+  end
+
   def setup
     @name = names(:coprinus_comatus)
   end
@@ -49,75 +46,41 @@ class Tab::Name::ObsLinkTest < UnitTestCase
     assert_equal("taxon_obss_other_names", tab.alt_title)
   end
 
-  # --- html_options data attrs ----------------------------------
-
-  def test_html_options_empty_when_not_linked
-    tab = build_tab(Tab::Name::ObsLink::ThisName, count: 0)
-
-    # Allow the Tab::Base composer to add a derived selector
-    # class, but the data attrs must be absent.
-    assert_nil(tab.html_options[:data])
-  end
-
-  def test_html_options_carries_filter_caption_data_when_linked
-    tab = build_tab(Tab::Name::ObsLink::ThisName, count: 4)
-
-    data = tab.html_options[:data]
-    assert_not_nil(data)
-    assert(data[:query_params].present?)
-    assert(data[:query_record].positive?)
-    assert(data[:query_alph].present?)
-  end
-
-  # --- Query shape per subclass --------------------------------
+  # --- Path per subclass ------------------------------------------
 
   # Each subclass's flag combination (synonyms, exclude_consensus,
-  # etc.) lives in the same-named Observation scope now, not in
-  # `query.params` -- see obs_link_query_integration_test.rb for the
+  # etc.) lives in the same-named Query::Observations attr, not
+  # here -- see obs_link_query_integration_test.rb for the
   # results-based coverage of that behavior. These just pin which
-  # attr each subclass wires up.
-  def test_this_name_query_has_lookup_only
-    q = build_tab(Tab::Name::ObsLink::ThisName, count: 1).query
-
-    assert_equal([@name.id.to_s], q.params[:this_name])
-  end
-
-  def test_other_names_query_has_synonyms_and_exclude
-    q = build_tab(Tab::Name::ObsLink::OtherNames, count: 1).query
-
-    assert_equal([@name.id.to_s], q.params[:other_names])
-  end
-
-  def test_any_name_query_includes_synonyms_no_exclude
-    q = build_tab(Tab::Name::ObsLink::AnyName, count: 1).query
-
-    assert_equal([@name.id.to_s], q.params[:any_name])
-  end
-
-  def test_taxon_proposed_query_excludes_consensus
-    q = build_tab(Tab::Name::ObsLink::TaxonProposed, count: 1).query
-
-    assert_equal(@name.id, q.params[:look_alikes])
-  end
-
-  def test_name_proposed_query_has_all_proposals_no_synonyms
-    q = build_tab(Tab::Name::ObsLink::NameProposed, count: 1).query
-
-    assert_equal([@name.id.to_s], q.params[:name_proposed])
-  end
-
-  # --- Query memoization saves once ----------------------------
-
-  def test_query_save_runs_once
+  # attr each subclass's path wires up.
+  def test_this_name_path
     tab = build_tab(Tab::Name::ObsLink::ThisName, count: 1)
 
-    # First read triggers build + save; second read returns the
-    # memoized instance without rebuilding.
-    first = tab.query
-    second = tab.query
+    assert_equal(routes.observations_path(this_name: @name.id), tab.path)
+  end
 
-    assert_same(first, second,
-                "memoization should return the same instance")
+  def test_other_names_path
+    tab = build_tab(Tab::Name::ObsLink::OtherNames, count: 1)
+
+    assert_equal(routes.observations_path(other_names: @name.id), tab.path)
+  end
+
+  def test_any_name_path
+    tab = build_tab(Tab::Name::ObsLink::AnyName, count: 1)
+
+    assert_equal(routes.observations_path(any_name: @name.id), tab.path)
+  end
+
+  def test_taxon_proposed_path
+    tab = build_tab(Tab::Name::ObsLink::TaxonProposed, count: 1)
+
+    assert_equal(routes.observations_path(look_alikes: @name.id), tab.path)
+  end
+
+  def test_name_proposed_path
+    tab = build_tab(Tab::Name::ObsLink::NameProposed, count: 1)
+
+    assert_equal(routes.observations_path(name_proposed: @name.id), tab.path)
   end
 
   # --- Subtaxa wraps a controller-provided query ---------------
@@ -135,6 +98,6 @@ class Tab::Name::ObsLinkTest < UnitTestCase
   private
 
   def build_tab(klass, count:)
-    klass.new(name: @name, count: count, controller: nil)
+    klass.new(name: @name, count: count)
   end
 end


### PR DESCRIPTION
Result of now having top-level query params for indexes, and new query_attrs for `:look_alikes` and `:related_taxa`.

## Summary

The Observation show page's "about this taxon" links (`Tab::Observation::OfName`/`OfLookAlikes`/`OfRelatedTaxa`) already point at plain `observations_path(name: id)`-style URLs -- no `Query` object, just a URL param the generic index-filter dispatch resolves. The Name show page's equivalent 5 links (`Tab::Name::ObsLink::ThisName`/`OtherNames`/`AnyName`/`TaxonProposed`/`NameProposed`), in the "About this taxon" panel, instead built and saved a full `Query::Observations` record just to generate the same kind of link. All 5 underlying filters are already registered `query_attr`s on `Query::Observations`, so this PR converts them to the simpler pattern.

`Tab::Name::ObsLink::Subtaxa`, the 6th tab in that panel, is left alone -- it wraps a Query the controller already built for other page chrome (the header pager), so building it again from a URL param would duplicate work instead of saving it.

## Why this was safe

The counts these tabs display (`(N)`) come from `Name::Observations`, a PORO that runs one query for the whole page and computes all 5 counts by filtering that one result set in Ruby. Counting doesn't touch the Tab's Query object -- confirmed by reading the code before changing anything, not assumed.

Also removed: the `data-query-{params,record,alph}` attrs the old tabs put on the link. These were for human legibility of the produced query, which is now improved at the source.

## Benchmark

Two measurements, each run on the unmodified code first, then on the converted code, in the same process per side.

**Building the 5 tabs directly** (a name with no prior page view for these params, so nothing is cached):

| | Queries | `QueryRecord` rows written |
|---|---|---|
| Before | 10 | 5 |
| After | 0 | 0 |

**Full Name show page load** (`NamesController#show`, 5 requests in one test run -- first request is cold, next 4 are steady-state):

| | Queries (per request) | Median wall time |
|---|---|---|
| Before | 89, 69, 66, 66, 66 | 0.1044s |
| After | 77, 66, 63, 63, 63 | 0.0888s |

Steady-state queries drop by 3 per request even after the old code's `QueryRecord`s already exist (a small per-request dedup-lookup cost that's gone completely now), and by 12 on a page with no prior view under these params. Wall time is noisy at 5 samples but consistently lower.

## Changes

- `Tab::Name::ObsLink` (base) — now extends `Tab::Base` directly, builds `path` via `observations_path(filter_attr => @name.id)`. No `query`, no `html_options` override, no `controller:` needed.
- `Tab::Name::ObsLink::Subtaxa` — now extends `Tab::QueryLink` directly instead of the (now-unrelated) `Tab::Name::ObsLink` base, since it's the only one still using the saved-Query pattern.
- `Tab::Name::ObsLink::All` — stops passing `controller:` to the 5 standard tabs; still passes it to `Subtaxa`.
- `Tab::QueryLink` — doc comment updated to name `Subtaxa` instead of the whole (now half-converted) `Tab::Name::ObsLink::*` family as an example subclass.
- `ThisName`/`OtherNames`/`AnyName`/`TaxonProposed`/`NameProposed` are unchanged -- they only declared `label_key`/`filter_attr`, and that interface stayed the same.

## Test plan

- [x] `bin/rails test test/classes/tab/name/obs_link_test.rb` -- rewritten: path assertions per subclass via route helpers instead of `query.params` pins; dropped the `html_options`/data-attr and query-memoization tests since there's no query to memoize now.
- [x] `bin/rails test test/classes/tab/name/obs_link_query_integration_test.rb` -- same 6-observation/2-synonym fixture-grid coverage, now asserting `Query.lookup(:Observation, attr => name.id)` directly instead of routing through the Tab (which doesn't build one anymore).
- [x] `bin/rails test test/classes/tab/name/obs_link/all_test.rb` -- unchanged, still passes.
- [x] `bin/rails test test/classes/tab/query_link_test.rb` -- unchanged, still passes.
- [x] `bin/rails test test/controllers/names_controller_show_test.rb` -- unchanged, still passes.
- [x] `bundle exec rubocop` on every touched file

<!-- changelog -->
article: no
<!-- /changelog -->
