### PR TITLE
SolidQueue batches migration

### DIFF
--- a/db/migrate/20260831223601_add_batches_to_solid_queue.rb
+++ b/db/migrate/20260831223601_add_batches_to_solid_queue.rb
@@ -1,0 +1,39 @@
+class AddBatchesToSolidQueue < ActiveRecord::Migration[7.1]
+  def change
+    # Fresh installs create all of this with the base schema, so skip
+    # anything that already exists
+    add_column :solid_queue_jobs, :batch_id, :bigint, if_not_exists: true
+    add_index :solid_queue_jobs, :batch_id, if_not_exists: true
+
+    create_table :solid_queue_batches, if_not_exists: true do |t|
+      t.string :active_job_batch_id
+      t.string :description
+      t.text :on_finish
+      t.text :on_success
+      t.text :on_failure
+      t.text :metadata
+      t.integer :total_jobs, default: 0, null: false
+      t.integer :completed_jobs, default: 0, null: false
+      t.integer :failed_jobs, default: 0, null: false
+      t.datetime :enqueued_at
+      t.datetime :finished_at
+      t.datetime :failed_at
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+
+      t.index :active_job_batch_id, unique: true
+      t.index :finished_at
+    end
+
+    create_table :solid_queue_batch_executions, if_not_exists: true do |t|
+      t.bigint :job_id, null: false
+      t.bigint :batch_id, null: false
+      t.datetime :created_at, null: false
+
+      t.index :job_id, unique: true
+      t.index :batch_id
+      t.foreign_key :solid_queue_batches, column: :batch_id, on_delete: :cascade
+      t.foreign_key :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    end
+  end
+end

--- a/db/migrate/20260831223601_add_batches_to_solid_queue.rb
+++ b/db/migrate/20260831223601_add_batches_to_solid_queue.rb
@@ -1,39 +1,58 @@
-class AddBatchesToSolidQueue < ActiveRecord::Migration[7.1]
+# frozen_string_literal: true
+
+class AddBatchesToSolidQueue < ActiveRecord::Migration[7.2]
   def change
     # Fresh installs create all of this with the base schema, so skip
     # anything that already exists
-    add_column :solid_queue_jobs, :batch_id, :bigint, if_not_exists: true
-    add_index :solid_queue_jobs, :batch_id, if_not_exists: true
+    add_column(:solid_queue_jobs, :batch_id, :bigint, if_not_exists: true)
+    add_index(:solid_queue_jobs, :batch_id, if_not_exists: true)
+    create_batches
+    create_batch_executions
+  end
 
-    create_table :solid_queue_batches, if_not_exists: true do |t|
-      t.string :active_job_batch_id
-      t.string :description
-      t.text :on_finish
-      t.text :on_success
-      t.text :on_failure
-      t.text :metadata
-      t.integer :total_jobs, default: 0, null: false
-      t.integer :completed_jobs, default: 0, null: false
-      t.integer :failed_jobs, default: 0, null: false
-      t.datetime :enqueued_at
-      t.datetime :finished_at
-      t.datetime :failed_at
-      t.datetime :created_at, null: false
-      t.datetime :updated_at, null: false
+  private
 
-      t.index :active_job_batch_id, unique: true
-      t.index :finished_at
+  def create_batches
+    create_table(:solid_queue_batches, if_not_exists: true) do |t|
+      t.string(:active_job_batch_id)
+      t.string(:description)
+      t.text(:on_finish)
+      t.text(:on_success)
+      t.text(:on_failure)
+      t.text(:metadata)
+      batch_counters(t)
+      batch_timestamps(t)
+      t.datetime(:created_at, null: false)
+      t.datetime(:updated_at, null: false)
+
+      t.index(:active_job_batch_id, unique: true)
+      t.index(:finished_at)
     end
+  end
 
-    create_table :solid_queue_batch_executions, if_not_exists: true do |t|
-      t.bigint :job_id, null: false
-      t.bigint :batch_id, null: false
-      t.datetime :created_at, null: false
+  def batch_counters(table)
+    table.integer(:total_jobs, default: 0, null: false)
+    table.integer(:completed_jobs, default: 0, null: false)
+    table.integer(:failed_jobs, default: 0, null: false)
+  end
 
-      t.index :job_id, unique: true
-      t.index :batch_id
-      t.foreign_key :solid_queue_batches, column: :batch_id, on_delete: :cascade
-      t.foreign_key :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  def batch_timestamps(table)
+    table.datetime(:enqueued_at)
+    table.datetime(:finished_at)
+    table.datetime(:failed_at)
+  end
+
+  def create_batch_executions
+    create_table(:solid_queue_batch_executions, if_not_exists: true) do |t|
+      t.bigint(:job_id, null: false)
+      t.bigint(:batch_id, null: false)
+      t.datetime(:created_at, null: false)
+
+      t.index(:job_id, unique: true)
+      t.index(:batch_id)
+      t.foreign_key(:solid_queue_batches, column: :batch_id,
+                                          on_delete: :cascade)
+      t.foreign_key(:solid_queue_jobs, column: :job_id, on_delete: :cascade)
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_26_114215) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_31_223601) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -805,6 +805,33 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_26_114215) do
     t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
   end
 
+  create_table "solid_queue_batch_executions", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "batch_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["batch_id"], name: "index_solid_queue_batch_executions_on_batch_id"
+    t.index ["job_id"], name: "index_solid_queue_batch_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_batches", charset: "utf8mb3", force: :cascade do |t|
+    t.string "active_job_batch_id"
+    t.string "description"
+    t.text "on_finish"
+    t.text "on_success"
+    t.text "on_failure"
+    t.text "metadata"
+    t.integer "total_jobs", default: 0, null: false
+    t.integer "completed_jobs", default: 0, null: false
+    t.integer "failed_jobs", default: 0, null: false
+    t.datetime "enqueued_at"
+    t.datetime "finished_at"
+    t.datetime "failed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_batch_id"], name: "index_solid_queue_batches_on_active_job_batch_id", unique: true
+    t.index ["finished_at"], name: "index_solid_queue_batches_on_finished_at"
+  end
+
   create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
@@ -843,7 +870,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_26_114215) do
     t.string "concurrency_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "batch_id"
     t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["batch_id"], name: "index_solid_queue_jobs_on_batch_id"
     t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
     t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
     t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
@@ -1104,6 +1133,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_26_114215) do
 
   add_foreign_key "observations", "users", column: "collector_user_id"
   add_foreign_key "project_aliases", "projects"
+  add_foreign_key "solid_queue_batch_executions", "solid_queue_batches", column: "batch_id", on_delete: :cascade
+  add_foreign_key "solid_queue_batch_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -805,7 +805,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_31_223601) do
     t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
   end
 
-  create_table "solid_queue_batch_executions", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_batch_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.bigint "batch_id", null: false
     t.datetime "created_at", null: false
@@ -813,7 +813,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_31_223601) do
     t.index ["job_id"], name: "index_solid_queue_batch_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_batches", charset: "utf8mb3", force: :cascade do |t|
+  create_table "solid_queue_batches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "active_job_batch_id"
     t.string "description"
     t.text "on_finish"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -44,7 +44,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     # `Capybara.server = :puma` cannot suppress it. Wrap that
     # registration and force Silent: true so NoTestConsoleNoise
     # doesn't flag the first system test on each parallel worker/port.
-    unless Capybara.servers.key?(:puma_silent)
+    unless Capybara.servers.names.include?(:puma_silent)
       Capybara.register_server(:puma_silent) do |app, port, host|
         Capybara.servers[:puma].call(app, port, host, Silent: true)
       end


### PR DESCRIPTION
## Summary

Fixes  Solid Queue pending database migrations warning which appeared when starting rails s

## Test plan

rails test

<!-- changelog -->
article: no
Solid Queue pending database migrations warning 

<!-- /changelog -->
