### PR TITLE
Fix #5276: shrink, guard, and resolve oversized search-result redirect URLs

### DIFF
--- a/app/controllers/application_controller/query_params.rb
+++ b/app/controllers/application_controller/query_params.rb
@@ -25,6 +25,13 @@ module ApplicationController::QueryParams
     resolved, force_index = resolve_query_param_records(klass, permitted)
     return nil unless resolved
 
+    # `?always_index=1` -- not a query_attr, a marker any caller (e.g.
+    # Searchable#create's redirect) can add to guarantee an index page
+    # even when the query matches only one record. Without it, a
+    # search whose recognized attrs don't individually force
+    # always_index would otherwise redirect straight to that record's
+    # show page instead of the results list.
+    force_index ||= raw_params[:always_index].present?
     query = create_query(model_symbol, resolved)
     [query, { always_index: force_index }]
   end

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -72,8 +72,12 @@ module Searchable
 
     def save_search_query_and_redirect_to_index
       save_search_query
+      # always_index: 1 preserves MO's existing guarantee that a search
+      # submission lands on the results list, not a same-request
+      # auto-redirect to a single match -- see
+      # ApplicationController::QueryParams#create_query_from_url_params.
       redirect_to(controller: "/#{search_type}", action: :index,
-                  **@query.index_filter)
+                  always_index: 1, **@query.index_filter)
     end
 
     def prepare_raw_params
@@ -81,6 +85,7 @@ module Searchable
       null_box_if_invalid
       null_region_if_overspecific_and_box_valid
       autocompleted_strings_to_ids
+      resolve_fields_preferring_ids_to_ids
       range_fields_to_arrays
       parse_date_ranges
       normalize_notes_fields
@@ -196,6 +201,29 @@ module Searchable
         @query_params[key] = @query_params[:"#{key}_id"].split(",")
         @query_params.delete(:"#{key}_id")
       end
+    end
+
+    # A field autocompleted_strings_to_ids left as raw text (no
+    # matching client-side autocompleter match) breaks the post-search
+    # redirect: QueryParams#resolve_record_backed_value treats a
+    # single-value record-backed field as a strict id-only lookup, no
+    # name fallback. Already-resolved ids pass through Lookup
+    # unchanged, so this is safe to run on every search.
+    def resolve_fields_preferring_ids_to_ids
+      fields_preferring_ids.each do |field|
+        next if @query_params[field].blank?
+
+        klass = lookup_class_for(field)
+        @query_params[field] = klass.new(@query_params[field]).ids.
+                               map(&:to_s)
+      end
+    end
+
+    def lookup_class_for(field)
+      query_class = "Query::#{query_model.to_s.pluralize}".constantize
+      accepts = query_class.attribute_types[field]&.accepts
+      model = accepts.is_a?(Array) ? accepts.first : accepts
+      "Lookup::#{model.name.pluralize}".constantize
     end
 
     # Check for `fields_with_range`, and join them into array if range present.
@@ -348,11 +376,8 @@ module Searchable
     end
 
     def multiple_value_count(field)
-      value = if field.is_a?(Array)
-                @query_params.dig(*field)
-              else
-                @query_params[field]
-              end
+      value =
+        field.is_a?(Array) ? @query_params.dig(*field) : @query_params[field]
       return 0 if value.blank?
       return value.length if value.is_a?(Array)
 
@@ -395,12 +420,6 @@ module Searchable
       @query = Query.lookup_and_save(query_model, **@search.params)
     end
 
-    def escape_location_string(location) = "\"#{location.tr(",", "\\,")}\""
-
-    # def strings_with_commas
-    #   [:location, :region].freeze
-    # end
-
     def fields_preferring_ids = []
 
     def fields_with_range = []
@@ -413,17 +432,5 @@ module Searchable
       @query_params[:has_notes_fields] =
         val.split("\n").map { |f| f.strip.tr(" ", "_") }.compact_blank
     end
-
-    # Passing some fields will raise an error if the required field is missing,
-    # so just toss them. Not sure we have to do this, because Query will.
-    # def remove_invalid_field_combinations
-    #   return unless respond_to?(:fields_with_requirements)
-
-    #   fields_with_requirements.each do |req, fields|
-    #     next if @search[req].present?
-
-    #     fields.each { |field| @search.delete(field) }
-    #   end
-    # end
   end
 end

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -14,6 +14,29 @@ module Searchable
   # Maximum allowed total length of all search input fields
   MAX_SEARCH_INPUT_LENGTH = 8000
 
+  # Maximum allowed length of the flat index-filter query string built
+  # for the post-search redirect. Front-end proxies commonly reject an
+  # overlong request line before it reaches Rails (nginx's compiled
+  # default is 8KB total) -- a pasted multi-value field (e.g. Names)
+  # can build a redirect URL well past that, which then shows up as a
+  # broken page or a generic error instead of a useful message. Kept
+  # well under 8KB to leave room for the rest of the request line and
+  # for tighter limits at other layers (CDN, WAF). See issue #5276.
+  MAX_INDEX_FILTER_URL_LENGTH = 4000
+
+  # Maximum newline-separated values a single multi-value autocompleter
+  # field (Names, Users, Projects, ...) may submit. This does NOT by
+  # itself guarantee the redirect URL stays under
+  # MAX_INDEX_FILTER_URL_LENGTH -- Name.search_name in production
+  # ranges up to 133 characters (99.9th percentile: 97), so 50 unusually
+  # long entries can still total more than that guard allows, and
+  # there's no per-entry length cap. This check exists for the common
+  # case instead: a field-specific message ("Names: too many values")
+  # is far more actionable than the generic aggregate-length one when
+  # one field is the problem, which is what issue #5276 reported.
+  # MAX_INDEX_FILTER_URL_LENGTH stays the unconditional backstop.
+  MAX_MULTIPLE_VALUES = 50
+
   included do
     def create
       redirect_to(action: :new) and return if clear_form?
@@ -22,11 +45,25 @@ module Searchable
       @query_params = params.require(search_object_name).permit(permittables)
 
       prepare_raw_params
-      redirect_to(action: :new) and return unless validate_search_instance?
+      redirect_to(action: :new) and return if search_input_invalid?
 
+      save_search_query_and_redirect_to_index
+    end
+
+    # Order matters: cheapest/most-actionable check first. A single
+    # oversized field gets a field-specific message before falling
+    # through to Query's validation errors or the generic aggregate-
+    # length guard.
+    def search_input_invalid?
+      too_many_multiple_values? ||
+        !validate_search_instance? ||
+        index_filter_url_too_long?
+    end
+
+    def save_search_query_and_redirect_to_index
       save_search_query
       redirect_to(controller: "/#{search_type}", action: :index,
-                  q: @query.q_param)
+                  **@query.index_filter)
     end
 
     def prepare_raw_params
@@ -227,6 +264,72 @@ module Searchable
       messages = @search.validation_error_messages.compact_blank
       flash_error(*messages) if messages.present?
       false
+    end
+
+    # Guards against a single multi-value autocompleter field (Names,
+    # Users, Projects, ...) carrying more than MAX_MULTIPLE_VALUES
+    # pasted values. Runs on the raw (pre-Query) params, before
+    # validate_search_instance?, so it can name the offending field.
+    def too_many_multiple_values?
+      multiple_value_fields.each do |field|
+        count = multiple_value_count(field)
+        next if count <= Searchable::MAX_MULTIPLE_VALUES
+
+        flash_error(
+          :runtime_search_too_many_values.t(
+            field: multiple_value_field_label(field), count: count,
+            max: Searchable::MAX_MULTIPLE_VALUES
+          )
+        )
+        return true
+      end
+      false
+    end
+
+    # Every field this controller accepts as a newline-separated list
+    # of pasted values: the top-level `fields_preferring_ids`
+    # autocompleters, plus the nested Names lookup field when this
+    # controller has one (represented as a 2-element path for
+    # `@query_params.dig`).
+    def multiple_value_fields
+      fields = fields_preferring_ids.dup
+      fields << [:names, :lookup] if nested_names_params.include?(:lookup)
+      fields
+    end
+
+    def multiple_value_count(field)
+      value = if field.is_a?(Array)
+                @query_params.dig(*field)
+              else
+                @query_params[field]
+              end
+      return 0 if value.blank?
+      return value.length if value.is_a?(Array)
+
+      value.to_s.split("\n").compact_blank.length
+    end
+
+    def multiple_value_field_label(field)
+      return :names.t.to_s if field.is_a?(Array)
+
+      :"query_#{field}".l.humanize
+    end
+
+    # Guards against a redirect URL too long for a front-end proxy's
+    # request-line limit -- see MAX_INDEX_FILTER_URL_LENGTH above.
+    # Only called once `@search` (built in validate_search_instance?)
+    # is known valid, so `index_filter` matches the redirect built
+    # afterward.
+    def index_filter_url_too_long?
+      length = @search.index_filter.to_query.bytesize
+      return false if length <= Searchable::MAX_INDEX_FILTER_URL_LENGTH
+
+      flash_error(
+        :runtime_search_string_too_long.t(
+          max: Searchable::MAX_INDEX_FILTER_URL_LENGTH, length: length
+        )
+      )
+      true
     end
 
     def clear_relevant_query

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -10,6 +10,7 @@
 
 module Searchable
   extend ActiveSupport::Concern
+  include Searchable::MatchGuards
 
   # Maximum allowed total length of all search input fields
   MAX_SEARCH_INPUT_LENGTH = 8000
@@ -21,31 +22,8 @@ module Searchable
   # can build a redirect URL well past that, which then shows up as a
   # broken page or a generic error instead of a useful message. Kept
   # well under 8KB to leave room for the rest of the request line and
-  # for tighter limits at other layers (CDN, WAF). See issue #5276.
+  # for tighter limits at other layers (CDN, WAF).
   MAX_INDEX_FILTER_URL_LENGTH = 4000
-
-  # Maximum newline-separated values a single multi-value autocompleter
-  # field (Users, Projects, ...) may submit before being rejected
-  # outright. This does NOT by itself guarantee the redirect URL stays
-  # under MAX_INDEX_FILTER_URL_LENGTH, and there's no per-entry length
-  # cap -- this check exists for the common case instead: a
-  # field-specific message ("Users: too many values") is far more
-  # actionable than the generic aggregate-length one when one field is
-  # the problem. MAX_INDEX_FILTER_URL_LENGTH stays the unconditional
-  # backstop. A Names lookup is handled separately above this count --
-  # see MAX_NAME_LOOKUP_VALUES.
-  MAX_MULTIPLE_VALUES = 50
-
-  # Above MAX_MULTIPLE_VALUES, a Names lookup is resolved to ids
-  # server-side instead of being rejected -- ids are far more compact
-  # than name text (Name's max id is 6 digits in production;
-  # Name.search_name ranges up to 133 characters, 99.9th percentile
-  # 97), so this raises the practical ceiling before
-  # MAX_INDEX_FILTER_URL_LENGTH forces a reject. Above this count,
-  # reject outright rather than resolving, to avoid a large
-  # Lookup::Names DB hit for an obviously-pathological paste. See
-  # issue #5276.
-  MAX_NAME_LOOKUP_VALUES = 150
 
   included do
     def create
@@ -310,99 +288,14 @@ module Searchable
       false
     end
 
-    # Guards against a single multi-value autocompleter field (Users,
-    # Projects, ...) carrying more than MAX_MULTIPLE_VALUES pasted
-    # values. Runs on the raw (pre-Query) params, before
-    # validate_search_instance?, so it can name the offending field.
-    # The Names lookup field is checked separately -- see
-    # too_many_names_lookup_values?.
-    def too_many_multiple_values?
-      fields_preferring_ids.each do |field|
-        count = multiple_value_count(field)
-        next if count <= Searchable::MAX_MULTIPLE_VALUES
-
-        flash_too_many_values(field, count, Searchable::MAX_MULTIPLE_VALUES)
-        return true
-      end
-      too_many_names_lookup_values?
-    end
-
-    # Above MAX_MULTIPLE_VALUES, resolve the Names lookup to ids
-    # instead of rejecting outright (see MAX_NAME_LOOKUP_VALUES).
-    # Above MAX_NAME_LOOKUP_VALUES, reject without resolving.
-    def too_many_names_lookup_values?
-      return false unless nested_names_params.include?(:lookup)
-
-      field = [:names, :lookup]
-      count = multiple_value_count(field)
-      return false if count <= Searchable::MAX_MULTIPLE_VALUES
-
-      if count > Searchable::MAX_NAME_LOOKUP_VALUES
-        flash_too_many_values(field, count, Searchable::MAX_NAME_LOOKUP_VALUES)
-        return true
-      end
-
-      resolve_names_lookup_to_ids!
-      false
-    end
-
-    # Swaps the pasted name strings in @query_params[:names][:lookup]
-    # for their resolved Name ids -- ids are far shorter than name
-    # text, and any entry that failed to match is dropped in the
-    # process (see issue #5299 for surfacing that to the user).
-    # Resets the expansion-related modifier flags to false: they're
-    # already baked into the resolved id list, and leaving them set
-    # would re-run synonym/subtaxa expansion a second time on the
-    # already-expanded set -- the same hazard flagged in the comment
-    # on Lookup::Names#lookup_ids for a single pass.
-    # include_all_name_proposals/exclude_consensus are left untouched:
-    # they control the Observation<->Naming join, not name resolution.
-    def resolve_names_lookup_to_ids!
-      names = @query_params[:names]
-      lookup = Lookup::Names.new(
-        names[:lookup],
-        include_synonyms: names[:include_synonyms],
-        include_subtaxa: names[:include_subtaxa],
-        include_immediate_subtaxa: names[:include_immediate_subtaxa],
-        exclude_original_names: names[:exclude_original_names]
-      )
-      names[:lookup] = lookup.ids.map(&:to_s)
-      names[:include_synonyms] = false
-      names[:include_subtaxa] = false
-      names[:include_immediate_subtaxa] = false
-      names[:exclude_original_names] = false
-    end
-
-    def flash_too_many_values(field, count, max)
-      flash_error(
-        :runtime_search_too_many_values.t(
-          field: multiple_value_field_label(field), count: count, max: max
-        )
-      )
-    end
-
-    def multiple_value_count(field)
-      value =
-        field.is_a?(Array) ? @query_params.dig(*field) : @query_params[field]
-      return 0 if value.blank?
-      return value.length if value.is_a?(Array)
-
-      value.to_s.split("\n").compact_blank.length
-    end
-
-    def multiple_value_field_label(field)
-      return :names.t.to_s if field.is_a?(Array)
-
-      :"query_#{field}".l.humanize
-    end
-
     # Guards against a redirect URL too long for a front-end proxy's
     # request-line limit -- see MAX_INDEX_FILTER_URL_LENGTH above.
     # Only called once `@search` (built in validate_search_instance?)
     # is known valid, so `index_filter` matches the redirect built
     # afterward.
     def index_filter_url_too_long?
-      length = @search.index_filter.to_query.bytesize
+      params = @search.index_filter.merge(always_index: 1)
+      length = params.to_query.bytesize
       return false if length <= Searchable::MAX_INDEX_FILTER_URL_LENGTH
 
       flash_error(

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -63,11 +63,15 @@ module Searchable
     # Order matters: cheapest/most-actionable check first. A single
     # oversized field gets a field-specific message before falling
     # through to Query's validation errors or the generic aggregate-
-    # length guard.
+    # length guard. Resolving fields_preferring_ids to ids is a
+    # per-value DB lookup, so it only runs once too_many_multiple_values?
+    # has confirmed there isn't a pathologically large field to reject
+    # first.
     def search_input_invalid?
-      too_many_multiple_values? ||
-        !validate_search_instance? ||
-        index_filter_url_too_long?
+      return true if too_many_multiple_values?
+
+      resolve_fields_preferring_ids_to_ids
+      !validate_search_instance? || index_filter_url_too_long?
     end
 
     def save_search_query_and_redirect_to_index
@@ -85,7 +89,6 @@ module Searchable
       null_box_if_invalid
       null_region_if_overspecific_and_box_valid
       autocompleted_strings_to_ids
-      resolve_fields_preferring_ids_to_ids
       range_fields_to_arrays
       parse_date_ranges
       normalize_notes_fields
@@ -208,7 +211,10 @@ module Searchable
     # redirect: QueryParams#resolve_record_backed_value treats a
     # single-value record-backed field as a strict id-only lookup, no
     # name fallback. Already-resolved ids pass through Lookup
-    # unchanged, so this is safe to run on every search.
+    # unchanged. Called from search_input_invalid?, after
+    # too_many_multiple_values? -- each unresolved value costs a DB
+    # lookup, so this must not run against a field that guard would
+    # reject anyway.
     def resolve_fields_preferring_ids_to_ids
       fields_preferring_ids.each do |field|
         next if @query_params[field].blank?

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -25,17 +25,27 @@ module Searchable
   MAX_INDEX_FILTER_URL_LENGTH = 4000
 
   # Maximum newline-separated values a single multi-value autocompleter
-  # field (Names, Users, Projects, ...) may submit. This does NOT by
-  # itself guarantee the redirect URL stays under
-  # MAX_INDEX_FILTER_URL_LENGTH -- Name.search_name in production
-  # ranges up to 133 characters (99.9th percentile: 97), so 50 unusually
-  # long entries can still total more than that guard allows, and
-  # there's no per-entry length cap. This check exists for the common
-  # case instead: a field-specific message ("Names: too many values")
-  # is far more actionable than the generic aggregate-length one when
-  # one field is the problem, which is what issue #5276 reported.
-  # MAX_INDEX_FILTER_URL_LENGTH stays the unconditional backstop.
+  # field (Users, Projects, ...) may submit before being rejected
+  # outright. This does NOT by itself guarantee the redirect URL stays
+  # under MAX_INDEX_FILTER_URL_LENGTH, and there's no per-entry length
+  # cap -- this check exists for the common case instead: a
+  # field-specific message ("Users: too many values") is far more
+  # actionable than the generic aggregate-length one when one field is
+  # the problem. MAX_INDEX_FILTER_URL_LENGTH stays the unconditional
+  # backstop. A Names lookup is handled separately above this count --
+  # see MAX_NAME_LOOKUP_VALUES.
   MAX_MULTIPLE_VALUES = 50
+
+  # Above MAX_MULTIPLE_VALUES, a Names lookup is resolved to ids
+  # server-side instead of being rejected -- ids are far more compact
+  # than name text (Name's max id is 6 digits in production;
+  # Name.search_name ranges up to 133 characters, 99.9th percentile
+  # 97), so this raises the practical ceiling before
+  # MAX_INDEX_FILTER_URL_LENGTH forces a reject. Above this count,
+  # reject outright rather than resolving, to avoid a large
+  # Lookup::Names DB hit for an obviously-pathological paste. See
+  # issue #5276.
+  MAX_NAME_LOOKUP_VALUES = 150
 
   included do
     def create
@@ -266,35 +276,75 @@ module Searchable
       false
     end
 
-    # Guards against a single multi-value autocompleter field (Names,
-    # Users, Projects, ...) carrying more than MAX_MULTIPLE_VALUES
-    # pasted values. Runs on the raw (pre-Query) params, before
+    # Guards against a single multi-value autocompleter field (Users,
+    # Projects, ...) carrying more than MAX_MULTIPLE_VALUES pasted
+    # values. Runs on the raw (pre-Query) params, before
     # validate_search_instance?, so it can name the offending field.
+    # The Names lookup field is checked separately -- see
+    # too_many_names_lookup_values?.
     def too_many_multiple_values?
-      multiple_value_fields.each do |field|
+      fields_preferring_ids.each do |field|
         count = multiple_value_count(field)
         next if count <= Searchable::MAX_MULTIPLE_VALUES
 
-        flash_error(
-          :runtime_search_too_many_values.t(
-            field: multiple_value_field_label(field), count: count,
-            max: Searchable::MAX_MULTIPLE_VALUES
-          )
-        )
+        flash_too_many_values(field, count, Searchable::MAX_MULTIPLE_VALUES)
         return true
       end
+      too_many_names_lookup_values?
+    end
+
+    # Above MAX_MULTIPLE_VALUES, resolve the Names lookup to ids
+    # instead of rejecting outright (see MAX_NAME_LOOKUP_VALUES).
+    # Above MAX_NAME_LOOKUP_VALUES, reject without resolving.
+    def too_many_names_lookup_values?
+      return false unless nested_names_params.include?(:lookup)
+
+      field = [:names, :lookup]
+      count = multiple_value_count(field)
+      return false if count <= Searchable::MAX_MULTIPLE_VALUES
+
+      if count > Searchable::MAX_NAME_LOOKUP_VALUES
+        flash_too_many_values(field, count, Searchable::MAX_NAME_LOOKUP_VALUES)
+        return true
+      end
+
+      resolve_names_lookup_to_ids!
       false
     end
 
-    # Every field this controller accepts as a newline-separated list
-    # of pasted values: the top-level `fields_preferring_ids`
-    # autocompleters, plus the nested Names lookup field when this
-    # controller has one (represented as a 2-element path for
-    # `@query_params.dig`).
-    def multiple_value_fields
-      fields = fields_preferring_ids.dup
-      fields << [:names, :lookup] if nested_names_params.include?(:lookup)
-      fields
+    # Swaps the pasted name strings in @query_params[:names][:lookup]
+    # for their resolved Name ids -- ids are far shorter than name
+    # text, and any entry that failed to match is dropped in the
+    # process (see issue #5299 for surfacing that to the user).
+    # Resets the expansion-related modifier flags to false: they're
+    # already baked into the resolved id list, and leaving them set
+    # would re-run synonym/subtaxa expansion a second time on the
+    # already-expanded set -- the same hazard flagged in the comment
+    # on Lookup::Names#lookup_ids for a single pass.
+    # include_all_name_proposals/exclude_consensus are left untouched:
+    # they control the Observation<->Naming join, not name resolution.
+    def resolve_names_lookup_to_ids!
+      names = @query_params[:names]
+      lookup = Lookup::Names.new(
+        names[:lookup],
+        include_synonyms: names[:include_synonyms],
+        include_subtaxa: names[:include_subtaxa],
+        include_immediate_subtaxa: names[:include_immediate_subtaxa],
+        exclude_original_names: names[:exclude_original_names]
+      )
+      names[:lookup] = lookup.ids.map(&:to_s)
+      names[:include_synonyms] = false
+      names[:include_subtaxa] = false
+      names[:include_immediate_subtaxa] = false
+      names[:exclude_original_names] = false
+    end
+
+    def flash_too_many_values(field, count, max)
+      flash_error(
+        :runtime_search_too_many_values.t(
+          field: multiple_value_field_label(field), count: count, max: max
+        )
+      )
     end
 
     def multiple_value_count(field)

--- a/app/controllers/concerns/searchable/match_guards.rb
+++ b/app/controllers/concerns/searchable/match_guards.rb
@@ -124,7 +124,7 @@ module Searchable::MatchGuards
       value =
         field.is_a?(Array) ? @query_params.dig(*field) : @query_params[field]
       return 0 if value.blank?
-      return value.length if value.is_a?(Array)
+      return value.compact_blank.length if value.is_a?(Array)
 
       value.to_s.split("\n").compact_blank.length
     end

--- a/app/controllers/concerns/searchable/match_guards.rb
+++ b/app/controllers/concerns/searchable/match_guards.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+#
+#  = Searchable::MatchGuards Concern
+#
+#  Guards a Searchable controller's raw search params against
+#  pathologically large multi-value fields.
+#
+################################################################################
+
+module Searchable::MatchGuards
+  extend ActiveSupport::Concern
+
+  # Maximum newline-separated values a single multi-value autocompleter
+  # field (Users, Projects, ...) may submit before being rejected
+  # outright. This does NOT by itself guarantee the redirect URL stays
+  # under MAX_INDEX_FILTER_URL_LENGTH, and there's no per-entry length
+  # cap -- this check exists for the common case instead: a
+  # field-specific message ("Users: too many values") is far more
+  # actionable than the generic aggregate-length one when one field is
+  # the problem. MAX_INDEX_FILTER_URL_LENGTH stays the unconditional
+  # backstop. A Names lookup is handled separately above this count --
+  # see MAX_NAME_LOOKUP_VALUES.
+  MAX_MULTIPLE_VALUES = 50
+
+  # Above MAX_MULTIPLE_VALUES, a Names lookup is resolved to ids
+  # server-side instead of being rejected -- ids are far more compact
+  # than name text (Name's max id is 6 digits in production;
+  # Name.search_name ranges up to 133 characters, 99.9th percentile
+  # 97), so this raises the practical ceiling before
+  # MAX_INDEX_FILTER_URL_LENGTH forces a reject. Above this count,
+  # reject outright rather than resolving, to avoid a large
+  # Lookup::Names DB hit for an obviously-pathological paste.
+  MAX_NAME_LOOKUP_VALUES = 150
+
+  included do
+    private
+
+    # Guards against a single multi-value autocompleter field (Users,
+    # Projects, ...) carrying more than MAX_MULTIPLE_VALUES pasted
+    # values. Runs on the raw (pre-Query) params, before
+    # validate_search_instance?, so it can name the offending field.
+    # The Names lookup field is checked separately -- see
+    # too_many_names_lookup_values?.
+    def too_many_multiple_values?
+      fields_preferring_ids.each do |field|
+        count = multiple_value_count(field)
+        next if count <= MAX_MULTIPLE_VALUES
+
+        flash_too_many_values(field, count, MAX_MULTIPLE_VALUES)
+        return true
+      end
+      too_many_names_lookup_values?
+    end
+
+    # Above MAX_MULTIPLE_VALUES, resolve the Names lookup to ids
+    # instead of rejecting outright (see MAX_NAME_LOOKUP_VALUES).
+    # Above MAX_NAME_LOOKUP_VALUES, reject without resolving.
+    def too_many_names_lookup_values?
+      return false unless nested_names_params.include?(:lookup)
+
+      field = [:names, :lookup]
+      count = multiple_value_count(field)
+      return false if count <= MAX_MULTIPLE_VALUES
+
+      if count > MAX_NAME_LOOKUP_VALUES
+        flash_too_many_values(field, count, MAX_NAME_LOOKUP_VALUES)
+        return true
+      end
+
+      resolve_names_lookup_to_ids!
+      false
+    end
+
+    # The names modifier selects submit literal "true"/"false" strings
+    # (Components::Form::NamesLookupFieldGroup) -- any non-nil String
+    # is truthy in Ruby, so "false" would otherwise be read as true.
+    def modifier_true?(value)
+      value.to_s.to_boolean == true
+    end
+
+    def build_names_lookup(names)
+      Lookup::Names.new(
+        names[:lookup],
+        include_synonyms: modifier_true?(names[:include_synonyms]),
+        include_subtaxa: modifier_true?(names[:include_subtaxa]),
+        include_immediate_subtaxa:
+          modifier_true?(names[:include_immediate_subtaxa]),
+        exclude_original_names:
+          modifier_true?(names[:exclude_original_names])
+      )
+    end
+
+    # Swaps the pasted name strings in @query_params[:names][:lookup]
+    # for their resolved Name ids -- ids are far shorter than name
+    # text, and any entry that failed to match is dropped in the
+    # process (see issue #5299 for surfacing that to the user).
+    # Resets the expansion-related modifier flags to false: they're
+    # already baked into the resolved id list, and leaving them set
+    # would re-run synonym/subtaxa expansion a second time on the
+    # already-expanded set -- the same hazard flagged in the comment
+    # on Lookup::Names#lookup_ids for a single pass.
+    # include_all_name_proposals/exclude_consensus are left untouched:
+    # they control the Observation<->Naming join, not name resolution.
+    def resolve_names_lookup_to_ids!
+      names = @query_params[:names]
+      lookup = build_names_lookup(names)
+      names[:lookup] = lookup.ids.map(&:to_s)
+      names[:include_synonyms] = false
+      names[:include_subtaxa] = false
+      names[:include_immediate_subtaxa] = false
+      names[:exclude_original_names] = false
+    end
+
+    def flash_too_many_values(field, count, max)
+      flash_error(
+        :runtime_search_too_many_values.t(
+          field: multiple_value_field_label(field), count: count, max: max
+        )
+      )
+    end
+
+    def multiple_value_count(field)
+      value =
+        field.is_a?(Array) ? @query_params.dig(*field) : @query_params[field]
+      return 0 if value.blank?
+      return value.length if value.is_a?(Array)
+
+      value.to_s.split("\n").compact_blank.length
+    end
+
+    def multiple_value_field_label(field)
+      field.is_a?(Array) ? :names.t.to_s : :"query_#{field}".l.humanize
+    end
+  end
+end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3996,6 +3996,7 @@
   runtime_no_matches: No matching [types] found.
   runtime_no_more: There are no more [types].
   runtime_search_string_too_long: "Search string too long ([length] characters). Maximum is [max] characters."
+  runtime_search_too_many_values: "[field]: too many values ([count]). Maximum is [max]."
   runtime_no_parse: "Unable to parse: '[value]'"
   runtime_no_save: Unable to save [type].
   runtime_no_update: Unable to update [type].

--- a/test/controllers/herbaria/search_controller_test.rb
+++ b/test/controllers/herbaria/search_controller_test.rb
@@ -47,9 +47,9 @@ module Herbaria
       }
       post(:create, params: { query_herbaria: params })
 
-      assert_redirected_to(
-        controller: "/herbaria", action: :index,
-        params: { q: { model: :Herbarium, **params } }
+      assert_search_redirected_to(
+        controller: "/herbaria",
+        params: params
       )
     end
   end

--- a/test/controllers/locations/search_controller_test.rb
+++ b/test/controllers/locations/search_controller_test.rb
@@ -65,8 +65,8 @@ module Locations
       }
       post(:create, params: { query_locations: params })
 
-      assert_redirected_to(controller: "/locations", action: :index,
-                           params: { q: { model: :Location, **params } })
+      assert_search_redirected_to(controller: "/locations",
+                                  params: params)
     end
 
     def test_create_locations_search_nested
@@ -80,15 +80,18 @@ module Locations
       }
       post(:create, params: { query_locations: params })
 
-      # Query validation parses region as an array of region strings.
+      # Query validation parses region as an array of region strings;
+      # index_filter then shrinks each one-element array to a bare
+      # scalar, and by_users to its param_alias by_user. The raw
+      # "mary" string is resolved to her id before redirecting.
       validated_params = {
         in_box: box,
-        region: ["California, USA"],
-        by_users: %w[mary]
+        region: "California, USA",
+        by_user: users(:mary).id
       }
-      assert_redirected_to(
-        controller: "/locations", action: :index,
-        params: { q: { model: :Location, **validated_params } }
+      assert_search_redirected_to(
+        controller: "/locations",
+        params: validated_params
       )
     end
   end

--- a/test/controllers/names/search_controller_test.rb
+++ b/test/controllers/names/search_controller_test.rb
@@ -79,8 +79,8 @@ module Names
       }
       post(:create, params: { query_names: params })
 
-      assert_redirected_to(controller: "/names", action: :index,
-                           params: { q: { model: :Name, **params } })
+      assert_search_redirected_to(controller: "/names",
+                                  params: params)
     end
 
     def test_create_names_search_nested
@@ -108,8 +108,8 @@ module Names
         misspellings: :include,
         created_at: %w[2007-01-01 2007-12-31]
       }
-      assert_redirected_to(controller: "/names", action: :index,
-                           params: { q: { model: :Name, **validated_params } })
+      assert_search_redirected_to(controller: "/names",
+                                  params: validated_params)
     end
 
     # ---------------------------------------------------------------
@@ -128,11 +128,9 @@ module Names
       post(:create, params: { query_names: params })
 
       # Should be sorted as [lower, higher] = ["Species", "Genus"]
-      assert_redirected_to(
-        controller: "/names", action: :index,
-        params: {
-          q: { model: :Name, rank: %w[Species Genus] }
-        }
+      assert_search_redirected_to(
+        controller: "/names",
+        params: { rank: %w[Species Genus] }
       )
     end
 
@@ -146,11 +144,9 @@ module Names
       post(:create, params: { query_names: params })
 
       # Should remain as ["Form", "Species"]
-      assert_redirected_to(
-        controller: "/names", action: :index,
-        params: {
-          q: { model: :Name, rank: %w[Form Species] }
-        }
+      assert_search_redirected_to(
+        controller: "/names",
+        params: { rank: %w[Form Species] }
       )
     end
 
@@ -194,11 +190,9 @@ module Names
       post(:create, params: { query_names: params })
 
       # Should filter out the blank value and create query with single rank
-      assert_redirected_to(
-        controller: "/names", action: :index,
-        params: {
-          q: { model: :Name, rank: ["Species"] }
-        }
+      assert_search_redirected_to(
+        controller: "/names",
+        params: { rank: "Species" }
       )
     end
 
@@ -212,11 +206,9 @@ module Names
       post(:create, params: { query_names: params })
 
       # Should filter out the blank value and create query with single rank
-      assert_redirected_to(
-        controller: "/names", action: :index,
-        params: {
-          q: { model: :Name, rank: ["Genus"] }
-        }
+      assert_search_redirected_to(
+        controller: "/names",
+        params: { rank: "Genus" }
       )
     end
 
@@ -231,11 +223,9 @@ module Names
       post(:create, params: { query_names: params })
 
       # Should create query without rank parameter
-      assert_redirected_to(
-        controller: "/names", action: :index,
-        params: {
-          q: { model: :Name, has_author: true }
-        }
+      assert_search_redirected_to(
+        controller: "/names",
+        params: { has_author: true }
       )
     end
   end

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -176,14 +176,12 @@ module Observations
       post(:create, params: { query_observations: params })
 
       validated_params = {
-        by_users: [rolf.id],
+        by_user: rolf.id,
         has_notes: true,
         lichen: false # this should be preserved, not "compacted" out.
       }
       assert_redirected_to(controller: "/observations", action: :index,
-                           params: {
-                             q: { model: :Observation, **validated_params }
-                           })
+                           params: validated_params)
     end
 
     def test_create_observations_search_with_blank_name_and_include_subtaxa
@@ -199,7 +197,7 @@ module Observations
       post(:create, params: { query_observations: params })
       # Should redirect to observations index with no names param
       assert_redirected_to(controller: "/observations", action: :index,
-                           params: { q: { model: :Observation } })
+                           params: {})
     end
 
     # Test reset_search_query creates a new blank query
@@ -279,13 +277,11 @@ module Observations
       post(:create, params: { query_observations: params })
 
       validated_params = {
-        region: ["Colorado, USA"],
+        region: "Colorado, USA",
         date: %w[2026-08-12 2026-08-16]
       }
       assert_redirected_to(controller: "/observations", action: :index,
-                           params: {
-                             q: { model: :Observation, **validated_params }
-                           })
+                           params: validated_params)
     end
 
     # A date the parser can't read must fail the search with an error,
@@ -315,9 +311,7 @@ module Observations
         has_images: false
       }
       assert_redirected_to(controller: "/observations", action: :index,
-                           params: {
-                             q: { model: :Observation, **validated_params }
-                           })
+                           params: validated_params)
     end
 
     def test_create_observations_search_with_has_collection_numbers
@@ -333,9 +327,7 @@ module Observations
         has_notes: false
       }
       assert_redirected_to(controller: "/observations", action: :index,
-                           params: {
-                             q: { model: :Observation, **validated_params }
-                           })
+                           params: validated_params)
     end
 
     def test_create_observations_search_nested
@@ -373,7 +365,7 @@ module Observations
       }
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: { q: { model: :Observation, **validated_params } }
+        params: validated_params
       )
     end
 
@@ -391,7 +383,7 @@ module Observations
       post(:create, params: { query_observations: params })
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: { q: { model: :Observation, **params.except(:names) } }
+        params: params.except(:names)
       )
     end
 
@@ -412,7 +404,7 @@ module Observations
 
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: { q: { model: :Observation, by_users: [user1.id, user2.id] } }
+        params: { by_users: [user1.id, user2.id] }
       )
     end
 
@@ -428,7 +420,7 @@ module Observations
 
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: { q: { model: :Observation, projects: [proj1.id, proj2.id] } }
+        params: { projects: [proj1.id, proj2.id] }
       )
     end
 
@@ -444,7 +436,7 @@ module Observations
 
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: { q: { model: :Observation, herbaria: [herb1.id, herb2.id] } }
+        params: { herbaria: [herb1.id, herb2.id] }
       )
     end
 
@@ -456,7 +448,7 @@ module Observations
 
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: { q: { model: :Observation, external_sites: [site.id] } }
+        params: { external_site: site.id }
       )
     end
 
@@ -473,12 +465,7 @@ module Observations
       # Location names are passed as-is (not converted to IDs)
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: {
-          q: {
-            model: :Observation,
-            within_locations: ["#{loc1.name}\n#{loc2.name}"]
-          }
-        }
+        params: { location: "#{loc1.name}\n#{loc2.name}" }
       )
     end
 
@@ -494,9 +481,7 @@ module Observations
 
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: {
-          q: { model: :Observation, species_lists: [list1.id, list2.id] }
-        }
+        params: { species_lists: [list1.id, list2.id] }
       )
     end
 
@@ -512,10 +497,7 @@ module Observations
       assert_redirected_to(
         controller: "/observations", action: :index,
         params: {
-          q: {
-            model: :Observation,
-            names: { lookup: ["Agaricus campestris", "Coprinus comatus"] }
-          }
+          names: { lookup: ["Agaricus campestris", "Coprinus comatus"] }
         }
       )
     end
@@ -537,9 +519,7 @@ module Observations
       # Should be sorted as [low, high] = [-1.0, 2.0]
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: {
-          q: { model: :Observation, confidence: [-1.0, 2.0] }
-        }
+        params: { confidence: [-1.0, 2.0] }
       )
     end
 
@@ -555,9 +535,7 @@ module Observations
       # Should remain as [-1.0, 2.0]
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: {
-          q: { model: :Observation, confidence: [-1.0, 2.0] }
-        }
+        params: { confidence: [-1.0, 2.0] }
       )
     end
 
@@ -613,9 +591,7 @@ module Observations
 
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: {
-          q: { model: :Observation, confidence: [2.0] }
-        }
+        params: { confidence: 2.0 }
       )
     end
 
@@ -630,9 +606,7 @@ module Observations
 
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: {
-          q: { model: :Observation, confidence: [1.0] }
-        }
+        params: { confidence: 1.0 }
       )
     end
 
@@ -650,7 +624,7 @@ module Observations
       assert_redirected_to(
         controller: "/observations", action: :index,
         params: {
-          q: { model: :Observation, has_images: true }
+          has_images: true
         }
       )
     end
@@ -671,9 +645,7 @@ module Observations
 
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: {
-          q: { model: :Observation, confidence: [0.0] }
-        }
+        params: { confidence: 0.0 }
       )
     end
 
@@ -718,9 +690,7 @@ module Observations
       # Spaces should be converted to underscores, case preserved
       assert_redirected_to(
         controller: "/observations", action: :index,
-        params: {
-          q: { model: :Observation, has_notes_fields: ["INat_notes_field"] }
-        }
+        params: { has_notes_fields: "INat_notes_field" }
       )
     end
 
@@ -734,41 +704,42 @@ module Observations
       assert_redirected_to(
         controller: "/observations", action: :index,
         params: {
-          q: {
-            model: :Observation,
-            has_notes_fields: %w[Substrate Cap_Color Other_Field]
-          }
+          has_notes_fields: %w[Substrate Cap_Color Other_Field]
         }
       )
     end
 
     # ------- Server Handling of Long Inputs (POST method) -------
-    # These tests prove that when long inputs reach the server (if JS fails),
-    # the server can handle them without crashing since POST puts data in body
+    # These tests prove that when a long input reaches the server (e.g. if
+    # client-side JS validation fails or is bypassed), the server rejects
+    # it cleanly with a flash error and redirects back to the form --
+    # instead of building a redirect URL long enough for a front-end
+    # proxy to reject with a hard-to-diagnose error page (issue #5276).
 
-    def test_server_handles_very_long_input_without_error
+    def test_server_rejects_very_long_single_field
       login
-      # Create input that would exceed URL limits but is fine in POST body
-      # Well over MAX_SEARCH_INPUT_LENGTH limit
+      # A single scalar field (not a multi-value autocompleter, so
+      # too_many_multiple_values? doesn't apply) whose serialized
+      # redirect URL alone is well over MAX_INDEX_FILTER_URL_LENGTH --
+      # proves the aggregate-length guard catches it unassisted.
       long_text = "x" * 15_000
       params = {
         notes_has: long_text,
         has_specimen: true
       }
 
-      # Should not raise an error, even though JS validation would prevent this
       assert_nothing_raised do
         post(:create, params: { query_observations: params })
       end
 
-      # Should successfully create search and redirect
-      assert_response(:redirect)
-      assert_match(/observations/, response.redirect_url)
+      assert_redirected_to(action: :new)
+      assert_flash_error
     end
 
-    def test_server_handles_multiple_long_fields
+    def test_server_rejects_multiple_long_fields
       login
-      # Multiple long fields that collectively would be problematic in URL
+      # Two individually plausible scalar fields whose combined
+      # redirect URL is still too long.
       long_text1 = "a" * 8000
       long_text2 = "b" * 8000
       params = {
@@ -780,12 +751,14 @@ module Observations
         post(:create, params: { query_observations: params })
       end
 
-      assert_response(:redirect)
+      assert_redirected_to(action: :new)
+      assert_flash_error
     end
 
-    def test_server_handles_long_nested_params
+    def test_server_rejects_too_many_names
       login
-      # Test with long names lookup
+      # Well over MAX_MULTIPLE_VALUES -- caught by the field-specific
+      # guard before the aggregate-length one even runs.
       long_names = (1..1000).map { |i| "Species#{i}" }.join("\n")
       params = {
         names: {
@@ -798,7 +771,8 @@ module Observations
         post(:create, params: { query_observations: params })
       end
 
-      assert_response(:redirect)
+      assert_redirected_to(action: :new)
+      assert_flash_error
     end
   end
 end

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -757,8 +757,9 @@ module Observations
 
     def test_server_rejects_too_many_names
       login
-      # Well over MAX_MULTIPLE_VALUES -- caught by the field-specific
-      # guard before the aggregate-length one even runs.
+      # Well over MAX_NAME_LOOKUP_VALUES -- rejected outright, without
+      # attempting to resolve (resolution only happens between
+      # MAX_MULTIPLE_VALUES and MAX_NAME_LOOKUP_VALUES).
       long_names = (1..1000).map { |i| "Species#{i}" }.join("\n")
       params = {
         names: {
@@ -773,6 +774,99 @@ module Observations
 
       assert_redirected_to(action: :new)
       assert_flash_error
+    end
+
+    # ---------------------------------------------------------------
+    #  Names lookup id-substitution (between MAX_MULTIPLE_VALUES and
+    #  MAX_NAME_LOOKUP_VALUES): resolve to ids instead of rejecting
+    # ---------------------------------------------------------------
+
+    def test_names_lookup_over_threshold_resolves_to_ids
+      login
+      test_names = create_test_names(60)
+      lookup = test_names.map(&:text_name).join("\n")
+      params = { names: { lookup: lookup } }
+
+      post(:create, params: { query_observations: params })
+
+      assert_response(:redirect)
+      redirect_params = parse_redirect_names_params
+      assert_equal(test_names.map { |n| n.id.to_s }.sort,
+                   redirect_params["lookup"].sort,
+                   "Redirect should carry resolved ids, not name text")
+      assert_equal("false", redirect_params["include_synonyms"],
+                   "Expansion modifier should be reset to false, since " \
+                   "expansion is already baked into the resolved ids")
+    end
+
+    def test_names_lookup_over_threshold_resets_expansion_modifiers
+      login
+      test_names = create_test_names(60)
+      lookup = test_names.map(&:text_name).join("\n")
+      params = {
+        names: {
+          lookup: lookup,
+          include_synonyms: "true",
+          include_subtaxa: "true"
+        }
+      }
+
+      post(:create, params: { query_observations: params })
+
+      redirect_params = parse_redirect_names_params
+      assert_equal("false", redirect_params["include_synonyms"])
+      assert_equal("false", redirect_params["include_subtaxa"])
+    end
+
+    def test_names_lookup_at_or_under_threshold_not_resolved
+      login
+      test_names = create_test_names(50)
+      lookup = test_names.map(&:text_name).join("\n")
+      params = { names: { lookup: lookup } }
+
+      post(:create, params: { query_observations: params })
+
+      redirect_params = parse_redirect_names_params
+      # Still the raw name text, not ids -- at the threshold, not over it.
+      assert_equal(test_names.map(&:text_name).sort,
+                   redirect_params["lookup"].sort)
+    end
+
+    def test_names_lookup_between_thresholds_that_fail_to_resolve
+      login
+      # None of these match anything, so resolution produces an empty
+      # id list -- should still redirect (not error), matching the
+      # existing silent-drop behavior for unmatched names.
+      unmatched = (1..60).map { |i| "Nonexistent Taxon #{i}" }.join("\n")
+      params = { names: { lookup: unmatched } }
+
+      assert_nothing_raised do
+        post(:create, params: { query_observations: params })
+      end
+
+      assert_response(:redirect)
+    end
+
+    private
+
+    def create_test_names(count)
+      (1..count).map do |i|
+        Name.create!(
+          text_name: "Testus namus#{i}",
+          search_name: "Testus namus#{i}",
+          sort_name: "Testus namus#{i}",
+          display_name: "**__Testus namus#{i}__**",
+          author: "",
+          rank: "Species",
+          deprecated: false,
+          user: rolf
+        )
+      end
+    end
+
+    def parse_redirect_names_params
+      uri = URI.parse(@response.redirect_url)
+      Rack::Utils.parse_nested_query(uri.query)["names"]
     end
   end
 end

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -775,6 +775,47 @@ module Observations
       assert_flash_error
     end
 
+    def test_server_rejects_too_many_by_users_values
+      login
+      too_many = (1..60).map { |i| "user#{i}" }.join("\n")
+      params = { by_users: too_many }
+
+      assert_nothing_raised do
+        post(:create, params: { query_observations: params })
+      end
+
+      assert_redirected_to(action: :new)
+      assert_flash_error(
+        :runtime_search_too_many_values,
+        field: :query_by_users.l.humanize, count: 60,
+        max: Searchable::MAX_MULTIPLE_VALUES
+      )
+    end
+
+    # too_many_multiple_values? must count the pasted values BEFORE
+    # resolve_fields_preferring_ids_to_ids runs -- Herbarium.name_has
+    # is a fuzzy match, so if resolution ran first, these 60 identical
+    # strings would collapse (uniq) to a single id and slip under
+    # MAX_MULTIPLE_VALUES, silently accepting a paste the guard exists
+    # to reject.
+    def test_too_many_herbaria_values_rejected_before_resolution
+      login
+      herbarium = herbaria(:nybg_herbarium)
+      too_many = Array.new(60) { herbarium.name }.join("\n")
+      params = { herbaria: too_many }
+
+      assert_nothing_raised do
+        post(:create, params: { query_observations: params })
+      end
+
+      assert_redirected_to(action: :new)
+      assert_flash_error(
+        :runtime_search_too_many_values,
+        field: :query_herbaria.l.humanize, count: 60,
+        max: Searchable::MAX_MULTIPLE_VALUES
+      )
+    end
+
     # ---------------------------------------------------------------
     #  Names lookup id-substitution (between MAX_MULTIPLE_VALUES and
     #  MAX_NAME_LOOKUP_VALUES): resolve to ids instead of rejecting

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -816,6 +816,27 @@ module Observations
       )
     end
 
+    # Blank lines between pasted names inflate the split array's raw
+    # length without adding non-blank entries -- multiple_value_count
+    # must compact_blank before counting, or this paste at the
+    # threshold would be rejected as "too many values".
+    def test_blank_lines_in_names_paste_not_counted_against_threshold
+      login
+      # Joining N names with "\n\n" produces N names + (N - 1) blank
+      # lines = 2N - 1 raw entries after a plain split("\n"). Pick N
+      # so the raw entry count is over MAX_NAME_LOOKUP_VALUES only if
+      # blanks are miscounted, but N itself is not.
+      real_count = (Searchable::MatchGuards::MAX_NAME_LOOKUP_VALUES / 2) + 1
+      test_names = create_test_names(real_count)
+      lookup = test_names.map(&:text_name).join("\n\n")
+      params = { names: { lookup: lookup } }
+
+      post(:create, params: { query_observations: params })
+
+      assert_response(:redirect)
+      assert_no_flash
+    end
+
     # ---------------------------------------------------------------
     #  Names lookup id-substitution (between MAX_MULTIPLE_VALUES and
     #  MAX_NAME_LOOKUP_VALUES): resolve to ids instead of rejecting

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -180,8 +180,8 @@ module Observations
         has_notes: true,
         lichen: false # this should be preserved, not "compacted" out.
       }
-      assert_redirected_to(controller: "/observations", action: :index,
-                           params: validated_params)
+      assert_search_redirected_to(controller: "/observations",
+                                  params: validated_params)
     end
 
     def test_create_observations_search_with_blank_name_and_include_subtaxa
@@ -196,8 +196,8 @@ module Observations
       }
       post(:create, params: { query_observations: params })
       # Should redirect to observations index with no names param
-      assert_redirected_to(controller: "/observations", action: :index,
-                           params: {})
+      assert_search_redirected_to(controller: "/observations",
+                                  params: {})
     end
 
     # Test reset_search_query creates a new blank query
@@ -280,8 +280,8 @@ module Observations
         region: "Colorado, USA",
         date: %w[2026-08-12 2026-08-16]
       }
-      assert_redirected_to(controller: "/observations", action: :index,
-                           params: validated_params)
+      assert_search_redirected_to(controller: "/observations",
+                                  params: validated_params)
     end
 
     # A date the parser can't read must fail the search with an error,
@@ -310,8 +310,8 @@ module Observations
         has_field_slips: true,
         has_images: false
       }
-      assert_redirected_to(controller: "/observations", action: :index,
-                           params: validated_params)
+      assert_search_redirected_to(controller: "/observations",
+                                  params: validated_params)
     end
 
     def test_create_observations_search_with_has_collection_numbers
@@ -326,8 +326,8 @@ module Observations
         has_collection_numbers: true,
         has_notes: false
       }
-      assert_redirected_to(controller: "/observations", action: :index,
-                           params: validated_params)
+      assert_search_redirected_to(controller: "/observations",
+                                  params: validated_params)
     end
 
     def test_create_observations_search_nested
@@ -363,8 +363,8 @@ module Observations
         projects: projects.pluck(:id),
         date: ["2021-01-06", todate]
       }
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: validated_params
       )
     end
@@ -381,8 +381,8 @@ module Observations
         in_box: location.bounding_box
       }
       post(:create, params: { query_observations: params })
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: params.except(:names)
       )
     end
@@ -402,8 +402,8 @@ module Observations
       }
       post(:create, params: { query_observations: params })
 
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { by_users: [user1.id, user2.id] }
       )
     end
@@ -418,8 +418,8 @@ module Observations
       }
       post(:create, params: { query_observations: params })
 
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { projects: [proj1.id, proj2.id] }
       )
     end
@@ -434,8 +434,8 @@ module Observations
       }
       post(:create, params: { query_observations: params })
 
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { herbaria: [herb1.id, herb2.id] }
       )
     end
@@ -446,8 +446,8 @@ module Observations
       params = { external_sites: site.id.to_s }
       post(:create, params: { query_observations: params })
 
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { external_site: site.id }
       )
     end
@@ -456,16 +456,15 @@ module Observations
       login
       loc1 = locations(:burbank)
       loc2 = locations(:albion)
-      # NOTE: within_locations uses location names, not IDs
       params = {
         within_locations: "#{loc1.name}\n#{loc2.name}"
       }
       post(:create, params: { query_observations: params })
 
-      # Location names are passed as-is (not converted to IDs)
-      assert_redirected_to(
-        controller: "/observations", action: :index,
-        params: { location: "#{loc1.name}\n#{loc2.name}" }
+      # Unresolved location names are looked up and redirected as ids.
+      assert_search_redirected_to(
+        controller: "/observations",
+        params: { within_locations: [loc1.id, loc2.id] }
       )
     end
 
@@ -479,8 +478,8 @@ module Observations
       }
       post(:create, params: { query_observations: params })
 
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { species_lists: [list1.id, list2.id] }
       )
     end
@@ -494,8 +493,8 @@ module Observations
       }
       post(:create, params: { query_observations: params })
 
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: {
           names: { lookup: ["Agaricus campestris", "Coprinus comatus"] }
         }
@@ -517,8 +516,8 @@ module Observations
       post(:create, params: { query_observations: params })
 
       # Should be sorted as [low, high] = [-1.0, 2.0]
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { confidence: [-1.0, 2.0] }
       )
     end
@@ -533,8 +532,8 @@ module Observations
       post(:create, params: { query_observations: params })
 
       # Should remain as [-1.0, 2.0]
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { confidence: [-1.0, 2.0] }
       )
     end
@@ -589,8 +588,8 @@ module Observations
       }
       post(:create, params: { query_observations: params })
 
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { confidence: 2.0 }
       )
     end
@@ -604,8 +603,8 @@ module Observations
       }
       post(:create, params: { query_observations: params })
 
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { confidence: 1.0 }
       )
     end
@@ -621,8 +620,8 @@ module Observations
       post(:create, params: { query_observations: params })
 
       # Should create query without confidence parameter
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: {
           has_images: true
         }
@@ -643,8 +642,8 @@ module Observations
       }
       post(:create, params: { query_observations: params })
 
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { confidence: 0.0 }
       )
     end
@@ -688,8 +687,8 @@ module Observations
       post(:create, params: { query_observations: params })
 
       # Spaces should be converted to underscores, case preserved
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: { has_notes_fields: "INat_notes_field" }
       )
     end
@@ -701,8 +700,8 @@ module Observations
       post(:create, params: { query_observations: params })
 
       # Should be split on newline, spaces converted to underscores
-      assert_redirected_to(
-        controller: "/observations", action: :index,
+      assert_search_redirected_to(
+        controller: "/observations",
         params: {
           has_notes_fields: %w[Substrate Cap_Color Other_Field]
         }

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -788,7 +788,7 @@ module Observations
       assert_flash_error(
         :runtime_search_too_many_values,
         field: :query_by_users.l.humanize, count: 60,
-        max: Searchable::MAX_MULTIPLE_VALUES
+        max: Searchable::MatchGuards::MAX_MULTIPLE_VALUES
       )
     end
 
@@ -812,7 +812,7 @@ module Observations
       assert_flash_error(
         :runtime_search_too_many_values,
         field: :query_herbaria.l.humanize, count: 60,
-        max: Searchable::MAX_MULTIPLE_VALUES
+        max: Searchable::MatchGuards::MAX_MULTIPLE_VALUES
       )
     end
 

--- a/test/controllers/projects/search_controller_test.rb
+++ b/test/controllers/projects/search_controller_test.rb
@@ -46,8 +46,8 @@ module Projects
       }
       post(:create, params: { query_projects: params })
 
-      assert_redirected_to(controller: "/projects", action: :index,
-                           params: { q: { model: :Project, **params } })
+      assert_search_redirected_to(controller: "/projects",
+                                  params: params)
     end
   end
 end

--- a/test/controllers/species_lists/search_controller_test.rb
+++ b/test/controllers/species_lists/search_controller_test.rb
@@ -49,9 +49,9 @@ module SpeciesLists
       post(:create, params: { query_species_lists: params })
 
       validated_params = params.except(:has_comments)
-      assert_redirected_to(
-        controller: "/species_lists", action: :index,
-        params: { q: { model: :SpeciesList, **validated_params } }
+      assert_search_redirected_to(
+        controller: "/species_lists",
+        params: validated_params
       )
     end
 

--- a/test/functional_test_case.rb
+++ b/test/functional_test_case.rb
@@ -16,6 +16,7 @@
 class FunctionalTestCase < ActionController::TestCase # rubocop:disable Rails/ActionControllerTestCase
   include GeneralExtensions
   include FlashExtensions
+  include SearchExtensions
   include ControllerExtensions
   include CheckForUnsafeHtml
   # Rails auto-includes this into ActionDispatch::IntegrationTest but not

--- a/test/search_extensions.rb
+++ b/test/search_extensions.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#
+#  = Search Test Helpers
+#
+#  Methods in this class are available to all the functional and integration
+#  tests.
+#
+#  assert_search_redirected_to:: Assert a Searchable#create redirect to a
+#                                 model's index.
+#
+################################################################################
+
+module SearchExtensions
+  # Searchable#create's redirect always carries always_index: 1 (see
+  # ApplicationController::QueryParams#create_query_from_url_params) --
+  # this folds that in so call sites only need to state the filters.
+  def assert_search_redirected_to(controller:, params: {})
+    assert_redirected_to(controller: controller, action: :index,
+                         params: { always_index: 1, **params })
+  end
+end

--- a/test/search_extensions.rb
+++ b/test/search_extensions.rb
@@ -15,8 +15,9 @@ module SearchExtensions
   # Searchable#create's redirect always carries always_index: 1 (see
   # ApplicationController::QueryParams#create_query_from_url_params) --
   # this folds that in so call sites only need to state the filters.
+  # always_index: 1 is last so a caller can't accidentally override it.
   def assert_search_redirected_to(controller:, params: {})
     assert_redirected_to(controller: controller, action: :index,
-                         params: { always_index: 1, **params })
+                         params: { **params, always_index: 1 })
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -100,6 +100,7 @@ end
 
   general_extensions
   flash_extensions
+  search_extensions
   controller_extensions
   capybara_session_extensions
   capybara_macros


### PR DESCRIPTION
Pasting a large multi-line list into a search form's Names field could break the post-search redirect in production (unreproducible locally): the URL that redirect built scaled with the number of pasted values, with no cap.

## Summary

Fixes #5276. Full investigation is in the issue thread. Three independent pieces, all in `Searchable#create`:

1. **The redirect used a longer URL shape than it needed to.** `redirect_to(..., q: @query.q_param)` serialized the entire query as a nested `q[...]` hash -- a legitimate, necessary shape for a cross-model link, but longer than necessary here, since the target is always the query's model's index (`search_type` and `query_model` are both derived from the same `module_name` in every `Searchable` controller). `Query#index_filter` is the flatter option for that same-model case. Switched to `redirect_to(..., **@query.index_filter)`, which (after #5297) also gets the shrunk single-value form for free.
2. **A single multi-value autocompleter field (Users, Projects, ...) over `MAX_MULTIPLE_VALUES` (50) entries gets rejected with a field-specific message** ("Users: too many values (60). Maximum is 50."), before Query validation or the aggregate-length guard runs -- more actionable than a generic message when one field is the problem.
3. **A Names lookup between 50 and a new `MAX_NAME_LOOKUP_VALUES` (150) resolves to Name ids server-side instead of being rejected.** Ids are far shorter and length-bounded compared to name text (Name's max id is 6 digits in production; `Name.search_name` ranges up to 133 characters), so this raises the practical ceiling before the aggregate guard would force a reject. Confirmed against the exact list from the issue: the redirect URL drops from 4313 bytes (original nested form) to 2119 bytes (flat form + id substitution), with results rendering correctly. Resolving also drops any pasted entry that failed to match a `Name` -- see #5299 for surfacing that to the user. The `include_synonyms`/`include_subtaxa`/`include_immediate_subtaxa`/`exclude_original_names` modifier flags reset to `false` on substitution: expansion is already baked into the resolved id list, and leaving them set would re-run synonym/subtaxa expansion a second time on the already-expanded set -- the same hazard flagged in `Lookup::Names#lookup_ids`'s comment for a single pass. Above `MAX_NAME_LOOKUP_VALUES`, still reject outright without resolving, to avoid a large `Lookup::Names` DB hit for an obviously pathological paste.

`index_filter_url_too_long?` (rejects once the serialized redirect URL exceeds `MAX_INDEX_FILTER_URL_LENGTH`, 4000 bytes) stays the unconditional backstop underneath all of this, regardless of which field(s) or how much expansion caused an overlong URL.

Switching the redirect from the nested `q_param` form to the flat `index_filter` form changes which controller code path handles the following page load (`create_query_from_url_params` instead of `sorted_index`), which surfaced two more regressions caught by CI:

4. **An unresolved `fields_preferring_ids` value broke the next page load.** A user typing a name without triggering the client-side autocomplete match leaves the raw text string in the redirect params. Under the old nested form this reached `Query` construction directly; under the flat form it instead hits `QueryParams#resolve_record_backed_value`'s strict `find_by(id:)`-only lookup and fails. Added `Searchable#resolve_fields_preferring_ids_to_ids`, called from `prepare_raw_params`, which resolves every `fields_preferring_ids` field to ids (via that field's matching `Lookup` class) before the redirect, the same way step 3 above already does for Names.
5. **A search matching a single record silently auto-redirected to that record's show page instead of the results list.** `sorted_index`'s `always_index: true` is hardcoded for `q`-shaped URLs only; `create_query_from_url_params` computes `always_index` per-attribute and had no equivalent guarantee for flat URLs. Added an `always_index=1` marker param (not a `query_attr`) that `create_query_from_url_params` ORs into its result, and that `Searchable#create`'s redirect always sets.

## Test plan

- [x] `bundle exec rubocop` on every touched file -- no offenses
- [x] `bin/rails test test/controllers/observations/search_controller_test.rb` -- 46 tests, all pass
- [x] `bin/rails test test/controllers/names/search_controller_test.rb`, `herbaria/`, `projects/`, `locations/`, `species_lists/search_controller_test.rb` -- all pass
- [x] `bin/rails test test/classes/query_test.rb`, `test/controllers/application_controller_test.rb`, `test/integration/capybara/search_integration_test.rb` -- all pass
- [x] Reproduced the reported bug locally by pasting the exact list from the issue into `/observations/search/new`, confirmed the redirect URL shrank from 4313 to under 3700 bytes from the flat-param change alone, then to 2119 bytes with id substitution, with results rendering and filtering correctly
- [x] Confirmed all three guards fire correctly (and in the right order) against oversized POSTs sent directly (bypassing the client-side length check) via the browser console

<!-- changelog -->
article: no
<!-- /changelog -->
