### PR TITLE
Require root for dev setup dispatcher

### DIFF
--- a/script/dev_setup
+++ b/script/dev_setup
@@ -21,6 +21,14 @@ else
 fi
 mo_ensure_repo
 
+if [ "${EUID}" -ne 0 ]; then
+    if ! command -v sudo >/dev/null 2>&1; then
+        echo "This setup script must run as root, but sudo is not available." >&2
+        exit 1
+    fi
+    exec sudo script/dev_setup "$@"
+fi
+
 case "$(uname -s)" in
     Darwin)
         exec script/dev_setup_components/dev_setup_macos "$@"


### PR DESCRIPTION
## Summary

- re-run the checked-out dev setup dispatcher through sudo when invoked by a non-root user
- preserve all setup arguments across privilege escalation
- fail with a clear message when sudo is unavailable

Escalation happens after repository bootstrapping so the documented curl-pipe flow can re-execute the canonical checked-out script.

## Test plan

- bash -n script/dev_setup
- git diff --check
- mocked a non-root invocation and verified sudo receives the script path, --icons-only, and an argument containing spaces unchanged
- ShellCheck reports only the two pre-existing warnings for dynamic source statements

<!-- changelog -->
article: no

<!-- /changelog -->