### PR TITLE
Fix flaky EXIF lat/lng system tests with granular per-step waits

### DIFF
--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1134,15 +1134,13 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     # Upload geotagged image (Miami/University Park area - 25.7582, -80.3731)
     click_attach_file("geotagged.jpg")
 
-    # Verify EXIF coordinates were copied
-    #
-    # wait: 20, not 10 -- EXIF extraction is client-side FileReader +
-    # binary parsing (form-exif_controller.js), CPU-bound like the map
-    # readiness wait above. Flaked at 10s under full-file contention
-    # (16 preceding heavy tests), reliable alone. Same bump applied to
-    # every occurrence of this wait in this file.
-    assert_field("observation_lat", with: GEOTAGGED_EXIF[:lat].to_s, wait: 20)
-    assert_field("observation_lng", with: GEOTAGGED_EXIF[:lng].to_s)
+    # Granular per-step waits (carousel item present -> EXIF text
+    # populated -> "use exif" button enabled -> geolocation collapse
+    # expanded -> field values set) instead of one wait on the final
+    # field value, which conflated several independent async steps
+    # (EXIF FileReader parsing, jQuery collapse animation) into a
+    # single timeout that flaked under full-suite contention.
+    assert_image_gps_copied_to_obs(GEOTAGGED_EXIF)
 
     # Autocompleter should be in location_containing mode (MO location exists)
     assert_selector("[data-type='location_containing']", wait: 10)
@@ -1379,7 +1377,10 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     assert_selector("body.observations__new")
 
     click_attach_file("geotagged.jpg")
-    assert_field("observation_lat", with: GEOTAGGED_EXIF[:lat].to_s, wait: 10)
+    # Granular per-step waits instead of one wait on the final field
+    # value -- see the comment on assert_image_gps_copied_to_obs's
+    # use in test_manual_lat_lng_overrides_exif_location above.
+    assert_image_gps_copied_to_obs(GEOTAGGED_EXIF)
     assert_selector("[data-type='location_containing']", wait: 10)
     sleep(2)
 


### PR DESCRIPTION
Two system tests that intermittently failed under full-suite load now wait for each intermediate UI step separately instead of one combined timeout, so a future failure will point at the specific step that's slow.

## Summary

Tracked in `.claude/local/todos.md`: this specific `observation_lat`/`observation_lng` field assertion has been "fixed" at least 5 times across separate PRs and keeps recurring, most recently by bumping a `wait:` value from 10 to 20.

Traced the failure mechanism this time instead of bumping the wait again: `assert_field("observation_lat", with: ..., wait: N)` requires the field to be *visible*, but the field's containing pane (`#observation_geolocation`) starts collapsed and only opens via a jQuery Bootstrap 3 `$(...).collapse('show')` call inside `form-exif_controller.js#showFields`, gated on EXIF extraction finishing first (`ExifReader.load`, client-side FileReader + binary parsing, CPU-bound). So the single assertion was waiting on two independent async operations — EXIF parsing and a CSS collapse animation — bundled into one timeout, with no way to tell from a failure which one was slow.

`test_manual_lat_lng_overrides_exif_location` and `test_typing_coordinates_does_not_steal_focus` are the two tests in `observation_form_system_test.rb` that hand-rolled this single wait. Other EXIF tests in the same file already use a shared helper, `assert_image_gps_copied_to_obs`, that breaks this into separate assertions: carousel item present → EXIF text populated in `.exif_lat` → "use exif" button enabled → geolocation collapse expanded (`#observation_geolocation.in`) → field values set. Switched both flaky tests to call it instead of hand-rolling a single wait.

## Test plan

- [x] `bundle exec rubocop` — no offenses
- [x] `bin/rails test test/system/observation_form_system_test.rb -n "/test_manual_lat_lng_overrides_exif_location|test_typing_coordinates_does_not_steal_focus/"` — both pass. (The original flake only manifested under full-suite CPU contention per the existing code comment, so passing in isolation doesn't fully prove the fix — but this now uses the identical pattern that keeps the file's other EXIF tests reliably green under that same contention.)

<!-- changelog -->
article: no
<!-- /changelog -->
