### PR TITLE
Fix theme change not applying until manual reload (`Account::PreferencesController#update`)

### DIFF
--- a/app/controllers/account/preferences_controller.rb
+++ b/app/controllers/account/preferences_controller.rb
@@ -18,7 +18,9 @@ module Account
       success = prefs_changed_successfully
 
       respond_to do |format|
-        format.turbo_stream { render(turbo_stream: turbo_stream_flash_update) }
+        format.turbo_stream do
+          render(turbo_stream: turbo_stream_update_response(success))
+        end
         format.html { render_update_response(success) }
       end
     end
@@ -188,6 +190,19 @@ module Account
         result = true
       end
       result
+    end
+
+    # The turbo_stream branch only patches the flash slot, so a theme
+    # change doesn't reach the <body class> / stylesheet <link> that
+    # apply it. `request_id: nil` is required -- Turbo skips a refresh
+    # whose request-id matches the request that just submitted the
+    # form, which `turbo_stream.refresh`'s default request-id would.
+    def turbo_stream_update_response(success)
+      streams = [turbo_stream_flash_update]
+      if success && @user.saved_change_to_theme?
+        streams << turbo_stream.refresh(request_id: nil)
+      end
+      streams
     end
 
     # Table for converting form value to object value

--- a/test/controllers/account/preferences_controller_test.rb
+++ b/test/controllers/account/preferences_controller_test.rb
@@ -383,6 +383,33 @@ module Account
       assert_flash(:runtime_prefs_success)
     end
 
+    def test_update_turbo_stream_theme_change_adds_refresh_stream
+      login("rolf")
+      rolf.update(theme: "Agaricus")
+
+      patch(:update,
+            params: { user: { theme: "Cyberland" } },
+            format: :turbo_stream)
+
+      assert_response(:success)
+      assert_select("turbo-stream[action='update'][target='page_flash']")
+      assert_select("turbo-stream[action='refresh']")
+      assert_equal("Cyberland", rolf.reload.theme)
+    end
+
+    def test_update_turbo_stream_no_theme_change_omits_refresh_stream
+      login("rolf")
+      rolf.update(theme: "Agaricus")
+
+      patch(:update,
+            params: { user: { theme: "Agaricus" } },
+            format: :turbo_stream)
+
+      assert_response(:success)
+      assert_select("turbo-stream[action='update'][target='page_flash']")
+      assert_select("turbo-stream[action='refresh']", count: 0)
+    end
+
     def test_update_turbo_stream_failure
       login("rolf")
 


### PR DESCRIPTION
Changing your theme on the Preferences page now applies immediately instead of only after a manual page reload.

Fixes #5284.

## Summary

`Account::PreferencesController#update`'s `edit.rb` form is `turbo: true`, so every save auto-sends `Accept: text/vnd.turbo-stream.html` and the controller's `respond_to` routes it through `format.turbo_stream`, not `format.html`. That branch renders only `turbo_stream_flash_update` (`turbo_stream.update("page_flash") { ... }`) — it doesn't re-render the layout, so a saved theme change doesn't reach the `<body class="theme-...">` or the per-theme stylesheet `<link>` in `<head>`. The DB write succeeds; the visible page stays on the old theme until a manual reload does a fresh full-document GET.

Fix: when `@user.saved_change_to_theme?` is true after a successful save, add a `<turbo-stream action="refresh">` to the response alongside the flash update. `turbo_stream.refresh` (turbo-rails 2.0.23, Turbo 8's morph-based page refresh) re-fetches and morphs the current page, correctly picking up the new `<body class>` and stylesheet `<link>`.

One gotcha: `turbo_stream.refresh` defaults its `request-id` attribute to `Turbo.current_request_id` — the id of the request returning this response. Turbo's client-side dedup logic skips a refresh whose request-id matches a request the client itself just made, since that mechanism exists to stop an ActionCable broadcast from redundantly refreshing the client that triggered it. Here the response is the request that needs it to refresh, so `request_id: nil` is required so the client doesn't skip it.

## Test plan

- [x] `bin/rails test test/controllers/account/preferences_controller_test.rb` — 20 tests, all pass, including two new ones: a theme change adds the refresh stream, an unchanged theme omits it.
- [x] `bundle exec rubocop app/controllers/account/preferences_controller.rb test/controllers/account/preferences_controller_test.rb` — no offenses
- [x] Verified live in browser by the user: theme change now applies without a manual reload

<!-- changelog -->
article: yes
Fix theme changes not applying until a page reload
<!-- /changelog -->
