### PR TITLE
Deploy from the pre-release changelog and publish the MO Article rows

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -98,7 +98,11 @@ Textile row per `article: yes` PR merged since the last deploy. The
 rows in that file are what the deploy publishes to the Article — edit
 them in the PR; blockless PRs are listed in the PR body for a
 verdict. Re-run after last-minute merges; merge the PR last, then
-deploy.
+deploy. `deploy.sh` tags the deploy with the heading's tag name and
+publishes the rows (best-effort) via
+`script/update_article_changelog.rb`; with no pre-release it warns
+and offers a force deploy that skips both, rolling the PRs into the
+next cycle.
 
 `script/article_rows.rb --since YYYY-MM-DD [--until YYYY-MM-DD]`
 prints rows for a date range (backfills, audits), newest first,

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -105,7 +105,7 @@ if [ "$(git branch | grep '^\*')" != "* main" ]; then
     exit 1
 fi
 
-echo Fetching latest from origin... && git fetch origin
+echo Fetching latest from origin... && git fetch --tags origin
 if [ $? -ne 0 ]; then
     echo git fetch failed.
     exit 1
@@ -120,6 +120,51 @@ if [ "$EXPECTED_RUBY" != "$CURRENT_RUBY" ]; then
     echo "Please install and activate Ruby $EXPECTED_RUBY before deploying."
     echo "See README_RUBY_34_UPGRADE.md for instructions."
     exit 1
+fi
+
+# Pre-release changelog check (issue #5155). The pre-release PR wrote
+# the upcoming deploy's tag name into CHANGELOG.md's top heading; a
+# top heading whose tag already exists in git means no pre-release ran
+# for this deploy. Checked against origin/main (the code that will be
+# pulled below), before anything is paused or stopped.
+update_article=0
+pending_tag=`git show origin/main:CHANGELOG.md 2>/dev/null | \
+    grep -m1 -oE '^## [0-9-]+ \(deploy-[0-9-]+\)' | \
+    sed -E 's/.*\((deploy-[0-9-]+)\).*/\1/'`
+if [ -n "$pending_tag" ] && \
+   ! git rev-parse -q --verify "refs/tags/$pending_tag" >/dev/null; then
+    tag="$pending_tag"
+    update_article=1
+    echo "Pre-release found: tagging this deploy $tag and updating the"
+    echo "MO Article from article_pending.textile."
+else
+    echo ""
+    echo "WARNING: no pre-release changelog found for this deploy, so"
+    echo "CHANGELOG.md has no section for it and the MO Article will not"
+    echo "be updated."
+    echo ""
+    echo "The pre-release process (issue #5155):"
+    echo "  1. On a dev machine: ruby script/prerelease.rb --apply"
+    echo "     (builds the changelog-pending PR with the next CHANGELOG.md"
+    echo "      section and article_pending.textile's MO Article rows)"
+    echo "  2. Review and merge that PR as the last PR before deploying."
+    echo "  3. Run script/deploy.sh -- it tags the deploy with the"
+    echo "     pre-release's tag name and publishes the Article rows."
+    echo ""
+    echo "Forcing deploys main as-is (useful for an urgent fix); the"
+    echo "skipped PRs roll into the next pre-release/deploy cycle."
+    printf "Force the deploy without a changelog? [y/N] "
+    read -r answer
+    case "$answer" in
+        y|Y|yes|YES)
+            echo "Forcing deploy without changelog or MO Article update."
+            ;;
+        *)
+            echo "Deploy aborted. Run the pre-release, then deploy again."
+            exit 1
+            ;;
+    esac
+    tag=`date "+deploy-%Y-%m-%d-%H-%M"`
 fi
 
 # Pause all queues so no NEW jobs start, then wait (up to the drain timeout)
@@ -148,7 +193,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-tag=`date "+deploy-%Y-%m-%d-%H-%M"`
 echo Going for it\!
 
 # Put up the maintenance page BEFORE stopping puma so users hit a
@@ -228,10 +272,7 @@ echo Precompiling assets... && rake assets:precompile && \
 echo Starting puma... && sudo service puma start && \
 echo Starting solidqueue... && sudo service solidqueue start && \
 echo Resuming queues... && bundle exec rails runner script/resume_jobs.rb && \
-echo Taking down maintenance page... && rm -f public/maintenance.html && \
-echo Tagging repo with $tag... && git tag $tag && \
-echo Pushing new tag... && git push --tags && \
-echo SUCCESS\!
+echo Taking down maintenance page... && rm -f public/maintenance.html
 
 if [ $? -ne 0 ]; then
     echo ""
@@ -239,5 +280,28 @@ if [ $? -ne 0 ]; then
     sudo service puma start
     sudo service solidqueue start
     echo Resuming queues... && bundle exec rails runner script/resume_jobs.rb
+    exit 1
+fi
+
+# Best-effort (#5155): a failure here warns and the deploy still
+# succeeds -- the Article is cosmetic; the site is already up.
+if [ "$update_article" = "1" ]; then
+    echo Updating the MO Article from article_pending.textile...
+    bundle exec rails runner script/update_article_changelog.rb --apply
+    if [ $? -ne 0 ]; then
+        echo "WARNING: MO Article update failed; the deploy continues."
+        echo "Retry by hand:"
+        echo "  bundle exec rails runner script/update_article_changelog.rb --apply"
+    fi
+fi
+
+echo Tagging repo with $tag... && git tag $tag && \
+echo Pushing new tag... && git push --tags && \
+echo SUCCESS\!
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "Site is up, but tagging/pushing $tag failed. Fix and re-run:"
+    echo "  git tag $tag && git push --tags"
     exit 1
 fi

--- a/script/update_article_changelog.rb
+++ b/script/update_article_changelog.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Publishes article_pending.textile (written by the pre-release PR,
+# see script/prerelease.rb and issue #5155) into the MO Article
+# changelog. Run by script/deploy.sh after a pre-release deploy; safe
+# to re-run by hand if that step failed.
+#
+#   Dry run (default -- reports what WOULD change, writes nothing):
+#     bundle exec rails runner script/update_article_changelog.rb
+#   Live run:
+#     bundle exec rails runner script/update_article_changelog.rb --apply
+#
+# The rows are inserted just below the article's table header line.
+# Idempotent: if the article body already contains the first pending
+# row, nothing is written (covers a re-run after a failed deploy step
+# and a deploy with a stale, already-published file).
+#
+# The article id is bumped by hand at yearly rollover (create the next
+# year's article, update the constant) -- article creation is not
+# automated.
+ARTICLE_ID = 55
+PENDING_FILE = "article_pending.textile"
+HEADER_ROW = "| +date+ | +what+ | +link+ |"
+SCRIPT = "bundle exec rails runner script/update_article_changelog.rb"
+
+args = ARGV.dup
+apply = args.delete("--apply") ? true : false
+abort("Unknown arguments: #{args.join(" ")}") unless args.empty?
+
+unless File.exist?(PENDING_FILE)
+  puts("No #{PENDING_FILE}; nothing to publish.")
+  exit(0)
+end
+
+rows = File.read(PENDING_FILE).lines.map(&:chomp).reject(&:empty?)
+if rows.empty?
+  puts("#{PENDING_FILE} is empty; nothing to publish.")
+  exit(0)
+end
+
+article = Article.find(ARTICLE_ID)
+
+if article.body.to_s.include?(rows.first)
+  puts("Article #{ARTICLE_ID} already contains the first pending row; " \
+       "nothing to publish.")
+  exit(0)
+end
+
+# The body may carry CRLF line endings (it is pasted through a web
+# form); insert with whatever the body uses.
+eol = article.body.to_s.include?("\r\n") ? "\r\n" : "\n"
+lines = article.body.to_s.split(/\r?\n/, -1)
+header_index = lines.index { |line| line.strip == HEADER_ROW }
+unless header_index
+  abort("Article #{ARTICLE_ID} has no #{HEADER_ROW.inspect} header " \
+        "line; fix the article body, then re-run: #{SCRIPT} --apply")
+end
+
+puts("Inserting #{rows.size} row(s) below the header of Article " \
+     "#{ARTICLE_ID} (#{article.title}):")
+rows.each { |row| puts("  #{row}") }
+
+unless apply
+  puts("Dry run - nothing written. To apply: #{SCRIPT} --apply")
+  exit(0)
+end
+
+new_lines = lines[0..header_index] + rows + lines[(header_index + 1)..]
+# update_columns: Article autologs updates to the activity feed, and a
+# routine changelog append should not post a feed entry per deploy.
+article.update_columns(body: new_lines.join(eol),
+                       updated_at: Time.zone.now)
+puts("Done: Article #{ARTICLE_ID} updated.")


### PR DESCRIPTION
Phase 2 of the #5155 pre-release workflow (phase 1: #5281). `deploy.sh` now applies the pre-release PR's output; a deploy without a pre-release warns, explains the process, and offers a force.

## `script/deploy.sh`

- **Pre-release check, before anything pauses or stops.** Reads the top `## YYYY-MM-DD (deploy-…)` heading from `origin/main:CHANGELOG.md` (the code about to be pulled). A heading whose tag does not exist in git = the pending pre-release: the deploy tags with that name and enables the Article step. (The existing `git fetch origin` gained `--tags` so the existence test is against current tags.)
- **No pre-release found**: warns that CHANGELOG.md has no section for this deploy and the MO Article will not be updated, prints the three-step pre-release process, and prompts `Force the deploy without a changelog? [y/N]`. Decline aborts before anything has been touched; force proceeds as the current script does (mints a date tag, no changelog/Article writes) — for urgent fixes; the skipped PRs roll into the next pre-release cycle.
- **MO Article step**: after the site is back up (post-migrations, maintenance page down), best-effort — a failure warns with the retry command and the deploy still succeeds. Runs only on the pre-release path.
- The tag/push step now has a separate failure message (the site is already up at that point; the old "restarting with existing code" text was wrong for it).

## `script/update_article_changelog.rb`

Publishes `article_pending.textile` into the Article (id constant 55; yearly rollover stays manual — create the next year's article, bump the constant). Dry-run by default, `--apply` from deploy.sh. Inserts the rows just below the `| +date+ | +what+ | +link+ |` header, preserving the body's CRLF/LF style. Idempotent: skips when the body already contains the first pending row (re-run after a failed step, or a stale already-published file). Missing header line aborts with a fix-and-retry message. Uses `update_columns` deliberately: `Article` autologs `:updated!` to the activity feed, and a routine append should not post a feed entry per deploy — say the word if you'd rather each deploy's Article update show in the feed.

## Verified

- Runner tested against a local Article 55 in the new format: dry run, apply (rows landed under the header, CRLF preserved), idempotent re-apply, and the missing-header abort. RuboCop clean; `bash -n` clean; force-prompt branch tested with piped y/n.
- The tag-extraction pipeline run against today's `origin/main` correctly finds the live pending pre-release `deploy-2026-09-01-23-58` — so the next deploy is the first end-to-end exercise, with `article_pending.textile`'s 4 rows.

## Test plan

- [ ] Reviewer: next deploy — confirm it announces the pre-release, tags `deploy-2026-09-01-23-58`, and the 4 pending rows appear under the Article's header. Then, some deploy without a pre-release: confirm the warning + prompt, that `n` aborts cleanly, and (if forcing) that everything else behaves as before.

<!-- changelog -->
article: no
<!-- /changelog -->
