### PR TITLE
Permit the scalar URL form of Array-typed `query_attr`s (`?this_name=<id>`)

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -382,7 +382,10 @@ class Query
   # ApplicationController::QueryParams#create_query_from_url_params use
   # to decide which top-level URL params are live index filters.
   # A scalar attr (or param_alias) permits as a bare symbol; an
-  # Array-typed attr permits via `attr: []`; a Hash-typed attr --
+  # Array-typed attr permits both as a bare symbol (its scalar URL
+  # form, wrapped into an array by
+  # QueryParams#resolve_scalar_query_param) and via `attr: []`; a
+  # Hash-typed attr --
   # including a subquery hash like `location_query: { subquery: :Location }`
   # -- permits via `attr: {}`, Rails' "allow this key with any nested
   # content" filter. Validating what's inside an Array/Hash value is
@@ -393,7 +396,13 @@ class Query
     scalars = []
     attribute_types.each do |attr, type|
       case type.accepts
-      when Array then containers[attr] = []
+      when Array
+        # Both forms: `?names=x` and `?names[]=x&names[]=y`. A bare
+        # `attr: []` filter makes strong params silently drop the
+        # scalar form, which turned the Name-show observation links
+        # (`?this_name=<id>`) into unfiltered indexes.
+        scalars << attr
+        containers[attr] = []
       when Hash
         if enum_hash?(type.accepts)
           scalars << attr

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -347,14 +347,30 @@ class QueryTest < UnitTestCase
     # until permit_filters learned to tell enum hashes apart from
     # structural ones).
     assert_includes(filters, :location_undefined)
-    # Array-typed attrs permit via `attr: []`.
+    # Array-typed attrs permit both ways: bare symbol for the scalar
+    # URL form (`?projects=123`), `attr: []` for the array form
+    # (`?projects[]=123`). Array-only filters silently dropped the
+    # scalar form (the Name-show `?this_name=<id>` links).
     assert_equal([], containers[:by_users])
     assert_equal([], containers[:projects])
+    assert_includes(filters, :by_users)
+    assert_includes(filters, :projects)
+    assert_includes(filters, :this_name)
     # Structural hash-typed attrs, including subqueries, permit via
     # `attr: {}`.
     assert_equal({}, containers[:names])
     assert_equal({}, containers[:in_box])
     assert_equal({}, containers[:location_query])
+  end
+
+  def test_permit_filters_permits_array_typed_param_as_scalar
+    raw = ActionController::Parameters.new(this_name: "31346",
+                                           projects: "17")
+
+    permitted = raw.permit(*Query::Observations.permit_filters)
+
+    assert_equal("31346", permitted[:this_name])
+    assert_equal("17", permitted[:projects])
   end
 
   def test_permit_filters_permits_enum_hash_typed_param_as_scalar

--- a/test/controllers/observations_controller_index_test.rb
+++ b/test/controllers/observations_controller_index_test.rb
@@ -487,6 +487,28 @@ class ObservationsControllerIndexTest < FunctionalTestCase
     end
   end
 
+  # The scalar form of an Array-typed attr (`?this_name=<id>`, the URL
+  # the Name-show observation links generate) must filter the index --
+  # an array-only permit filter dropped it silently, rendering the
+  # unfiltered index instead.
+  def test_index_this_name_scalar_param
+    name = names(:fungi)
+    ids = Observation.where(name: name).map(&:id)
+    assert(ids.length.positive?, "Test needs different fixture for 'name'")
+
+    login("zero")
+    get(:index, params: { this_name: name.id })
+
+    assert_response(:success)
+    assert_displayed_filters("#{:query_this_name.l}: #{name.text_name}")
+    ids.each do |id|
+      assert_select(
+        "a:match('href', ?)", %r{^/obs/#{id}}, true,
+        "Observations of this Name should link to each Observation"
+      )
+    end
+  end
+
   def test_index_user_by_known_user
     # Make sure fixtures are still okay
     obs = observations(:coprinus_comatus_obs)


### PR DESCRIPTION
Fixes the Name show page "About this taxon" observation links rendering the unfiltered Observations index (user-reported: `/observations?this_name=31346` showed all 4,332 pages; `/observations?name=31346` showed the correct 3).

## Cause

`create_query_from_url_params` gates params through `raw_params.permit(*klass.permit_filters)`, and `Query.permit_filters` permitted an Array-typed attr only as `attr: []`. Rails strong params, given an array-only filter, silently drops the scalar form — so `?this_name=31346` permitted to `{}` and the dispatcher built an unfiltered query. No error, no flash.

`?name=` worked because `:name` is `any_name`'s `param_alias`, and aliases are permitted as bare scalars; the scalar then gets wrapped by `resolve_scalar_query_param`/`wrap_if_array_attr`. The attr names themselves lacked that path — since #5270 converted `Tab::Name::ObsLink#path` to plain route helpers emitting `?<attr>=<id>`, four of the five links (`this_name`, `any_name`, `other_names`, `name_proposed`) were broken this way; only `look_alikes` (record-typed, scalar permit) worked. The gap is wider than the tabs: every Array-typed query_attr ignored its scalar URL form (`?projects=123` was dropped; only `?project=123` or `?projects[]=123` worked), contrary to `.claude/rules/index_filter_params.md`.

## Fix

`Query.permit_filters` now permits every Array-typed attr in both forms — bare symbol (scalar) and `attr: []` (array). Rails accepts a key listed both ways, and the scalar path reuses the existing wrap machinery the aliases already exercise. One structural change; no per-attr or per-controller edits.

## Tests

- `Query` unit: array-typed attrs present in both permit forms; a scalar `this_name`/`projects` survives `permit`.
- `ObservationsController` index: `get(:index, params: { this_name: name.id })` renders the filtered index with the `this name` filter caption and links to each matching Observation (mirrors the existing `?name=` test).
- Regression: `test/classes/query_test.rb`, `test/classes/query/` (all subclasses), `observations_controller_index_test.rb`, `names_controller_index_test.rb` — 649 tests, 0 failures. RuboCop clean.

## Test plan

- [ ] Reviewer: on a Name show page, click "this name (N)" — the index should show N observations, not everything. Same for "any name", "other names", "name proposed".

<!-- changelog -->
article: yes
Fix Name page Observation links showing every Observation
<!-- /changelog -->
