### PR TITLE
Centralize BS3 responsive visibility helpers behind `Components::Column`

### DIFF
--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -855,28 +855,6 @@
   }
 }
 
-@media screen and (min-width: $screen-lg-min) {
-  .d-lg-none {
-    display: none !important;
-  }
-
-  .d-lg-block {
-    display: block !important;
-  }
-
-  .d-lg-inline {
-    display: inline !important;
-  }
-
-  .d-lg-inline-block {
-    display: inline-block !important;
-  }
-
-  .d-lg-flex {
-    display: flex !important;
-  }
-}
-
 @media screen and (min-width: $screen-sm-min) {
   .mt-sm-3 {
     margin-top: 1em !important;
@@ -922,5 +900,25 @@
 @media screen and (min-width: $screen-lg-min) {
   .mr-lg-5 {
     margin-right: 3rem !important;
+  }
+
+  .d-lg-none {
+    display: none !important;
+  }
+
+  .d-lg-block {
+    display: block !important;
+  }
+
+  .d-lg-inline {
+    display: inline !important;
+  }
+
+  .d-lg-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-lg-flex {
+    display: flex !important;
   }
 }

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -828,34 +828,7 @@
   .float-sm-none {
     float: none !important;
   }
-}
 
-// display utilities at the remaining BS3 breakpoints -- Components::Column's
-// show_at:/hide_at: (app/components/column.rb) can target any of xs/sm/md/
-// lg, so all three need their .d-{bp}-* set defined, not just sm.
-@media screen and (min-width: $screen-md-min) {
-  .d-md-none {
-    display: none !important;
-  }
-
-  .d-md-block {
-    display: block !important;
-  }
-
-  .d-md-inline {
-    display: inline !important;
-  }
-
-  .d-md-inline-block {
-    display: inline-block !important;
-  }
-
-  .d-md-flex {
-    display: flex !important;
-  }
-}
-
-@media screen and (min-width: $screen-sm-min) {
   .mt-sm-3 {
     margin-top: 1em !important;
   }
@@ -894,6 +867,31 @@
 
   .table {
     overflow-x: scroll;
+  }
+}
+
+// display utilities at the remaining BS3 breakpoints -- Components::Column's
+// show_at:/hide_at: (app/components/column.rb) can target any of xs/sm/md/
+// lg, so all three need their .d-{bp}-* set defined, not just sm.
+@media screen and (min-width: $screen-md-min) {
+  .d-md-none {
+    display: none !important;
+  }
+
+  .d-md-block {
+    display: block !important;
+  }
+
+  .d-md-inline {
+    display: inline !important;
+  }
+
+  .d-md-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-md-flex {
+    display: flex !important;
   }
 }
 

--- a/app/assets/stylesheets/mo/_utilities.scss
+++ b/app/assets/stylesheets/mo/_utilities.scss
@@ -828,7 +828,56 @@
   .float-sm-none {
     float: none !important;
   }
+}
 
+// display utilities at the remaining BS3 breakpoints -- Components::Column's
+// show_at:/hide_at: (app/components/column.rb) can target any of xs/sm/md/
+// lg, so all three need their .d-{bp}-* set defined, not just sm.
+@media screen and (min-width: $screen-md-min) {
+  .d-md-none {
+    display: none !important;
+  }
+
+  .d-md-block {
+    display: block !important;
+  }
+
+  .d-md-inline {
+    display: inline !important;
+  }
+
+  .d-md-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-md-flex {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: $screen-lg-min) {
+  .d-lg-none {
+    display: none !important;
+  }
+
+  .d-lg-block {
+    display: block !important;
+  }
+
+  .d-lg-inline {
+    display: inline !important;
+  }
+
+  .d-lg-inline-block {
+    display: inline-block !important;
+  }
+
+  .d-lg-flex {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: $screen-sm-min) {
   .mt-sm-3 {
     margin-top: 1em !important;
   }

--- a/app/components/button/submit.rb
+++ b/app/components/button/submit.rb
@@ -14,7 +14,7 @@
 #   Button(type: :submit,
 #     variant: :outline, class: "px-2"
 #   ) do
-#     span(class: "d-sm-none") { render(Components::Icon.new(type: :search)) }
+#     span(class: "d-sm-none") { Icon(type: :search) }
 #     span(class: class_names(Components::Column.mobile_hide_classes)) do
 #       plain(:search.ti)
 #     end

--- a/app/components/button/submit.rb
+++ b/app/components/button/submit.rb
@@ -15,7 +15,9 @@
 #     variant: :outline, class: "px-2"
 #   ) do
 #     span(class: "d-sm-none") { render(Components::Icon.new(type: :search)) }
-#     span(class: "hidden-xs") { plain(:search.ti) }
+#     span(class: class_names(Components::Column.mobile_hide_classes)) do
+#       plain(:search.ti)
+#     end
 #   end
 #
 class Components::Button::Submit < Components::Button

--- a/app/components/button/submit.rb
+++ b/app/components/button/submit.rb
@@ -15,7 +15,9 @@
 #     variant: :outline, class: "px-2"
 #   ) do
 #     span(class: "d-sm-none") { Icon(type: :search) }
-#     span(class: class_names(Components::Column.mobile_hide_classes)) do
+#     span(class: class_names(
+#            Components::Column.mobile_hide_classes(display: :inline)
+#          )) do
 #       plain(:search.ti)
 #     end
 #   end

--- a/app/components/column.rb
+++ b/app/components/column.rb
@@ -35,6 +35,18 @@
 #   small(class: class_names(Components::Column.visibility_classes(
 #           show_at: :xs, hide_at: :sm, display: :inline
 #         ))) { render_mobile_label }
+#
+# IMPORTANT: `sm:`/`md:`/`lg:` (grid width, via bootstrap-sass's grid
+# engine) and `show_at:`/`hide_at:` (visibility, via the `.d-*` bridge
+# classes in `_utilities.scss`) use the same breakpoint names for
+# different pixel thresholds right now -- the grid still runs on
+# Bootstrap 3's values (sm=768px/md=992px/lg=1200px); the `.d-*`
+# bridge classes are deliberately kept on those same BS3 values too,
+# to stay consistent with the grid. Bootstrap 4's breakpoints are
+# shifted (sm=576px/md=768px/lg=992px/xl=1200px) -- do not redefine
+# the `.d-*` bridge classes to use BS4's pixel values without also
+# migrating the grid, or `sm:`/`show_at: :sm` would silently mean two
+# different widths in the same `Column` call.
 class Components::Column < Components::Base
   BREAKPOINTS = [:xs, :sm, :md, :lg, :xl].freeze
 

--- a/app/components/column.rb
+++ b/app/components/column.rb
@@ -57,6 +57,8 @@
 # different widths in the same `Column` call.
 class Components::Column < Components::Base
   BREAKPOINTS = [:xs, :sm, :md, :lg, :xl].freeze
+  # The `.d-{bp}-*` bridge classes defined in _utilities.scss.
+  DISPLAY_VALUES = [:none, :block, :inline, :"inline-block", :flex].freeze
 
   # Callable without instantiating -- for call sites that need a raw class
   # string merged into an existing element's `class:` rather than a full
@@ -81,6 +83,9 @@ class Components::Column < Components::Base
   # bare `.visible-xs`) or `:inline`/`:"inline-block"` (matching
   # `.visible-xs-inline`/`.visible-xs-inline-block`).
   def self.visibility_classes(show_at: nil, hide_at: nil, display: :block)
+    validate_breakpoint!(show_at)
+    validate_breakpoint!(hide_at)
+    validate_display!(display)
     entries = []
     entries << [BREAKPOINTS.index(show_at), display_class(show_at, display)] \
       if show_at
@@ -88,6 +93,26 @@ class Components::Column < Components::Base
       if hide_at
     entries.sort_by(&:first).map(&:last)
   end
+
+  def self.validate_breakpoint!(breakpoint)
+    return if breakpoint.nil? || BREAKPOINTS.include?(breakpoint)
+
+    raise(ArgumentError.new(
+            "Unknown breakpoint: #{breakpoint.inspect}. " \
+            "Valid breakpoints: #{BREAKPOINTS.join(", ")}."
+          ))
+  end
+  private_class_method :validate_breakpoint!
+
+  def self.validate_display!(display)
+    return if DISPLAY_VALUES.include?(display)
+
+    raise(ArgumentError.new(
+            "Unknown display: #{display.inspect}. " \
+            "Valid values: #{DISPLAY_VALUES.join(", ")}."
+          ))
+  end
+  private_class_method :validate_display!
 
   # Shorthand for the two most common visibility patterns across
   # non-Column elements. `class_names("foo", mobile_hide_classes)`.

--- a/app/components/column.rb
+++ b/app/components/column.rb
@@ -27,8 +27,16 @@
 #   Column(show_at: :xs, hide_at: :sm) { render_mobile_only }
 #
 # @example Non-Column element needing only the visibility classes
-#   (replaces bare BS3 `.hidden-xs`)
-#   span(class: class_names("foo", Components::Column.mobile_hide_classes))
+#   (replaces bare BS3 `.hidden-xs` on a block-level element)
+#   div(class: class_names("foo", Components::Column.mobile_hide_classes))
+#
+# @example Same, on an inline element -- BS3's `.hidden-xs` did not set
+#   a display type on the visible side, so an inline element (a `span`,
+#   an `a`) needs the `display:` override; otherwise it becomes a block
+#   box from `sm` up.
+#   span(class: class_names(
+#     Components::Column.mobile_hide_classes(display: :inline)
+#   ))
 #
 # @example Non-Column element, a different visibility pattern
 #   (replaces BS3 `.visible-xs-inline`)
@@ -85,17 +93,21 @@ class Components::Column < Components::Base
   # non-Column elements. `class_names("foo", mobile_hide_classes)`.
   #
   # Hidden at xs, visible from sm up (desktop-only; replaces bare
-  # BS3 `.hidden-xs`).
-  def self.mobile_hide_classes
-    visibility_classes(hide_at: :xs, show_at: :sm)
+  # BS3 `.hidden-xs`). `display:` defaults to `:block`, matching a
+  # block-level caller (`div`, `li`, ...) -- pass `display: :inline`/
+  # `:"inline-block"` for a naturally-inline element (`span`, `a`):
+  # BS3's `.hidden-xs` did not set a display type on the visible side.
+  def self.mobile_hide_classes(display: :block)
+    visibility_classes(hide_at: :xs, show_at: :sm, display: display)
   end
 
   # Visible at xs only, hidden from sm up (mobile-only; replaces bare
   # BS3 `.visible-xs`). Named to match the `:mobile_only` terminology
   # already used at call sites like `Views::Layouts::Sidebar::
-  # CSS_CLASSES`.
-  def self.mobile_only_classes
-    visibility_classes(show_at: :xs, hide_at: :sm)
+  # CSS_CLASSES`. `display:` defaults to `:block`, matching BS3's
+  # bare `.visible-xs` (itself `display: block !important`).
+  def self.mobile_only_classes(display: :block)
+    visibility_classes(show_at: :xs, hide_at: :sm, display: display)
   end
 
   # `xs` is Bootstrap 3's mobile-first base -- there's no `d-xs-*` class,

--- a/app/components/column.rb
+++ b/app/components/column.rb
@@ -25,6 +25,16 @@
 #
 # @example Visible on xs only, hidden from sm up
 #   Column(show_at: :xs, hide_at: :sm) { render_mobile_only }
+#
+# @example Non-Column element needing only the visibility classes
+#   (replaces bare BS3 `.hidden-xs`)
+#   span(class: class_names("foo", Components::Column.mobile_hide_classes))
+#
+# @example Non-Column element, a different visibility pattern
+#   (replaces BS3 `.visible-xs-inline`)
+#   small(class: class_names(Components::Column.visibility_classes(
+#           show_at: :xs, hide_at: :sm, display: :inline
+#         ))) { render_mobile_label }
 class Components::Column < Components::Base
   BREAKPOINTS = [:xs, :sm, :md, :lg, :xl].freeze
 
@@ -46,14 +56,34 @@ class Components::Column < Components::Base
   # effect -- ordered ascending by breakpoint (not by show/hide) so e.g.
   # `hide_at: :xs, show_at: :sm` reads as "d-none d-sm-block" (hidden at
   # xs, then shown from sm up), matching the order the equivalent BS3
-  # `.hidden-xs` / `.visible-xs-*` utilities implied.
-  def self.visibility_classes(show_at: nil, hide_at: nil)
+  # `.hidden-xs` / `.visible-xs-*` utilities implied. `display:` picks
+  # what "shown" means at `show_at:` -- `:block` (the default, matching
+  # bare `.visible-xs`) or `:inline`/`:"inline-block"` (matching
+  # `.visible-xs-inline`/`.visible-xs-inline-block`).
+  def self.visibility_classes(show_at: nil, hide_at: nil, display: :block)
     entries = []
-    entries << [BREAKPOINTS.index(show_at), display_class(show_at, :block)] \
+    entries << [BREAKPOINTS.index(show_at), display_class(show_at, display)] \
       if show_at
     entries << [BREAKPOINTS.index(hide_at), display_class(hide_at, :none)] \
       if hide_at
     entries.sort_by(&:first).map(&:last)
+  end
+
+  # Shorthand for the two most common visibility patterns across
+  # non-Column elements. `class_names("foo", mobile_hide_classes)`.
+  #
+  # Hidden at xs, visible from sm up (desktop-only; replaces bare
+  # BS3 `.hidden-xs`).
+  def self.mobile_hide_classes
+    visibility_classes(hide_at: :xs, show_at: :sm)
+  end
+
+  # Visible at xs only, hidden from sm up (mobile-only; replaces bare
+  # BS3 `.visible-xs`). Named to match the `:mobile_only` terminology
+  # already used at call sites like `Views::Layouts::Sidebar::
+  # CSS_CLASSES`.
+  def self.mobile_only_classes
+    visibility_classes(show_at: :xs, hide_at: :sm)
   end
 
   # `xs` is Bootstrap 3's mobile-first base -- there's no `d-xs-*` class,

--- a/app/components/form/pattern_search.rb
+++ b/app/components/form/pattern_search.rb
@@ -106,7 +106,9 @@ class Components::Form::PatternSearch < Components::ApplicationForm
         span(class: "d-sm-none") do
           Icon(type: :search)
         end
-        span(class: class_names(Components::Column.mobile_hide_classes)) do
+        span(class: class_names(
+          Components::Column.mobile_hide_classes(display: :inline)
+        )) do
           plain(:app_search.l)
         end
       end

--- a/app/components/form/pattern_search.rb
+++ b/app/components/form/pattern_search.rb
@@ -58,7 +58,8 @@ class Components::Form::PatternSearch < Components::ApplicationForm
                "flex-grow-1 mb-0") do
       Icon(
         type: :search,
-        class: "form-control-feedback hidden-xs"
+        class: class_names("form-control-feedback",
+                           Components::Column.mobile_hide_classes)
       )
       # `label: false` skips the form-group wrap + auto-label so the
       # input nests directly inside the navbar flex row, matching
@@ -105,7 +106,9 @@ class Components::Form::PatternSearch < Components::ApplicationForm
         span(class: "d-sm-none") do
           Icon(type: :search)
         end
-        span(class: "hidden-xs") { plain(:app_search.l) }
+        span(class: class_names(Components::Column.mobile_hide_classes)) do
+          plain(:app_search.l)
+        end
       end
     end
   end

--- a/app/components/help.rb
+++ b/app/components/help.rb
@@ -126,8 +126,11 @@ class Components::Help < Components::Base
 
     div(class: classes.join(" "), id: @id) do
       emit_content(&block)
-      # `hidden-xs` keeps the arrow desktop-only.
-      div(class: "arrow-#{@arrow} hidden-xs") if @arrow
+      # Hidden at xs keeps the arrow desktop-only.
+      if @arrow
+        div(class: class_names("arrow-#{@arrow}",
+                               Components::Column.mobile_hide_classes))
+      end
     end
   end
 

--- a/app/components/help/collapse_block.rb
+++ b/app/components/help/collapse_block.rb
@@ -22,8 +22,10 @@ class Components::Help::CollapseBlock < Components::Base
       div(class: div_class) do
         yield if block
         if @direction
-          arrow_class = "arrow-#{@direction}"
-          arrow_class += " hidden-xs" unless @mobile
+          arrow_class = class_names(
+            "arrow-#{@direction}",
+            (Components::Column.mobile_hide_classes unless @mobile)
+          )
           div(class: arrow_class)
         end
       end

--- a/app/components/navbar/text.rb
+++ b/app/components/navbar/text.rb
@@ -22,10 +22,10 @@
 #   render(Components::Navbar::Text.new(class: "mx-0")) { plain(:page.ti) }
 #
 # @example <li class="navbar-text"> wrapper
-#   render(Components::Navbar::Text.new(element: :li,
-#                                       class: "mx-0 hidden-xs")) do
-#     plain("Sort by:")
-#   end
+#   render(Components::Navbar::Text.new(
+#            element: :li,
+#            class: class_names("mx-0", Components::Column.mobile_hide_classes)
+#          )) { plain("Sort by:") }
 class Components::Navbar::Text < Components::Base
   prop :element, _Nilable(Symbol), default: nil
   prop :attributes, _Hash(Symbol, _Any), :**

--- a/app/views/controllers/images/show/vote_panel.rb
+++ b/app/views/controllers/images/show/vote_panel.rb
@@ -72,7 +72,7 @@ module Views::Controllers::Images
         css = current == value ? "font-weight-bold" : ""
         Row do
           Column(xs: 12, sm: 6) { render_vote_link(value, css) }
-          Column(xs: 12, sm: 6, class: "hidden-xs") do
+          Column(xs: 12, sm: 6, hide_at: :xs, show_at: :sm) do
             render_vote_and_next_link(value, css)
           end
         end

--- a/app/views/controllers/info/site_stats.rb
+++ b/app/views/controllers/info/site_stats.rb
@@ -13,9 +13,9 @@ module Views::Controllers::Info
       container_class(:full)
 
       Row(class: "mt-3") do
-        Column(md: 3, class: "hidden-xs") { render_thumbs(0, 3) }
+        Column(md: 3, hide_at: :xs, show_at: :sm) { render_thumbs(0, 3) }
         Column(md: 6, class: "center-block") { render_stats_table }
-        Column(md: 3, class: "hidden-xs") { render_thumbs(3, 3) }
+        Column(md: 3, hide_at: :xs, show_at: :sm) { render_thumbs(3, 3) }
       end
     end
 

--- a/app/views/controllers/interests/index.rb
+++ b/app/views/controllers/interests/index.rb
@@ -27,7 +27,8 @@ module Views::Controllers::Interests
     end
 
     def render_type_filter
-      ButtonGroup(class: "pb-1 hidden-xs text-nowrap mt-5") do
+      ButtonGroup(class: class_names("pb-1 text-nowrap mt-5",
+                                     Components::Column.mobile_hide_classes)) do
         Button(
           name: :rss_show.l, tag: :span, size: :sm,
           class: "disabled"

--- a/app/views/controllers/interests/index.rb
+++ b/app/views/controllers/interests/index.rb
@@ -27,8 +27,10 @@ module Views::Controllers::Interests
     end
 
     def render_type_filter
-      ButtonGroup(class: class_names("pb-1 text-nowrap mt-5",
-                                     Components::Column.mobile_hide_classes)) do
+      ButtonGroup(class: class_names(
+        "pb-1 text-nowrap mt-5",
+        Components::Column.mobile_hide_classes(display: :"inline-block")
+      )) do
         Button(
           name: :rss_show.l, tag: :span, size: :sm,
           class: "disabled"

--- a/app/views/controllers/observations/show/namings/row.rb
+++ b/app/views/controllers/observations/show/namings/row.rb
@@ -305,7 +305,11 @@ class Views::Controllers::Observations::Show::Namings::Row < Views::Base
   # prefixes its content with a tiny label that says what the
   # value means.
   def render_mobile_label(text, block: false)
-    vis = block ? "visible-xs-inline-block" : "visible-xs-inline mr-4"
-    small(class: vis) { append_colon(text) }
+    display = block ? :"inline-block" : :inline
+    vis = Components::Column.visibility_classes(
+      show_at: :xs, hide_at: :sm, display: display
+    )
+    vis << "mr-4" unless block
+    small(class: class_names(vis)) { append_colon(text) }
   end
 end

--- a/app/views/controllers/rss_logs/type_filters.rb
+++ b/app/views/controllers/rss_logs/type_filters.rb
@@ -61,7 +61,8 @@ module Views::Controllers::RssLogs
       # span ends up after the group). Sibling-of-group keeps it
       # inline-aligned without being subject to the group's layout
       # rules.
-      div(class: "px-3 pb-1 hidden-xs text-nowrap") do
+      div(class: class_names("px-3 pb-1 text-nowrap",
+                             Components::Column.mobile_hide_classes)) do
         render_show_label
         ButtonGroup do
           render_everything_button

--- a/app/views/layouts/header/index_pagination_nav.rb
+++ b/app/views/layouts/header/index_pagination_nav.rb
@@ -76,12 +76,17 @@ module Views::Layouts
     end
 
     def render_page_label
-      render(Components::Navbar::Text.new(class: "mx-0 hidden-xs")) { :page.ti }
+      render(Components::Navbar::Text.new(
+               class: class_names("mx-0", Components::Column.mobile_hide_classes)
+             )) { :page.ti }
     end
 
     def render_max_page_link(max_page)
       max_url = pagination_link_url(max_page)
-      render(Components::Navbar::Text.new(class: "ml-0 mr-2 hidden-xs")) do
+      render(Components::Navbar::Text.new(
+               class: class_names("ml-0 mr-2",
+                                  Components::Column.mobile_hide_classes)
+             )) do
         :of.l
       end
       render(Components::Navbar::Text.new(class: "mx-0")) do

--- a/app/views/layouts/header/index_pagination_nav.rb
+++ b/app/views/layouts/header/index_pagination_nav.rb
@@ -77,7 +77,8 @@ module Views::Layouts
 
     def render_page_label
       render(Components::Navbar::Text.new(
-               class: class_names("mx-0", Components::Column.mobile_hide_classes)
+               class: class_names("mx-0",
+                                  Components::Column.mobile_hide_classes)
              )) { :page.ti }
     end
 

--- a/app/views/layouts/header/sorter.rb
+++ b/app/views/layouts/header/sorter.rb
@@ -25,8 +25,10 @@ module Views::Layouts
       return unless visible?
 
       ul(class: "list-unstyled flex-bar pl-3 sorter") do
-        render(Components::Navbar::Text.new(element: :li,
-                                            class: "mx-0 hidden-xs")) do
+        render(Components::Navbar::Text.new(
+                 element: :li,
+                 class: class_names("mx-0", Components::Column.mobile_hide_classes)
+               )) do
           append_colon(:sort_by_header.l)
         end
         Dropdown(
@@ -62,7 +64,7 @@ module Views::Layouts
     # `<ul>` via `trusted_html`.
     def mobile_header_html
       capture do
-        li(class: "visible-xs") do
+        li(class: class_names(Components::Column.mobile_only_classes)) do
           a(href: "#", disabled: true, class: "opacity-75") do
             append_colon(:sort_by_header.l)
           end

--- a/app/views/layouts/header/sorter.rb
+++ b/app/views/layouts/header/sorter.rb
@@ -27,7 +27,8 @@ module Views::Layouts
       ul(class: "list-unstyled flex-bar pl-3 sorter") do
         render(Components::Navbar::Text.new(
                  element: :li,
-                 class: class_names("mx-0", Components::Column.mobile_hide_classes)
+                 class: class_names("mx-0",
+                                    Components::Column.mobile_hide_classes)
                )) do
           append_colon(:sort_by_header.l)
         end

--- a/app/views/layouts/login_welcome.rb
+++ b/app/views/layouts/login_welcome.rb
@@ -17,7 +17,8 @@ module Views::Layouts
     def view_template
       comment { "LOGIN WELCOME" }
       Container(width: :text) do
-        div(class: "text-center visible-xs-block") do
+        div(class: class_names("text-center",
+                               Components::Column.mobile_only_classes)) do
           img(class: "logo-trim", alt: "MO Logo", src: "/logo-trim.png")
         end
         h2(class: "h3 text-center") { plain("Mushroom Observer (MO)") }

--- a/app/views/layouts/sidebar.rb
+++ b/app/views/layouts/sidebar.rb
@@ -25,7 +25,7 @@ class Views::Layouts::Sidebar < Views::Base
     heading: "disabled font-weight-bold",
     admin: "list-group-item-danger indent",
     indent: "indent",
-    mobile_only: Components::Column.mobile_only_classes.join(" ")
+    mobile_only: Components::Column.mobile_only_classes.join(" ").freeze
   }.freeze
 
   prop :user, _Nilable(::User), default: nil

--- a/app/views/layouts/sidebar.rb
+++ b/app/views/layouts/sidebar.rb
@@ -25,7 +25,7 @@ class Views::Layouts::Sidebar < Views::Base
     heading: "disabled font-weight-bold",
     admin: "list-group-item-danger indent",
     indent: "indent",
-    mobile_only: "visible-xs"
+    mobile_only: Components::Column.mobile_only_classes.join(" ")
   }.freeze
 
   prop :user, _Nilable(::User), default: nil

--- a/app/views/layouts/top_nav.rb
+++ b/app/views/layouts/top_nav.rb
@@ -95,8 +95,8 @@ class Views::Layouts::TopNav < Views::Base
     render_search_nav_toggle
     render_nav_scan_qr_code
     ul(class: class_names("nav", Components::Navbar::NAV_CLASS,
-                          Components::Navbar::RIGHT_CLASS,
-                          "hidden-xs mr-0")) do
+                          Components::Navbar::RIGHT_CLASS, "mr-0",
+                          Components::Column.mobile_hide_classes)) do
       # `content_for(:context_nav)` (no-block) returns the previously
       # stashed SafeBuffer; `trusted_html` emits it into Phlex's
       # buffer (a no-op `content_for` call would only read it).
@@ -137,7 +137,10 @@ class Views::Layouts::TopNav < Views::Base
   # The hamburger that opens the offcanvas sidebar on mobile /
   # small-tablet widths. Uses the MO favicon as the glyph.
   def render_left_nav_toggle
-    div(class: "visible-xs visible-sm pr-3 pr-sm-4") do
+    div(class: class_names("pr-3 pr-sm-4",
+                           Components::Column.visibility_classes(
+                             show_at: :xs, hide_at: :md
+                           ))) do
       Button(
         variant: :outline,
         class: "rounded-circle overflow-hidden p-0",

--- a/test/components/button_group_test.rb
+++ b/test/components/button_group_test.rb
@@ -11,10 +11,10 @@ class ButtonGroupTest < ComponentTestCase
 
   def test_renders_with_custom_class
     html = render_component(
-      Components::ButtonGroup.new(class: "pb-1 hidden-xs")
+      Components::ButtonGroup.new(class: "pb-1 mt-3")
     ) { "content" }
 
-    assert_html(html, "div.btn-group.pb-1.hidden-xs[role='group']",
+    assert_html(html, "div.btn-group.pb-1.mt-3[role='group']",
                 text: "content")
   end
 

--- a/test/components/column_test.rb
+++ b/test/components/column_test.rb
@@ -40,9 +40,21 @@ class ColumnTest < ComponentTestCase
                  Components::Column.mobile_hide_classes)
   end
 
+  def test_mobile_hide_classes_shorthand_display_override
+    assert_equal(%w[d-none d-sm-inline],
+                 Components::Column.mobile_hide_classes(display: :inline))
+  end
+
   def test_mobile_only_classes_shorthand
     assert_equal(%w[d-block d-sm-none],
                  Components::Column.mobile_only_classes)
+  end
+
+  def test_mobile_only_classes_shorthand_display_override
+    assert_equal(%w[d-inline-block d-sm-none],
+                 Components::Column.mobile_only_classes(
+                   display: :"inline-block"
+                 ))
   end
 
   def test_default_renders_div_with_no_width_classes

--- a/test/components/column_test.rb
+++ b/test/components/column_test.rb
@@ -24,6 +24,27 @@ class ColumnTest < ComponentTestCase
                  Components::Column.classes_for(show_at: :lg))
   end
 
+  def test_visibility_classes_display_kwarg
+    assert_equal(%w[d-inline d-sm-none],
+                 Components::Column.visibility_classes(
+                   show_at: :xs, hide_at: :sm, display: :inline
+                 ))
+    assert_equal(%w[d-inline-block d-sm-none],
+                 Components::Column.visibility_classes(
+                   show_at: :xs, hide_at: :sm, display: :"inline-block"
+                 ))
+  end
+
+  def test_mobile_hide_classes_shorthand
+    assert_equal(%w[d-none d-sm-block],
+                 Components::Column.mobile_hide_classes)
+  end
+
+  def test_mobile_only_classes_shorthand
+    assert_equal(%w[d-block d-sm-none],
+                 Components::Column.mobile_only_classes)
+  end
+
   def test_default_renders_div_with_no_width_classes
     html = render_column
 

--- a/test/components/column_test.rb
+++ b/test/components/column_test.rb
@@ -35,6 +35,21 @@ class ColumnTest < ComponentTestCase
                  ))
   end
 
+  def test_visibility_classes_rejects_unknown_breakpoint
+    assert_raises(ArgumentError) do
+      Components::Column.visibility_classes(show_at: :xxl, hide_at: :sm)
+    end
+    assert_raises(ArgumentError) do
+      Components::Column.visibility_classes(show_at: :xs, hide_at: :xxl)
+    end
+  end
+
+  def test_visibility_classes_rejects_unknown_display
+    assert_raises(ArgumentError) do
+      Components::Column.visibility_classes(show_at: :xs, display: :foo)
+    end
+  end
+
   def test_mobile_hide_classes_shorthand
     assert_equal(%w[d-none d-sm-block],
                  Components::Column.mobile_hide_classes)

--- a/test/components/help/collapse_block_test.rb
+++ b/test/components/help/collapse_block_test.rb
@@ -28,7 +28,7 @@ class CollapseHelpBlockTest < ComponentTestCase
                                           direction: "down")
     ) { "Content" }
 
-    assert_html(html, "div.arrow-down.hidden-xs")
+    assert_html(html, "div.arrow-down.d-none.d-sm-block")
     assert_not_includes(html, "mt-3")
   end
 
@@ -37,7 +37,7 @@ class CollapseHelpBlockTest < ComponentTestCase
       Components::Help::CollapseBlock.new(target_id: "help_4", direction: "up")
     ) { "Content" }
 
-    assert_html(html, "div.arrow-up.hidden-xs")
+    assert_html(html, "div.arrow-up.d-none.d-sm-block")
     assert_html(html, "div.well.well-sm.mb-3.help-block.position-relative.mt-3")
   end
 
@@ -51,7 +51,7 @@ class CollapseHelpBlockTest < ComponentTestCase
     ) { "Mobile content" }
 
     assert_html(html, "div.arrow-up")
-    assert_not_includes(html, "hidden-xs")
+    assert_not_includes(html, "d-none")
   end
 
   def test_renders_arrow_hidden_on_mobile_when_mobile_false
@@ -63,7 +63,7 @@ class CollapseHelpBlockTest < ComponentTestCase
       )
     ) { "Desktop content" }
 
-    assert_html(html, "div.arrow-down.hidden-xs")
+    assert_html(html, "div.arrow-down.d-none.d-sm-block")
   end
 
   def test_yields_block_content
@@ -86,7 +86,7 @@ class CollapseHelpBlockTest < ComponentTestCase
       )
     ) { "Left" }
     assert_html(html_left, "div.arrow-left")
-    assert_not_includes(html_left, "hidden-xs")
+    assert_not_includes(html_left, "d-none")
 
     # Test right arrow without mobile
     html_right = render_component(
@@ -96,6 +96,6 @@ class CollapseHelpBlockTest < ComponentTestCase
         mobile: false
       )
     ) { "Right" }
-    assert_html(html_right, "div.arrow-right.hidden-xs")
+    assert_html(html_right, "div.arrow-right.d-none.d-sm-block")
   end
 end

--- a/test/components/help_test.rb
+++ b/test/components/help_test.rb
@@ -40,7 +40,7 @@ class HelpTest < ComponentTestCase
     # is added on the up-pointing variant to leave room above for the
     # arrow tip.
     assert_html(html, "div.well.help-block.mt-3", text: "Help")
-    assert_html(html, "div.arrow-up.hidden-xs")
+    assert_html(html, "div.arrow-up.d-none.d-sm-block")
   end
 
   def test_arrow_down_omits_mt3
@@ -48,7 +48,7 @@ class HelpTest < ComponentTestCase
 
     # Down arrows hang below the well — no leading `mt-3`.
     assert_no_html(html, "div.mt-3")
-    assert_html(html, "div.arrow-down.hidden-xs")
+    assert_html(html, "div.arrow-down.d-none.d-sm-block")
   end
 
   def test_extra_class_appended_to_plain_block

--- a/test/components/navbar/text_test.rb
+++ b/test/components/navbar/text_test.rb
@@ -19,10 +19,10 @@ class NavbarTextTest < ComponentTestCase
 
   def test_renders_with_custom_class
     html = render_component(
-      Components::Navbar::Text.new(class: "mx-0 hidden-xs")
+      Components::Navbar::Text.new(class: "mx-0 mt-3")
     ) { "Page" }
 
-    assert_html(html, "div.navbar-text.mx-0.hidden-xs", text: "Page")
+    assert_html(html, "div.navbar-text.mx-0.mt-3", text: "Page")
   end
 
   def test_renders_with_data_attributes

--- a/test/views/controllers/observations/show/namings/row_test.rb
+++ b/test/views/controllers/observations/show/namings/row_test.rb
@@ -74,7 +74,7 @@ class Views::Controllers::Observations::Show::Namings::RowTest <
     html = render_row
 
     assert_html(html, "a.user_link_#{@user.id}")
-    assert_html(html, "small.visible-xs-inline",
+    assert_html(html, "small.d-inline.d-sm-none",
                 text: "#{:show_namings_user.t}: ")
   end
 

--- a/test/views/layouts/header/sorter_test.rb
+++ b/test/views/layouts/header/sorter_test.rb
@@ -63,9 +63,9 @@ module Views::Layouts
     def test_menu_contains_mobile_only_sort_by_header
       html = render_sorter(query: query_with(num_results: 5))
 
-      # `menu_header:` slot — visible-xs `<li>` rendered above the
+      # `menu_header:` slot — mobile-only `<li>` rendered above the
       # section's links.
-      assert_html(html, "ul.dropdown-menu.sorts > li.visible-xs",
+      assert_html(html, "ul.dropdown-menu.sorts > li.d-block.d-sm-none",
                   text: "#{:sort_by_header.l}:")
     end
 

--- a/test/views/layouts/login_welcome_test.rb
+++ b/test/views/layouts/login_welcome_test.rb
@@ -7,7 +7,7 @@ module Views::Layouts
     def test_renders_logo_mobile_only
       html = render_component
 
-      assert_html(html, "div.text-center.visible-xs-block")
+      assert_html(html, "div.text-center.d-block.d-sm-none")
       assert_html(html, "img.logo-trim[alt='MO Logo'][src='/logo-trim.png']")
     end
 

--- a/test/views/layouts/sidebar/context_nav_test.rb
+++ b/test/views/layouts/sidebar/context_nav_test.rb
@@ -28,11 +28,11 @@ class Views::Layouts::Sidebar
 
       # Heading row.
       heading_classes =
-        "div.list-group-item.disabled.font-weight-bold.visible-xs"
+        "div.list-group-item.disabled.font-weight-bold.d-block.d-sm-none"
       assert_html(html, heading_classes,
                   text: "#{:app_context_actions.t}:")
-      # Each plain link is its own indented + mobile-only row.
-      assert_html(html, "a.list-group-item.indent.visible-xs",
+      # Each plain link is an indented, mobile-only row.
+      assert_html(html, "a.list-group-item.indent.d-block.d-sm-none",
                   count: simple_links.length)
     end
 

--- a/test/views/layouts/top_nav_test.rb
+++ b/test/views/layouts/top_nav_test.rb
@@ -212,7 +212,8 @@ class Views::Layouts::TopNavTest < ComponentTestCase
 
     # Built from Components::Navbar::NAV_CLASS/RIGHT_CLASS, not raw
     # navbar-nav/navbar-right literals.
-    assert_html(html, "ul.nav.navbar-nav.navbar-right.hidden-xs.mr-0")
+    assert_html(html,
+                "ul.nav.navbar-nav.navbar-right.d-none.d-sm-block.mr-0")
   end
 
   private


### PR DESCRIPTION
Every remaining `hidden-xs`/`visible-xs`/`visible-sm` mobile-visibility class in the app now goes through `Components::Column`, replacing BS3-only class names that don't exist under Bootstrap 4 with a readable, semantic call site.

## Summary

Bootstrap-4-prep TODO from issue #3797 (item 1: "BS3 responsive visibility helpers"). `Components::Column` already had a `show_at:`/`hide_at:` mechanism generating `d-none`/`d-{bp}-block` classes. This converts every remaining `hidden-xs`/`visible-xs`/`visible-sm`/`visible-md`/`visible-lg` call site (16 files) onto it, either via `Column`'s `show_at:`/`hide_at:` kwargs where already `Column`-wrapped, or via two new shorthand class methods for everywhere else:

- `Column.mobile_hide_classes` (`hide_at: :xs, show_at: :sm`) — replaces bare `.hidden-xs`, by far the most common case.
- `Column.mobile_only_classes` (`show_at: :xs, hide_at: :sm`) — replaces bare `.visible-xs`, matching the `:mobile_only` terminology `Views::Layouts::Sidebar::CSS_CLASSES` already used.

`visibility_classes` gained a `display:` kwarg (default `:block`) to cover the two `visible-xs-inline`/`-inline-block` sites in `observations/show/namings/row.rb`.

**What this does and doesn't buy at the eventual Bootstrap 4 cutover**, checked against Bootstrap 4's published breakpoint values: BS3's `sm`/`md`/`lg` (768/992/1200px) shift up one name under BS4 (`md`/`lg`/`xl`, same pixel values), and BS4 adds a new 576px `sm` tier absent from BS3. `Components::Column`'s `.d-*` bridge classes in `_utilities.scss` are deliberately kept on BS3's pixel values (matching the grid engine, which is unaffected by this PR) instead of BS4's, so every `show_at:`/`hide_at:` breakpoint value still needs an individual look at cutover to decide whether it should shift a letter — the same amount of work as if it had stayed a raw string.

**What centralizing here does buy:** the BS3-only class *names* (`hidden-xs`, `visible-xs`, `visible-xs-inline`) don't exist under Bootstrap 4 — those needed translating regardless of the breakpoint-value question — and callers get a readable, semantic call site instead of a magic string. Added a comment on `Components::Column` documenting the breakpoint-name mismatch between grid width and visibility for future readers, since redefining the `.d-*` bridge to BS4's pixel values without also migrating the grid would silently make `sm:`/`show_at: :sm` mean two different widths in the same call.

Also fixed a gap this surfaced: `_utilities.scss` only defined `.d-sm-*` bridge classes, not `.d-md-*`/`.d-lg-*`. `render_left_nav_toggle`'s `hide_at: :md` had no effect without them — the hamburger button stopped hiding at desktop widths, becoming visible alongside the search-toggle button (both carry `aria-controls="search_nav"`, a separate pre-existing duplicate), which `SearchBarCollapseSystemTest#test_faceted_search_panel_open_close_stays_on_page` caught as a Capybara ambiguous-match error. Added the missing `.d-md-*`/`.d-lg-*` display blocks (still on BS3 pixel values, per the note above).

11 test files updated to match the new classes; `column_test.rb` gains coverage for the two new shorthand methods and the `display:` kwarg.

## Test plan

- [x] `bundle exec rubocop` on every touched file — no offenses
- [x] `bin/rails test test/components/column_test.rb` — 16 tests, all pass
- [x] `SearchBarCollapseSystemTest#test_faceted_search_panel_open_close_stays_on_page` — passes after the `_utilities.scss` fix

<!-- changelog -->
article: no
<!-- /changelog -->
