### PR TITLE
Add flat top-level query params (`Query#index_filter`); migrate 6 same-model `Tab::*` links

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -507,6 +507,19 @@ class Query
     { model: model.name.to_sym, **params }
   end
 
+  # The query's filter attrs, for use as flat top-level URL params on
+  # a link to this model's index page (`?project=123`, not
+  # `?q[projects][]=123`). Unlike q_param, deliberately excludes
+  # :model -- the target index action infers its model from the
+  # controller (see ApplicationController::Indexes), so a link built
+  # from this only works for a query whose model matches the target
+  # controller. A link that crosses models (e.g. forwarding an
+  # RssLog query to an Observation's show page) still needs q_param,
+  # not this.
+  def index_filter
+    params
+  end
+
   # Merges an already-resolved `q` param value into a path's
   # existing query string (preserving other params, e.g. `flow=next`).
   # A plain utility, not tied to any Query instance -- shared by two
@@ -534,6 +547,20 @@ class Query
     uri = URI.parse(path)
     parsed = uri.query ? Rack::Utils.parse_query(uri.query) : {}
     parsed["q"] = q_param_value
+    uri.query = parsed.to_query
+    uri.to_s
+  end
+
+  # Merges an index_filter hash into a path's existing query string
+  # as flat top-level params (not nested under q[...]), preserving
+  # other params already in the path. See merge_q_param_into_url for
+  # the cross-model, nested equivalent.
+  def self.merge_index_filters_into_url(path, filters)
+    return path if filters.blank?
+
+    uri = URI.parse(path)
+    parsed = uri.query ? Rack::Utils.parse_query(uri.query) : {}
+    parsed.merge!(filters.stringify_keys)
     uri.query = parsed.to_query
     uri.to_s
   end

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -516,8 +516,13 @@ class Query
   # controller. A link that crosses models (e.g. forwarding an
   # RssLog query to an Observation's show page) still needs q_param,
   # not this.
+  # Excludes :controller/:action/:id/:format defensively -- merged
+  # directly onto a Rails route-helper args hash by Tab classes
+  # (`args.merge(@index_filter)`), and a future query_attr sharing
+  # one of those names would silently clobber the routing key it's
+  # merged over instead of raising.
   def index_filter
-    params
+    params.except(:controller, :action, :id, :format)
   end
 
   # Merges an already-resolved `q` param value into a path's
@@ -544,11 +549,7 @@ class Query
   def self.merge_q_param_into_url(path, q_param_value)
     return path if q_param_value.blank?
 
-    uri = URI.parse(path)
-    parsed = uri.query ? Rack::Utils.parse_query(uri.query) : {}
-    parsed["q"] = q_param_value
-    uri.query = parsed.to_query
-    uri.to_s
+    merge_query_params_into_url(path) { |parsed| parsed["q"] = q_param_value }
   end
 
   # Merges an index_filter hash into a path's existing query string
@@ -558,12 +559,24 @@ class Query
   def self.merge_index_filters_into_url(path, filters)
     return path if filters.blank?
 
+    merge_query_params_into_url(path) do |parsed|
+      parsed.merge!(filters.stringify_keys)
+    end
+  end
+
+  # Shared by merge_q_param_into_url/merge_index_filters_into_url:
+  # parses path's existing query string, yields it for the caller to
+  # update, then rebuilds the URL. Uses Hash#to_query, not
+  # Rack::Utils.build_query -- see merge_q_param_into_url's history
+  # for why (a nested Hash value needs to recurse correctly).
+  def self.merge_query_params_into_url(path)
     uri = URI.parse(path)
     parsed = uri.query ? Rack::Utils.parse_query(uri.query) : {}
-    parsed.merge!(filters.stringify_keys)
+    yield(parsed)
     uri.query = parsed.to_query
     uri.to_s
   end
+  private_class_method :merge_query_params_into_url
 
   # Serialize the query params, adding the model, for saving to a QueryRecord.
   # We use this column of QueryRecord to identify an existing query record that

--- a/app/classes/tab/base.rb
+++ b/app/classes/tab/base.rb
@@ -146,6 +146,13 @@ class Tab::Base
     Query.merge_q_param_into_url(path, q_param_value)
   end
 
+  # Same as with_q_param, but flat top-level params (`?project=123`),
+  # not nested under q[...]. Only use this when `path` is a link to
+  # the model `filters` came from -- see Query#index_filter.
+  def with_index_filter(path, filters)
+    Query.merge_index_filters_into_url(path, filters)
+  end
+
   # Stable key NavTabs matches against `current:` to decide `.active`.
   # Defaults to `alt_title` when set (the same short identifier used
   # for the selector class) — this aligns with the existing MO

--- a/app/classes/tab/collection_number/back_to_index.rb
+++ b/app/classes/tab/collection_number/back_to_index.rb
@@ -3,10 +3,10 @@
 # "Back to collection_numbers index" link (used by the edit form
 # when arriving from the index). Carries the current Query through.
 class Tab::CollectionNumber::BackToIndex < Tab::Base
-  def initialize(collection_number:, q_param: nil)
+  def initialize(collection_number:, index_filter: nil)
     super()
     @collection_number = collection_number
-    @q_param = q_param
+    @index_filter = index_filter
   end
 
   def title
@@ -15,7 +15,7 @@ class Tab::CollectionNumber::BackToIndex < Tab::Base
 
   def path
     args = @collection_number.index_link_args
-    @q_param ? args.merge(q: @q_param) : args
+    @index_filter ? args.merge(@index_filter) : args
   end
 
   def model

--- a/app/classes/tab/collection_number/form_edit.rb
+++ b/app/classes/tab/collection_number/form_edit.rb
@@ -5,12 +5,12 @@
 # to the index (`BackToIndex`); otherwise back to whatever
 # `back_object` is (typically the parent Observation).
 class Tab::CollectionNumber::FormEdit < Tab::Collection
-  def initialize(collection_number:, back:, back_object:, q_param: nil)
+  def initialize(collection_number:, back:, back_object:, index_filter: nil)
     super()
     @collection_number = collection_number
     @back = back
     @back_object = back_object
-    @q_param = q_param
+    @index_filter = index_filter
   end
 
   private
@@ -23,7 +23,7 @@ class Tab::CollectionNumber::FormEdit < Tab::Collection
 
   def back_to_index
     Tab::CollectionNumber::BackToIndex.new(
-      collection_number: @collection_number, q_param: @q_param
+      collection_number: @collection_number, index_filter: @index_filter
     )
   end
 end

--- a/app/classes/tab/herbarium_record/back_to_index.rb
+++ b/app/classes/tab/herbarium_record/back_to_index.rb
@@ -3,9 +3,9 @@
 # "Back to herbarium_records index" link (used by the edit form when
 # arriving from the index). Carries the current Query through.
 class Tab::HerbariumRecord::BackToIndex < Tab::Base
-  def initialize(q_param: nil)
+  def initialize(index_filter: nil)
     super()
-    @q_param = q_param
+    @index_filter = index_filter
   end
 
   def title
@@ -13,6 +13,10 @@ class Tab::HerbariumRecord::BackToIndex < Tab::Base
   end
 
   def path
-    @q_param ? herbarium_records_path(q: @q_param) : herbarium_records_path
+    if @index_filter
+      herbarium_records_path(**@index_filter)
+    else
+      herbarium_records_path
+    end
   end
 end

--- a/app/classes/tab/herbarium_record/form_edit.rb
+++ b/app/classes/tab/herbarium_record/form_edit.rb
@@ -5,11 +5,12 @@
 # the herbarium_records index; otherwise → return to `back_object`
 # (typically the parent Observation).
 class Tab::HerbariumRecord::FormEdit < Tab::Collection
-  def initialize(back:, back_object:, q_param: nil)
+  def initialize(back:, back_object:, q_param: nil, index_filter: nil)
     super()
     @back = back
     @back_object = back_object
     @q_param = q_param
+    @index_filter = index_filter
   end
 
   private
@@ -23,8 +24,11 @@ class Tab::HerbariumRecord::FormEdit < Tab::Collection
   end
 
   def back_link
-    return Tab::HerbariumRecord::BackToIndex.new(q_param: @q_param) \
-      if @back == "index"
+    if @back == "index"
+      return Tab::HerbariumRecord::BackToIndex.new(
+        index_filter: @index_filter
+      )
+    end
     return Tab::Object::Return.new(object: @back_object) if @back_object
 
     nil

--- a/app/classes/tab/name/form_edit.rb
+++ b/app/classes/tab/name/form_edit.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Tab::Name::FormEdit < Tab::Collection
-  def initialize(name:, q_param: nil)
+  def initialize(name:, index_filter: nil)
     super()
     @name = name
-    @q_param = q_param
+    @index_filter = index_filter
   end
 
   private
@@ -12,7 +12,7 @@ class Tab::Name::FormEdit < Tab::Collection
   def tabs
     [
       Tab::Object::Return.new(object: @name),
-      Tab::Object::Index.new(object: @name, q_param: @q_param)
+      Tab::Object::Index.new(object: @name, index_filter: @index_filter)
     ]
   end
 end

--- a/app/classes/tab/object/index.rb
+++ b/app/classes/tab/object/index.rb
@@ -2,12 +2,14 @@
 
 # Polymorphic "List Xs" index link. Replaces
 # `Tabs::GeneralHelper#object_index_tab`. Carries the current Query
-# through via `q_param`.
+# through via `index_filter` -- callers must pass a query whose
+# model matches `object`'s, since this always links to that model's
+# index page (see Query#index_filter).
 class Tab::Object::Index < Tab::Base
-  def initialize(object:, q_param: nil, title: nil)
+  def initialize(object:, index_filter: nil, title: nil)
     super()
     @object = object
-    @q_param = q_param
+    @index_filter = index_filter
     @title_override = title
   end
 
@@ -17,9 +19,9 @@ class Tab::Object::Index < Tab::Base
 
   def path
     args = @object.index_link_args
-    return args unless @q_param && args.is_a?(Hash)
+    return args unless @index_filter && args.is_a?(Hash)
 
-    args.merge(q: @q_param)
+    args.merge(@index_filter)
   end
 
   def html_options

--- a/app/classes/tab/observation/form_new.rb
+++ b/app/classes/tab/observation/form_new.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class Tab::Observation::FormNew < Tab::Collection
-  def initialize(q_param: nil)
+  def initialize(q_param: nil, index_filter: nil)
     super()
     @q_param = q_param
+    @index_filter = index_filter
   end
 
   private
@@ -11,7 +12,7 @@ class Tab::Observation::FormNew < Tab::Collection
   def tabs
     [
       Tab::Observation::InatImport.new(q_param: @q_param),
-      Tab::Observation::Index.new(q_param: @q_param)
+      Tab::Observation::Index.new(index_filter: @index_filter)
     ]
   end
 end

--- a/app/classes/tab/observation/index.rb
+++ b/app/classes/tab/observation/index.rb
@@ -2,9 +2,9 @@
 
 # "Cancel to observations index" action-nav link.
 class Tab::Observation::Index < Tab::Base
-  def initialize(q_param: nil)
+  def initialize(index_filter: nil)
     super()
-    @q_param = q_param
+    @index_filter = index_filter
   end
 
   def title
@@ -12,6 +12,6 @@ class Tab::Observation::Index < Tab::Base
   end
 
   def path
-    with_q_param(observations_path, @q_param)
+    with_index_filter(observations_path, @index_filter)
   end
 end

--- a/app/classes/tab/species_list/form_new.rb
+++ b/app/classes/tab/species_list/form_new.rb
@@ -3,9 +3,9 @@
 # Action-nav for the new species_list form: Name Lister + cancel
 # to index.
 class Tab::SpeciesList::FormNew < Tab::Collection
-  def initialize(q_param: nil)
+  def initialize(index_filter: nil)
     super()
-    @q_param = q_param
+    @index_filter = index_filter
   end
 
   private
@@ -13,7 +13,7 @@ class Tab::SpeciesList::FormNew < Tab::Collection
   def tabs
     [
       Tab::SpeciesList::NameLister.new,
-      Tab::SpeciesList::Index.new(q_param: @q_param)
+      Tab::SpeciesList::Index.new(index_filter: @index_filter)
     ]
   end
 end

--- a/app/classes/tab/species_list/form_observations.rb
+++ b/app/classes/tab/species_list/form_observations.rb
@@ -4,14 +4,16 @@
 # cancel link back to the observations index (preserving the
 # current Query so the filter survives the round trip).
 class Tab::SpeciesList::FormObservations < Tab::Collection
-  def initialize(q_param: nil)
+  def initialize(index_filter: nil)
     super()
-    @q_param = q_param
+    @index_filter = index_filter
   end
 
   private
 
   def tabs
-    [Tab::SpeciesList::ObservationsIndexReturn.new(q_param: @q_param)]
+    [Tab::SpeciesList::ObservationsIndexReturn.new(
+      index_filter: @index_filter
+    )]
   end
 end

--- a/app/classes/tab/species_list/index.rb
+++ b/app/classes/tab/species_list/index.rb
@@ -2,9 +2,9 @@
 
 # "Cancel to species list index" action-nav link.
 class Tab::SpeciesList::Index < Tab::Base
-  def initialize(q_param: nil)
+  def initialize(index_filter: nil)
     super()
-    @q_param = q_param
+    @index_filter = index_filter
   end
 
   def title
@@ -12,6 +12,6 @@ class Tab::SpeciesList::Index < Tab::Base
   end
 
   def path
-    with_q_param(species_lists_path, @q_param)
+    with_index_filter(species_lists_path, @index_filter)
   end
 end

--- a/app/classes/tab/species_list/observations_index_return.rb
+++ b/app/classes/tab/species_list/observations_index_return.rb
@@ -5,9 +5,9 @@
 # helper carried no per-model selector; auto-derived class is a
 # plain title-derived `<…>_link`.
 class Tab::SpeciesList::ObservationsIndexReturn < Tab::Base
-  def initialize(q_param: nil)
+  def initialize(index_filter: nil)
     super()
-    @q_param = q_param
+    @index_filter = index_filter
   end
 
   def title
@@ -15,6 +15,6 @@ class Tab::SpeciesList::ObservationsIndexReturn < Tab::Base
   end
 
   def path
-    with_q_param(observations_path, @q_param)
+    with_index_filter(observations_path, @index_filter)
   end
 end

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -53,6 +53,8 @@ class Components::Base < Phlex::HTML
   register_value_helper :url_for
   register_value_helper :add_q_param
   register_value_helper :q_param
+  register_value_helper :add_index_filters
+  register_value_helper :index_filter
   # The Query for "what the user is currently looking at" — pulled
   # from the controller's `@query` ivar, the URL's `q` param, or the
   # session's stored query_record (in that order, via

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -53,7 +53,6 @@ class Components::Base < Phlex::HTML
   register_value_helper :url_for
   register_value_helper :add_q_param
   register_value_helper :q_param
-  register_value_helper :add_index_filters
   register_value_helper :index_filter
   # The Query for "what the user is currently looking at" — pulled
   # from the controller's `@query` ivar, the URL's `q` param, or the

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -16,7 +16,6 @@
 #  query_from_session::     Query instance from the session[:query_record]
 #  add_q_param::            Adds :q param to path or hash. Accepts passed query.
 #  q_param::                Returns :q param hash. Accepts passed query.
-#  add_index_filters::      Flat, same-model add_q_param -- see index_filter.
 #  index_filter::           Flat, same-model q_param -- see Query#index_filter.
 #  redirect_to_next_object:: Find next object from a Query and redirect to its
 #                            show page.
@@ -25,7 +24,7 @@ module ApplicationController::Queries
   def self.included(base)
     base.helper_method(
       :query_from_session, :query_params, :add_q_param, :q_param,
-      :add_index_filters, :index_filter, :find_or_create_query, :current_query
+      :index_filter, :find_or_create_query, :current_query
     )
   end
 
@@ -298,21 +297,6 @@ module ApplicationController::Queries
   end
   # helper_method :add_q_param
 
-  # Same as add_q_param, but flat top-level params (`?project=123`)
-  # for a link to a model's index page. Use only when path_or_params'
-  # target indexes the model `query` is for -- see Query#index_filter.
-  def add_index_filters(path_or_params, query = nil)
-    return path_or_params if browser.bot? || !(filters = index_filter(query))
-
-    if path_or_params.is_a?(String)
-      Query.merge_index_filters_into_url(path_or_params, filters)
-    else
-      path_or_params.merge!(filters)
-      path_or_params
-    end
-  end
-  # helper_method :add_index_filters
-
   private
 
   # Internal to query_from_q_param_hash: true only for a real Query subclass.
@@ -341,9 +325,23 @@ module ApplicationController::Queries
   # helper_method :q_param # defined in application_controller.rb
 
   # Same as q_param, but returns the flat filter hash (no :model) --
-  # see Query#index_filter.
-  def index_filter(query = nil)
-    resolve_query_param(query)&.index_filter
+  # see Query#index_filter. Unlike q_param, `model` is required: the
+  # ambient `current_query` fallback in resolve_query_param can be
+  # leftover state from browsing a different model (e.g. the last
+  # search was Observations, then the user navigates to a Name edit
+  # page with no query set for it). q_param stays safe in that case
+  # because it tags the mismatched query with :model for the
+  # receiving page to reconcile or ignore, but a flat index_filter
+  # hash carries no such tag, so returning it unchecked could apply
+  # an unrelated model's filter attrs to this page's index link
+  # whenever the attribute names happen to coincide. Returns nil
+  # (no filter) rather than the ambient query's filters when the
+  # models don't match.
+  def index_filter(model, query = nil)
+    resolved = resolve_query_param(query)
+    return nil unless resolved && resolved.model.name.to_sym == model.to_sym
+
+    resolved.index_filter
   end
   # helper_method :index_filter
 

--- a/app/controllers/application_controller/queries.rb
+++ b/app/controllers/application_controller/queries.rb
@@ -7,8 +7,7 @@
 #
 #  update_stored_query::    Saves a passed query and stores id in the session.
 #  clear_query_in_session:: Clears out Query stored in session below.
-#  store_query_in_session:: Stores Query in session for use by
-#                           create_species_list.
+#  store_query_in_session:: Stores Query in session for create_species_list.
 #  query_from_session::     Gets Query that was stored in the session above.
 #
 #  current_query::          Returns @query, #query_from_q_param or
@@ -17,6 +16,8 @@
 #  query_from_session::     Query instance from the session[:query_record]
 #  add_q_param::            Adds :q param to path or hash. Accepts passed query.
 #  q_param::                Returns :q param hash. Accepts passed query.
+#  add_index_filters::      Flat, same-model add_q_param -- see index_filter.
+#  index_filter::           Flat, same-model q_param -- see Query#index_filter.
 #  redirect_to_next_object:: Find next object from a Query and redirect to its
 #                            show page.
 #
@@ -24,7 +25,7 @@ module ApplicationController::Queries
   def self.included(base)
     base.helper_method(
       :query_from_session, :query_params, :add_q_param, :q_param,
-      :find_or_create_query, :current_query
+      :add_index_filters, :index_filter, :find_or_create_query, :current_query
     )
   end
 
@@ -297,6 +298,21 @@ module ApplicationController::Queries
   end
   # helper_method :add_q_param
 
+  # Same as add_q_param, but flat top-level params (`?project=123`)
+  # for a link to a model's index page. Use only when path_or_params'
+  # target indexes the model `query` is for -- see Query#index_filter.
+  def add_index_filters(path_or_params, query = nil)
+    return path_or_params if browser.bot? || !(filters = index_filter(query))
+
+    if path_or_params.is_a?(String)
+      Query.merge_index_filters_into_url(path_or_params, filters)
+    else
+      path_or_params.merge!(filters)
+      path_or_params
+    end
+  end
+  # helper_method :add_index_filters
+
   private
 
   # Internal to query_from_q_param_hash: true only for a real Query subclass.
@@ -305,19 +321,31 @@ module ApplicationController::Queries
     klass.is_a?(Class) && klass < Query
   end
 
+  # Shared by q_param/index_filter: nil for bots, else the passed
+  # query (saved first if unsaved) or current_query.
+  def resolve_query_param(query)
+    return nil if browser.bot?
+
+    query.save if query && !query.id
+    query || current_query
+  end
+
   public
 
   # Allows us to add any passed query, or the current to a path helper:
   #   link_to(@object.show_link_args.merge(q: q_param))
   # Saves the query, but does not set session[:query_record]
   def q_param(query = nil)
-    return nil if browser.bot?
-
-    query.save if query && !query.id
-    query ||= current_query
-    query&.q_param
+    resolve_query_param(query)&.q_param
   end
   # helper_method :q_param # defined in application_controller.rb
+
+  # Same as q_param, but returns the flat filter hash (no :model) --
+  # see Query#index_filter.
+  def index_filter(query = nil)
+    resolve_query_param(query)&.index_filter
+  end
+  # helper_method :index_filter
 
   # NOTE: these two methods add q: param to urls built from controllers/actions.
   def redirect_with_query(args, query = nil)

--- a/app/views/controllers/collection_numbers/edit.rb
+++ b/app/views/controllers/collection_numbers/edit.rb
@@ -17,7 +17,7 @@ module Views::Controllers::CollectionNumbers
         Tab::CollectionNumber::FormEdit.new(
           collection_number: @collection_number,
           back: @back, back_object: @back_object,
-          q_param: q_param
+          index_filter: index_filter
         )
       )
 

--- a/app/views/controllers/collection_numbers/edit.rb
+++ b/app/views/controllers/collection_numbers/edit.rb
@@ -17,7 +17,7 @@ module Views::Controllers::CollectionNumbers
         Tab::CollectionNumber::FormEdit.new(
           collection_number: @collection_number,
           back: @back, back_object: @back_object,
-          index_filter: index_filter
+          index_filter: index_filter(:CollectionNumber)
         )
       )
 

--- a/app/views/controllers/herbarium_records/edit.rb
+++ b/app/views/controllers/herbarium_records/edit.rb
@@ -15,7 +15,8 @@ module Views::Controllers::HerbariumRecords
       add_edit_title(@herbarium_record)
       add_context_nav(
         Tab::HerbariumRecord::FormEdit.new(
-          back: @back, back_object: @back_object, q_param: q_param
+          back: @back, back_object: @back_object,
+          q_param: q_param, index_filter: index_filter
         )
       )
 

--- a/app/views/controllers/herbarium_records/edit.rb
+++ b/app/views/controllers/herbarium_records/edit.rb
@@ -16,7 +16,7 @@ module Views::Controllers::HerbariumRecords
       add_context_nav(
         Tab::HerbariumRecord::FormEdit.new(
           back: @back, back_object: @back_object,
-          q_param: q_param, index_filter: index_filter
+          q_param: q_param, index_filter: index_filter(:HerbariumRecord)
         )
       )
 

--- a/app/views/controllers/names/edit.rb
+++ b/app/views/controllers/names/edit.rb
@@ -13,7 +13,9 @@ module Views::Controllers::Names
     def view_template
       add_edit_title(@name, user: @user)
       add_context_nav(
-        Tab::Name::FormEdit.new(name: @name, index_filter: index_filter)
+        Tab::Name::FormEdit.new(
+          name: @name, index_filter: index_filter(:Name)
+        )
       )
 
       render(Form.new(

--- a/app/views/controllers/names/edit.rb
+++ b/app/views/controllers/names/edit.rb
@@ -13,7 +13,7 @@ module Views::Controllers::Names
     def view_template
       add_edit_title(@name, user: @user)
       add_context_nav(
-        Tab::Name::FormEdit.new(name: @name, q_param: q_param)
+        Tab::Name::FormEdit.new(name: @name, index_filter: index_filter)
       )
 
       render(Form.new(

--- a/app/views/controllers/observations/new.rb
+++ b/app/views/controllers/observations/new.rb
@@ -41,7 +41,8 @@ module Views::Controllers::Observations
     def view_template
       add_new_title(:create_object, :observation)
       add_context_nav(Tab::Observation::FormNew.new(
-                        q_param: q_param, index_filter: index_filter
+                        q_param: q_param,
+                        index_filter: index_filter(:Observation)
                       ))
       container_class(:wide)
 

--- a/app/views/controllers/observations/new.rb
+++ b/app/views/controllers/observations/new.rb
@@ -40,7 +40,9 @@ module Views::Controllers::Observations
 
     def view_template
       add_new_title(:create_object, :observation)
-      add_context_nav(Tab::Observation::FormNew.new(q_param: q_param))
+      add_context_nav(Tab::Observation::FormNew.new(
+                        q_param: q_param, index_filter: index_filter
+                      ))
       container_class(:wide)
 
       render(Form.new(@observation, **form_attrs))

--- a/app/views/controllers/species_lists/new.rb
+++ b/app/views/controllers/species_lists/new.rb
@@ -21,7 +21,9 @@ module Views::Controllers::SpeciesLists
     def view_template
       add_new_title(:create_object, :species_list)
       add_context_nav(
-        ::Tab::SpeciesList::FormNew.new(index_filter: index_filter)
+        ::Tab::SpeciesList::FormNew.new(
+          index_filter: index_filter(:SpeciesList)
+        )
       )
       container_class(:text)
 

--- a/app/views/controllers/species_lists/new.rb
+++ b/app/views/controllers/species_lists/new.rb
@@ -20,7 +20,9 @@ module Views::Controllers::SpeciesLists
 
     def view_template
       add_new_title(:create_object, :species_list)
-      add_context_nav(::Tab::SpeciesList::FormNew.new(q_param: q_param))
+      add_context_nav(
+        ::Tab::SpeciesList::FormNew.new(index_filter: index_filter)
+      )
       container_class(:text)
 
       render(Views::Controllers::SpeciesLists::Form.new(

--- a/app/views/controllers/species_lists/observations/edit.rb
+++ b/app/views/controllers/species_lists/observations/edit.rb
@@ -12,7 +12,7 @@ module Views::Controllers::SpeciesLists::Observations
     def view_template
       add_page_title(:species_list_add_remove_title.t)
       add_context_nav(::Tab::SpeciesList::FormObservations.new(
-                        q_param: q_param
+                        index_filter: index_filter
                       ))
       # Sibling reference within the module.
       render(Form.new(

--- a/app/views/controllers/species_lists/observations/edit.rb
+++ b/app/views/controllers/species_lists/observations/edit.rb
@@ -12,7 +12,7 @@ module Views::Controllers::SpeciesLists::Observations
     def view_template
       add_page_title(:species_list_add_remove_title.t)
       add_context_nav(::Tab::SpeciesList::FormObservations.new(
-                        index_filter: index_filter
+                        index_filter: index_filter(:Observation)
                       ))
       # Sibling reference within the module.
       render(Form.new(

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -1407,6 +1407,17 @@ class QueryTest < UnitTestCase
     assert_equal(query.index_filter, params)
   end
 
+  def test_index_filter_excludes_routing_keys
+    query = Query.lookup(:Observation, by_users: [rolf.id])
+    # No query_attr is currently named these, but a future one could
+    # be -- defensively strip them so they can't clobber the route-
+    # helper args index_filter gets merged into.
+    query.params = query.params.merge(controller: "x", action: "y",
+                                      id: 1, format: "json")
+
+    assert_equal({ by_users: [rolf.id] }, query.index_filter)
+  end
+
   def test_merge_q_param_into_url
     assert_equal(
       "/observations", Query.merge_q_param_into_url("/observations", nil)

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -1400,6 +1400,13 @@ class QueryTest < UnitTestCase
     assert_equal(query.q_param, { model: :Observation, **params })
   end
 
+  def test_index_filter
+    params = { by_users: [rolf.id], names: { lookup: ["Coprinus comatus"] } }
+    query = Query.lookup(:Observation, **params)
+    # Same params as q_param, but no :model.
+    assert_equal(query.index_filter, params)
+  end
+
   def test_merge_q_param_into_url
     assert_equal(
       "/observations", Query.merge_q_param_into_url("/observations", nil)
@@ -1427,6 +1434,34 @@ class QueryTest < UnitTestCase
       "q%5Blocations%5D%5B%5D=1&q%5Bmodel%5D=Observation",
       URI.parse(merged).query
     )
+  end
+
+  def test_merge_index_filters_into_url
+    assert_equal(
+      "/observations",
+      Query.merge_index_filters_into_url("/observations", nil)
+    )
+    assert_equal(
+      "/observations",
+      Query.merge_index_filters_into_url("/observations", {})
+    )
+    assert_equal(
+      "/observations?by_user=1",
+      Query.merge_index_filters_into_url("/observations", by_user: 1)
+    )
+    # Preserves an existing query param already on the path.
+    assert_equal(
+      "/observations?by_user=1&flow=next",
+      Query.merge_index_filters_into_url(
+        "/observations?flow=next", by_user: 1
+      )
+    )
+    # Flat, not nested under q[...] -- an array-valued filter still
+    # round-trips correctly via Hash#to_query.
+    merged = Query.merge_index_filters_into_url(
+      "/observations", locations: [1]
+    )
+    assert_equal("locations%5B%5D=1", URI.parse(merged).query)
   end
 
   ##############################################################################

--- a/test/classes/tab/collection_number/tabs_test.rb
+++ b/test/classes/tab/collection_number/tabs_test.rb
@@ -90,5 +90,16 @@ module Tab::CollectionNumber
       assert_equal(@collection_number.index_link_args, tab.path)
       assert_equal(@collection_number, tab.model)
     end
+
+    def test_back_to_index_with_index_filter
+      tab = Tab::CollectionNumber::BackToIndex.new(
+        collection_number: @collection_number, index_filter: { by_user: 1 }
+      )
+
+      assert_equal(1, tab.path[:by_user])
+      @collection_number.index_link_args.each do |k, v|
+        assert_equal(v, tab.path[k])
+      end
+    end
   end
 end

--- a/test/classes/tab/herbarium_record/tabs_test.rb
+++ b/test/classes/tab/herbarium_record/tabs_test.rb
@@ -66,17 +66,21 @@ module Tab::HerbariumRecord
       )
     end
 
-    def test_back_to_index_without_q_param
+    def test_back_to_index_without_index_filter
       tab = Tab::HerbariumRecord::BackToIndex.new
 
       assert_equal(:edit_herbarium_record_back_to_index.l, tab.title)
       assert_equal(routes.herbarium_records_path, tab.path)
     end
 
-    def test_back_to_index_with_q_param
-      tab = Tab::HerbariumRecord::BackToIndex.new(q_param: "ABCDE")
+    def test_back_to_index_with_index_filter
+      tab = Tab::HerbariumRecord::BackToIndex.new(
+        index_filter: { by_user: 1 }
+      )
 
-      assert_equal(routes.herbarium_records_path(q: "ABCDE"), tab.path)
+      assert_equal(
+        routes.herbarium_records_path(by_user: 1), tab.path
+      )
     end
   end
 end

--- a/test/classes/tab/herbarium_record/tabs_test.rb
+++ b/test/classes/tab/herbarium_record/tabs_test.rb
@@ -82,5 +82,19 @@ module Tab::HerbariumRecord
         routes.herbarium_records_path(by_user: 1), tab.path
       )
     end
+
+    # Array-valued filters (the common shape for most query_attrs,
+    # e.g. by_users:) go through the same **@index_filter splat as a
+    # scalar one -- confirm it round-trips correctly, not just the
+    # scalar case above.
+    def test_back_to_index_with_array_valued_index_filter
+      tab = Tab::HerbariumRecord::BackToIndex.new(
+        index_filter: { by_users: [1, 2] }
+      )
+
+      assert_equal(
+        routes.herbarium_records_path(by_users: [1, 2]), tab.path
+      )
+    end
   end
 end

--- a/test/classes/tab/object/tabs_test.rb
+++ b/test/classes/tab/object/tabs_test.rb
@@ -60,11 +60,13 @@ module Tab::Object
       assert_includes(tab.html_options[:class], "projects_index_link")
     end
 
-    def test_index_with_q_param
-      tab = Tab::Object::Index.new(object: @project, q_param: "ABC")
+    def test_index_with_index_filter
+      tab = Tab::Object::Index.new(
+        object: @project, index_filter: { by_user: 1 }
+      )
       path = tab.path
 
-      assert_equal("ABC", path[:q])
+      assert_equal(1, path[:by_user])
       # Original hash entries are preserved.
       @project.index_link_args.each do |k, v|
         assert_equal(v, path[k])

--- a/test/classes/tab/observation/tabs_test.rb
+++ b/test/classes/tab/observation/tabs_test.rb
@@ -162,10 +162,20 @@ module Tab::Observation
       with_filter = Tab::Observation::Index.new(
         index_filter: { by_user: 1 }
       )
+      # Array-valued filters go through Query.merge_index_filters_into_url
+      # (via with_index_filter), a different code path than the plain
+      # Hash#merge the other migrated Tab classes use -- confirm it
+      # round-trips correctly too.
+      with_array_filter = Tab::Observation::Index.new(
+        index_filter: { by_users: [1, 2] }
+      )
 
       assert_equal(:cancel_to_index.t(type: :observation), tab.title)
       assert_equal(routes.observations_path, tab.path)
       assert_equal(routes.observations_path(by_user: 1), with_filter.path)
+      assert_equal(
+        routes.observations_path(by_users: [1, 2]), with_array_filter.path
+      )
     end
 
     def test_edit

--- a/test/classes/tab/observation/tabs_test.rb
+++ b/test/classes/tab/observation/tabs_test.rb
@@ -159,9 +159,13 @@ module Tab::Observation
 
     def test_index
       tab = Tab::Observation::Index.new
+      with_filter = Tab::Observation::Index.new(
+        index_filter: { by_user: 1 }
+      )
 
       assert_equal(:cancel_to_index.t(type: :observation), tab.title)
       assert_equal(routes.observations_path, tab.path)
+      assert_equal(routes.observations_path(by_user: 1), with_filter.path)
     end
 
     def test_edit

--- a/test/classes/tab/species_list/tabs_test.rb
+++ b/test/classes/tab/species_list/tabs_test.rb
@@ -124,12 +124,12 @@ module Tab::SpeciesList
 
     def test_observations_index_return
       bare = Tab::SpeciesList::ObservationsIndexReturn.new.path
-      with_q = Tab::SpeciesList::ObservationsIndexReturn.new(
-        q_param: "Z"
+      with_filter = Tab::SpeciesList::ObservationsIndexReturn.new(
+        index_filter: { by_user: 1 }
       ).path
 
       assert_equal(routes.observations_path, bare)
-      assert_equal(routes.observations_path(q: "Z"), with_q)
+      assert_equal(routes.observations_path(by_user: 1), with_filter)
     end
 
     def test_name_lister
@@ -141,11 +141,13 @@ module Tab::SpeciesList
 
     def test_index
       bare = Tab::SpeciesList::Index.new
-      with_q = Tab::SpeciesList::Index.new(q_param: "Y")
+      with_filter = Tab::SpeciesList::Index.new(
+        index_filter: { by_user: 1 }
+      )
 
       assert_equal(:cancel_to_index.t(type: :species_list), bare.title)
       assert_equal(routes.species_lists_path, bare.path)
-      assert_includes(with_q.path, "q=Y")
+      assert_includes(with_filter.path, "by_user=1")
     end
 
     def test_create

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -267,4 +267,44 @@ class ApplicationControllerTest < FunctionalTestCase
 
     assert_equal(1, @controller.send(:paginator_number, :page))
   end
+
+  # `index_filter`'s explicit `model:` argument guards against a
+  # stale/mismatched ambient current_query (session[:query_record]
+  # left over from browsing a different model) leaking that model's
+  # filter attrs onto an unrelated index link -- unlike q_param,
+  # which stays safe because it tags the mismatched query with
+  # :model for the receiving page to reconcile. Reproduces the
+  # scenario directly: an Observations query left in the session,
+  # then a page asking for a Name filter without one set for it.
+  def test_index_filter_rejects_mismatched_ambient_query
+    login("rolf")
+    get(:intro)
+    observation_query = Query.lookup_and_save(:Observation,
+                                              by_users: [rolf.id])
+    @controller.store_query_in_session(observation_query)
+
+    assert_nil(@controller.index_filter(:Name))
+  end
+
+  def test_index_filter_returns_filter_for_matching_ambient_query
+    login("rolf")
+    get(:intro)
+    name_query = Query.lookup_and_save(:Name, by_users: [rolf.id])
+    @controller.store_query_in_session(name_query)
+
+    assert_equal({ by_users: [rolf.id] }, @controller.index_filter(:Name))
+  end
+
+  def test_index_filter_with_explicit_query_checks_model_too
+    login("rolf")
+    get(:intro)
+    observation_query = Query.lookup_and_save(:Observation,
+                                              by_users: [rolf.id])
+
+    assert_nil(@controller.index_filter(:Name, observation_query))
+    assert_equal(
+      { by_users: [rolf.id] },
+      @controller.index_filter(:Observation, observation_query)
+    )
+  end
 end


### PR DESCRIPTION
Since it's now possible to send flat query params, i.e. index filters, this modifies some of the `add_q_param` callers to instead add the flat params, with a new method `add_index_filters`. 

## Summary

Fixes #5254. Started from the issue's original plan — modify `add_q_param`/`Query#q_param`/`Query.merge_q_param_into_url` in place to emit flat params — but that turned out to be unsafe: those methods are relied on for cross-model links (an `RssLog` query forwarded to an `Observation` show page for next/prev navigation, an `Observation` query forwarded to `LocationsController#new`, an ambient `current_query` of any model forwarded to a project-members breadcrumb). Flattening them in place would have silently broken those.

Instead, kept `Query#q_param`/`ApplicationController::Queries#add_q_param`/`q_param`/`Query.merge_q_param_into_url`/`Tab::Base#with_q_param` unchanged, and added parallel flat-param primitives:

- `Query#index_filter` — same as `q_param`, but no `:model` key.
- `Query.merge_index_filters_into_url` — flat merge into a URL's query string, not nested under `q[...]`.
- `ApplicationController::Queries#add_index_filters`/`#index_filter` — same shape as the `add_q_param`/`q_param` pair.
- `Tab::Base#with_index_filter` — same shape as `with_q_param`.

`:model` is safe to drop only when the link target's controller can infer the model from the controller class — the generic flat-param index dispatch (#5140) already does this via `controller_model_name`, without reading a `model` param.

## The audit

The migration targets turned out to be the ~35 `Tab::*` PORO classes that thread a `q_param:` constructor kwarg through to a generated link, not the handful of files the original issue happened to list (most of those were either pure pass-through — `IndexPaginationNav` just echoes whatever's in the current URL — or cross-model).

Checked every one of those ~35 classes by tracing construction call sites (not by class name), to confirm what model's query is ambient at each one. Two are reused across multiple different-model page contexts and must stay on `q_param` as a class (a leaf's `#path` can look same-model in isolation, but if it's constructed from two different-model contexts it can't be both): `Tab::Herbarium::NonpersonalIndex` (Herbarium context and HerbariumRecord context) and `Tab::Location::Map` (Location context and LocationDescription context).

Migrated the 6 classes confirmed safe — a single, verified same-model link to that model's index page:

- `Tab::Observation::Index` → `observations_path`
- `Tab::SpeciesList::Index` → `species_lists_path`
- `Tab::CollectionNumber::BackToIndex` → its index
- `Tab::HerbariumRecord::BackToIndex` → `herbarium_records_path`
- `Tab::Object::Index` (polymorphic, currently only used Name-context)
- `Tab::SpeciesList::ObservationsIndexReturn` → `observations_path`

Everything else stays on `q_param` — cross-model reuse, single-object edit/new routes, or download/map-popup pages using session-based query lookup instead of the generic index dispatch.

`app/views/controllers/rss_logs/type_filters.rb` is a confirmed same-model candidate too (an `RssLog` query linking to `activity_logs_path`, RssLogsController's index), but it hand-flattens `q_param` into bracketed hidden-field names (`q[model]`, `q[types][]`) throughout a hand-rolled GET form — migrating it needs restructuring, not a mechanical swap. Left as a follow-up.

## Test plan

- [x] `bin/rails test` on every touched file's test file (`query_test.rb`, every affected `Tab::*` unit test, every affected controller test) — all pass
- [x] `bundle exec rubocop` on every touched Ruby file — no offenses
- [x] Manually verified live in browser: `species_lists/new`'s "Cancel" link renders `/species_lists?by_users%5B%5D=...` — flat, no `q[...]` nesting

<!-- changelog -->
article: no
<!-- /changelog -->
