### PR TITLE
Fix Turbo Frame badges silently swallowed by `collapse-fallback`

### DIFF
--- a/app/components/link/collapse_toggle.rb
+++ b/app/components/link/collapse_toggle.rb
@@ -106,12 +106,15 @@ class Components::Link::CollapseToggle < Components::Link
     # navigation when data-target is absent; fallback_href needs
     # data-target present so collapse.js can find the pane, so the
     # navigation has to be prevented explicitly instead. See
-    # app/javascript/controllers/collapse-fallback_controller.js.
+    # app/javascript/controllers/collapse-fallback_controller.js --
+    # no :prevent action modifier here, the controller itself decides
+    # whether to call preventDefault() (it skips it for a
+    # data-turbo-frame trigger, letting Turbo handle that case).
     extra_data.merge(target: "##{@target_id}",
                      controller: [extra_data[:controller],
                                   "collapse-fallback"].compact.join(" "),
                      action: [extra_data[:action],
-                              "click->collapse-fallback#intercept:prevent"].
+                              "click->collapse-fallback#intercept"].
                              compact.join(" "))
   end
 

--- a/app/javascript/controllers/collapse-fallback_controller.js
+++ b/app/javascript/controllers/collapse-fallback_controller.js
@@ -6,14 +6,25 @@ import { Controller } from "@hotwired/stimulus"
 // fallback_href option sets both an href and data-target (so collapse.js
 // can still find the pane), so Bootstrap doesn't prevent the default
 // navigation -- the click both toggles the pane and follows the href.
-// This controller's only job is the preventDefault(); the :prevent
-// action modifier calls it, and collapse.js's own delegated document
-// click handler still runs and does the actual toggling.
+// This controller's job is that preventDefault(), EXCEPT when the
+// trigger also carries data-turbo-frame: Turbo's own click handling
+// already checks event.defaultPrevented before deciding whether to
+// intercept a frame-targeted link, so calling preventDefault() here
+// first would silently stop Turbo from ever fetching the frame --
+// collapse.js still toggles the pane open (a separate, unprevented
+// listener), leaving it permanently empty. Turbo already prevents the
+// full-page navigation itself once it takes over a data-turbo-frame
+// click, so no manual prevention is needed for that case.
 //
 // Bootstrap 3-specific workaround. Re-check whether this is still
-// needed when MO migrates to Bootstrap 4/5 (issue #3797) --
-// collapse.js's data-API may behave differently there.
+// needed when MO migrates to Bootstrap 4/5 (issue #3797) -- confirmed
+// NOT needed there: Bootstrap 4's collapse.js data-API calls
+// preventDefault() unconditionally for every <a> trigger.
 // Connects to data-controller="collapse-fallback"
 export default class extends Controller {
-  intercept() {}
+  intercept(event) {
+    if (!event.currentTarget.dataset.turboFrame) {
+      event.preventDefault()
+    }
+  }
 }

--- a/test/components/link/collapse_toggle_test.rb
+++ b/test/components/link/collapse_toggle_test.rb
@@ -89,10 +89,13 @@ class CollapseToggleLinkTest < ComponentTestCase
     # Bootstrap's collapse data-API only calls preventDefault() when
     # data-target is absent, so fallback_href needs an explicit
     # preventDefault() or the click always follows href instead of
-    # toggling -- see collapse-fallback_controller.js.
+    # toggling -- see collapse-fallback_controller.js. No :prevent
+    # action modifier -- the controller itself decides whether to
+    # call preventDefault(), skipping it for a data-turbo-frame
+    # trigger so Turbo can handle that case instead.
     assert_html(html, "a[data-controller='collapse-fallback']")
     assert_html(
-      html, "a[data-action='click->collapse-fallback#intercept:prevent']"
+      html, "a[data-action='click->collapse-fallback#intercept']"
     )
   end
 


### PR DESCRIPTION
Clicking the "iNat" badge on an imported Observation now shows the linked iNaturalist info and Sync button instead of an empty panel.

Fixes #5285.

## Summary

`Components::Link::CollapseToggle`'s `collapse-fallback` Stimulus controller (added to work around Bootstrap 3's collapse data-API not calling `preventDefault()` when `fallback_href:` is set) wired its `preventDefault()` call via Stimulus's `:prevent` action modifier, unconditionally, on every click. Turbo checks `event.defaultPrevented` before deciding whether to intercept a `data-turbo-frame` link — so on the "Shared with iNat" badge, which combines `fallback_href:` with `data-turbo-frame`, that `preventDefault()` ran first and stopped Turbo from fetching the frame. Bootstrap's `collapse.js` listener isn't prevented, so the pane still opened — just permanently empty, with no Sync button or iNat info, matching the reported symptom.

Confirmed via a live DOM/network trace: the badge click set `aria-expanded="true"` and the pane got Bootstrap's `.collapse.in` class, but zero network requests fired to `/external_links/:id`.

Fix: `intercept(event)` now only calls `event.preventDefault()` when the trigger has no `data-turbo-frame` attribute, letting Turbo handle that case — it already prevents the full navigation once it takes over a frame-targeted click. The `api_keys` "+Add Key" button (`fallback_href:` only, no `data-turbo-frame`) is unaffected and still works (verified live).

Checked whether this workaround is permanent: fetched Bootstrap 4's `collapse.js` source (v4.6.2) — its data-API calls `preventDefault()` unconditionally for every `<a>` trigger, unlike Bootstrap 3's conditional behavior. So `collapse-fallback_controller.js` (and the `fallback_href`/`collapse-fallback` wiring in `CollapseToggle`) is confirmed Bootstrap-3-specific and can be deleted once MO migrates to BS4 (issue #3797) — no change needed to the `api_keys` button either way.

## Test plan

- [x] `bundle exec rubocop` on every touched file — no offenses
- [x] `bin/rails test test/components/link/collapse_toggle_test.rb` — 22 tests, all pass
- [x] `bin/rails test test/system/observation_show_system_test.rb -n test_add_external_link_and_view_shared_with_badge` — an existing system test exercises this exact flow (click the iNat badge, assert the pane's text). Passes.
- [x] Verified live in browser: iNat badge now opens with populated info; `api_keys` "+Add Key" inline form still works with no regression

<!-- changelog -->
article: yes
Fix the iNat badge on imported Observations showing an empty panel
<!-- /changelog -->
