### PR TITLE
Fix `Lookup` classes not surfacing entries that fail to resolve (#5299)

### DIFF
--- a/app/classes/lookup.rb
+++ b/app/classes/lookup.rb
@@ -32,6 +32,8 @@
 # instances:  Array of instances of those records
 # titles:     Array of names of those records, via @title_column set in subclass
 #             (A `names` method seemed too confusing, because Lookup::Names...)
+# unmatched:  Array of the input vals that matched no record. Populated as a
+#             side effect of `ids`/`instances` -- call one of those first.
 #
 # Class constants:
 #   (defined in subclass)
@@ -40,7 +42,7 @@
 # TITLE_METHOD:
 #
 class Lookup
-  attr_reader :vals, :params
+  attr_reader :vals, :params, :unmatched
 
   def initialize(vals, params = {})
     unless defined?(self.class::MODEL)
@@ -51,6 +53,7 @@ class Lookup
     @title_method = self.class::TITLE_METHOD
     @vals = prepare_vals(vals)
     @params = params
+    @unmatched = []
   end
 
   def prepare_vals(vals)
@@ -93,6 +96,7 @@ class Lookup
   end
 
   def evaluate_values_as_ids
+    @unmatched = []
     @vals.map do |val|
       if val.is_a?(@model)
         val.id
@@ -101,12 +105,15 @@ class Lookup
       elsif /^\d+$/.match?(val.to_s)
         val
       else
-        lookup_method(val).map(&:id) # each lookup returns an array
+        found = lookup_method(val).map(&:id) # each lookup returns an array
+        @unmatched << val if found.empty?
+        found
       end
     end.flatten.uniq.compact
   end
 
   def evaluate_values_as_instances
+    @unmatched = []
     @vals.map do |val|
       if val.is_a?(@model)
         val
@@ -115,7 +122,9 @@ class Lookup
       elsif /^\d+$/.match?(val.to_s)
         @model.find(val.to_i)
       else
-        lookup_method(val)
+        found = lookup_method(val)
+        @unmatched << val if found.blank?
+        found
       end
     end.flatten.uniq.compact
   end

--- a/app/classes/lookup.rb
+++ b/app/classes/lookup.rb
@@ -114,18 +114,23 @@ class Lookup
 
   def evaluate_values_as_instances
     @unmatched = []
-    @vals.map do |val|
-      if val.is_a?(@model)
-        val
-      elsif val.is_a?(AbstractModel)
-        raise("Passed a #{val.class} to LookupIDs for #{@model}.")
-      elsif /^\d+$/.match?(val.to_s)
-        @model.find(val.to_i)
-      else
-        found = lookup_method(val)
-        @unmatched << val if found.blank?
-        found
-      end
-    end.flatten.uniq.compact
+    @vals.map { |val| match_one_instance(val) }.flatten.uniq.compact
+  end
+
+  def match_one_instance(val)
+    if val.is_a?(@model)
+      val
+    elsif val.is_a?(AbstractModel)
+      raise("Passed a #{val.class} to LookupIDs for #{@model}.")
+    elsif /^\d+$/.match?(val.to_s)
+      @model.find(val.to_i)
+    else
+      # Materialize before checking emptiness -- checking a
+      # still-unloaded Relation, then flattening it, would query
+      # twice (an EXISTS probe, then loading the records).
+      found = lookup_method(val).to_a
+      @unmatched << val if found.empty?
+      found
+    end
   end
 end

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -60,17 +60,22 @@ class Lookup::Names < Lookup
   end
 
   def map_matches
-    @vals.map do |val|
-      if val.is_a?(@model)
-        val
-      elsif val.is_a?(AbstractModel)
-        raise("Passed a #{val.class} to LookupIDs for #{@model}.")
-      elsif /^\d+$/.match?(val.to_s) # from an id
-        Name.where(id: val).select(*minimal_name_columns)
-      else # from a string
-        find_matching_names(val)
-      end
-    end.flatten.uniq.compact
+    @unmatched = []
+    @vals.map { |val| match_one(val) }.flatten.uniq.compact
+  end
+
+  def match_one(val)
+    if val.is_a?(@model)
+      val
+    elsif val.is_a?(AbstractModel)
+      raise("Passed a #{val.class} to LookupIDs for #{@model}.")
+    elsif /^\d+$/.match?(val.to_s) # from an id
+      Name.where(id: val).select(*minimal_name_columns)
+    else # from a string
+      found = find_matching_names(val)
+      @unmatched << val if found.empty?
+      found
+    end
   end
 
   def numeric_list?(list)

--- a/app/classes/lookup/names.rb
+++ b/app/classes/lookup/names.rb
@@ -72,7 +72,10 @@ class Lookup::Names < Lookup
     elsif /^\d+$/.match?(val.to_s) # from an id
       Name.where(id: val).select(*minimal_name_columns)
     else # from a string
-      found = find_matching_names(val)
+      # Materialize before checking emptiness -- checking a
+      # still-unloaded Relation, then flattening it, would query
+      # twice (an EXISTS probe, then loading the records).
+      found = find_matching_names(val).to_a
       @unmatched << val if found.empty?
       found
     end

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -147,7 +147,8 @@ module Searchable
         return
       end
 
-      @query_params[:names][:lookup] = vals.split("\n").map(&:strip)
+      @query_params[:names][:lookup] =
+        vals.split("\n").map(&:strip).compact_blank
     end
 
     # Nested blank values will make for null query results,

--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -10,6 +10,7 @@
 
 module Searchable
   extend ActiveSupport::Concern
+  include Searchable::MatchGuards
 
   # Maximum allowed total length of all search input fields
   MAX_SEARCH_INPUT_LENGTH = 8000
@@ -21,31 +22,8 @@ module Searchable
   # can build a redirect URL well past that, which then shows up as a
   # broken page or a generic error instead of a useful message. Kept
   # well under 8KB to leave room for the rest of the request line and
-  # for tighter limits at other layers (CDN, WAF). See issue #5276.
+  # for tighter limits at other layers (CDN, WAF).
   MAX_INDEX_FILTER_URL_LENGTH = 4000
-
-  # Maximum newline-separated values a single multi-value autocompleter
-  # field (Users, Projects, ...) may submit before being rejected
-  # outright. This does NOT by itself guarantee the redirect URL stays
-  # under MAX_INDEX_FILTER_URL_LENGTH, and there's no per-entry length
-  # cap -- this check exists for the common case instead: a
-  # field-specific message ("Users: too many values") is far more
-  # actionable than the generic aggregate-length one when one field is
-  # the problem. MAX_INDEX_FILTER_URL_LENGTH stays the unconditional
-  # backstop. A Names lookup is handled separately above this count --
-  # see MAX_NAME_LOOKUP_VALUES.
-  MAX_MULTIPLE_VALUES = 50
-
-  # Above MAX_MULTIPLE_VALUES, a Names lookup is resolved to ids
-  # server-side instead of being rejected -- ids are far more compact
-  # than name text (Name's max id is 6 digits in production;
-  # Name.search_name ranges up to 133 characters, 99.9th percentile
-  # 97), so this raises the practical ceiling before
-  # MAX_INDEX_FILTER_URL_LENGTH forces a reject. Above this count,
-  # reject outright rather than resolving, to avoid a large
-  # Lookup::Names DB hit for an obviously-pathological paste. See
-  # issue #5276.
-  MAX_NAME_LOOKUP_VALUES = 150
 
   included do
     def create
@@ -75,6 +53,7 @@ module Searchable
     end
 
     def save_search_query_and_redirect_to_index
+      flash_unmatched_lookups
       save_search_query
       # always_index: 1 preserves MO's existing guarantee that a search
       # submission lands on the results list, not a same-request
@@ -220,8 +199,9 @@ module Searchable
         next if @query_params[field].blank?
 
         klass = lookup_class_for(field)
-        @query_params[field] = klass.new(@query_params[field]).ids.
-                               map(&:to_s)
+        lookup = klass.new(@query_params[field])
+        @query_params[field] = lookup.ids.map(&:to_s)
+        record_unmatched(field, lookup.unmatched)
       end
     end
 
@@ -308,92 +288,6 @@ module Searchable
       messages = @search.validation_error_messages.compact_blank
       flash_error(*messages) if messages.present?
       false
-    end
-
-    # Guards against a single multi-value autocompleter field (Users,
-    # Projects, ...) carrying more than MAX_MULTIPLE_VALUES pasted
-    # values. Runs on the raw (pre-Query) params, before
-    # validate_search_instance?, so it can name the offending field.
-    # The Names lookup field is checked separately -- see
-    # too_many_names_lookup_values?.
-    def too_many_multiple_values?
-      fields_preferring_ids.each do |field|
-        count = multiple_value_count(field)
-        next if count <= Searchable::MAX_MULTIPLE_VALUES
-
-        flash_too_many_values(field, count, Searchable::MAX_MULTIPLE_VALUES)
-        return true
-      end
-      too_many_names_lookup_values?
-    end
-
-    # Above MAX_MULTIPLE_VALUES, resolve the Names lookup to ids
-    # instead of rejecting outright (see MAX_NAME_LOOKUP_VALUES).
-    # Above MAX_NAME_LOOKUP_VALUES, reject without resolving.
-    def too_many_names_lookup_values?
-      return false unless nested_names_params.include?(:lookup)
-
-      field = [:names, :lookup]
-      count = multiple_value_count(field)
-      return false if count <= Searchable::MAX_MULTIPLE_VALUES
-
-      if count > Searchable::MAX_NAME_LOOKUP_VALUES
-        flash_too_many_values(field, count, Searchable::MAX_NAME_LOOKUP_VALUES)
-        return true
-      end
-
-      resolve_names_lookup_to_ids!
-      false
-    end
-
-    # Swaps the pasted name strings in @query_params[:names][:lookup]
-    # for their resolved Name ids -- ids are far shorter than name
-    # text, and any entry that failed to match is dropped in the
-    # process (see issue #5299 for surfacing that to the user).
-    # Resets the expansion-related modifier flags to false: they're
-    # already baked into the resolved id list, and leaving them set
-    # would re-run synonym/subtaxa expansion a second time on the
-    # already-expanded set -- the same hazard flagged in the comment
-    # on Lookup::Names#lookup_ids for a single pass.
-    # include_all_name_proposals/exclude_consensus are left untouched:
-    # they control the Observation<->Naming join, not name resolution.
-    def resolve_names_lookup_to_ids!
-      names = @query_params[:names]
-      lookup = Lookup::Names.new(
-        names[:lookup],
-        include_synonyms: names[:include_synonyms],
-        include_subtaxa: names[:include_subtaxa],
-        include_immediate_subtaxa: names[:include_immediate_subtaxa],
-        exclude_original_names: names[:exclude_original_names]
-      )
-      names[:lookup] = lookup.ids.map(&:to_s)
-      names[:include_synonyms] = false
-      names[:include_subtaxa] = false
-      names[:include_immediate_subtaxa] = false
-      names[:exclude_original_names] = false
-    end
-
-    def flash_too_many_values(field, count, max)
-      flash_error(
-        :runtime_search_too_many_values.t(
-          field: multiple_value_field_label(field), count: count, max: max
-        )
-      )
-    end
-
-    def multiple_value_count(field)
-      value =
-        field.is_a?(Array) ? @query_params.dig(*field) : @query_params[field]
-      return 0 if value.blank?
-      return value.length if value.is_a?(Array)
-
-      value.to_s.split("\n").compact_blank.length
-    end
-
-    def multiple_value_field_label(field)
-      return :names.t.to_s if field.is_a?(Array)
-
-      :"query_#{field}".l.humanize
     end
 
     # Guards against a redirect URL too long for a front-end proxy's

--- a/app/controllers/concerns/searchable/match_guards.rb
+++ b/app/controllers/concerns/searchable/match_guards.rb
@@ -38,6 +38,13 @@ module Searchable::MatchGuards
   # before falling back to "... and N more".
   MAX_UNMATCHED_VALUES_DISPLAYED = 10
 
+  # Length each displayed unmatched entry is truncated to. A paste
+  # with no newlines (values separated by commas/tabs/spaces instead)
+  # becomes one long "unmatched" entry -- unbounded, since nothing
+  # limits an individual line's length before it reaches here. session
+  # is cookie-backed, so embedding it whole risks CookieOverflow.
+  MAX_UNMATCHED_VALUE_LENGTH = 50
+
   included do
     private
 
@@ -166,10 +173,18 @@ module Searchable::MatchGuards
     end
 
     def truncated_unmatched_list(vals)
-      shown = vals.first(MAX_UNMATCHED_VALUES_DISPLAYED)
+      shown = vals.first(MAX_UNMATCHED_VALUES_DISPLAYED).map do |val|
+        truncate_unmatched_value(val)
+      end
       return shown.join(", ") if shown.length == vals.length
 
       "#{shown.join(", ")}, and #{vals.length - shown.length} more"
+    end
+
+    def truncate_unmatched_value(val)
+      return val if val.length <= MAX_UNMATCHED_VALUE_LENGTH
+
+      "#{val[0, MAX_UNMATCHED_VALUE_LENGTH]}..."
     end
 
     def multiple_value_count(field)

--- a/app/controllers/concerns/searchable/match_guards.rb
+++ b/app/controllers/concerns/searchable/match_guards.rb
@@ -80,15 +80,19 @@ module Searchable::MatchGuards
     end
 
     # Below MAX_MULTIPLE_VALUES the raw text stays as-is (still short
-    # enough to be readable in the URL) -- lookup.ids is still called,
-    # just to find which entries didn't match anything.
+    # enough to be readable in the URL) -- original_names is still
+    # called, just to find which entries didn't match anything.
+    # original_names stops after the first resolution pass, skipping
+    # the synonym/subtaxa expansion .ids would trigger (expensive, and
+    # unneeded here since unmatched is already populated by that
+    # point).
     def check_names_lookup_matches(count)
       names = @query_params[:names]
       lookup = build_names_lookup(names)
       if count > MAX_MULTIPLE_VALUES
         resolve_names_lookup_to_ids!(names, lookup)
       else
-        lookup.ids
+        lookup.original_names
       end
       record_unmatched([:names, :lookup], lookup.unmatched)
     end
@@ -137,23 +141,28 @@ module Searchable::MatchGuards
       )
     end
 
+    # Dedup here, once, so the flashed count and list stay in sync --
+    # a repeated typo shouldn't inflate the "N value(s) didn't match"
+    # count or fill the truncated list with copies of itself.
     def record_unmatched(field, unmatched_vals)
       return if unmatched_vals.blank?
 
-      (@unmatched_lookups ||= []) << [field, unmatched_vals]
+      (@unmatched_lookups ||= []) << [field, unmatched_vals.uniq]
     end
 
+    # One flash_warning call, so multiple fields with misses land as
+    # separate paragraphs in a single flash box instead of one box per
+    # field.
     def flash_unmatched_lookups
       return if @unmatched_lookups.blank?
 
-      @unmatched_lookups.each do |field, vals|
-        flash_warning(
-          :runtime_search_unmatched_values.t(
-            field: multiple_value_field_label(field), count: vals.length,
-            list: truncated_unmatched_list(vals)
-          )
+      messages = @unmatched_lookups.map do |field, vals|
+        :runtime_search_unmatched_values.t(
+          field: multiple_value_field_label(field), count: vals.length,
+          list: truncated_unmatched_list(vals)
         )
       end
+      flash_warning(*messages)
     end
 
     def truncated_unmatched_list(vals)

--- a/app/controllers/concerns/searchable/match_guards.rb
+++ b/app/controllers/concerns/searchable/match_guards.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+#
+#  = Searchable::MatchGuards Concern
+#
+#  Guards a Searchable controller's raw search params against
+#  pathologically large multi-value fields, and tracks/flashes any
+#  pasted value that failed to match a record.
+#
+################################################################################
+
+module Searchable::MatchGuards
+  extend ActiveSupport::Concern
+
+  # Maximum newline-separated values a single multi-value autocompleter
+  # field (Users, Projects, ...) may submit before being rejected
+  # outright. This does NOT by itself guarantee the redirect URL stays
+  # under MAX_INDEX_FILTER_URL_LENGTH, and there's no per-entry length
+  # cap -- this check exists for the common case instead: a
+  # field-specific message ("Users: too many values") is far more
+  # actionable than the generic aggregate-length one when one field is
+  # the problem. MAX_INDEX_FILTER_URL_LENGTH stays the unconditional
+  # backstop. A Names lookup is handled separately above this count --
+  # see MAX_NAME_LOOKUP_VALUES.
+  MAX_MULTIPLE_VALUES = 50
+
+  # Above MAX_MULTIPLE_VALUES, a Names lookup is resolved to ids
+  # server-side instead of being rejected -- ids are far more compact
+  # than name text (Name's max id is 6 digits in production;
+  # Name.search_name ranges up to 133 characters, 99.9th percentile
+  # 97), so this raises the practical ceiling before
+  # MAX_INDEX_FILTER_URL_LENGTH forces a reject. Above this count,
+  # reject outright rather than resolving, to avoid a large
+  # Lookup::Names DB hit for an obviously-pathological paste.
+  MAX_NAME_LOOKUP_VALUES = 150
+
+  # Unmatched entries listed by name in the "didn't match" warning
+  # before falling back to "... and N more".
+  MAX_UNMATCHED_VALUES_DISPLAYED = 10
+
+  included do
+    private
+
+    # Guards against a single multi-value autocompleter field (Users,
+    # Projects, ...) carrying more than MAX_MULTIPLE_VALUES pasted
+    # values. Runs on the raw (pre-Query) params, before
+    # validate_search_instance?, so it can name the offending field.
+    # The Names lookup field is checked separately -- see
+    # too_many_names_lookup_values?.
+    def too_many_multiple_values?
+      fields_preferring_ids.each do |field|
+        count = multiple_value_count(field)
+        next if count <= MAX_MULTIPLE_VALUES
+
+        flash_too_many_values(field, count, MAX_MULTIPLE_VALUES)
+        return true
+      end
+      too_many_names_lookup_values?
+    end
+
+    # Above MAX_MULTIPLE_VALUES, resolve the Names lookup to ids
+    # instead of rejecting outright (see MAX_NAME_LOOKUP_VALUES).
+    # Above MAX_NAME_LOOKUP_VALUES, reject without resolving. At or
+    # under MAX_MULTIPLE_VALUES, the raw text stays as-is, but is
+    # still checked for unmatched entries either way.
+    def too_many_names_lookup_values?
+      return false unless nested_names_params.include?(:lookup)
+
+      field = [:names, :lookup]
+      count = multiple_value_count(field)
+      return false if count.zero?
+
+      if count > MAX_NAME_LOOKUP_VALUES
+        flash_too_many_values(field, count, MAX_NAME_LOOKUP_VALUES)
+        return true
+      end
+
+      check_names_lookup_matches(count)
+      false
+    end
+
+    # Below MAX_MULTIPLE_VALUES the raw text stays as-is (still short
+    # enough to be readable in the URL) -- lookup.ids is still called,
+    # just to find which entries didn't match anything.
+    def check_names_lookup_matches(count)
+      names = @query_params[:names]
+      lookup = build_names_lookup(names)
+      if count > MAX_MULTIPLE_VALUES
+        resolve_names_lookup_to_ids!(names, lookup)
+      else
+        lookup.ids
+      end
+      record_unmatched([:names, :lookup], lookup.unmatched)
+    end
+
+    def build_names_lookup(names)
+      Lookup::Names.new(
+        names[:lookup],
+        include_synonyms: names[:include_synonyms],
+        include_subtaxa: names[:include_subtaxa],
+        include_immediate_subtaxa: names[:include_immediate_subtaxa],
+        exclude_original_names: names[:exclude_original_names]
+      )
+    end
+
+    # Swaps the pasted name strings for their resolved Name ids -- ids
+    # are far shorter than name text. Resets the expansion-related
+    # modifier flags to false: they're already baked into the
+    # resolved id list, and leaving them set would re-run
+    # synonym/subtaxa expansion a second time on the already-expanded
+    # set -- the same hazard flagged in the comment on
+    # Lookup::Names#lookup_ids for a single pass.
+    # include_all_name_proposals/exclude_consensus are left untouched:
+    # they control the Observation<->Naming join, not name resolution.
+    def resolve_names_lookup_to_ids!(names, lookup)
+      names[:lookup] = lookup.ids.map(&:to_s)
+      names[:include_synonyms] = false
+      names[:include_subtaxa] = false
+      names[:include_immediate_subtaxa] = false
+      names[:exclude_original_names] = false
+    end
+
+    def flash_too_many_values(field, count, max)
+      flash_error(
+        :runtime_search_too_many_values.t(
+          field: multiple_value_field_label(field), count: count, max: max
+        )
+      )
+    end
+
+    def record_unmatched(field, unmatched_vals)
+      return if unmatched_vals.blank?
+
+      (@unmatched_lookups ||= []) << [field, unmatched_vals]
+    end
+
+    def flash_unmatched_lookups
+      return if @unmatched_lookups.blank?
+
+      @unmatched_lookups.each do |field, vals|
+        flash_warning(
+          :runtime_search_unmatched_values.t(
+            field: multiple_value_field_label(field), count: vals.length,
+            list: truncated_unmatched_list(vals)
+          )
+        )
+      end
+    end
+
+    def truncated_unmatched_list(vals)
+      shown = vals.first(MAX_UNMATCHED_VALUES_DISPLAYED)
+      return shown.join(", ") if shown.length == vals.length
+
+      "#{shown.join(", ")}, and #{vals.length - shown.length} more"
+    end
+
+    def multiple_value_count(field)
+      value =
+        field.is_a?(Array) ? @query_params.dig(*field) : @query_params[field]
+      return 0 if value.blank?
+      return value.length if value.is_a?(Array)
+
+      value.to_s.split("\n").compact_blank.length
+    end
+
+    def multiple_value_field_label(field)
+      return :names.t.to_s if field.is_a?(Array)
+
+      :"query_#{field}".l.humanize
+    end
+  end
+end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -3997,6 +3997,7 @@
   runtime_no_more: There are no more [types].
   runtime_search_string_too_long: "Search string too long ([length] characters). Maximum is [max] characters."
   runtime_search_too_many_values: "[field]: too many values ([count]). Maximum is [max]."
+  runtime_search_unmatched_values: "[field]: [count] value(s) did not match anything: [list]."
   runtime_no_parse: "Unable to parse: '[value]'"
   runtime_no_save: Unable to save [type].
   runtime_no_update: Unable to update [type].

--- a/test/classes/lookup_test.rb
+++ b/test/classes/lookup_test.rb
@@ -66,6 +66,22 @@ class LookupTest < UnitTestCase
     assert_lookup_objects(:Observations, expects, expects.map(&:id))
   end
 
+  def test_lookup_unmatched_tracks_misses
+    herb = herbaria(:rolf_herbarium)
+    lookup = Lookup::Herbaria.new([herb.name, "Nonexistent Herbarium XYZ"])
+
+    assert_equal([herb.id], lookup.ids)
+    assert_equal(["Nonexistent Herbarium XYZ"], lookup.unmatched)
+  end
+
+  def test_lookup_unmatched_empty_when_all_match
+    herb = herbaria(:rolf_herbarium)
+    lookup = Lookup::Herbaria.new([herb.name])
+
+    lookup.ids
+    assert_equal([], lookup.unmatched)
+  end
+
   ########################################################################
   # tests of Lookup::Names
   #
@@ -184,6 +200,25 @@ class LookupTest < UnitTestCase
 
   def test_lookup_names_by_name_invalid
     assert_lookup_names([], ["¡not a name!"])
+  end
+
+  def test_lookup_names_unmatched_tracks_misses
+    name = names(:coprinus_comatus)
+    lookup = Lookup::Names.new([name.text_name, "¡not a name!"])
+
+    assert_equal([name.id], lookup.ids)
+    assert_equal(["¡not a name!"], lookup.unmatched)
+  end
+
+  # Expansion (synonyms/subtaxa) adds names beyond the literal matches --
+  # unmatched must reflect only the original resolution, not that growth.
+  def test_lookup_names_unmatched_unaffected_by_subtaxa_expansion
+    name1 = names(:macrolepiota)
+    lookup = Lookup::Names.new([name1.text_name, "¡not a name!"],
+                               include_subtaxa: true)
+
+    assert_operator(lookup.ids.length, :>, 1)
+    assert_equal(["¡not a name!"], lookup.unmatched)
   end
 
   def create_test_name(name)

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -964,6 +964,69 @@ module Observations
       assert_no_flash
     end
 
+    # Under-threshold unmatched-tracking calls original_names, not ids
+    # (skips subtaxa expansion) -- confirm it still finds the miss
+    # correctly with include_subtaxa on, the search form's default.
+    def test_names_lookup_unmatched_check_works_with_subtaxa_enabled
+      login
+      name = names(:macrolepiota)
+      params = {
+        names: {
+          lookup: "#{name.text_name}\nNonexistent Taxon",
+          include_subtaxa: "true"
+        }
+      }
+
+      post(:create, params: { query_observations: params })
+
+      assert_response(:redirect)
+      assert_flash_warning(
+        :runtime_search_unmatched_values,
+        field: :names.t.to_s, count: 1, list: "Nonexistent Taxon"
+      )
+    end
+
+    def test_names_lookup_unmatched_entries_deduped
+      login
+      lookup = "Nonexistent Taxon\nNonexistent Taxon"
+      params = { names: { lookup: lookup } }
+
+      post(:create, params: { query_observations: params })
+
+      assert_flash_warning(
+        :runtime_search_unmatched_values,
+        field: :names.t.to_s, count: 1, list: "Nonexistent Taxon"
+      )
+    end
+
+    # Two different fields with misses must land in the same flash,
+    # each as a separate paragraph -- neither call should overwrite
+    # the other's message. The Array form of assert_flash_warning
+    # checks the exact concatenated text, in order, so it fails if
+    # either message went missing or got clobbered.
+    def test_multiple_fields_with_unmatched_entries_flash_together
+      login
+      herbarium = herbaria(:nybg_herbarium)
+      name = names(:coprinus_comatus)
+      params = {
+        herbaria: "#{herbarium.name}\nNonexistent Herbarium XYZ",
+        names: { lookup: "#{name.text_name}\nNonexistent Taxon" }
+      }
+
+      post(:create, params: { query_observations: params })
+
+      assert_response(:redirect)
+      assert_flash_warning(
+        [
+          [:runtime_search_unmatched_values,
+           { field: :names.t.to_s, count: 1, list: "Nonexistent Taxon" }],
+          [:runtime_search_unmatched_values,
+           { field: :query_herbaria.l.humanize, count: 1,
+             list: "Nonexistent Herbarium XYZ" }]
+        ]
+      )
+    end
+
     private
 
     def create_test_names(count)

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -1027,6 +1027,26 @@ module Observations
       )
     end
 
+    # A paste with no newlines (values separated by commas/tabs/spaces
+    # instead) becomes one long unmatched "value" -- must not embed
+    # it whole in the flash. session is cookie-backed; an unbounded
+    # value there risks CookieOverflow.
+    def test_unmatched_long_unseparated_entry_truncated_in_flash
+      login
+      long_paste = "Species " * 200
+      params = { names: { lookup: long_paste } }
+
+      post(:create, params: { query_observations: params })
+
+      assert_response(:redirect)
+      max = Searchable::MatchGuards::MAX_UNMATCHED_VALUE_LENGTH
+      assert_flash_warning(
+        :runtime_search_unmatched_values,
+        field: :names.t.to_s, count: 1,
+        list: "#{long_paste[0, max]}..."
+      )
+    end
+
     private
 
     def create_test_names(count)

--- a/test/controllers/observations/search_controller_test.rb
+++ b/test/controllers/observations/search_controller_test.rb
@@ -788,7 +788,7 @@ module Observations
       assert_flash_error(
         :runtime_search_too_many_values,
         field: :query_by_users.l.humanize, count: 60,
-        max: Searchable::MAX_MULTIPLE_VALUES
+        max: Searchable::MatchGuards::MAX_MULTIPLE_VALUES
       )
     end
 
@@ -812,7 +812,7 @@ module Observations
       assert_flash_error(
         :runtime_search_too_many_values,
         field: :query_herbaria.l.humanize, count: 60,
-        max: Searchable::MAX_MULTIPLE_VALUES
+        max: Searchable::MatchGuards::MAX_MULTIPLE_VALUES
       )
     end
 
@@ -875,8 +875,8 @@ module Observations
     def test_names_lookup_between_thresholds_that_fail_to_resolve
       login
       # None of these match anything, so resolution produces an empty
-      # id list -- should still redirect (not error), matching the
-      # existing silent-drop behavior for unmatched names.
+      # id list -- should still redirect (not error), with a warning
+      # listing (a truncated sample of) what didn't match.
       unmatched = (1..60).map { |i| "Nonexistent Taxon #{i}" }.join("\n")
       params = { names: { lookup: unmatched } }
 
@@ -885,6 +885,62 @@ module Observations
       end
 
       assert_response(:redirect)
+      shown = (1..10).map { |i| "Nonexistent Taxon #{i}" }.join(", ")
+      expected_list = "#{shown}, and 50 more"
+      assert_flash_warning(
+        :runtime_search_unmatched_values,
+        field: :names.t.to_s, count: 60, list: expected_list
+      )
+    end
+
+    # ---------------------------------------------------------------
+    #  Unmatched-entry feedback (issue #5299)
+    # ---------------------------------------------------------------
+
+    def test_fields_preferring_ids_unmatched_entries_flashed
+      login
+      user = users(:mary)
+      params = { by_users: "#{user.login}\nnonexistent_login_xyz" }
+
+      post(:create, params: { query_observations: params })
+
+      assert_flash_warning(
+        :runtime_search_unmatched_values,
+        field: :query_by_users.l.humanize, count: 1,
+        list: "nonexistent_login_xyz"
+      )
+      assert_search_redirected_to(
+        controller: "/observations",
+        params: { by_user: user.id }
+      )
+    end
+
+    def test_names_lookup_unmatched_entries_flashed_under_threshold
+      login
+      name = names(:coprinus_comatus)
+      lookup = "#{name.text_name}\nNonexistent Taxon"
+      params = { names: { lookup: lookup } }
+
+      post(:create, params: { query_observations: params })
+
+      assert_flash_warning(
+        :runtime_search_unmatched_values,
+        field: :names.t.to_s, count: 1, list: "Nonexistent Taxon"
+      )
+      # Under threshold: raw text stays as-is, not resolved to ids.
+      redirect_params = parse_redirect_names_params
+      assert_equal([name.text_name, "Nonexistent Taxon"],
+                   redirect_params["lookup"])
+    end
+
+    def test_names_lookup_no_warning_when_all_match
+      login
+      name = names(:coprinus_comatus)
+      params = { names: { lookup: name.text_name } }
+
+      post(:create, params: { query_observations: params })
+
+      assert_no_flash
     end
 
     private


### PR DESCRIPTION
Gives the user flash feedback when looked up values don't resolve, from user input an autocompleted search field. 

## Summary

Fixes #5299. `Lookup#evaluate_values_as_ids`/`#evaluate_values_as_instances` and `Lookup::Names#map_matches` iterate the pasted values and silently drop any that produce zero matches -- a search for 74 names where only 3 resolve runs identically to a search for those 3 names alone, with no count, no list, no signal that 71 lines were ignored.

1. **`Lookup#unmatched`** -- tracks which input values produced no match, populated as a side effect of `ids`/`instances`. `Lookup::Names#map_matches` gets the same tracking on its override path, at the original-resolution stage, before synonym/subtaxa expansion -- so expansion growth isn't mistaken for a miss.
2. **Wired into `Searchable#create`.** `fields_preferring_ids` (Users, Herbaria, Projects, SpeciesLists, Locations) already resolves to ids on every search (from #5298's fix), so unmatched-tracking there is free. Names now also runs a full unmatched check on every search with a Names filter, not only the already-resolved >50-value case from #5298 -- one extra DB round-trip on a typical search, in exchange for catching the scenario from the bug report (a handful of typos in an otherwise normal-sized search). Below the id-substitution threshold, the raw text is still left as-is in the redirect; only the unmatched check runs.
3. **Flash.** One `flash_warning` per field with misses, e.g. `"Herbaria: 3 value(s) did not match anything: Foo, Bar, Baz."`, truncated to 10 named entries plus `"... and N more"` for a large paste.

**Scope, per the issue:** the channel stops at `Searchable#create`. The ~25 other `Lookup` call sites (`Observation::Scopes`, `Name::Scopes`, model instance methods, `filter_caption.rb`, the autocompleter-prefill component) have no controller or flash context for a miss to surface through, and restructuring them to have one is a separate, larger change. `Lookup::ProjectSpeciesLists` is also untouched -- it resolves a set of Project ids and returns every SpeciesList across all of them collectively, so there's no "this specific input didn't match" concept there. The numeric-id path (`@model.find(val.to_i)` in `evaluate_values_as_instances`) already raises `RecordNotFound` rather than silently dropping -- a different failure mode, also untouched.

**`Searchable::MatchGuards`** -- the too-many-values guards plus this new unmatched-tracking logic moved into a separate concern (`app/controllers/concerns/searchable/match_guards.rb`), mirroring the existing `Descriptions`/`Descriptions::Permissions` split in this codebase. `Searchable` itself went over `Metrics/ModuleLength` once the unmatched-flash logic landed; splitting the guard logic out was cleaner than shaving lines to fit a budget. Composed via `include Searchable::MatchGuards` at the top of `Searchable` -- Concern's dependency-composition means every controller that includes `Searchable` gets `MatchGuards`' `included do` block too, with no per-controller change needed. Its methods stay `private`, matching their visibility before the split.

## Test plan

- [x] `bundle exec rubocop` on every touched file -- no offenses
- [x] `bin/rails test test/classes/lookup_test.rb` -- all pass
- [x] `bin/rails test test/controllers/observations/search_controller_test.rb` -- all pass

<!-- changelog -->
article: no
<!-- /changelog -->

