### PR TITLE
Fix `update_projects`/`update_species_lists` N+1 for power users

### DIFF
--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -26,6 +26,7 @@
 #    strip_images!
 #
 #    update_projects
+#    desired_change_ids
 #    update_species_lists
 #
 module ObservationsController::SharedFormMethods

--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -359,10 +359,17 @@ module ObservationsController::SharedFormMethods
     return unless submitted_ids
 
     desired = submitted_ids.compact_blank.map(&:to_i)
-    changed_ids = desired_change_ids(desired, @observation.project_ids)
+    member_projects = @user.projects_member
+    # A project id on the observation the user isn't a member of (e.g.
+    # an admin added it, or the user has since left) has no checkbox
+    # to submit it in `desired`. Intersecting keeps such ids out of
+    # the diff, so they don't mark the request "changed" and defeat
+    # the empty-diff return below.
+    current = @observation.project_ids & member_projects.map(&:id)
+    changed_ids = desired_change_ids(desired, current)
     return if changed_ids.empty?
 
-    @user.projects_member.each do |project|
+    member_projects.each do |project|
       next unless changed_ids.include?(project.id)
 
       if desired.include?(project.id)

--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -411,7 +411,15 @@ module ObservationsController::SharedFormMethods
     return unless submitted_ids
 
     desired = submitted_ids.compact_blank.map(&:to_i)
-    changed_ids = desired_change_ids(desired, @observation.species_list_ids)
+    # A species-list id on the observation the user can't edit (e.g. a
+    # list shared into a project the user has since left) has no
+    # checkbox to submit it in `desired`. Scope the "current" side to
+    # the editable subset of the observation's ids, not the user's
+    # full editable-lists set, so such an id doesn't mark the request
+    # "changed" and defeat the empty-diff return below.
+    current = @user.all_editable_species_lists.
+              where(id: @observation.species_list_ids).pluck(:id)
+    changed_ids = desired_change_ids(desired, current)
     return if changed_ids.empty?
 
     @user.all_editable_species_lists.where(id: changed_ids).find_each do |list|

--- a/app/controllers/observations_controller/shared_form_methods.rb
+++ b/app/controllers/observations_controller/shared_form_methods.rb
@@ -344,7 +344,13 @@ module ObservationsController::SharedFormMethods
   # the user wants the obs attached to. Only `@user.projects_member`
   # projects are toggled — non-member projects the obs belongs to are
   # preserved by omission (disabled checkboxes don't submit, and the
-  # iteration excludes them anyway).
+  # id-set comparison below excludes them anyway).
+  #
+  # Compares id arrays (one lightweight `project_ids` query) rather
+  # than loading every member project's `observations` to run
+  # `@observation.projects.include?` per project -- for a user in
+  # hundreds of projects that eager load dominated the request (#5245).
+  # Only the ids whose membership changed get touched.
   def update_projects
     submitted_ids =
       params.permit(observation: { project_ids: [] }).
@@ -352,18 +358,25 @@ module ObservationsController::SharedFormMethods
     return unless submitted_ids
 
     desired = submitted_ids.compact_blank.map(&:to_i)
-    @user.projects_member(include: :observations).each do |project|
-      before = @observation.projects.include?(project)
-      after = desired.include?(project.id)
-      next unless before != after
+    changed_ids = desired_change_ids(desired, @observation.project_ids)
+    return if changed_ids.empty?
 
-      if after
+    @user.projects_member.each do |project|
+      next unless changed_ids.include?(project.id)
+
+      if desired.include?(project.id)
         project.add_observation(@observation)
         name_flash_for_project(@observation.name, project)
       else
         flash_project_removal(project, project.remove_observation(@observation))
       end
     end
+  end
+
+  # Ids that differ between `desired` and `current` -- the membership
+  # changes that still need to happen.
+  def desired_change_ids(desired, current)
+    (desired - current) | (current - desired)
   end
 
   # Unchecking one box can move up to Occurrence::MAX_OBSERVATIONS
@@ -380,6 +393,9 @@ module ObservationsController::SharedFormMethods
     end
   end
 
+  # See `update_projects` -- same id-set comparison, same reason: a
+  # user editable on hundreds of species lists no longer means loading
+  # hundreds of lists' `observations` (#5245).
   def update_species_lists
     submitted_ids =
       params.permit(observation: { species_list_ids: [] }).
@@ -387,13 +403,11 @@ module ObservationsController::SharedFormMethods
     return unless submitted_ids
 
     desired = submitted_ids.compact_blank.map(&:to_i)
-    @user.all_editable_species_lists.includes(:observations).
-      find_each do |list|
-      before = @observation.species_lists.include?(list)
-      after = desired.include?(list.id)
-      next unless before != after
+    changed_ids = desired_change_ids(desired, @observation.species_list_ids)
+    return if changed_ids.empty?
 
-      if after
+    @user.all_editable_species_lists.where(id: changed_ids).find_each do |list|
+      if desired.include?(list.id)
         list.add_observation(@observation)
         flash_notice(:added_to_list.t(list: list.title))
       else

--- a/test/controllers/observations_controller_project_list_test.rb
+++ b/test/controllers/observations_controller_project_list_test.rb
@@ -357,6 +357,24 @@ class ObservationsControllerProjectListTest < FunctionalTestCase
     assert_list_checks(@spl1.id => :checked_but_disabled, @spl2.id => :checked)
   end
 
+  # Copilot review on PR #5302: a species-list id on the observation
+  # that the current user can't edit has no checkbox to submit it, so
+  # it shouldn't count as a "change" and defeat the no-op fast path.
+  def test_update_species_lists_no_op_preserves_non_editable_list
+    init_for_list_checkbox_tests
+    @spl1.add_observation(@obs2) # mary can't edit @spl1 (owned by rolf)
+
+    login("mary")
+    put(:update,
+        params: {
+          id: @obs2.id,
+          observation: { species_list_ids: [@spl2.id.to_s] }
+        })
+
+    assert_response(:redirect)
+    assert_obj_arrays_equal([@spl1, @spl2], @obs2.reload.species_lists, :sort)
+  end
+
   def init_for_list_checkbox_tests
     @spl1 = species_lists(:first_species_list)
     @spl2 = species_lists(:unknown_species_list)

--- a/test/controllers/observations_controller_project_list_test.rb
+++ b/test/controllers/observations_controller_project_list_test.rb
@@ -144,6 +144,26 @@ class ObservationsControllerProjectListTest < FunctionalTestCase
                           @proj2.id => :checked)
   end
 
+  # Copilot review on PR #5302: a project id on the observation that
+  # the current user isn't a member of has no checkbox to submit it,
+  # so it shouldn't count as a "change" and force a full member-project
+  # scan. Confirms a no-op project update leaves it untouched either way.
+  def test_update_projects_no_op_preserves_non_member_project
+    init_for_project_checkbox_tests
+    @proj1.add_observation(@obs1) # dick isn't a member of @proj1
+
+    login("dick")
+    put(:update,
+        params: {
+          id: @obs1.id,
+          observation: { good_image_ids: @obs1_img_ids.join(" "),
+                         project_ids: [@proj2.id.to_s] }
+        })
+
+    assert_response(:redirect)
+    assert_obj_arrays_equal([@proj1, @proj2], @obs1.reload.projects, :sort)
+  end
+
   def init_for_project_checkbox_tests
     @proj1 = projects(:eol_project)
     @proj2 = projects(:bolete_project)


### PR DESCRIPTION
## Summary

Fixes #5245 -- `ObservationsController::SharedFormMethods#update_projects`/`#update_species_lists` (called on both create and update) did N+1-shaped work that scales with how many projects/species-lists a user belongs to or can edit, not with how many the user is toggling.

Both methods iterated every project/species-list the user could toggle, and for each one loaded its associated `observations` (`.includes(:observations)`) just to check membership via `.include?` on the loaded association. For a user in hundreds of projects or editable on hundreds of species lists, that eager load dominated the request -- flagged by @mo-nathan during the #5238/#5239 investigation, where it showed up as a multi-second `create` for one account with an outsized project/list count.

## Fix

Replace the per-item association check with an id-set comparison. A shared private method, `desired_change_ids(desired, current)`, diffs the submitted ids against the observation's current ids and returns only the ids whose membership needs to change:

- `update_projects` computes `current` as `@observation.project_ids` intersected with the ids of `@user.projects_member`, then iterates `@user.projects_member` (one bounded query, no `include: :observations`), skipping every project not in `changed_ids`.
- `update_species_lists` computes `current` as the subset of `@observation.species_list_ids` the user can edit (`@user.all_editable_species_lists.where(id: @observation.species_list_ids).pluck(:id)` -- one query scoped to the observation's ids, not the user's full editable set), then queries `@user.all_editable_species_lists.where(id: changed_ids)` instead of `.includes(:observations).find_each` over everything.

The member/editable intersection on the `current` side (added responding to Copilot's review, see below) matters for correctness of the no-op fast path: a project/list id on the observation that the user isn't a member of or can't edit has no checkbox to submit it, so without the intersection it would land in `changed_ids` as a spurious "removal" and defeat the early return even when nothing the user controls changed.

Authorization is unchanged: a submitted id for a project/list the user isn't a member of or can't edit still doesn't get touched, since the loop/query is still scoped to `@user.projects_member`/`@user.all_editable_species_lists`.

## Copilot review

Flagged that `update_projects`' no-op fast path could be defeated by a non-member project id on the observation (`current - desired` would spuriously include it), forcing a full `projects_member` scan even when nothing changed. Applied the fix described above to both methods (the same issue existed in `update_species_lists`, not just the flagged one), and added a regression test for each: `test_update_projects_no_op_preserves_non_member_project`, `test_update_species_lists_no_op_preserves_non_editable_list`.

## Verified

Profiled against a dev-DB account (Heelsplitter, 372 editable species lists) with `ActiveSupport::Notifications` counting `sql.active_record` events, comparing the old logic (reimplemented inline) against the current code, both run against fresh `User`/`Observation` instances inside a rolled-back transaction, for the no-op case (submitted ids match what the user is currently able to toggle -- the common path when a user doesn't touch the project/list checkboxes):

- **species_lists**: 387 queries / ~12.9s -> 3 queries / ~35ms
- **projects**: 12 queries / ~65ms -> 5 queries / ~2ms (this account belongs to few projects, so the win is smaller here than on the species-list side, which is where its account size skews)

The first pass at this profiling undercounted the new code (excluded the id-lookup query from the timed block, reporting 0 queries for the no-op case) -- corrected here to include it.

## Test plan

- [x] `bin/rails test test/controllers/observations_controller_project_list_test.rb` -- 16/16 pass (14 pre-existing + 2 new regression tests)
- [x] `bin/rails test test/controllers/observations_controller_update_test.rb -n test_unchecking_a_project_reports_the_whole_collection` -- covers the removal branch, passes
- [x] `bin/rails test test/controllers/observations_controller_create_test.rb` -- 111/111 pass
- [x] `bundle exec rubocop app/controllers/observations_controller/shared_form_methods.rb test/controllers/observations_controller_project_list_test.rb` -- no offenses

<!-- changelog -->
article: no
<!-- /changelog -->
