### PR TITLE
Fix `Date::Error` crash on out-of-range month in date search

### DIFF
--- a/app/classes/date_range_parser.rb
+++ b/app/classes/date_range_parser.rb
@@ -89,24 +89,47 @@ class DateRangeParser
     match_date_patterns(parse_date_words)
   end
 
-  def yyyymmdd(from, to)
-    [format("%04<year>d-%02<month>d-%02<day>d",
-            year: from.first, month: from.second.to_i,
-            day: from.third.to_i),
-     format("%04<year>d-%02<month>d-%02<day>d",
-            year: to.first, month: to.second.to_i,
-            day: [to.third.to_i, eom(to.first, to.second).to_i].min)]
+  # A month digit-count matches the "\d\d?" patterns above for any
+  # value from 0 to 99, not just 1-12 -- garbage like "2024-99" has to
+  # be rejected here rather than reaching Date.new, which raises
+  # Date::Error on an out-of-range month instead of returning nil.
+  def valid_month?(month)
+    month.between?(1, 12)
   end
 
+  def yyyymmdd(from, to)
+    from_month = from.second.to_i
+    to_month = to.second.to_i
+    return nil unless valid_month?(from_month) && valid_month?(to_month)
+
+    [yyyymmdd_string(from.first, from_month, from.third.to_i),
+     yyyymmdd_string(to.first, to_month, clamped_day(to, to_month))]
+  end
+
+  def clamped_day(to, to_month)
+    [to.third.to_i, eom(to.first, to_month).to_i].min
+  end
+
+  def yyyymmdd_string(year, month, day)
+    format("%04<year>d-%02<month>d-%02<day>d",
+           year: year, month: month, day: day)
+  end
+
+  # `from`/`to` here are [month, day] pairs, unlike yyyymmdd's
+  # [year, month, day] -- the month is `.first`, not `.second`.
   def mmdd(from, to)
+    from_month = from.first.to_i
+    to_month = to.first.to_i
+    return nil unless valid_month?(from_month) && valid_month?(to_month)
+
     [format("%02<year>d-%02<month>d",
-            year: from.first.to_i, month: from.second.to_i),
+            year: from_month, month: from.second.to_i),
      format("%02<year>d-%02<month>d",
-            year: to.first.to_i, month: to.second.to_i)]
+            year: to_month, month: to.second.to_i)]
   end
 
   def eom(year, month)
-    Date.new(year.to_i, month.to_i).end_of_month.strftime("%d")
+    Date.new(year.to_i, month).end_of_month.strftime("%d")
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/test/classes/date_range_parser_test.rb
+++ b/test/classes/date_range_parser_test.rb
@@ -58,6 +58,19 @@ class DateRangeParserTest < UnitTestCase
     assert_nil(parse(nil))
   end
 
+  # An out-of-range month (matches the "\d\d?" patterns' digit-count
+  # regex, since that doesn't check the value) used to reach Date.new
+  # unguarded and raise Date::Error instead of failing the search
+  # cleanly -- a production 500 on /observations/search.
+  def test_out_of_range_month_is_nil
+    assert_nil(parse("2026-99"))
+    assert_nil(parse("2026-00"))
+    assert_nil(parse("99"))
+    assert_nil(parse("99-15"))
+    assert_nil(parse("2026-13-2026-01"))
+    assert_nil(parse("2026-08-2026-99"))
+  end
+
   # Exactly two endpoints: a list of three dates is rejected, not
   # silently spanned first-to-last.
   def test_separators_do_not_nest


### PR DESCRIPTION
## Summary

Fixes a production 500 on `POST /observations/search`: `DateRangeParser`'s `"\d\d?"` regex patterns match any 1-2 digit value by digit count, not by range, so a garbage month like `"2024-99"` or `"99-15"` passed the pattern check and reached `Date.new(year, 99)` unguarded in `eom`, raising `Date::Error` instead of returning `nil`.

```
Date::Error: invalid date
app/classes/date_range_parser.rb:110:in 'Date#initialize'
app/classes/date_range_parser.rb:110:in 'DateRangeParser#eom'
```

## Why this matters beyond the crash

`Observations::SearchController` already has a graceful path for a date it can't parse -- `dates_parseable?` flashes `:search_term_date_unparseable` and re-renders the search form -- gated on `DateRangeParser#range` returning `nil`. There's a comment right above the call site: *"A date the parser doesn't understand must fail the search, not silently broaden it."* The crash bypassed that path entirely instead of triggering it.

## Fix

Validate month is between 1 and 12 before it reaches `Date.new`, in both `yyyymmdd` and `mmdd`. Caught a mixed-up field reference in `mmdd` via the existing test suite before it shipped: `mmdd`'s arrays are `[month, day]`, unlike `yyyymmdd`'s `[year, month, day]`, so validating the wrong index (`.second` instead of `.first`) broke the legitimate `"02-08"` month-range case -- the test suite failed immediately and caught it.

## Verified

- `bin/rails runner` against a range of garbage inputs (`"2024-99"`, `"2024-00"`, `"99-15"`, `"2024-13-2024-01"`, `"13-99-15-01"`) -- all return `nil` cleanly now, no crash.
- Same check against legitimate inputs (`"02-08"`, `"8"`, `"2026-08-12-2026-08-16"`) -- unchanged, still parse correctly.
- `bin/rails test test/classes/date_range_parser_test.rb` -- 8/8 pass, including two new tests covering out-of-range months.
- `bin/rails test test/controllers/observations/search_controller_test.rb` -- 56/56 pass.
- `bundle exec rubocop` on both touched files -- no offenses.

<!-- changelog -->
article: yes
Fix an error searching Observations by an invalid date
<!-- /changelog -->
