### PR TITLE
Shrink `Query#index_filter` URLs: bare scalars, `names`→`this_name`

### DIFF
--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -575,6 +575,8 @@ class Query
       names[:lookup].length == 1 &&
       (names.keys - [:lookup]).all? { |k| names[k].blank? }
   end
+  private :shrink_multi_value_filters, :collapse_names_to_this_name,
+          :collapsible_to_this_name?
 
   # Merges an already-resolved `q` param value into a path's
   # existing query string (preserving other params, e.g. `flow=next`).

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -559,6 +559,10 @@ class Query
   # as `scope :this_name`'s bare call).
   def collapse_names_to_this_name(filters)
     return filters unless self.class.has_attribute?(:this_name)
+    # Don't clobber an already-present :this_name filter -- both keys
+    # are independently recognized top-level params, so a request can
+    # legitimately carry both at once.
+    return filters if filters.key?(:this_name)
 
     names = filters[:names]
     return filters unless collapsible_to_this_name?(names)

--- a/app/classes/query.rb
+++ b/app/classes/query.rb
@@ -531,7 +531,45 @@ class Query
   # one of those names would silently clobber the routing key it's
   # merged over instead of raising.
   def index_filter
-    params.except(:controller, :action, :id, :format)
+    shrink_multi_value_filters(
+      collapse_names_to_this_name(
+        params.except(:controller, :action, :id, :format)
+      )
+    )
+  end
+
+  # `?project=123` instead of `?projects[]=123`. Round-trips
+  # correctly, not just cosmetic -- `permit_filters` already permits
+  # a bare scalar for every Array-typed attr, and `array_validate`
+  # wraps it back into a one-element array.
+  def shrink_multi_value_filters(filters)
+    attr_to_alias = self.class.param_aliases.invert
+    filters.each_with_object({}) do |(attr, val), result|
+      if val.is_a?(Array) && val.length == 1
+        result[attr_to_alias[attr] || attr] = val.first
+      else
+        result[attr] = val
+      end
+    end
+  end
+
+  # Query::Observations-only: `names: {lookup: [x]}` with every
+  # modifier flag absent/false is identical to `this_name: [x]`
+  # (`Observation::Scopes#names` treats absent kwargs as falsy, same
+  # as `scope :this_name`'s bare call).
+  def collapse_names_to_this_name(filters)
+    return filters unless self.class.has_attribute?(:this_name)
+
+    names = filters[:names]
+    return filters unless collapsible_to_this_name?(names)
+
+    filters.except(:names).merge(this_name: names[:lookup])
+  end
+
+  def collapsible_to_this_name?(names)
+    names.is_a?(Hash) && names[:lookup].is_a?(Array) &&
+      names[:lookup].length == 1 &&
+      (names.keys - [:lookup]).all? { |k| names[k].blank? }
   end
 
   # Merges an already-resolved `q` param value into a path's

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -1419,8 +1419,52 @@ class QueryTest < UnitTestCase
   def test_index_filter
     params = { by_users: [rolf.id], names: { lookup: ["Coprinus comatus"] } }
     query = Query.lookup(:Observation, **params)
-    # Same params as q_param, but no :model.
-    assert_equal(query.index_filter, params)
+    # Same params as q_param minus :model, but with each one-element
+    # array shrunk to a bare scalar -- by_users -> its param_alias
+    # by_user, and the one-name/no-modifiers names: hash collapsed to
+    # this_name (Query::Observations-only; see collapse_names_to_this_name).
+    assert_equal({ by_user: rolf.id, this_name: "Coprinus comatus" },
+                 query.index_filter)
+  end
+
+  def test_index_filter_multiple_values_keeps_bracket_array_form
+    list1 = species_lists(:first_species_list)
+    list2 = species_lists(:another_species_list)
+    query = Query.lookup(:Observation, species_lists: [list1.id, list2.id])
+
+    # More than one value: no alias substitution, stays an array.
+    assert_equal({ species_lists: [list1.id, list2.id] }, query.index_filter)
+  end
+
+  def test_index_filter_names_not_collapsed_with_multiple_lookup_values
+    query = Query.lookup(:Observation,
+                         names: { lookup: %w[Agaricus Boletus] })
+
+    # More than one lookup value: not collapsible to this_name.
+    assert_equal({ names: { lookup: %w[Agaricus Boletus] } },
+                 query.index_filter)
+  end
+
+  def test_index_filter_names_not_collapsed_with_modifier_set
+    query = Query.lookup(:Observation,
+                         names: { lookup: ["Agaricus"],
+                                  include_synonyms: true })
+
+    # A modifier flag is set: not semantically equivalent to
+    # this_name, which carries no synonym/subtaxa expansion.
+    assert_equal(
+      { names: { lookup: ["Agaricus"], include_synonyms: true } },
+      query.index_filter
+    )
+  end
+
+  def test_index_filter_names_not_collapsed_without_this_name_attr
+    # Query::Names has no :this_name attr -- collapse_names_to_this_name
+    # must no-op rather than emitting a param the class won't recognize.
+    assert_not(Query::Names.has_attribute?(:this_name))
+    query = Query.lookup(:Name, names: { lookup: ["Agaricus"] })
+
+    assert_equal({ names: { lookup: ["Agaricus"] } }, query.index_filter)
   end
 
   def test_index_filter_excludes_routing_keys
@@ -1431,7 +1475,7 @@ class QueryTest < UnitTestCase
     query.params = query.params.merge(controller: "x", action: "y",
                                       id: 1, format: "json")
 
-    assert_equal({ by_users: [rolf.id] }, query.index_filter)
+    assert_equal({ by_user: rolf.id }, query.index_filter)
   end
 
   def test_merge_q_param_into_url

--- a/test/classes/query_test.rb
+++ b/test/classes/query_test.rb
@@ -1467,6 +1467,18 @@ class QueryTest < UnitTestCase
     assert_equal({ names: { lookup: ["Agaricus"] } }, query.index_filter)
   end
 
+  def test_index_filter_does_not_clobber_explicit_this_name
+    # Both :this_name and :names are independently recognized
+    # top-level params -- a request can legitimately carry both, and
+    # collapse_names_to_this_name must not silently drop the explicit
+    # this_name filter in favor of the derived one.
+    query = Query.lookup(:Observation, this_name: ["Foo"],
+                                       names: { lookup: ["Bar"] })
+
+    assert_equal({ this_name: "Foo", names: { lookup: ["Bar"] } },
+                 query.index_filter)
+  end
+
   def test_index_filter_excludes_routing_keys
     query = Query.lookup(:Observation, by_users: [rolf.id])
     # No query_attr is currently named these, but a future one could

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -292,7 +292,7 @@ class ApplicationControllerTest < FunctionalTestCase
     name_query = Query.lookup_and_save(:Name, by_users: [rolf.id])
     @controller.store_query_in_session(name_query)
 
-    assert_equal({ by_users: [rolf.id] }, @controller.index_filter(:Name))
+    assert_equal({ by_user: rolf.id }, @controller.index_filter(:Name))
   end
 
   def test_index_filter_with_explicit_query_checks_model_too
@@ -303,7 +303,7 @@ class ApplicationControllerTest < FunctionalTestCase
 
     assert_nil(@controller.index_filter(:Name, observation_query))
     assert_equal(
-      { by_users: [rolf.id] },
+      { by_user: rolf.id },
       @controller.index_filter(:Observation, observation_query)
     )
   end


### PR DESCRIPTION
Every index-filter link built from `Query#index_filter` now prefers the shortest URL form that still parses correctly, instead of always emitting a bracketed array.

## Summary

`Query#index_filter` produced the same nested params structure as `q_param`, minus `:model` -- a one-element Array value always serialized as a bracketed array (`?projects[]=380`) rather than a bare scalar (`?project=380`). But `permit_filters` already permits every Array-typed attr both ways, and `array_validate` already wraps a bare scalar back into a one-element array during query construction. This is not only cosmetic: the bare-scalar form was already load-bearing for `this_name`'s Name-show observation links (see `permit_filters`'s comment).

Two changes, both inside `index_filter`:

1. **Bare scalar for single-value attrs.** Any one-element Array value shrinks to a bare scalar, preferring a declared `param_alias` name (`project`) over the attr's plural name (`projects`) when one exists.
2. **`Query::Observations`-only: `names` collapses to `this_name` when possible.** `names: {lookup: [x]}` with every modifier flag absent/false is identical to `this_name: [x]` -- `Observation::Scopes#names` treats absent kwargs as falsy, matching `scope :this_name`'s bare call. Guarded by `has_attribute?(:this_name)`, since `Query::Names`/`Query::Projects`/`Query::SpeciesLists` share the same `names` shape but have no `this_name`-equivalent attr.

Every consumer of `Query#index_filter` was checked against this change: the `ApplicationController::Queries#index_filter` helper (and its callers in `app/views/controllers/*`), and the `Tab::*` classes that build "return to index" links off it (`Tab::SpeciesList::Index`, `Tab::Observation::Index`, `Tab::SpeciesList::ObservationsIndexReturn`).

## Test plan

- [x] `bundle exec rubocop` on every touched file -- no offenses
- [x] `bin/rails test test/classes/query_test.rb` -- 82 tests, all pass (3 new tests added covering the non-collapsible cases: multiple lookup values, a modifier flag set, and a model with no `this_name` attr)
- [x] `bin/rails test test/controllers/application_controller_test.rb` -- 20 tests, all pass
- [x] Every `Tab::*` test file that exercises `index_filter` -- run individually, all pass
- [x] `observations_controller_index_test.rb`, `interests_controller_test.rb`, `articles_controller_test.rb` -- run individually, all pass

<!-- changelog -->
article: no
<!-- /changelog -->
