### PR TITLE
Repair changelog sections from the transitional deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026-09-03 (deploy-2026-09-03-10-42)
+## 2026-09-03 (deploy-2026-09-03-12-00)
 
 - Add `script/prerelease.rb` to build the pre-deploy changelog PR ([PR5281](https://github.com/MushroomObserver/mushroom-observer/pull/5281), @mo-nathan)
 - Deploy from the pre-release changelog and publish the MO Article rows ([PR5294](https://github.com/MushroomObserver/mushroom-observer/pull/5294), @mo-nathan)
@@ -12,6 +12,20 @@
 - Fold project/field-slip standardization into the iNat importer (#5259) ([PR5301](https://github.com/MushroomObserver/mushroom-observer/pull/5301), @mo-nathan)
 - Speed up observation creation and lighten the upload lock (#5238) ([PR5239](https://github.com/MushroomObserver/mushroom-observer/pull/5239), @mo-nathan)
 - Fix `update_projects`/`update_species_lists` N+1 for power users ([PR5302](https://github.com/MushroomObserver/mushroom-observer/pull/5302), @nimmolo)
+- Changelog for `deploy-2026-09-03-10-42` ([PR5303](https://github.com/MushroomObserver/mushroom-observer/pull/5303), @mo-nathan)
+
+## 2026-09-02 (deploy-2026-09-02-00-00)
+
+- Changelog for `deploy-2026-09-01-11-59` ([PR5282](https://github.com/MushroomObserver/mushroom-observer/pull/5282), @mo-nathan)
+- Fix theme change not applying until manual reload (`Account::PreferencesController#update`) ([PR5286](https://github.com/MushroomObserver/mushroom-observer/pull/5286), @nimmolo)
+- Add `MO/NoHandRolledColumnClass` cop; extend `NoRawBootstrapComponent` for Row/Container ([PR5280](https://github.com/MushroomObserver/mushroom-observer/pull/5280), @nimmolo)
+- Add flat top-level query params (`Query#index_filter`); migrate 6 same-model `Tab::*` links ([PR5279](https://github.com/MushroomObserver/mushroom-observer/pull/5279), @nimmolo)
+- Fix Turbo Frame badges silently swallowed by `collapse-fallback` ([PR5288](https://github.com/MushroomObserver/mushroom-observer/pull/5288), @nimmolo)
+- Fix form label row layout, `label_appends` slot, double-colon labels ([PR5287](https://github.com/MushroomObserver/mushroom-observer/pull/5287), @nimmolo)
+- Fix flaky EXIF lat/lng system tests with granular per-step waits ([PR5290](https://github.com/MushroomObserver/mushroom-observer/pull/5290), @nimmolo)
+- Permit the scalar URL form of Array-typed `query_attr`s (`?this_name=<id>`) ([PR5291](https://github.com/MushroomObserver/mushroom-observer/pull/5291), @mo-nathan)
+- Centralize BS3 responsive visibility helpers behind `Components::Column` ([PR5289](https://github.com/MushroomObserver/mushroom-observer/pull/5289), @nimmolo)
+- Changelog for `deploy-2026-09-01-23-58` ([PR5292](https://github.com/MushroomObserver/mushroom-observer/pull/5292), @mo-nathan)
 
 ## 2026-09-01 (deploy-2026-09-01-11-59)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,9 @@
 - Fold project/field-slip standardization into the iNat importer (#5259) ([PR5301](https://github.com/MushroomObserver/mushroom-observer/pull/5301), @mo-nathan)
 - Speed up observation creation and lighten the upload lock (#5238) ([PR5239](https://github.com/MushroomObserver/mushroom-observer/pull/5239), @mo-nathan)
 - Fix `update_projects`/`update_species_lists` N+1 for power users ([PR5302](https://github.com/MushroomObserver/mushroom-observer/pull/5302), @nimmolo)
-- Changelog for `deploy-2026-09-03-10-42` ([PR5303](https://github.com/MushroomObserver/mushroom-observer/pull/5303), @mo-nathan)
 
 ## 2026-09-02 (deploy-2026-09-02-00-00)
 
-- Changelog for `deploy-2026-09-01-11-59` ([PR5282](https://github.com/MushroomObserver/mushroom-observer/pull/5282), @mo-nathan)
 - Fix theme change not applying until manual reload (`Account::PreferencesController#update`) ([PR5286](https://github.com/MushroomObserver/mushroom-observer/pull/5286), @nimmolo)
 - Add `MO/NoHandRolledColumnClass` cop; extend `NoRawBootstrapComponent` for Row/Container ([PR5280](https://github.com/MushroomObserver/mushroom-observer/pull/5280), @nimmolo)
 - Add flat top-level query params (`Query#index_filter`); migrate 6 same-model `Tab::*` links ([PR5279](https://github.com/MushroomObserver/mushroom-observer/pull/5279), @nimmolo)
@@ -25,7 +23,6 @@
 - Fix flaky EXIF lat/lng system tests with granular per-step waits ([PR5290](https://github.com/MushroomObserver/mushroom-observer/pull/5290), @nimmolo)
 - Permit the scalar URL form of Array-typed `query_attr`s (`?this_name=<id>`) ([PR5291](https://github.com/MushroomObserver/mushroom-observer/pull/5291), @mo-nathan)
 - Centralize BS3 responsive visibility helpers behind `Components::Column` ([PR5289](https://github.com/MushroomObserver/mushroom-observer/pull/5289), @nimmolo)
-- Changelog for `deploy-2026-09-01-23-58` ([PR5292](https://github.com/MushroomObserver/mushroom-observer/pull/5292), @mo-nathan)
 
 ## 2026-09-01 (deploy-2026-09-01-11-59)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@
 - Convert `Tab::Name::ObsLink::*` to plain route-helper paths ([PR5270](https://github.com/MushroomObserver/mushroom-observer/pull/5270), @nimmolo)
 - Add `Superorder` rank ([PR5272](https://github.com/MushroomObserver/mushroom-observer/pull/5272), @JoeCohen)
 - Require root for dev setup dispatcher ([PR5274](https://github.com/MushroomObserver/mushroom-observer/pull/5274), @AlanRockefeller)
-- Changelog for `deploy-2026-08-29-11-00` ([PR5267](https://github.com/MushroomObserver/mushroom-observer/pull/5267), @mo-nathan)
 - Bundle update 20260831 ([PR5275](https://github.com/MushroomObserver/mushroom-observer/pull/5275), @JoeCohen)
 - Refill "search URL" field with complete URL ([PR5223](https://github.com/MushroomObserver/mushroom-observer/pull/5223), @JoeCohen)
 - Allow emoji in copyright holder ([PR5187](https://github.com/MushroomObserver/mushroom-observer/pull/5187), @JoeCohen)
@@ -47,7 +46,6 @@
 - `Projects::ViolationsController#index`- no discarded query, paginate directly ([PR5255](https://github.com/MushroomObserver/mushroom-observer/pull/5255), @nimmolo)
 - Query params - Collapse `default_sort_order` to `controller_query_class.default_order` ([PR5257](https://github.com/MushroomObserver/mushroom-observer/pull/5257), @nimmolo)
 - Gate the observation-list panel on editable lists; redirect to the observation ([PR5260](https://github.com/MushroomObserver/mushroom-observer/pull/5260), @mo-nathan)
-- Changelog for `deploy-2026-08-27-23-19` and `deploy-2026-08-28-12-10` ([PR5253](https://github.com/MushroomObserver/mushroom-observer/pull/5253), @mo-nathan)
 - Render field slip name-approval radios inside the review form ([PR5262](https://github.com/MushroomObserver/mushroom-observer/pull/5262), @mo-nathan)
 - Attach a read field slip onto a companion occurrence ([PR5266](https://github.com/MushroomObserver/mushroom-observer/pull/5266), @mo-nathan)
 
@@ -63,7 +61,6 @@
 ## 2026-08-27 (deploy-2026-08-27-23-19)
 
 - Query params — Move complex params to scopes and set ivars in ApplicationController, part 1 ([PR5217](https://github.com/MushroomObserver/mushroom-observer/pull/5217), @nimmolo)
-- Changelog for `deploy-2026-08-25-22-30` ([PR5222](https://github.com/MushroomObserver/mushroom-observer/pull/5222), @mo-nathan)
 - Revert accidental direct push to `main` ([PR5227](https://github.com/MushroomObserver/mushroom-observer/pull/5227), @nimmolo)
 - Add spacing to Account preferences `InputGroupAddon` buttons with icons ([PR5226](https://github.com/MushroomObserver/mushroom-observer/pull/5226), @nimmolo)
 - Query params — Finish `index_active_params` -> `create_query_from_url_params` sweep ([PR5225](https://github.com/MushroomObserver/mushroom-observer/pull/5225), @nimmolo)
@@ -78,7 +75,6 @@
 
 ## 2026-08-25 (deploy-2026-08-25-22-30)
 
-- Changelog for `deploy-2026-08-25-12-00` and `deploy-2026-08-25-12-05` ([PR5219](https://github.com/MushroomObserver/mushroom-observer/pull/5219), @mo-nathan)
 - Stop the iNat resync from overwriting coordinates with obscured data (#4215) ([PR5220](https://github.com/MushroomObserver/mushroom-observer/pull/5220), @mo-nathan)
 - Query params — Migrate pass-thru `index_active_params` to `query_attr` alias ([PR5216](https://github.com/MushroomObserver/mushroom-observer/pull/5216), @nimmolo)
 - Namings endpoint ([PR5206](https://github.com/MushroomObserver/mushroom-observer/pull/5206), @JoeCohen)
@@ -89,7 +85,6 @@
 
 ## 2026-08-25 (deploy-2026-08-25-12-00)
 
-- Changelog for `deploy-2026-08-24-12-01`; fix pool timezone skew ([PR5191](https://github.com/MushroomObserver/mushroom-observer/pull/5191), @mo-nathan)
 - Changelog blocks: no UI jargon, capitalize MO object names ([PR5190](https://github.com/MushroomObserver/mushroom-observer/pull/5190), @mo-nathan)
 - Block deleting a read-only reflection (#5180) ([PR5193](https://github.com/MushroomObserver/mushroom-observer/pull/5193), @mo-nathan)
 - Add daily batch resync of read-only iNat reflections (#4215) ([PR5194](https://github.com/MushroomObserver/mushroom-observer/pull/5194), @mo-nathan)
@@ -758,7 +753,7 @@
 - .claude hooks: Run git commit before blocking a behind-branch push ([PR4742](https://github.com/MushroomObserver/mushroom-observer/pull/4742), @nimmolo)
 - Remove dead `@@last_update` class variable from Language ([PR4739](https://github.com/MushroomObserver/mushroom-observer/pull/4739), @nimmolo)
 - Delete `RunLevel` entirely ([PR4740](https://github.com/MushroomObserver/mushroom-observer/pull/4740), @nimmolo)
-- Halt daily "reviewed observation  (insert)" ([PR4702](https://github.com/MushroomObserver/mushroom-observer/pull/4702), @JoeCohen)
+- Halt daily "reviewed observation (insert)" ([PR4702](https://github.com/MushroomObserver/mushroom-observer/pull/4702), @JoeCohen)
 
 ## 2026-07-09 (deploy-2026-07-09-04-15)
 
@@ -933,7 +928,7 @@
 
 ## 2026-06-29 (deploy-2026-06-29-22-04)
 
-- Fix 500 on unauthenticated request to  engine controller  ([PR4622](https://github.com/MushroomObserver/mushroom-observer/pull/4622), @JoeCohen)
+- Fix 500 on unauthenticated request to engine controller ([PR4622](https://github.com/MushroomObserver/mushroom-observer/pull/4622), @JoeCohen)
 
 ## 2026-06-29 (deploy-2026-06-29-16-16)
 

--- a/script/generate_changelog.rb
+++ b/script/generate_changelog.rb
@@ -180,12 +180,21 @@ class ChangelogGenerator
   end
 
   # PRs whose merge commit is in prev..target, in commit order.
+  # Changelog PRs are bookkeeping about this file and are left out of
+  # every section (#5155), the same way the pre-release PR leaves
+  # itself out of the section it creates.
   def merged_prs(prev_tag, target_tag)
     order = run_cmd("git", "rev-list", "--reverse",
                     "#{prev_tag}..#{target_tag}").
             split("\n").each_with_index.to_h
     pr_pool.select { |pull| order.key?(merge_sha(pull)) }.
+      reject { |pull| changelog_pr?(pull) }.
       sort_by { |pull| order[merge_sha(pull)] }
+  end
+
+  def changelog_pr?(pull)
+    pull["headRefName"] == "changelog-pending" ||
+      pull["title"].to_s.start_with?("Changelog for ")
   end
 
   def merge_sha(pull)


### PR DESCRIPTION
Repairs the CHANGELOG.md damage from the two transitional deploys — the runs where the pre-release PR existed but the server still executed the pre-#5294 `deploy.sh` (the new script only takes effect the deploy after it lands, since `deploy.sh` runs before `git pull`). The old script minted fresh date tags instead of reading the pending headings:

- The 2026-09-02 deploy tagged `deploy-2026-09-02-00-00`, orphaning the pending `deploy-2026-09-01-23-58` heading. This morning's pre-release run then dropped that stale section (as `apply_pending` is designed to), so the 2026-09-02 deploy's PRs were missing from CHANGELOG.md entirely.
- Today's deploy tagged `deploy-2026-09-03-12-00`, orphaning the pending `deploy-2026-09-03-10-42` heading the same way — the next pre-release run would have dropped that section too.

Fix, generated not hand-written: `script/generate_changelog.rb --since deploy-2026-09-01-11-59 --replace --apply` rebuilt both sections keyed to the tags that exist (`deploy-2026-09-02-00-00`, 8 PRs; `deploy-2026-09-03-12-00`, 10 PRs), and the stale `deploy-2026-09-03-10-42` section was removed (its contents are a subset of the `12-00` section).

Also, per review: **"Changelog for …" PRs no longer appear in any generated section.** The self-exclusion previously lived only in the pre-release's pending path; `generate_changelog.rb#merged_prs` now rejects changelog PRs (`changelog-pending` head branch, or a "Changelog for " title) in every mode. A full-history regeneration then scrubbed the 5 historical entries (#5191, #5219, #5222, #5253, #5267 — changelog PRs only began 2026-08-24) and normalized stray double spaces in two old titles; everything else regenerated byte-identical, a nice determinism check on the generator.

Transitional only otherwise: the deployed `deploy.sh` now reads the pending heading and tags with it, so heading and tag can no longer diverge.

<!-- changelog -->
article: no
<!-- /changelog -->
