### PR TITLE
Fix production 500 on `glossary_terms#index` for admins

### DIFF
--- a/app/components/table.rb
+++ b/app/components/table.rb
@@ -45,7 +45,9 @@
 #         variant: :striped,
 #         identifier: "user-list") do |t|
 #     t.column("Name", width: "33%") { |user| user.name }
-#     t.column("Actions", class: "text-right") { |u| destroy_button(u) }
+#     t.column("Actions", class: "text-right") do |u|
+#       Button(type: :delete, target: u)
+#     end
 #   end
 #
 # @example Row mode (Stimulus-rooted rows)

--- a/app/views/controllers/glossary_terms/index/item.rb
+++ b/app/views/controllers/glossary_terms/index/item.rb
@@ -32,9 +32,7 @@ module Views::Controllers::GlossaryTerms
       end
 
       def render_destroy_button
-        destroy_button(target: @glossary_term,
-                       name: :destroy_object.t(type: :glossary_term),
-                       variant: :strip)
+        Button(type: :delete, target: @glossary_term, variant: :strip)
       end
 
       def render_thumbnail

--- a/test/controllers/glossary_terms_controller_test.rb
+++ b/test/controllers/glossary_terms_controller_test.rb
@@ -56,6 +56,21 @@ class GlossaryTermsControllerTest < FunctionalTestCase
     )
   end
 
+  # Regression: Views::Controllers::GlossaryTerms::Index::Item called
+  # the removed `destroy_button` helper directly, 500ing for any admin
+  # who visited the index -- no test exercised the index in admin mode.
+  def test_index_admin_delete
+    login
+    make_admin
+    get(:index)
+
+    assert_response(:success)
+    assert_select("form input[value='delete']",
+                  { count: GlossaryTerm.count },
+                  "Page is missing a way for admin to destroy each " \
+                  "glossary term")
+  end
+
   def q_pattern(pattern)
     { q: { model: :GlossaryTerm, pattern: } }
   end


### PR DESCRIPTION
There was an unconverted ERB helper for `destroy_button` in a GlossaryTerm admin page.

## Summary

Fixes a production 500 on `GET /glossary_terms` for any admin: `Views::Controllers::GlossaryTerms::Index::Item#render_destroy_button` called `destroy_button` directly, but that helper was removed in an earlier helper-cleanup sweep (4ff47df770). The glossary_terms ERB-to-Phlex conversion (4aaf92ddbe) carried the call over without updating it.

```
NoMethodError: undefined method 'destroy_button' for an instance of Views::Controllers::GlossaryTerms::Index::Item
app/views/controllers/glossary_terms/index/item.rb:35:in 'render_destroy_button'
```

## Fix

Route through the `Button(type: :delete, ...)` Kit dispatcher instead of the removed helper. `Components::Button::Delete`'s default `name:` already produces the exact `:destroy_object.t(type: target.type_tag)` text this call site was hardcoding, so the explicit `name:` is dropped too.

Also fixed the identical stale `destroy_button(...)` example in `Components::Table`'s doc comment, so it doesn't get copied into new code.

## Why this shipped undetected

No test exercised `glossary_terms#index` in admin mode -- every existing index test (`test_index`, `test_index_by_letter`, `test_index_by_id`) runs as a public/non-admin request, and `render_destroy_button` only runs `if in_admin_mode?`. Added `test_index_admin_delete`, mirroring the existing `test_show_admin_delete` pattern.

## Verified

- Confirmed the new test reproduces the exact production `NoMethodError` when run against the unfixed view (stashed the fix, ran the test, got the same error and backtrace shape; restored the fix, test passes).
- `bin/rails test test/controllers/glossary_terms_controller_test.rb` -- 35/35 pass.
- `bundle exec rubocop` on all three touched files -- no offenses.

<!-- changelog -->
article: no
<!-- /changelog -->
