### PR TITLE
Changelog for `deploy-2026-09-01-23-58`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-09-01 (deploy-2026-09-01-23-58)
+
+- Changelog for `deploy-2026-09-01-11-59` ([PR5282](https://github.com/MushroomObserver/mushroom-observer/pull/5282), @mo-nathan)
+- Fix theme change not applying until manual reload (`Account::PreferencesController#update`) ([PR5286](https://github.com/MushroomObserver/mushroom-observer/pull/5286), @nimmolo)
+- Add `MO/NoHandRolledColumnClass` cop; extend `NoRawBootstrapComponent` for Row/Container ([PR5280](https://github.com/MushroomObserver/mushroom-observer/pull/5280), @nimmolo)
+- Add flat top-level query params (`Query#index_filter`); migrate 6 same-model `Tab::*` links ([PR5279](https://github.com/MushroomObserver/mushroom-observer/pull/5279), @nimmolo)
+- Fix Turbo Frame badges silently swallowed by `collapse-fallback` ([PR5288](https://github.com/MushroomObserver/mushroom-observer/pull/5288), @nimmolo)
+- Fix form label row layout, `label_appends` slot, double-colon labels ([PR5287](https://github.com/MushroomObserver/mushroom-observer/pull/5287), @nimmolo)
+- Fix flaky EXIF lat/lng system tests with granular per-step waits ([PR5290](https://github.com/MushroomObserver/mushroom-observer/pull/5290), @nimmolo)
+- Permit the scalar URL form of Array-typed `query_attr`s (`?this_name=<id>`) ([PR5291](https://github.com/MushroomObserver/mushroom-observer/pull/5291), @mo-nathan)
+- Centralize BS3 responsive visibility helpers behind `Components::Column` ([PR5289](https://github.com/MushroomObserver/mushroom-observer/pull/5289), @nimmolo)
+
 ## 2026-09-01 (deploy-2026-09-01-11-59)
 
 - Adopt a field slip onto a slip-less occurrence in `Observation#field_slip=` ([PR5269](https://github.com/MushroomObserver/mushroom-observer/pull/5269), @mo-nathan)

--- a/article_pending.textile
+++ b/article_pending.textile
@@ -1,0 +1,4 @@
+|{white-space:nowrap}. 2026-09-01 | Fix Name page Observation links showing every Observation | "PR#5291":https://github.com/MushroomObserver/mushroom-observer/pull/5291 |
+|{white-space:nowrap}. 2026-09-01 | Fix form fields where help text overlapped the label | "PR#5287":https://github.com/MushroomObserver/mushroom-observer/pull/5287 |
+|{white-space:nowrap}. 2026-09-01 | Fix the iNat badge on imported Observations showing an empty panel | "PR#5288":https://github.com/MushroomObserver/mushroom-observer/pull/5288 |
+|{white-space:nowrap}. 2026-09-01 | Fix theme changes not applying until a page reload | "PR#5286":https://github.com/MushroomObserver/mushroom-observer/pull/5286 |


### PR DESCRIPTION
Pre-deploy changelog for `deploy-2026-09-01-23-58` (issue #5155): the CHANGELOG.md section for every PR merged since `deploy-2026-09-01-11-59`, and `article_pending.textile` with the MO Article rows the deploy will publish. Merge this as the last PR before deploying; re-running `script/prerelease.rb --apply` refreshes it with any later merges.

## Expected MO Article lines

```
|{white-space:nowrap}. 2026-09-01 | Fix Name page Observation links showing every Observation | "PR#5291":https://github.com/MushroomObserver/mushroom-observer/pull/5291 |
|{white-space:nowrap}. 2026-09-01 | Fix form fields where help text overlapped the label | "PR#5287":https://github.com/MushroomObserver/mushroom-observer/pull/5287 |
|{white-space:nowrap}. 2026-09-01 | Fix the iNat badge on imported Observations showing an empty panel | "PR#5288":https://github.com/MushroomObserver/mushroom-observer/pull/5288 |
|{white-space:nowrap}. 2026-09-01 | Fix theme changes not applying until a page reload | "PR#5286":https://github.com/MushroomObserver/mushroom-observer/pull/5286 |
```
(5 PR(s) marked `article: no`.) Edits to `article_pending.textile` in this PR are what the deploy publishes.

<!-- changelog -->
article: no
<!-- /changelog -->
