### PR TITLE
Fold project/field-slip standardization into the iNat importer (#5259)

### DIFF
--- a/app/classes/field_slip/attacher.rb
+++ b/app/classes/field_slip/attacher.rb
@@ -32,7 +32,17 @@ class FieldSlip
     end
 
     # Returns what happened, for the caller's log line.
+    ATTACHED_RESULTS = [:attached, :joined, :merged].freeze
+
     def attach
+      result = perform_attach
+      reconcile_import_project(result)
+      result
+    end
+
+    private
+
+    def perform_attach
       existing = FieldSlip.find_by(code: @code)
       return attach_with_occurrence(existing) if @observation.occurrence_id
       return join_or_refuse(existing) if existing&.occurrence
@@ -45,7 +55,17 @@ class FieldSlip
       :attached
     end
 
-    private
+    # Case-2 hook of the import standardization (#5259): a slip landing
+    # on an import-created observation whose import has a target
+    # project gets reconciled with that project. Best-effort -- the
+    # attach itself must not fail over it.
+    def reconcile_import_project(result)
+      return unless ATTACHED_RESULTS.include?(result)
+
+      Inat::ProjectSlipStandardizer.reconcile_after_attach(@observation)
+    rescue StandardError => e
+      Rails.logger.warn("Import project reconcile failed: #{e.message}")
+    end
 
     # The observation already belongs to an occurrence. Three shapes:
     # the code names a slip on a different occurrence (merge), the

--- a/app/classes/form_object/inat_import.rb
+++ b/app/classes/form_object/inat_import.rb
@@ -12,4 +12,6 @@ class FormObject::InatImport < FormObject::Base
   attribute :recheck_all, :string
   attribute :skip_inat_writeback, :string
   attribute :choose_method, :string
+  attribute :inat_project, :string
+  attribute :inat_project_id, :string
 end

--- a/app/classes/form_object/inat_import_confirm.rb
+++ b/app/classes/form_object/inat_import_confirm.rb
@@ -12,4 +12,6 @@ class FormObject::InatImportConfirm < FormObject::Base
   attribute :original_inat_url, :string
   attribute :recheck_all, :string
   attribute :skip_inat_writeback, :string
+  attribute :inat_project, :string
+  attribute :inat_project_id, :string
 end

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -22,6 +22,8 @@ class Inat
     attr_reader :inat_import, :user, :job,
                 :unlicensed_obs_count, :skipped_images_count, :image_ids
 
+    include Standardization
+
     def initialize(inat_import, user, job = nil)
       @inat_import = inat_import
       @user = user
@@ -53,6 +55,7 @@ class Inat
       return unless @observation
 
       accumulate_counts(builder)
+      standardize_for_project
       finalize_import
     end
 
@@ -192,6 +195,7 @@ class Inat
       @unlicensed_obs_count += builder.unlicensed_obs
       @skipped_images_count += builder.skipped_images
       @image_ids.concat(builder.created_image_ids)
+      record_unlicensed_images(builder)
       return unless builder.unlicensed_obs == 1
 
       inat_import.add_license_added_obs(inat_id: @inat_obs[:id])

--- a/app/classes/inat/observation_importer/standardization.rb
+++ b/app/classes/inat/observation_importer/standardization.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Inat
+  class ObservationImporter
+    # Per-observation project/field-slip standardization and
+    # unlicensed-image recording (#5259).
+    module Standardization
+      private
+
+      # Photos skipped for a missing iNat license, recorded with who
+      # and which license choice so the pattern is reviewable.
+      def record_unlicensed_images(builder)
+        return unless builder.skipped_images.positive?
+
+        @inat_import.add_unlicensed_image_event(
+          inat_id: @inat_obs[:id], login: @inat_obs[:user][:login],
+          license_code: @inat_obs[:license_code],
+          count: builder.skipped_images
+        )
+      end
+
+      # Inline standardization against the import's target project. A
+      # failure is logged; the observation's import still counts.
+      def standardize_for_project
+        standardizer.standardize(@observation, inat_id: @inat_obs[:id])
+      rescue StandardError => e
+        log_with_response_error(
+          "Standardization failed for iNat #{@inat_obs[:id]}: #{e.message}"
+        )
+      end
+
+      def standardizer
+        @standardizer ||= Inat::ProjectSlipStandardizer.new(@inat_import)
+      end
+    end
+  end
+end

--- a/app/classes/inat/project_slip_standardizer.rb
+++ b/app/classes/inat/project_slip_standardizer.rb
@@ -155,11 +155,26 @@ class Inat
     def ensure_member(observation)
       return if member?(observation)
 
+      enroll_importer
       if admin_import? || !@project.violates_constraints?(observation)
         @project.add_observation(observation)
       else
         @import.add_constraint_violation_obs(observation.id)
       end
+    end
+
+    # Filing observations into a project enrolls the importer, the way
+    # the field-slip attach path's `apply_project` does (#4932
+    # invariant 4: whoever puts observations in a project is a
+    # member). The form gate already refused a project the user can
+    # neither join nor administer.
+    def enroll_importer
+      return if @enrolled
+
+      @enrolled = true
+      return if @project.member?(@import.user)
+
+      @project.join(@import.user)
     end
 
     def member?(observation)

--- a/app/classes/inat/project_slip_standardizer.rb
+++ b/app/classes/inat/project_slip_standardizer.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+class Inat
+  # Standardizes one imported observation's project and field-slip
+  # associations against the import's target project (#5259). No-op
+  # when the import has no project.
+  #
+  # Two entry points:
+  #
+  # `standardize(observation, inat_id:)` runs inline, right after the
+  # importer creates the observation. Priority order:
+  #
+  #   1. iNat-linked native partner: a native (non-reflection)
+  #      observation whose notes cite this observation's iNat number
+  #      and which carries a field slip is the same physical specimen
+  #      scanned at the foray. The import observation joins that
+  #      native's occurrence (its correct slip wins); the native stays
+  #      primary, since a reflection may not be an occurrence's
+  #      primary. A slip already on the import observation yields via
+  #      `Occurrence.merge!`.
+  #   2. A slip already attached (reused/spare, wrong project): the
+  #      slip is reassigned to the target project.
+  #   3. A target-prefix code in the notes (the collector wrote the
+  #      code in the iNat description): attach it.
+  #   4. Otherwise, just add the observation to the project.
+  #
+  # `reconcile_after_attach(observation)` is the case-2 hook for slips
+  # the asynchronous QR scan attaches later (the scan is an
+  # `ObservationImage` callback, not part of the import pipeline, so
+  # it settles after the inline pass ran).
+  #
+  # Membership respects the plan's constraint rule: an import run by a
+  # project admin adds every observation; anyone else's adds respect
+  # the project's constraints, and the observations kept out are
+  # recorded on the import for review.
+  class ProjectSlipStandardizer
+    INAT_REF = %r{(?:observations/|iNat[^0-9]{0,4})(\d{6,})}i
+
+    def self.reconcile_after_attach(observation)
+      import = observation.inat_import
+      return unless import&.project_id
+
+      new(import).reconcile_slip(observation)
+    end
+
+    def initialize(inat_import)
+      @import = inat_import
+      @project = inat_import.project
+      @prefix = @project&.field_slip_prefix.to_s
+    end
+
+    def active?
+      @project.present?
+    end
+
+    def standardize(observation, inat_id:)
+      return unless active?
+
+      native = native_partner(observation, inat_id.to_s)
+      if native
+        link_to_native(observation, native)
+      elsif (slip = observation.occurrence&.field_slip)
+        reassign_slip(slip)
+      elsif (code = notes_slip_code(observation))
+        attach_from_notes(observation, code)
+      end
+      ensure_member(observation)
+    end
+
+    # Case 2 for a slip attached after the inline pass (QR scan,
+    # review save): move a wrong-project slip to the target project
+    # and keep a native member primary.
+    def reconcile_slip(observation)
+      return unless active?
+
+      slip = observation.occurrence&.field_slip
+      return unless slip
+
+      reassign_slip(slip)
+      keep_native_primary(observation.occurrence)
+      ensure_member(observation)
+    end
+
+    private
+
+    # A native observation citing this iNat number in its notes and
+    # carrying a field slip. Reflections are excluded -- another
+    # import's copy of the same record is not a foray scan.
+    def native_partner(observation, inat_id)
+      return nil if inat_id.blank?
+
+      Observation.where(Observation[:notes].matches("%#{inat_id}%")).
+        where(reflected_at: nil).where.not(id: observation.id).
+        includes(occurrence: :field_slip).
+        find { |cand| native_match?(cand, inat_id) }
+    end
+
+    def native_match?(cand, inat_id)
+      cand.occurrence&.field_slip_id &&
+        cand.notes.to_s.scan(INAT_REF).flatten.include?(inat_id)
+    end
+
+    # Case 1: join the native's occurrence; its slip wins.
+    def link_to_native(observation, native)
+      return if observation.occurrence_id == native.occurrence_id
+
+      if observation.occurrence_id
+        Occurrence.merge!(native.occurrence, observation.occurrence,
+                          @import.user)
+      else
+        observation.update!(occurrence: native.occurrence)
+      end
+    end
+
+    # Case 2. Set the column directly: `FieldSlip#project=` gates on
+    # the current user's add-slip permission and silently keeps nil
+    # here. The change fires `cascade_project_change`, which files the
+    # occurrence's observations into the project.
+    def reassign_slip(slip)
+      return if slip.project_id == @project.id
+
+      slip.update!(project_id: @project.id)
+    end
+
+    # Case 3: attach the slip named by a target-prefix code found in
+    # the notes.
+    def attach_from_notes(observation, code)
+      FieldSlip::Attacher.attach(observation: observation, code: code,
+                                 user: observation.user, join_in_use: true)
+      keep_native_primary(observation.reload.occurrence)
+    end
+
+    # An in-use code joins an existing occurrence and `Attacher` makes
+    # the joiner primary -- wrong when the joiner is a reflection and a
+    # native member is present. Hand primary to the oldest native
+    # member; an all-reflection occurrence keeps the reflection.
+    def keep_native_primary(occurrence)
+      return unless occurrence
+
+      occurrence.reload
+      return unless occurrence.primary_observation&.reflection?
+
+      native = occurrence.observations.reject(&:reflection?).min_by(&:id)
+      occurrence.update!(primary_observation: native) if native
+    end
+
+    # The first target-prefix code in the observation's notes.
+    def notes_slip_code(observation)
+      return nil if @prefix.blank?
+
+      observation.notes.to_s[/\b#{Regexp.escape(@prefix)}-\d{1,6}\b/i]&.
+        upcase
+    end
+
+    def ensure_member(observation)
+      return if member?(observation)
+
+      if admin_import? || !@project.violates_constraints?(observation)
+        @project.add_observation(observation)
+      else
+        @import.add_constraint_violation_obs(observation.id)
+      end
+    end
+
+    def member?(observation)
+      @project.observations.exists?(id: observation.id)
+    end
+
+    def admin_import?
+      @project.is_admin?(@import.user)
+    end
+  end
+end

--- a/app/controllers/inat_imports_controller.rb
+++ b/app/controllers/inat_imports_controller.rb
@@ -291,7 +291,8 @@ class InatImportsController < ApplicationController
       original_inat_url: params[:original_inat_url].presence,
       import_others: import_others?,
       recheck_all: recheck_all?,
-      writeback: writeback_policy
+      writeback: writeback_policy,
+      project_id: chosen_project_id
     }
   end
 
@@ -316,6 +317,12 @@ class InatImportsController < ApplicationController
     return nil if importing_all? || listing_url?
 
     inat_id_list.length
+  end
+
+  # Target project for the #5259 standardization; validated by
+  # `project_valid?`, which also fills in the id for a typed title.
+  def chosen_project_id
+    params[:inat_project_id].presence
   end
 
   # Returns whether this import covers other users' observations.

--- a/app/controllers/inat_imports_controller/form_builders.rb
+++ b/app/controllers/inat_imports_controller/form_builders.rb
@@ -4,7 +4,7 @@ module InatImportsController::FormBuilders
   # Params carried verbatim from the new form through the confirm page.
   PASSTHROUGH_PARAM_KEYS = [
     :inat_username, :inat_ids, :inat_url, :original_inat_url, :consent,
-    :recheck_all, :skip_inat_writeback
+    :recheck_all, :skip_inat_writeback, :inat_project, :inat_project_id
   ].freeze
 
   # Params that are literally "1" when checked/selected, absent or any
@@ -47,6 +47,8 @@ module InatImportsController::FormBuilders
       inat_url: reload_inat_url,
       choose_method: params[:choose_method] || derive_choose_method,
       skip_inat_writeback: initial_skip_writeback,
+      inat_project: params[:inat_project],
+      inat_project_id: params[:inat_project_id],
       **checkbox_flag_params
     )
   end

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -15,7 +15,40 @@ module InatImportsController::Validators
   def params_valid?
     import_adequately_constrained? &&
       imports_valid? &&
+      project_valid? &&
       consented?
+  end
+
+  # Optional target project (#5259). Blank is fine. A chosen project
+  # must exist and be one the user may put observations into (admin,
+  # member, or joinable -- #4932 invariant 4). Typed text that resolves
+  # to no project is refused rather than silently dropped.
+  def project_valid?
+    return true if params[:inat_project_id].blank? &&
+                   params[:inat_project].blank?
+
+    project = resolve_project_param
+    if project.nil?
+      flash_warning(:inat_project_not_recognized.l)
+      false
+    elsif project_usable?(project)
+      true
+    else
+      flash_warning(:inat_project_not_allowed.t(title: project.title))
+      false
+    end
+  end
+
+  def project_usable?(project)
+    project.is_admin?(@user) || project.member?(@user) ||
+      project.can_join?(@user)
+  end
+
+  def resolve_project_param
+    project = Project.safe_find(params[:inat_project_id]) ||
+              Project.find_by(title: params[:inat_project].to_s.strip)
+    params[:inat_project_id] = project&.id&.to_s
+    project
   end
 
   # See InatImport.adequate_constraints?

--- a/app/jobs/check_for_broken_references_job/checks.rb
+++ b/app/jobs/check_for_broken_references_job/checks.rb
@@ -73,6 +73,7 @@ class CheckForBrokenReferencesJob
       [Image,                        :license,              :alert],
       # [Image,                      :reviewer,             :alert],
       [Image,                        :user,                 :alert],
+      [InatImport,                   :project,              :nil],
       [InatImport,                   :user,                 :alert],
       [ImageVote,                    :image,                :delete],
       [ImageVote,                    :user,                 :delete],

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -68,11 +68,16 @@ class InatImport < ApplicationRecord
   }, prefix: true
 
   belongs_to :user
+  # Target project for the import's project/field-slip standardization
+  # (#5259); blank for ordinary user-driven imports.
+  belongs_to :project, optional: true
   has_many :observations, dependent: :nullify
 
   serialize :log, type: Array, coder: YAML
   serialize :date_missing_inat_ids, coder: JSON
   serialize :license_added_inat_ids, coder: JSON
+  serialize :constraint_violation_obs_ids, coder: JSON
+  serialize :unlicensed_image_events, coder: JSON
 
   after_update_commit lambda { |inat_import|
     html = ApplicationController.renderer.render(
@@ -150,6 +155,33 @@ class InatImport < ApplicationRecord
   def add_license_added_obs(inat_id:)
     reload
     update!(license_added_inat_ids: license_added_inat_ids + [inat_id])
+  end
+
+  # Serialized-JSON columns are NULL until first written.
+  def constraint_violation_obs_ids
+    super || []
+  end
+
+  def unlicensed_image_events
+    super || []
+  end
+
+  # An observation the standardizer kept out of the target project
+  # because it violates the project's constraints (#5259).
+  def add_constraint_violation_obs(obs_id)
+    reload
+    update!(constraint_violation_obs_ids:
+      constraint_violation_obs_ids + [obs_id])
+  end
+
+  # One imported observation whose photo(s) were skipped for lacking an
+  # iNat license -- recorded with the details needed to review the
+  # pattern (who, which license choice).
+  def add_unlicensed_image_event(inat_id:, login:, license_code:, count:)
+    reload
+    event = { "inat_id" => inat_id, "login" => login,
+              "license_code" => license_code, "count" => count }
+    update!(unlicensed_image_events: unlicensed_image_events + [event])
   end
 
   def reached_import_cap?

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -167,9 +167,13 @@ class InatImport < ApplicationRecord
   end
 
   # An observation the standardizer kept out of the target project
-  # because it violates the project's constraints (#5259).
+  # because it violates the project's constraints (#5259). The inline
+  # pass and a later slip-attach reconcile can both record the same
+  # observation, so appends are deduplicated.
   def add_constraint_violation_obs(obs_id)
     reload
+    return if constraint_violation_obs_ids.include?(obs_id)
+
     update!(constraint_violation_obs_ids:
       constraint_violation_obs_ids + [obs_id])
   end

--- a/app/views/controllers/inat_imports/confirm_form.rb
+++ b/app/views/controllers/inat_imports/confirm_form.rb
@@ -301,7 +301,7 @@ module Views::Controllers::InatImports
     def render_hidden_fields
       [:inat_username, :inat_ids, :import_all, :consent, :import_others,
        :inat_url, :original_inat_url, :recheck_all,
-       :skip_inat_writeback].each do |f|
+       :skip_inat_writeback, :inat_project, :inat_project_id].each do |f|
         hidden_field(f)
       end
     end

--- a/app/views/controllers/inat_imports/form.rb
+++ b/app/views/controllers/inat_imports/form.rb
@@ -14,6 +14,7 @@ module Views::Controllers::InatImports
         render_import_others_field if @super_importer
         render_consent_checkbox
         render_choose_observations_section
+        render_project_field
         render_skip_writeback_field if @admin
         render_details_panel
         submit(:submit.ti)
@@ -98,6 +99,19 @@ module Views::Controllers::InatImports
                      label: :inat_recheck_all,
                      help: :inat_recheck_all_help.l,
                      wrap_class: "mt-4")
+    end
+
+    # Optional target project (#5259): the import files observations
+    # into it and reconciles field slips against it.
+    def render_project_field
+      autocompleter_field(
+        :inat_project, type: :project,
+                       hidden_name: :inat_project_id,
+                       hidden_value: model.inat_project_id,
+                       label: :inat_project_label,
+                       help: :inat_project_help.l,
+                       wrap_class: "mt-3"
+      )
     end
 
     def render_consent_checkbox

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -8,6 +8,8 @@ module Views::Controllers::InatImports
   class Status < Components::Base
     prop :inat_import, ::InatImport
 
+    include ReviewSections
+
     def view_template
       div(
         id: "inat_import_#{@inat_import.id}",
@@ -194,6 +196,7 @@ module Views::Controllers::InatImports
         render_date_missing_row
       end
       render_license_added_section
+      render_review_sections
     end
 
     def render_ignored_row(caption_key, count)

--- a/app/views/controllers/inat_imports/status.rb
+++ b/app/views/controllers/inat_imports/status.rb
@@ -66,6 +66,7 @@ module Views::Controllers::InatImports
       render_ended_line
       render_error_line
       render_ignored_section
+      render_review_sections
     end
 
     def render_summary_paragraph
@@ -196,7 +197,6 @@ module Views::Controllers::InatImports
         render_date_missing_row
       end
       render_license_added_section
-      render_review_sections
     end
 
     def render_ignored_row(caption_key, count)

--- a/app/views/controllers/inat_imports/status/review_sections.rb
+++ b/app/views/controllers/inat_imports/status/review_sections.rb
@@ -41,10 +41,13 @@ module Views::Controllers::InatImports
       end
 
       def render_unlicensed_image_row(event)
-        license = event["license_code"].presence || "no license"
+        license = event["license_code"].presence ||
+                  :inat_import_tracker_no_license.l
         div(class: "mb-1") do
-          plain("iNat #{event["inat_id"]} — #{event["login"]} " \
-                "(#{license}) — #{event["count"]} photo(s)")
+          plain(:inat_import_tracker_unlicensed_images_row.t(
+                  inat_id: event["inat_id"], login: event["login"],
+                  license: license, count: event["count"]
+                ))
         end
       end
     end

--- a/app/views/controllers/inat_imports/status/review_sections.rb
+++ b/app/views/controllers/inat_imports/status/review_sections.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Views::Controllers::InatImports
+  class Status
+    # Post-import review sections (#5259): observations kept out of the
+    # target project by its constraints, and photos skipped for a
+    # missing iNat license.
+    module ReviewSections
+      private
+
+      def render_review_sections
+        render_constraint_violation_section
+        render_unlicensed_images_section
+      end
+
+      def render_constraint_violation_section
+        ids = @inat_import.constraint_violation_obs_ids
+        return if ids.empty?
+
+        Alert(level: :warning, class: "mt-3") do
+          h5 { plain(:inat_import_tracker_constraint_violations.l) }
+          div(class: "mb-1") do
+            plain(ids.size.to_s)
+            whitespace
+            render(Components::Link::Get.new(
+                     name: :inat_import_tracker_constraint_violations_link.l,
+                     target: observations_path(id_in_set: ids)
+                   ))
+          end
+        end
+      end
+
+      def render_unlicensed_images_section
+        events = @inat_import.unlicensed_image_events
+        return if events.empty?
+
+        Alert(level: :info, class: "mt-3") do
+          h5 { plain(:inat_import_tracker_unlicensed_images_heading.l) }
+          events.each { |event| render_unlicensed_image_row(event) }
+        end
+      end
+
+      def render_unlicensed_image_row(event)
+        license = event["license_code"].presence || "no license"
+        div(class: "mb-1") do
+          plain("iNat #{event["inat_id"]} — #{event["login"]} " \
+                "(#{license}) — #{event["count"]} photo(s)")
+        end
+      end
+    end
+  end
+end

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2910,8 +2910,8 @@
   inat_dqa_needs_id: Needs ID
   inat_dqa_research: Research Grade
 
-  inat_project_label: Foray or event project
-  inat_project_help: Optional. Choose a project to file this import's observations into; field slips and duplicate foray records are reconciled automatically. Leave blank for a normal import.
+  inat_project_label: Project
+  inat_project_help: Optional. Choose a project to file this import's observations into — a foray or event, or an ongoing project such as a challenge. Field slips and duplicate records are reconciled automatically. Leave blank for a normal import.
   inat_project_not_recognized: That project was not recognized. Pick one from the suggestions, or leave the field blank.
   inat_project_not_allowed: You cannot add observations to "[title]".
   inat_import_tracker_constraint_violations: Not added to the project (constraint violations)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2917,6 +2917,8 @@
   inat_import_tracker_constraint_violations: Not added to the project (constraint violations)
   inat_import_tracker_constraint_violations_link: view observations
   inat_import_tracker_unlicensed_images_heading: Photos skipped for missing iNat license
+  inat_import_tracker_unlicensed_images_row: iNat [inat_id] — [login] ([license]) — [count] photo(s)
+  inat_import_tracker_no_license: no license
   inat_import_confirm_title: Confirm iNat Import
   inat_import_confirm_requested_caption: Requested Observations
   inat_import_confirm_expected_caption: Expected imports

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2910,6 +2910,13 @@
   inat_dqa_needs_id: Needs ID
   inat_dqa_research: Research Grade
 
+  inat_project_label: Foray or event project
+  inat_project_help: Optional. Choose a project to file this import's observations into; field slips and duplicate foray records are reconciled automatically. Leave blank for a normal import.
+  inat_project_not_recognized: That project was not recognized. Pick one from the suggestions, or leave the field blank.
+  inat_project_not_allowed: You cannot add observations to "[title]".
+  inat_import_tracker_constraint_violations: Not added to the project (constraint violations)
+  inat_import_tracker_constraint_violations_link: view observations
+  inat_import_tracker_unlicensed_images_heading: Photos skipped for missing iNat license
   inat_import_confirm_title: Confirm iNat Import
   inat_import_confirm_requested_caption: Requested Observations
   inat_import_confirm_expected_caption: Expected imports

--- a/db/migrate/20260902200000_add_project_to_inat_imports.rb
+++ b/db/migrate/20260902200000_add_project_to_inat_imports.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddProjectToInatImports < ActiveRecord::Migration[7.2]
+  def change
+    add_column(:inat_imports, :project_id, :integer)
+    add_column(:inat_imports, :constraint_violation_obs_ids, :text)
+    add_column(:inat_imports, :unlicensed_image_events, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_31_223601) do
+ActiveRecord::Schema[7.2].define(version: 2026_09_02_200000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -265,6 +265,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_31_223601) do
     t.boolean "recheck_all", default: false, null: false
     t.integer "ignored_unlicensed_count", default: 0, null: false
     t.text "original_inat_url"
+    t.integer "project_id"
+    t.text "constraint_violation_obs_ids"
+    t.text "unlicensed_image_events"
   end
 
   create_table "inat_obs_extracts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/classes/field_slip/attacher_test.rb
+++ b/test/classes/field_slip/attacher_test.rb
@@ -30,6 +30,24 @@ class FieldSlip::AttacherTest < UnitTestCase
     assert_includes(@project.observations.reload, @obs)
   end
 
+  # The reconcile hook is best-effort: a failure inside it is logged
+  # and the attach result is unchanged.
+  def test_attach_survives_reconcile_failure
+    import = inat_imports(:rolf_inat_import)
+    import.update!(project: @project)
+    @obs.update!(inat_import: import)
+    boom = proc { raise("boom") }
+
+    result = Inat::ProjectSlipStandardizer.
+             stub(:reconcile_after_attach, boom) do
+      attach(code: "OPEN-0778")
+    end
+
+    assert_equal(:attached, result,
+                 "A reconcile failure must not break the attach")
+    assert_equal("OPEN-0778", @obs.reload.field_slip&.code)
+  end
+
   def test_attaches_a_new_slip_and_files_into_the_prefix_project
     user = @obs.user
 

--- a/test/classes/field_slip/attacher_test.rb
+++ b/test/classes/field_slip/attacher_test.rb
@@ -14,6 +14,22 @@ class FieldSlip::AttacherTest < UnitTestCase
     FieldSlip::Attacher.attach(observation: obs, code: code, user: user)
   end
 
+  # #5259: a slip landing on an import-created observation whose import
+  # has a target project gets reconciled with that project.
+  def test_attach_reconciles_import_target_project
+    import = inat_imports(:rolf_inat_import)
+    import.update!(project: @project)
+    @obs.update!(inat_import: import)
+
+    result = attach(code: "EOL-0777")
+
+    assert_equal(:attached, result)
+    slip = FieldSlip.find_by(code: "EOL-0777")
+    assert_equal(@project.id, slip.reload.project_id,
+                 "The wrong-prefix slip moves to the import's project")
+    assert_includes(@project.observations.reload, @obs)
+  end
+
   def test_attaches_a_new_slip_and_files_into_the_prefix_project
     user = @obs.user
 

--- a/test/classes/field_slip/attacher_test.rb
+++ b/test/classes/field_slip/attacher_test.rb
@@ -38,8 +38,8 @@ class FieldSlip::AttacherTest < UnitTestCase
     @obs.update!(inat_import: import)
     boom = proc { raise("boom") }
 
-    result = Inat::ProjectSlipStandardizer.
-             stub(:reconcile_after_attach, boom) do
+    standardizer = Inat::ProjectSlipStandardizer
+    result = standardizer.stub(:reconcile_after_attach, boom) do
       attach(code: "OPEN-0778")
     end
 

--- a/test/classes/inat_observation_importer_test.rb
+++ b/test/classes/inat_observation_importer_test.rb
@@ -46,6 +46,28 @@ class InatObservationImporterTest < UnitTestCase
     assert_equal([123, 456], importer.image_ids)
   end
 
+  # #5259: photos skipped for a missing license are recorded with the
+  # iNat id, login, and license choice.
+  def test_accumulate_counts_records_unlicensed_image_event
+    import = inat_imports(:rolf_inat_import)
+    importer = ::Inat::ObservationImporter.new(import, import.user)
+    importer.instance_variable_set(
+      :@inat_obs, { id: 777, user: { login: "flick" }, license_code: nil }
+    )
+    fake_builder = Object.new
+    fake_builder.define_singleton_method(:unlicensed_obs) { 0 }
+    fake_builder.define_singleton_method(:skipped_images) { 3 }
+    fake_builder.define_singleton_method(:created_image_ids) { [] }
+
+    importer.send(:accumulate_counts, fake_builder)
+
+    event = import.reload.unlicensed_image_events.first
+    assert_equal(777, event["inat_id"])
+    assert_equal("flick", event["login"])
+    assert_nil(event["license_code"])
+    assert_equal(3, event["count"])
+  end
+
   # #5259: the inline standardization files the new observation into
   # the import's target project.
   def test_standardize_for_project_adds_observation_to_project

--- a/test/classes/inat_observation_importer_test.rb
+++ b/test/classes/inat_observation_importer_test.rb
@@ -46,6 +46,43 @@ class InatObservationImporterTest < UnitTestCase
     assert_equal([123, 456], importer.image_ids)
   end
 
+  # #5259: the inline standardization files the new observation into
+  # the import's target project.
+  def test_standardize_for_project_adds_observation_to_project
+    import = inat_imports(:rolf_inat_import)
+    project = projects(:open_membership_project)
+    import.update!(project: project)
+    importer = ::Inat::ObservationImporter.new(import, import.user)
+    obs = observations(:minimal_unknown_obs)
+    obs.update_column(:occurrence_id, nil)
+    importer.instance_variable_set(:@inat_obs, { id: 424_242 })
+    importer.instance_variable_set(:@observation, obs)
+
+    importer.send(:standardize_for_project)
+
+    assert_includes(project.observations.reload, obs)
+  end
+
+  # A standardization failure is recorded and does not raise -- the
+  # observation's import still counts.
+  def test_standardize_for_project_logs_errors_and_continues
+    import = inat_imports(:rolf_inat_import)
+    import.update!(project: projects(:open_membership_project))
+    importer = ::Inat::ObservationImporter.new(import, import.user)
+    importer.instance_variable_set(:@inat_obs, { id: 424_243 })
+    importer.instance_variable_set(:@observation,
+                                   observations(:minimal_unknown_obs))
+    std = importer.send(:standardizer)
+    def std.standardize(*)
+      raise("boom")
+    end
+
+    importer.send(:standardize_for_project)
+
+    assert_match(/Standardization failed for iNat 424243/,
+                 import.reload.response_errors)
+  end
+
   def test_canceled
     import = inat_imports(:ollie_inat_import)
     assert(import.canceled?, "Test needs a canceled InatImport fixture")

--- a/test/classes/inat_project_slip_standardizer_test.rb
+++ b/test/classes/inat_project_slip_standardizer_test.rb
@@ -41,10 +41,13 @@ class InatProjectSlipStandardizerTest < UnitTestCase
 
   def test_bare_observation_joins_the_project
     obs = import_obs(:minimal_unknown_obs)
+    assert_not(@project.member?(@user), "premise: importer not a member")
 
     standardizer.standardize(obs, inat_id: "111222333")
 
     assert_includes(@project.observations.reload, obs)
+    assert(@project.member?(@user),
+           "Filing into the project enrolls the importer (#4932)")
   end
 
   def test_joins_native_partner_occurrence

--- a/test/classes/inat_project_slip_standardizer_test.rb
+++ b/test/classes/inat_project_slip_standardizer_test.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class InatProjectSlipStandardizerTest < UnitTestCase
+  def setup
+    @project = projects(:open_membership_project) # prefix OPEN
+    @import = inat_imports(:rolf_inat_import)
+    @import.update!(project: @project)
+    @user = @import.user
+  end
+
+  def standardizer
+    Inat::ProjectSlipStandardizer.new(@import)
+  end
+
+  def import_obs(fixture)
+    obs = observations(fixture)
+    obs.update_column(:occurrence_id, nil)
+    obs.update!(inat_import: @import, reflected_at: Time.zone.now)
+    obs
+  end
+
+  def native_with_slip(fixture, code:, citing:)
+    obs = observations(fixture)
+    obs.update_column(:occurrence_id, nil)
+    obs.update!(field_slip: FieldSlip.find_or_create_by_code(code, @user))
+    obs.update!(notes: { Other: "iNat #{citing}" })
+    obs
+  end
+
+  def test_inactive_without_a_project
+    @import.update!(project: nil)
+    obs = import_obs(:minimal_unknown_obs)
+
+    standardizer.standardize(obs, inat_id: "111222333")
+
+    assert_not(standardizer.active?)
+    assert_not_includes(@project.observations.reload, obs)
+  end
+
+  def test_bare_observation_joins_the_project
+    obs = import_obs(:minimal_unknown_obs)
+
+    standardizer.standardize(obs, inat_id: "111222333")
+
+    assert_includes(@project.observations.reload, obs)
+  end
+
+  def test_joins_native_partner_occurrence
+    inat_id = "987654321"
+    native = native_with_slip(:coprinus_comatus_obs, code: "OPEN-9001",
+                                                     citing: inat_id)
+    obs = import_obs(:detailed_unknown_obs)
+
+    standardizer.standardize(obs, inat_id: inat_id)
+
+    obs.reload
+    assert_equal(native.reload.occurrence_id, obs.occurrence_id,
+                 "Import observation should join the native's occurrence")
+    assert_equal(native.id, obs.occurrence.primary_observation_id,
+                 "The native member stays the occurrence's primary")
+    assert_includes(@project.observations.reload, obs)
+  end
+
+  def test_merges_reused_slip_occurrence_into_native
+    inat_id = "987650001"
+    native = native_with_slip(:coprinus_comatus_obs, code: "OPEN-9005",
+                                                     citing: inat_id)
+    obs = import_obs(:detailed_unknown_obs)
+    obs.update!(field_slip: FieldSlip.find_or_create_by_code("EOL-9005",
+                                                             @user))
+
+    standardizer.standardize(obs, inat_id: inat_id)
+
+    obs.reload
+    assert_equal(native.reload.occurrence_id, obs.occurrence_id,
+                 "The reused slip's occurrence should merge into the " \
+                 "native's; its correct slip wins")
+    assert_equal("OPEN-9005", obs.occurrence.field_slip.code)
+  end
+
+  def test_reassigns_wrong_project_slip
+    obs = import_obs(:minimal_unknown_obs)
+    slip = FieldSlip.find_or_create_by_code("EOL-9002", @user)
+    obs.update!(field_slip: slip)
+
+    standardizer.standardize(obs, inat_id: "111222444")
+
+    assert_equal(@project.id, slip.reload.project_id,
+                 "A slip from another prefix moves to the target project")
+    assert_includes(@project.observations.reload, obs)
+  end
+
+  def test_attaches_target_prefix_code_from_notes
+    obs = import_obs(:minimal_unknown_obs)
+    obs.update!(notes: { Other: "wrote code OPEN-9003 on the slip" })
+
+    standardizer.standardize(obs, inat_id: "111222555")
+
+    assert_equal("OPEN-9003", obs.reload.occurrence&.field_slip&.code,
+                 "The code written in the notes should attach its slip")
+    assert_includes(@project.observations.reload, obs)
+  end
+
+  def test_notes_code_join_keeps_native_primary
+    native = observations(:coprinus_comatus_obs)
+    native.update_column(:occurrence_id, nil)
+    native.update!(field_slip: FieldSlip.find_or_create_by_code("OPEN-9004",
+                                                                @user))
+    obs = import_obs(:detailed_unknown_obs)
+    obs.update!(notes: { Other: "slip OPEN-9004" })
+
+    standardizer.standardize(obs, inat_id: "111222666")
+
+    occurrence = obs.reload.occurrence
+    assert_equal(native.reload.occurrence_id, occurrence.id)
+    assert_equal(native.id, occurrence.primary_observation_id,
+                 "A reflection joining an in-use slip must not stay primary")
+  end
+
+  def test_non_admin_constraint_violation_is_recorded_not_added
+    @project.update!(start_date: Date.new(2020, 1, 1),
+                     end_date: Date.new(2020, 1, 2))
+    assert_not(@project.is_admin?(@user), "premise: importer is not admin")
+    obs = import_obs(:minimal_unknown_obs)
+    obs.update!(when: Date.new(2024, 6, 1))
+
+    standardizer.standardize(obs, inat_id: "111222777")
+
+    assert_not_includes(@project.observations.reload, obs)
+    assert_includes(@import.reload.constraint_violation_obs_ids, obs.id)
+  end
+
+  def test_admin_import_adds_despite_constraints
+    @project.update!(start_date: Date.new(2020, 1, 1),
+                     end_date: Date.new(2020, 1, 2))
+    admin = @project.admin_group.users.first
+    assert(admin, "premise: project has an admin")
+    @import.update!(user: admin)
+    obs = import_obs(:minimal_unknown_obs)
+    obs.update!(when: Date.new(2024, 6, 1))
+
+    standardizer.standardize(obs, inat_id: "111222888")
+
+    assert_includes(@project.observations.reload, obs)
+    assert_empty(@import.reload.constraint_violation_obs_ids)
+  end
+
+  def test_reconcile_after_attach_reassigns_slip_and_membership
+    obs = import_obs(:minimal_unknown_obs)
+    slip = FieldSlip.find_or_create_by_code("EOL-9006", @user)
+    obs.update!(field_slip: slip)
+
+    Inat::ProjectSlipStandardizer.reconcile_after_attach(obs)
+
+    assert_equal(@project.id, slip.reload.project_id)
+    assert_includes(@project.observations.reload, obs)
+  end
+
+  def test_reconcile_after_attach_ignores_non_import_observations
+    obs = observations(:minimal_unknown_obs)
+    obs.update_column(:occurrence_id, nil)
+    slip = FieldSlip.find_or_create_by_code("EOL-9007", @user)
+    obs.update!(field_slip: slip)
+
+    Inat::ProjectSlipStandardizer.reconcile_after_attach(obs)
+
+    assert_not_equal(@project.id, slip.reload.project_id)
+  end
+end

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -257,6 +257,26 @@ class InatImportsControllerTest < FunctionalTestCase
                   "Go Back should keep the chosen project id")
   end
 
+  # #5259: a project the user can neither join nor administer is
+  # refused (#4932 invariant 4).
+  def test_create_with_unjoinable_project
+    user = users(:rolf)
+    project = projects(:open_membership_project)
+    project.update!(open_membership: false)
+    assert_not(project.is_admin?(user) || project.member?(user) ||
+               project.can_join?(user),
+               "premise: rolf cannot use this project")
+    params = { inat_ids: "123", inat_username: "anything",
+               consent: 1, inat_project: project.title,
+               inat_project_id: project.id.to_s }
+
+    login(user.login)
+    post(:create, params: params)
+
+    assert_flash(:inat_project_not_allowed, title: project.title)
+    assert_form_action(action: :create)
+  end
+
   # #5259: typed project text that resolves to no project is refused.
   def test_create_with_unrecognized_project
     user = users(:rolf)

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -220,6 +220,24 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_form_action(action: :create)
   end
 
+  # #5259: the show page lists recorded constraint violations and
+  # unlicensed-photo events.
+  def test_show_renders_review_sections
+    import = inat_imports(:rolf_inat_import)
+    import.update!(
+      constraint_violation_obs_ids: [observations(:minimal_unknown_obs).id],
+      unlicensed_image_events: [{ "inat_id" => 123, "login" => "flick",
+                                  "license_code" => nil, "count" => 2 }]
+    )
+
+    login(import.user.login)
+    get(:show, params: { id: import.id })
+
+    assert_select("h5", text: :inat_import_tracker_constraint_violations.l)
+    assert_select("h5",
+                  text: :inat_import_tracker_unlicensed_images_heading.l)
+  end
+
   # #5259: Go Back keeps the chosen target project on the redisplayed
   # form.
   def test_create_go_back_keeps_project

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -220,6 +220,53 @@ class InatImportsControllerTest < FunctionalTestCase
     assert_form_action(action: :create)
   end
 
+  # #5259: Go Back keeps the chosen target project on the redisplayed
+  # form.
+  def test_create_go_back_keeps_project
+    user = users(:rolf)
+    project = projects(:open_membership_project)
+    params = { inat_ids: "123", inat_username: user.inat_username,
+               consent: 1, go_back: "1",
+               inat_project: project.title,
+               inat_project_id: project.id.to_s }
+
+    login(user.login)
+    post(:create, params: params)
+
+    assert_form_action(action: :create)
+    assert_select("input[name=?][value=?]",
+                  "inat_import[inat_project_id]", project.id.to_s, true,
+                  "Go Back should keep the chosen project id")
+  end
+
+  # #5259: typed project text that resolves to no project is refused.
+  def test_create_with_unrecognized_project
+    user = users(:rolf)
+    params = { inat_ids: "123", inat_username: "anything",
+               consent: 1, inat_project: "No Such Project Anywhere" }
+
+    login(user.login)
+    post(:create, params: params)
+
+    assert_flash(:inat_project_not_recognized)
+    assert_form_action(action: :create)
+  end
+
+  # #5259: a confirmed create stores the target project on the import.
+  def test_create_confirmed_stores_project
+    user = users(:rolf)
+    project = projects(:open_membership_project)
+    params = { inat_ids: "123", inat_username: "anything",
+               consent: 1, confirmed: 1,
+               inat_project: project.title,
+               inat_project_id: project.id.to_s }
+
+    login(user.login)
+    post(:create, params: params)
+
+    assert_equal(project.id, created_import(user).project_id)
+  end
+
   def test_reload_preserves_checkbox_state
     user = users(:rolf)
     params = { inat_ids: "123", consent: "1", all: "1" }

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -477,7 +477,9 @@ class InatImportTest < ActiveSupport::TestCase
     assert_equal([], import.constraint_violation_obs_ids)
     import.add_constraint_violation_obs(123)
     import.add_constraint_violation_obs(456)
-    assert_equal([123, 456], import.reload.constraint_violation_obs_ids)
+    import.add_constraint_violation_obs(123)
+    assert_equal([123, 456], import.reload.constraint_violation_obs_ids,
+                 "A re-recorded observation must not duplicate")
 
     assert_equal([], import.unlicensed_image_events)
     import.add_unlicensed_image_event(inat_id: 987, login: "somebody",

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -469,4 +469,23 @@ class InatImportTest < ActiveSupport::TestCase
       "reimport_url should be nil when neither URL column was stored"
     )
   end
+
+  # #5259 review recorders: both JSON columns default to [] and append.
+  def test_constraint_violation_and_unlicensed_image_recording
+    import = inat_imports(:rolf_inat_import)
+
+    assert_equal([], import.constraint_violation_obs_ids)
+    import.add_constraint_violation_obs(123)
+    import.add_constraint_violation_obs(456)
+    assert_equal([123, 456], import.reload.constraint_violation_obs_ids)
+
+    assert_equal([], import.unlicensed_image_events)
+    import.add_unlicensed_image_event(inat_id: 987, login: "somebody",
+                                      license_code: nil, count: 2)
+    event = import.reload.unlicensed_image_events.first
+    assert_equal(987, event["inat_id"])
+    assert_equal("somebody", event["login"])
+    assert_nil(event["license_code"])
+    assert_equal(2, event["count"])
+  end
 end


### PR DESCRIPTION
Implements the plan on #5259 (decision record, 2026-09-02): the #5258 script's project/field-slip standardization runs inside the iNat import, driven by an optional target project chosen on the import form.

## The form and flow

- `/inat_imports/new` gains an optional **project autocompleter** (`Autocompleter::ForProject`), default blank — user-driven imports change nothing. The selection round-trips the whole workflow: hidden id field, confirm-page passthrough, Go Back (controller test), and the `inat_imports.project_id` column carries it through the iNat OAuth hop.
- Validation (`project_valid?`): blank is fine; typed text resolving to no project is refused with a flash; a chosen project must be one the user may put observations into (admin, member, or joinable — #4932 invariant 4).

## The standardizer (`Inat::ProjectSlipStandardizer`)

Extracted from the #5258 script, per observation, in the plan's priority order: (1) an iNat-linked native partner (a non-reflection observation citing the iNat number in its notes and carrying a slip) — the import joins its occurrence, the native stays primary, a reused slip yields via `Occurrence.merge!`; (2) a wrong-project slip is reassigned to the target project (column write past the permission-gated setter; `cascade_project_change` files the members); (3) a target-prefix code in the notes attaches via `FieldSlip::Attacher` with the native-primary fixup; (4) otherwise the observation just joins the project.

Membership per the plan: a project-admin importer adds everything; anyone else's adds respect constraints, and the kept-out observations are recorded.

## Timing — inline plus scan-hook (option a)

- Cases 1/3/4 run inline from `Inat::ObservationImporter#import_one_result`, right after each observation is created (best-effort: a standardization failure is logged to the import's response errors and the observation still counts).
- Case 2 rides the slip-attach path: the QR scan is not part of the import pipeline (it is the `ObservationImage` after-create callback chain), so `FieldSlip::Attacher#attach` now calls `reconcile_after_attach` when it lands a slip on an observation whose import has a target project — wrong-project slip reassigned, native primary kept, membership ensured. Best-effort; a failure logs and the attach result is unchanged.

## Review surfaces (import show page)

- **Constraint violations**: count plus a link opening the recorded observations as an observation query.
- **Photos skipped for missing iNat license**: per-observation rows with iNat id, iNat login, and the license choice (previously only counts survived).

Both recorded on `inat_imports` (`constraint_violation_obs_ids`, `unlicensed_image_events`, serialized JSON, following the existing `*_inat_ids` pattern).

## Tests

- New `test/classes/inat_project_slip_standardizer_test.rb`: all four cases, the merge and native-primary fixups, non-admin constraint recording vs. admin force-add, the attach hook, non-import no-op, no-project no-op.
- Importer: inline standardization files into the project; a raised error is logged and swallowed.
- Attacher: wrong-prefix code on an import observation ends with the slip and membership on the target project.
- Controller: Go Back keeps the project; unrecognized text refused; confirmed create stores `project_id`. Model: both recorders.
- Suites run green: the five touched test files (183 tests) plus builder/field-slip/occurrence regression (336 tests). RuboCop clean; `zeitwerk:check` clean.

## Out of scope (per the plan)

Case 1 for project-less imports, and project-driven imports (a project page assessing new iNat content) — future work; `project_id` and the per-observation standardizer are the building blocks.

## Test plan

- [ ] Reviewer: run an id-list import with a foray project selected (a `2026-NAMA` test id works) — observations land in the project, a notes-code observation gets its slip, and the show page's new sections appear when applicable. Run one without a project — behavior unchanged.

<!-- changelog -->
article: yes
Add Project choice and automatic filing to iNat imports
<!-- /changelog -->
