### PR TITLE
Add `script/prerelease.rb` to build the pre-deploy changelog PR

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -90,8 +90,17 @@ counts.
 
 ## Producing the Article rows
 
+`script/prerelease.rb` (dry run by default; `--apply` to push) builds
+the pre-deploy changelog PR on the `changelog-pending` branch: the
+next CHANGELOG.md section (its heading names the deploy tag the
+deploy will create) plus `article_pending.textile` holding one
+Textile row per `article: yes` PR merged since the last deploy. The
+rows in that file are what the deploy publishes to the Article — edit
+them in the PR; blockless PRs are listed in the PR body for a
+verdict. Re-run after last-minute merges; merge the PR last, then
+deploy.
+
 `script/article_rows.rb --since YYYY-MM-DD [--until YYYY-MM-DD]`
-prints one Textile row per `article: yes` PR merged in the range,
-newest first, and lists the blockless PRs on stderr for a human
-verdict. Paste the rows into the Article by hand (they go under the
-blank separator row, newest first).
+prints rows for a date range (backfills, audits), newest first,
+blockless PRs on stderr. Hand-added rows go just below the
+`| +date+ | +what+ | +link+ |` header line, newest first.

--- a/script/article_rows.rb
+++ b/script/article_rows.rb
@@ -28,9 +28,14 @@ class ArticleRows
   # Longer sentences wrap the article's table.
   MAX_SENTENCE = 60
 
-  def initialize(argv)
+  # With argv: the CLI (date-ranged, fetches PRs itself). Without:
+  # library use -- script/prerelease.rb hands rows_for a PR set it
+  # already holds.
+  def initialize(argv = nil)
     @since = nil
     @until = Date.today # rubocop:disable Rails/Date -- plain Ruby, no zone
+    return unless argv
+
     parse_args(argv)
     abort(USAGE) unless @since
     abort("--until #{@until} is before --since #{@since}.") if @until < @since
@@ -42,6 +47,11 @@ class ArticleRows
     puts(rows)
     warn("#{rows.size} row(s); #{skipped} PR(s) marked article: no.")
     report_blockless(blockless)
+  end
+
+  # [rows, article-no count, blockless pulls] for an explicit PR set.
+  def rows_for(pulls)
+    classify(pulls.sort_by { |pull| pull["mergedAt"].to_s }.reverse)
   end
 
   private
@@ -153,4 +163,4 @@ class ArticleRows
   end
 end
 
-ArticleRows.new(ARGV).run
+ArticleRows.new(ARGV).run if $PROGRAM_NAME == __FILE__

--- a/script/generate_changelog.rb
+++ b/script/generate_changelog.rb
@@ -67,7 +67,53 @@ class ChangelogGenerator
     @since ? run_since(tags) : run_single(tags)
   end
 
+  # -- Pre-deploy (prerelease) API, driven by script/prerelease.rb --
+
+  # PRs merged since the last deploy tag up to origin/main, in commit
+  # order, minus the changelog PR's branch (the changelog PR is left
+  # out of the section it creates). Returns [previous_tag, pulls].
+  def pending_pulls(exclude_branch: nil)
+    tags = deploy_tags
+    abort("No deploy-* tags found.") if tags.empty?
+
+    @pool_from = tags.last
+    @pool_to = "origin/main"
+    pulls = merged_prs(tags.last, "origin/main")
+    pulls = pulls.reject { |pr| pr["headRefName"] == exclude_branch }
+    [tags.last, pulls]
+  end
+
+  # The section for a tag the prerelease run minted; the tag itself is
+  # created later, by the deploy that ships the section.
+  def pending_section(tag, pulls)
+    build_section(tag, pulls)
+  end
+
+  # Insert the pending section, first dropping any stale pending
+  # section -- a heading whose tag was minted by an earlier run and
+  # was not deployed (its tag does not exist in git).
+  def apply_pending(section, tag)
+    content = changelog_content
+    existing = deploy_tags
+    section_positions(content).map { |_pos, t| t }.
+      reject { |t| existing.include?(t) || t == tag }.
+      each { |t| content = drop_section(content, t) }
+    File.write(CHANGELOG, insert_sorted(content, section, tag))
+  end
+
   private
+
+  # Remove a section: its heading through the line before the next
+  # heading (or end of file).
+  def drop_section(content, tag)
+    positions = section_positions(content)
+    i = positions.index { |_pos, t| t == tag }
+    return content unless i
+
+    start = positions[i][0]
+    tail = positions[i + 1] ? content[positions[i + 1][0]..] : ""
+    "#{content[0...start]}#{tail}"
+  end
 
   def parse_args(argv)
     args = argv.dup
@@ -158,7 +204,9 @@ class ChangelogGenerator
       run_cmd("gh", "pr", "list", "--state", "merged",
               "--limit", SEARCH_CAP.to_s,
               "--search", "merged:#{from}..#{to}",
-              "--json", "number,title,author,url,mergeCommit")
+              "--json",
+              "number,title,author,url,mergeCommit,mergedAt,body," \
+              "headRefName")
     )
     if pulls.size >= SEARCH_CAP
       abort("#{pulls.size} PRs merged in #{from}..#{to} hits GitHub's " \
@@ -284,4 +332,4 @@ class ChangelogGenerator
   end
 end
 
-ChangelogGenerator.new(ARGV).run
+ChangelogGenerator.new(ARGV).run if $PROGRAM_NAME == __FILE__

--- a/script/prerelease.rb
+++ b/script/prerelease.rb
@@ -75,6 +75,8 @@ class Prerelease
          "(#{@pulls.size} PR(s) since #{@prev}) ===")
     puts
     puts(@section)
+    puts
+    puts
     puts("=== #{ARTICLE_FILE} (rows the deploy publishes to the " \
          "MO Article) ===")
     puts

--- a/script/prerelease.rb
+++ b/script/prerelease.rb
@@ -25,6 +25,7 @@
 
 require("json")
 require("open3")
+require("tempfile")
 require("tmpdir")
 require_relative("generate_changelog")
 require_relative("article_rows")
@@ -42,37 +43,57 @@ class Prerelease
   end
 
   def run
+    warn("Fetching tags and main from origin...")
     run_cmd("git", "fetch", "origin", "--tags")
-    # Local time, matching deploy.sh's `date "+deploy-%Y-%m-%d-%H-%M"`.
-    @tag = Time.now. # rubocop:disable Rails/TimeZone -- plain Ruby
-           strftime("deploy-%Y-%m-%d-%H-%M")
     generator = ChangelogGenerator.new([])
-    @prev, pulls = generator.pending_pulls(exclude_branch: BRANCH)
-    abort("No PRs merged since #{@prev}; nothing to prepare.") if pulls.empty?
-
-    @section = generator.pending_section(@tag, pulls)
-    @rows, @skipped, @blockless = ArticleRows.new.rows_for(pulls)
+    collect_pending(generator)
     @apply ? apply(generator) : preview
   end
 
   private
 
-  def preview
-    puts(@section)
-    puts("-- #{ARTICLE_FILE} --")
-    puts(@rows.empty? ? "(no article rows)" : @rows)
-    warn_blockless
-    warn("Dry run - nothing written. To apply: script/prerelease.rb --apply")
+  def collect_pending(generator)
+    # UTC: the server clock deploy.sh's `date` stamps tags with. A
+    # developer's local clock can run hours behind it, which would mint
+    # a name that sorts before the newest deployed tag.
+    @tag = Time.now.
+           utc.strftime("deploy-%Y-%m-%d-%H-%M")
+    warn("Collecting merged PRs from GitHub (several queries; ~10-20s)...")
+    @prev, @pulls = generator.pending_pulls(exclude_branch: BRANCH)
+    abort("No PRs merged since #{@prev}; nothing to prepare.") if
+      @pulls.empty?
+    warn("Found #{@pulls.size} PR(s) merged since #{@prev}.\n\n")
+
+    @section = generator.pending_section(@tag, @pulls)
+    @rows, @skipped, @blockless = ArticleRows.new.rows_for(@pulls)
   end
 
-  def warn_blockless
+  def preview
+    puts("Pending deploy: #{@tag}")
+    puts
+    puts("=== CHANGELOG.md section " \
+         "(#{@pulls.size} PR(s) since #{@prev}) ===")
+    puts
+    puts(@section)
+    puts("=== #{ARTICLE_FILE} (rows the deploy publishes to the " \
+         "MO Article) ===")
+    puts
+    puts(@rows.empty? ? "(none - no article: yes PRs)" : @rows)
+    puts
+    preview_blockless
+    puts("Dry run - nothing written. To apply: script/prerelease.rb --apply")
+  end
+
+  def preview_blockless
     return if @blockless.empty?
 
-    warn("#{@blockless.size} PR(s) with no changelog block " \
-         "(listed in the PR body for a verdict):")
+    puts("=== #{@blockless.size} PR(s) with no changelog block " \
+         "(need a verdict) ===")
+    puts
     @blockless.each do |pull|
-      warn("  PR##{pull["number"]} #{pull["title"]}")
+      puts("  PR##{pull["number"]} #{pull["title"]}")
     end
+    puts
   end
 
   def apply(generator)
@@ -81,6 +102,7 @@ class Prerelease
   end
 
   def push_branch(generator)
+    warn("Building #{BRANCH} in a temporary worktree...")
     Dir.mktmpdir("prerelease") do |tmp|
       dir = File.join(tmp, "wt")
       run_cmd("git", "worktree", "add", "--detach", dir, "origin/main")
@@ -106,15 +128,24 @@ class Prerelease
     end
   end
 
+  # The temp file must outlive the gh call; Tempfile.create's block
+  # guarantees that, then removes it.
   def upsert_pr
-    number = existing_pr
-    if number
+    Tempfile.create(["prerelease_pr_body", ".md"]) do |file|
+      file.write(pr_body)
+      file.flush
+      submit_pr(file.path)
+    end
+  end
+
+  def submit_pr(body_path)
+    if (number = existing_pr)
       run_cmd("gh", "pr", "edit", number.to_s, "--title", title,
-              "--body-file", body_file)
+              "--body-file", body_path)
       warn("Updated PR ##{number} (#{BRANCH}).")
     else
       out = run_cmd("gh", "pr", "create", "--draft", "--head", BRANCH,
-                    "--title", title, "--body-file", body_file)
+                    "--title", title, "--body-file", body_path)
       warn("Created #{out.strip}")
     end
   end

--- a/script/prerelease.rb
+++ b/script/prerelease.rb
@@ -1,0 +1,177 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Creates or updates the pre-deploy changelog PR (issue #5155). Run it
+# before a deploy; merge the PR it makes as the last PR, then deploy.
+#
+#   Dry run (default -- prints what the PR would contain):
+#     script/prerelease.rb
+#   Apply (pushes the changelog-pending branch, creates/updates the PR):
+#     script/prerelease.rb --apply
+#
+# What it does:
+# - mints the upcoming deploy tag name (deploy-YYYY-MM-DD-HH-MM, from
+#   the current time); deploy.sh tags with the name it finds in
+#   CHANGELOG.md's top heading
+# - builds the CHANGELOG.md section for every PR merged since the last
+#   deploy tag (the changelog PR is left out of the section it creates)
+# - writes article_pending.textile with the MO Article rows from the
+#   PRs' changelog blocks; reviewers edit the rows there, and the
+#   deploy applies the file as merged
+# - re-running replaces the branch, the PR body, and any stale pending
+#   section, so last-minute merges are picked up
+#
+# Works in a temporary git worktree; the current checkout stays put.
+
+require("json")
+require("open3")
+require("tmpdir")
+require_relative("generate_changelog")
+require_relative("article_rows")
+
+# Builds the changelog-pending branch and PR for the next deploy.
+class Prerelease
+  BRANCH = "changelog-pending"
+  ARTICLE_FILE = "article_pending.textile"
+  USAGE = "Usage: script/prerelease.rb [--apply]"
+
+  def initialize(argv)
+    args = argv.dup
+    @apply = args.delete("--apply") ? true : false
+    abort("Unknown arguments: #{args.join(" ")}\n#{USAGE}") if args.any?
+  end
+
+  def run
+    run_cmd("git", "fetch", "origin", "--tags")
+    # Local time, matching deploy.sh's `date "+deploy-%Y-%m-%d-%H-%M"`.
+    @tag = Time.now. # rubocop:disable Rails/TimeZone -- plain Ruby
+           strftime("deploy-%Y-%m-%d-%H-%M")
+    generator = ChangelogGenerator.new([])
+    @prev, pulls = generator.pending_pulls(exclude_branch: BRANCH)
+    abort("No PRs merged since #{@prev}; nothing to prepare.") if pulls.empty?
+
+    @section = generator.pending_section(@tag, pulls)
+    @rows, @skipped, @blockless = ArticleRows.new.rows_for(pulls)
+    @apply ? apply(generator) : preview
+  end
+
+  private
+
+  def preview
+    puts(@section)
+    puts("-- #{ARTICLE_FILE} --")
+    puts(@rows.empty? ? "(no article rows)" : @rows)
+    warn_blockless
+    warn("Dry run - nothing written. To apply: script/prerelease.rb --apply")
+  end
+
+  def warn_blockless
+    return if @blockless.empty?
+
+    warn("#{@blockless.size} PR(s) with no changelog block " \
+         "(listed in the PR body for a verdict):")
+    @blockless.each do |pull|
+      warn("  PR##{pull["number"]} #{pull["title"]}")
+    end
+  end
+
+  def apply(generator)
+    push_branch(generator)
+    upsert_pr
+  end
+
+  def push_branch(generator)
+    Dir.mktmpdir("prerelease") do |tmp|
+      dir = File.join(tmp, "wt")
+      run_cmd("git", "worktree", "add", "--detach", dir, "origin/main")
+      begin
+        write_files(generator, dir)
+        run_cmd("git", "-C", dir, "add",
+                ChangelogGenerator::CHANGELOG, ARTICLE_FILE)
+        run_cmd("git", "-C", dir, "commit", "-m", "Changelog for #{@tag}")
+        run_cmd("git", "-C", dir, "push", "--force", "origin",
+                "HEAD:refs/heads/#{BRANCH}")
+        warn("Pushed #{BRANCH}.")
+      ensure
+        run_cmd("git", "worktree", "remove", "--force", dir)
+      end
+    end
+  end
+
+  def write_files(generator, dir)
+    Dir.chdir(dir) do
+      generator.apply_pending(@section, @tag)
+      rows = @rows.empty? ? "" : "#{@rows.join("\n")}\n"
+      File.write(ARTICLE_FILE, rows)
+    end
+  end
+
+  def upsert_pr
+    number = existing_pr
+    if number
+      run_cmd("gh", "pr", "edit", number.to_s, "--title", title,
+              "--body-file", body_file)
+      warn("Updated PR ##{number} (#{BRANCH}).")
+    else
+      out = run_cmd("gh", "pr", "create", "--draft", "--head", BRANCH,
+                    "--title", title, "--body-file", body_file)
+      warn("Created #{out.strip}")
+    end
+  end
+
+  def title
+    "Changelog for `#{@tag}`"
+  end
+
+  def existing_pr
+    out = run_cmd("gh", "pr", "list", "--head", BRANCH, "--state", "open",
+                  "--json", "number")
+    JSON.parse(out).first&.fetch("number")
+  end
+
+  def body_file
+    path = File.join(Dir.tmpdir, "prerelease_pr_body.md")
+    File.write(path, pr_body)
+    path
+  end
+
+  def pr_body
+    <<~BODY
+      Pre-deploy changelog for `#{@tag}` (issue #5155): the CHANGELOG.md section for every PR merged since `#{@prev}`, and `#{ARTICLE_FILE}` with the MO Article rows the deploy will publish. Merge this as the last PR before deploying; re-running `script/prerelease.rb --apply` refreshes it with any later merges.
+
+      ## Expected MO Article lines
+
+      #{article_lines}
+
+      #{verdict_section}<!-- changelog -->
+      article: no
+      <!-- /changelog -->
+    BODY
+  end
+
+  def article_lines
+    return "None - no `article: yes` PRs in this deploy." if @rows.empty?
+
+    "```\n#{@rows.join("\n")}\n```\n(#{@skipped} PR(s) marked " \
+      "`article: no`.) Edits to `#{ARTICLE_FILE}` in this PR are what " \
+      "the deploy publishes."
+  end
+
+  def verdict_section
+    return "" if @blockless.empty?
+
+    list = @blockless.map do |pull|
+      "- PR##{pull["number"]} #{pull["title"]}"
+    end.join("\n")
+    "## Needs a verdict (no changelog block)\n\n#{list}\n\n" \
+      "To promote one, add a row to `#{ARTICLE_FILE}` in this PR.\n\n"
+  end
+
+  def run_cmd(*cmd)
+    out, err, status = Open3.capture3(*cmd)
+    abort("`#{cmd.join(" ")}` failed:\n#{err}") unless status.success?
+    out
+  end
+end
+
+Prerelease.new(ARGV).run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
First of the two PRs for the prerelease workflow decided on #5155 (2026-09-01 decision record). This adds the developer-side half; the `deploy.sh` half (read the tag from the changelog heading, publish `article_pending.textile` to the MO Article) is the follow-up PR.

## `script/prerelease.rb`

Dry run by default; `--apply` pushes. Run before a deploy, merge the PR it makes last, then deploy.

- Mints the upcoming deploy tag name (`deploy-YYYY-MM-DD-HH-MM`, local time, matching `deploy.sh`) and writes it into the new CHANGELOG.md section heading — the deploy will tag with the name it finds there.
- Builds the section for every PR merged since the last deploy tag, excluding the changelog PR from the section it creates (decided on the issue: let it go).
- Writes `article_pending.textile` holding one Textile row per `article: yes` PR — the reviewed rows are authoritative; the deploy publishes the file as merged. Each run rewrites it, which also clears the rows a previous deploy already published.
- Creates or updates a draft PR from the fixed `changelog-pending` branch (force-pushed single commit per run, built in a temporary git worktree so the developer's checkout stays put). The PR body carries the expected Article lines and a "needs a verdict" list of blockless PRs.
- Re-runnable to pick up last-minute merges: stale pending sections (a minted tag that was not deployed) are dropped and replaced.

## Changes to the existing scripts

- `script/generate_changelog.rb`: a pending API (`pending_pulls` / `pending_section` / `apply_pending`) for the `last-tag..origin/main` range; the PR pool now also fetches `mergedAt`, `body`, `headRefName`; requirable as a library (`$PROGRAM_NAME` guard).
- `script/article_rows.rb`: `rows_for(pulls)` renders rows for an explicit PR set (the CLI date-range mode is unchanged); requirable as a library.
- `.claude/rules/changelog.md`: "Producing the Article rows" rewritten for the new flow, including the Article's new header-row format (rows insert just below `| +date+ | +what+ | +link+ |`).

## Notes for review

- `--apply` has not been exercised yet (it pushes a branch and opens a PR); the dry run against the current pending range (13 PRs since `deploy-2026-08-29-11-00`, 5 Article rows) produced the expected section and rows.
- `article_pending.textile` will live at the repo root. If Copilot review starts erroring repo-wide after it first lands, that file is the suspect — the CHANGELOG.md incident (see #5155) was triggered by `[#NNNN](url)` markdown links in a root file; the Textile row format (`"PR#NNNN":url`) has not been through that wringer.

## Test plan

- [x] `bundle exec rubocop` clean on all three scripts.
- [x] `ruby script/prerelease.rb` (dry run) against the live repo: correct section for the 13 pending PRs, 5 Article rows, tag minted in deploy.sh's format.
- Reviewer: run `ruby script/prerelease.rb` (dry run, writes nothing) and check the section and rows look right; optionally `--apply` to see the changelog-pending PR get created, then re-run `--apply` to confirm it updates the same PR in place.

<!-- changelog -->
article: no
<!-- /changelog -->
