### PR TITLE
Update stale references to the pre-prerelease changelog flow

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -11,17 +11,20 @@ Add clustering and zoom to name list maps
 ```
 
 This is the PR-time half of the automated changelog (issue #5155).
-Two changelogs are generated from merged PRs at deploy time:
+Two changelogs are generated from merged PRs by the pre-release step
+(`script/prerelease.rb`, run before each deploy — see
+README_PRODUCTION_DEPLOY):
 
-- **`CHANGELOG.md`** — technical, lists every merged PR. Nothing to do
-  per-PR; the generator uses the PR title.
+- **`CHANGELOG.md`** — technical, lists every merged PR (except the
+  changelog PRs themselves). Nothing to do per-PR; the generator uses
+  the PR title.
 - **The MO Article changelog** (user-facing, curated) — fed by this
   block: `article:` decides whether the PR appears there, and the
-  sentence is what site users read.
+  sentence is what site users read. The deploy publishes the rows.
 
 Reviewers edit the block in place like any other part of the PR body.
-A PR with no block is excluded from the Article and flagged in the
-deploy output for manual review — the block is how a deliberate
+A PR with no block is excluded from the Article and listed in the
+pre-release PR's body for a verdict — the block is how a deliberate
 decision is told apart from an omission.
 
 ## Filling it in

--- a/script/article_rows.rb
+++ b/script/article_rows.rb
@@ -8,6 +8,10 @@
 # parseable block are listed on stderr for a human to judge. Nothing
 # is written anywhere -- paste the rows into the article by hand.
 #
+# For backfills and audits over a date range. The live flow runs
+# through script/prerelease.rb, which uses rows_for below and lets
+# the deploy publish the rows (see README_PRODUCTION_DEPLOY).
+#
 #   script/article_rows.rb --since 2026-08-22 [--until 2026-08-31]
 #
 # Rows come out newest first, in the article's table format, with the

--- a/script/generate_changelog.rb
+++ b/script/generate_changelog.rb
@@ -24,8 +24,9 @@
 # so a failure mid-run keeps what was already written, and a rerun
 # skips sections already present unless --replace is given.
 #
-# Standalone by design -- the deploy.sh hook comes later, once the
-# format has settled.
+# These CLI modes are for backfills and regeneration. The live flow
+# runs through script/prerelease.rb, which drives this class's
+# pending API to build the next deploy's section before the deploy.
 
 require("date")
 require("json")


### PR DESCRIPTION
Follow-up sweep after #5294/#5295: three texts still described the pre-#5155-phase-2 process.

- `.claude/rules/changelog.md` intro: said the changelogs are generated "at deploy time" and blockless PRs are "flagged in the deploy output" — now generated by the pre-release step, with blockless PRs listed in the pre-release PR's body; also notes the changelog PRs' self-exclusion and that the deploy publishes the Article rows.
- `script/generate_changelog.rb` header: dropped "Standalone by design -- the deploy.sh hook comes later"; the CLI modes are for backfills/regeneration, the live flow runs through `script/prerelease.rb`'s pending API.
- `script/article_rows.rb` header: kept the paste-by-hand CLI description (still what it does) but framed it as the backfill/audit tool, pointing at the live flow.

Comment-only; no behavior changes. Swept README*, `.claude/rules/`, `config/etc/`, `script/`, `CLAUDE.md`, `.github/` for other mentions of the old flow — the rest are current (`README_RUBY_34_UPGRADE.md`'s deploy mention still holds; `script/test_deploy.sh~` is an untracked local backup, not repo content).

<!-- changelog -->
article: no
<!-- /changelog -->
