### PR TITLE
Add `MO/NoHandRolledColumnClass` cop; extend `NoRawBootstrapComponent` for Row/Container

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ require:
   - ./lib/rubocop/cop/mo/lowercase_translation_tag
   - ./lib/rubocop/cop/mo/no_active_record_relation_prop
   - ./lib/rubocop/cop/mo/no_hand_rolled_colon_suffix
+  - ./lib/rubocop/cop/mo/no_hand_rolled_column_class
   - ./lib/rubocop/cop/mo/no_hand_rolled_form_tag
   - ./lib/rubocop/cop/mo/no_hand_rolled_method_field
   - ./lib/rubocop/cop/mo/no_hand_rolled_whitespace
@@ -186,7 +187,7 @@ MO/NoRawBootstrapComponent:
     Phlex views/components must not hand-roll the markup for a
     top-level Bootstrap UI component MO already has a Components::*
     wrapper for (Alert, Modal, Dropdown, ListGroup, NavTabs, Panel,
-    Navbar, Carousel, InputGroup, ButtonGroup) -- see
+    Navbar, Carousel, InputGroup, ButtonGroup, Row, Container) -- see
     lib/rubocop/cop/mo/no_raw_bootstrap_component.rb.
   Enabled: true
   Include:
@@ -205,6 +206,11 @@ MO/NoRawBootstrapComponent:
     # `<ul class="nav nav-tabs">` this cop exists to make everyone
     # else use NavTabs(...) for instead.
     - "app/components/nav_tabs.rb"
+    # Row's/Container's own implementations -- legitimately build the
+    # `.row`/`.container-*` markup this cop exists to make everyone
+    # else use Row(...)/Container(...) for instead.
+    - "app/components/row.rb"
+    - "app/components/container.rb"
     # Deliberate: the sidebar's `.list-group` wrapper holds several
     # independently `cache(...)`-wrapped sections that render
     # Components::ListGroup::Item/LinkItem directly, not via a
@@ -214,6 +220,25 @@ MO/NoRawBootstrapComponent:
     # caching (see list_group.rb's own docs, which name this file as
     # the deliberate exception).
     - "app/views/layouts/sidebar.rb"
+
+MO/NoHandRolledColumnClass:
+  Description: >-
+    Phlex views/components must not hand-roll Bootstrap grid column
+    classes (col-xs-6, col-sm-offset-4, etc.) -- use Column(...)
+    (Components::Column) instead. See
+    lib/rubocop/cop/mo/no_hand_rolled_column_class.rb.
+  Enabled: true
+  Include:
+    - "app/components/**/*.rb"
+    - "app/views/**/*.rb"
+  Exclude:
+    # Column's own implementation -- legitimately builds the col-*
+    # classes this cop exists to make everyone else use Column(...)
+    # for instead.
+    - "app/components/column.rb"
+    # Documented "keep the bug for visual parity" quirk -- see the
+    # comment at the call site.
+    - "app/views/layouts/header.rb"
 
 MO/NoRawLinkOrButtonTo:
   Description: >-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ plugins:
   - rubocop-rails
 
 require:
+  - ./lib/rubocop/cop/mo/mixin/class_keyword_pair
   - ./lib/rubocop/cop/mo/dry_test_render_helper
   - ./lib/rubocop/cop/mo/initialize_without_prop
   - ./lib/rubocop/cop/mo/lowercase_translation_tag

--- a/app/components/carousel.rb
+++ b/app/components/carousel.rb
@@ -154,7 +154,7 @@ class Components::Carousel < Components::Base
 
   def render_controls
     if @controls_wrap_class
-      div(class: @controls_wrap_class) { render_controls_inner }
+      Row(class: @controls_wrap_class) { render_controls_inner }
     else
       render_controls_inner
     end

--- a/app/components/form/upload_gallery.rb
+++ b/app/components/form/upload_gallery.rb
@@ -33,7 +33,7 @@ class Components::Form::UploadGallery < Components::Base
       inner_id: "added_images",
       indicators_id: "added_thumbnails",
       indicators_class_extra: indicators_d_none,
-      controls_wrap_class: "carousel-control-wrap row",
+      controls_wrap_class: "carousel-control-wrap",
       extra_data: {
         form_images_target: "carousel",
         form_exif_target: "carousel"

--- a/app/views/controllers/names/lifeforms/form.rb
+++ b/app/views/controllers/names/lifeforms/form.rb
@@ -15,7 +15,8 @@ module Views::Controllers::Names::Lifeforms
         t.column(nil) do |word|
           checkbox_field(word.to_sym, label: :"lifeform_#{word}")
         end
-        t.column(nil, class: "container-text") do |word|
+        t.column(nil,
+                 class: Components::Container.class_for(:text)) do |word|
           plain(lifeform_help_as_string(word))
         end
       end

--- a/app/views/controllers/names/lifeforms/propagate/form.rb
+++ b/app/views/controllers/names/lifeforms/propagate/form.rb
@@ -28,7 +28,8 @@ module Views::Controllers::Names::Lifeforms::Propagate
         t.column(nil) do |word|
           checkbox_field(:"add_#{word}", label: :"lifeform_#{word}")
         end
-        t.column(nil, class: "container-text") do |word|
+        t.column(nil,
+                 class: Components::Container.class_for(:text)) do |word|
           plain(lifeform_help_as_string(word))
         end
       end
@@ -47,7 +48,8 @@ module Views::Controllers::Names::Lifeforms::Propagate
         t.column(nil) do |word|
           checkbox_field(:"remove_#{word}", label: :"lifeform_#{word}")
         end
-        t.column(nil, class: "container-text") do |word|
+        t.column(nil,
+                 class: Components::Container.class_for(:text)) do |word|
           plain(lifeform_help_as_string(word))
         end
       end

--- a/app/views/controllers/observations/show/namings/footer_buttons.rb
+++ b/app/views/controllers/observations/show/namings/footer_buttons.rb
@@ -12,7 +12,7 @@ class Views::Controllers::Observations::Show::Namings::FooterButtons < Views::Ba
   def view_template
     Row do
       Column(sm: 11) do
-        div(class: "row") do
+        Row do
           Column(col: true, md: 4) { render_buttons }
           Column(col: true, md: 8) { render_consensus_help }
         end

--- a/app/views/controllers/observations/show/namings/footer_legend.rb
+++ b/app/views/controllers/observations/show/namings/footer_legend.rb
@@ -12,7 +12,7 @@ class Views::Controllers::Observations::Show::Namings::FooterLegend < Views::Bas
   def view_template
     Row do
       Column(sm: 11) do
-        div(class: "row") do
+        Row do
           Column(xs: 4, offset_xs: 4) do
             render_legend("vote-icon-yours", :show_namings_eye_help.t)
           end

--- a/lib/rubocop/cop/mo/mixin/class_keyword_pair.rb
+++ b/lib/rubocop/cop/mo/mixin/class_keyword_pair.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Shared by NoHandRolledColumnClass and NoRawBootstrapComponent:
+      # is this hash pair node a `class:`/`class!:` attribute? Phlex's
+      # `class!:` (see `mix` in phlex_reference.md) force-overrides
+      # rather than merges, but it's still a class attribute -- a
+      # hand-rolled Bootstrap class hiding behind `class!:` is just as
+      # much a violation as one behind plain `class:`.
+      module ClassKeywordPair
+        CLASS_KEYS = [:class, :class!].freeze
+
+        def class_keyword_pair?(pair)
+          pair.pair_type? && pair.key.sym_type? &&
+            CLASS_KEYS.include?(pair.key.value)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mo/no_hand_rolled_column_class.rb
+++ b/lib/rubocop/cop/mo/no_hand_rolled_column_class.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module MO
+      # Phlex views/components must not hand-roll Bootstrap grid
+      # column classes (`col-xs-6`, `col-sm-offset-4`, etc.) -- use
+      # `Column(...)` (Components::Column) instead. Unlike
+      # MO/NoRawBootstrapComponent, which matches a fixed set of
+      # component root classes by exact string, grid classes are
+      # parameterized by breakpoint and width, so this cop matches a
+      # pattern instead of a fixed list.
+      #
+      # Detects a string literal, used as a `class:` value or a
+      # `class_names(...)` argument, containing a `col-{breakpoint}-N`
+      # or `col-{breakpoint}-offset-N` token. Only plain string
+      # literals are checked -- an interpolated class string
+      # (`"col-lg-#{n}"`) isn't caught.
+      #
+      # Scoped via this cop's Include/Exclude in .rubocop.yml -- the
+      # Exclude list covers `Components::Column`'s implementation
+      # file, which legitimately builds these classes to BE the
+      # abstraction every other Phlex file is required to use
+      # instead (same shape as MO/NoRawBootstrapComponent's exclusion
+      # of the components it wraps), plus one documented "keep the
+      # bug for visual parity" exception.
+      #
+      # @example
+      #   # bad
+      #   div(class: "col-xs-12 col-sm-6") { ... }
+      #   div(class: class_names("col-lg-4", extra))
+      #
+      #   # good
+      #   Column(xs: 12, sm: 6) { ... }
+      #   Column(lg: 4, class: extra)
+      class NoHandRolledColumnClass < Base
+        MSG = "Don't hand-roll `.col-*` grid classes -- use `Column(...)` " \
+              "(Components::Column) instead."
+
+        COL_CLASS_PATTERN =
+          /(?:^|\s)col-(?:xs|sm|md|lg|xl)(?:-offset)?-\d+(?:\s|$)/
+
+        def on_str(node)
+          return unless node.value.match?(COL_CLASS_PATTERN)
+          return unless class_attribute_value?(node)
+
+          add_offense(node)
+        end
+
+        private
+
+        def class_attribute_value?(node)
+          parent = node.parent
+          return false unless parent
+
+          class_keyword_pair?(parent) || class_names_argument?(parent)
+        end
+
+        def class_keyword_pair?(parent)
+          parent.pair_type? && parent.key.sym_type? &&
+            parent.key.value == :class
+        end
+
+        def class_names_argument?(parent)
+          parent.send_type? && parent.method?(:class_names)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mo/no_hand_rolled_column_class.rb
+++ b/lib/rubocop/cop/mo/no_hand_rolled_column_class.rb
@@ -11,8 +11,8 @@ module RuboCop
       # parameterized by breakpoint and width, so this cop matches a
       # pattern instead of a fixed list.
       #
-      # Detects a string literal, used as a `class:` value or a
-      # `class_names(...)` argument, containing a `col-{breakpoint}-N`
+      # Detects a string literal, used as a `class:`/`class!:` value or
+      # a `class_names(...)` argument, containing a `col-{breakpoint}-N`
       # or `col-{breakpoint}-offset-N` token. Only plain string
       # literals are checked -- an interpolated class string
       # (`"col-lg-#{n}"`) isn't caught.
@@ -34,6 +34,8 @@ module RuboCop
       #   Column(xs: 12, sm: 6) { ... }
       #   Column(lg: 4, class: extra)
       class NoHandRolledColumnClass < Base
+        include ClassKeywordPair
+
         MSG = "Don't hand-roll `.col-*` grid classes -- use `Column(...)` " \
               "(Components::Column) instead."
 
@@ -54,11 +56,6 @@ module RuboCop
           return false unless parent
 
           class_keyword_pair?(parent) || class_names_argument?(parent)
-        end
-
-        def class_keyword_pair?(parent)
-          parent.pair_type? && parent.key.sym_type? &&
-            parent.key.value == :class
         end
 
         def class_names_argument?(parent)

--- a/lib/rubocop/cop/mo/no_raw_bootstrap_component.rb
+++ b/lib/rubocop/cop/mo/no_raw_bootstrap_component.rb
@@ -7,8 +7,8 @@ module RuboCop
       # top-level Bootstrap UI component MO already has a
       # `Components::*` wrapper for -- e.g. `div(class: "alert
       # alert-info")` instead of `Alert(level: :info)`. Detects a
-      # `div`/`ul`/`nav`/`main` tag call whose `class:` value is a
-      # string literal containing one of the known root classes
+      # `div`/`ul`/`nav`/`main` tag call whose `class:`/`class!:` value
+      # is a string literal containing one of the known root classes
       # below, and suggests the corresponding component.
       #
       # Scoped via this cop's Include/Exclude in .rubocop.yml -- the
@@ -27,6 +27,8 @@ module RuboCop
       #   Alert(level: :info) { ... }
       #   Modal(id: "x") { ... }
       class NoRawBootstrapComponent < Base
+        include ClassKeywordPair
+
         MSG = "Don't hand-roll `.%<css_class>s` markup -- use " \
               "`%<component>s(...)` (Components::%<component>s) instead."
 
@@ -97,9 +99,7 @@ module RuboCop
           hash = node.arguments.find(&:hash_type?)
           return nil unless hash
 
-          pair = hash.pairs.find do |p|
-            p.key.sym_type? && p.key.value == :class
-          end
+          pair = hash.pairs.find { |p| class_keyword_pair?(p) }
           pair&.value
         end
 

--- a/lib/rubocop/cop/mo/no_raw_bootstrap_component.rb
+++ b/lib/rubocop/cop/mo/no_raw_bootstrap_component.rb
@@ -7,8 +7,8 @@ module RuboCop
       # top-level Bootstrap UI component MO already has a
       # `Components::*` wrapper for -- e.g. `div(class: "alert
       # alert-info")` instead of `Alert(level: :info)`. Detects a
-      # `div`/`ul`/`nav` tag call whose `class:` value is a string
-      # literal containing one of the known Bootstrap root classes
+      # `div`/`ul`/`nav`/`main` tag call whose `class:` value is a
+      # string literal containing one of the known root classes
       # below, and suggests the corresponding component.
       #
       # Scoped via this cop's Include/Exclude in .rubocop.yml -- the
@@ -30,7 +30,7 @@ module RuboCop
         MSG = "Don't hand-roll `.%<css_class>s` markup -- use " \
               "`%<component>s(...)` (Components::%<component>s) instead."
 
-        RESTRICT_ON_SEND = [:div, :ul, :nav].freeze
+        RESTRICT_ON_SEND = [:div, :ul, :nav, :main].freeze
 
         ROOT_CLASS_TO_COMPONENT = {
           "alert" => "Alert",
@@ -43,7 +43,14 @@ module RuboCop
           "panel" => "Panel",
           "carousel" => "Carousel",
           "input-group" => "InputGroup",
-          "btn-group" => "ButtonGroup"
+          "btn-group" => "ButtonGroup",
+          "row" => "Row",
+          # MO's fixed-width classes (see Components::Container), not
+          # Bootstrap's .container/.container-fluid mechanism.
+          "container-text" => "Container",
+          "container-text-image" => "Container",
+          "container-wide" => "Container",
+          "container-full" => "Container"
         }.freeze
 
         def on_send(node)

--- a/test/components/carousel_test.rb
+++ b/test/components/carousel_test.rb
@@ -125,8 +125,9 @@ class CarouselTest < ComponentTestCase
 
   # `show_controls: true` (default) renders the prev/next Controls
   # subcomponent at the bottom of `.carousel-inner`. The
-  # `controls_wrap_class` prop, when set, wraps Controls in a div with
-  # that class (Form::UploadGallery uses `carousel-control-wrap row`).
+  # `controls_wrap_class` prop, when set, wraps Controls in a `Row`
+  # with that class -- `Row` auto-prepends "row" (Form::UploadGallery
+  # passes just `"carousel-control-wrap"`).
   def test_controls_render_inline_by_default
     html = render_carousel(carousel_args: { carousel_id: "c" },
                            slides: [{ content: "s" }])
@@ -140,7 +141,7 @@ class CarouselTest < ComponentTestCase
     html = render_carousel(
       carousel_args: {
         carousel_id: "c",
-        controls_wrap_class: "carousel-control-wrap row"
+        controls_wrap_class: "carousel-control-wrap"
       },
       slides: [{ content: "s" }]
     )


### PR DESCRIPTION
## Summary

Part of #3797 (Bootstrap 4 migration prep). No cop currently prevented a hand-rolled `col-lg-4` from bypassing `Components::Column`. `MO/NoRawBootstrapComponent` only matches a fixed set of root classes (`alert`, `modal`, `panel`, etc.) by exact string, and the `col-{breakpoint}-N` pattern needs regex matching instead — so it's a new cop rather than another hash entry.

`Row` and `Container` fit the existing cop's mechanism directly, though — `.row` is untouched Bootstrap, and MO's four `container-*` variants (`container-text`/`container-text-image`/`container-wide`/`container-full`) are a fixed, known list, not a breakpoint+number pattern. Added both as new entries to `MO/NoRawBootstrapComponent` instead of writing a third cop file. Also broadened `RESTRICT_ON_SEND` to include `:main`, matching `Container`'s documented `element: :main` use case (the shared layout's `<main>` wrapper).

## The sweep

Following the no-grandfathering convention for new MO cops (`MO/NoHandRolledColonSuffix`/`MO/NoHandRolledWhitespace`, #5273), swept every violation both cops found before landing them:

- `observations/show/namings/footer_buttons.rb` and `footer_legend.rb` each had a raw `div(class: "row")` nested inside an outer `Row` block.
- `names/lifeforms/form.rb` and `propagate/form.rb` (×2) passed a raw `"container-text"` string to a `Table` column instead of `Components::Container.class_for(:text)`, the pattern documented for callers that can't render the component directly.
- `form/upload_gallery.rb` passed `"carousel-control-wrap row"` as `Carousel`'s `controls_wrap_class` prop, which the component rendered via a raw `div`. Split the `"row"` token into `carousel.rb`'s `render_controls`, now rendered via `Row(...)` instead — confirmed it's the only caller of `controls_wrap_class:` in the app, so no other callers are affected by the class-name change.

## Test plan

- [x] `bundle exec rubocop --only MO/NoHandRolledColumnClass,MO/NoRawBootstrapComponent app/` — 1918 files inspected, no offenses
- [x] Full `bundle exec rubocop` on every touched file — no offenses
- [x] `bin/rails test` on every touched file's test file (`carousel_test.rb`, `upload_gallery_test.rb`, `footer_buttons_test.rb`, `footer_legend_test.rb`, `lifeforms_controller_test.rb`, `lifeforms/propagate/form_test.rb`) — all pass

<!-- changelog -->
article: no
<!-- /changelog -->
