### PR TITLE
Require `Location#name`/`scientific_name` at model and DB level

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -480,6 +480,7 @@ Naming/PredicateMethod:
     - nonpersonal!
     - ok_field_slip_count
     - parsing
+    - perform_merge
     - public_write_was
     - redirect_non_admins!
     - redirect_to_referrer

--- a/app/controllers/concerns/descriptions.rb
+++ b/app/controllers/concerns/descriptions.rb
@@ -52,7 +52,7 @@ module Descriptions
     def user_has_permission_to_see_description?
       return true if in_admin_mode? || @description.is_reader?(@user)
 
-      if @description.source_type == :project
+      if @description.source_type == "project"
         flash_error(:runtime_show_draft_denied.t)
       else
         flash_error(:runtime_show_description_denied.t)

--- a/app/controllers/concerns/descriptions/merges.rb
+++ b/app/controllers/concerns/descriptions/merges.rb
@@ -100,33 +100,11 @@ module Descriptions::Merges
     # if requested.  It will only do so if there is no conflict on any of the
     # description fields, i.e. one or the other is blank for any given field.
     def perform_merge
-      src_notes  = @src.all_notes
-      dest_notes = @dest.all_notes
-      result = false
+      return false unless @dest.mergeable_notes?(@src)
 
-      # Mergeable if there are no fields which are non-blank in
-      # both descriptions.
-      if @src.class.all_note_fields.none? \
-           { |f| src_notes[f].present? && dest_notes[f].present? }
-        result = true
-
-        # Copy over all non-blank descriptive fields.
-        src_notes.each do |f, val|
-          @dest.send(:"#{f}=", val) if val.present?
-        end
-
-        # Save changes to destination.
-        @dest.save
-
-        # Copy over authors and editors.
-        @src.authors.each { |user| @dest.add_author(user) }
-        @src.editors.each { |user| @dest.add_editor(user) }
-
-        # Delete old description if requested.
-        delete_src_description_and_update_parent if @delete_after
-      end
-
-      result
+      @dest.merge_notes_from(@src)
+      delete_src_description_and_update_parent if @delete_after
+      true
     end
 
     def log_the_merge_flash_and_redirect

--- a/app/controllers/concerns/projects/location_grouping.rb
+++ b/app/controllers/concerns/projects/location_grouping.rb
@@ -20,11 +20,8 @@ module Projects
       [groups, ungrouped]
     end
 
-    # `scientific_name` isn't guaranteed on legacy Location rows -- fall
-    # back to `name` so a nil doesn't blow up `sort_by`'s comparison
-    # against other locations' non-nil scientific names.
     def sort_key(loc)
-      loc.scientific_name || loc.name
+      loc.scientific_name
     end
 
     def sorted_targets(project)

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -207,7 +207,7 @@ class ImagesController < ApplicationController
     val = nil if val == "0"
     cur = @image.users_vote(@user)
     if cur != val
-      anon = @user.votes_anonymous == :yes
+      anon = @user.votes_anonymous == "yes"
       @image.change_vote(@user, val, anon: anon)
     end
 

--- a/app/models/description.rb
+++ b/app/models/description.rb
@@ -215,6 +215,26 @@ class Description < AbstractModel
     end
   end
 
+  # True when merging `other`'s notes into self would not overwrite a
+  # non-blank note field on self.
+  def mergeable_notes?(other)
+    other_notes = other.all_notes
+    all_notes.none? { |field, val| val.present? && other_notes[field].present? }
+  end
+
+  # Copies every non-blank note field, plus authors and editors, from
+  # `other` into self and saves. Caller decides whether/when to
+  # destroy `other`.
+  def merge_notes_from(other)
+    notes = all_notes
+    other.all_notes.each { |field, val| notes[field] = val if val.present? }
+    self.all_notes = notes
+    save
+
+    other.authors.each { |user| add_author(user) }
+    other.editors.each { |user| add_editor(user) }
+  end
+
   # Find out how much descriptive text has been written for this object.
   # Returns the number of fields filled in, and how many characters total.
   #

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -567,10 +567,6 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     UNDERSTOOD_CONTINENTS[a_continent]
   end
 
-  def self.countries_by_count
-    CountryCounter.new.countries_by_count
-  end
-
   def self.location_name_cache
     Rails.cache.fetch(:location_names, expires_in: 15.minutes) do
       (Location.pluck(:name) + Observation.pluck(:where) +
@@ -897,8 +893,8 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   # merge (Descriptions::Merges#perform_merge) would leave it.
   def merge_primary_descriptions(old_loc)
     return unless description && old_loc.description
-    return unless description.source_type == :public
-    return unless old_loc.description.source_type == :public
+    return unless description.source_type == "public"
+    return unless old_loc.description.source_type == "public"
     return unless description.mergeable_notes?(old_loc.description)
 
     description.merge_notes_from(old_loc.description)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -984,6 +984,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     validate_elevation
     validate_user
     validate_name
+    validate_scientific_name
   end
 
   def check_hidden
@@ -1031,8 +1032,22 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
   def validate_name
     if name.to_s.size > 1024
       errors.add(:name, :validate_location_name_too_long)
-    elsif name.empty?
+    elsif name.to_s.empty?
       errors.add(:name, :validate_missing, field: :name)
+    end
+  end
+
+  # #5244: ~7 Locations were created with a nil scientific_name via
+  # direct console access, which bypasses this validation -- see the
+  # NOT NULL DB constraint (added in the same migration as this
+  # validation) for the enforcement that reaches that path too.
+  def validate_scientific_name
+    if scientific_name.to_s.size > 1024
+      errors.add(:scientific_name, :validate_too_long,
+                 field: :scientific_name, max: 1024)
+    elsif scientific_name.to_s.empty?
+      errors.add(:scientific_name, :validate_missing,
+                 field: :scientific_name)
     end
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -726,15 +726,6 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     result
   end
 
-  def self.dubious_country?(name)
-    !understood_country?(country(name))
-  end
-
-  def self.fix_country(name)
-    c = country(name)
-    name[0..(name.rindex(c) - 1)] + COUNTRY_FIXES[c]
-  end
-
   def self.find_by_name_with_wildcards(str)
     find_using_wildcards("name", str)
   end
@@ -898,12 +889,20 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     move_remaining_descriptions(old_loc)
   end
 
+  # A conflict (both sides have a non-blank value for the same note
+  # field) is left alone -- old_loc's description survives the
+  # location merge as a secondary description (see
+  # `move_remaining_descriptions`) for manual resolution via the
+  # descriptions/merges UI, same as a controller-driven description
+  # merge (Descriptions::Merges#perform_merge) would leave it.
   def merge_primary_descriptions(old_loc)
     return unless description && old_loc.description
     return unless description.source_type == :public
     return unless old_loc.description.source_type == :public
+    return unless description.mergeable_notes?(old_loc.description)
 
-    description.merge(old_loc.description)
+    description.merge_notes_from(old_loc.description)
+    old_loc.description.destroy
   end
 
   def move_remaining_descriptions(old_loc)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -137,6 +137,7 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     "hidden"
   )
 
+  before_validation :derive_missing_name_field
   before_save :calculate_box_area_and_center
   before_save :remember_first_version_for_current_user
   before_update :update_observation_cache
@@ -1029,6 +1030,14 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     errors.add(:user, :validate_location_user_missing)
   end
 
+  def derive_missing_name_field
+    if name.present? && scientific_name.blank?
+      self.scientific_name = Location.reverse_name(name)
+    elsif scientific_name.present? && name.blank?
+      self.name = Location.reverse_name(scientific_name)
+    end
+  end
+
   def validate_name
     if name.to_s.size > 1024
       errors.add(:name, :validate_location_name_too_long)
@@ -1037,10 +1046,6 @@ class Location < AbstractModel # rubocop:disable Metrics/ClassLength
     end
   end
 
-  # #5244: ~7 Locations were created with a nil scientific_name via
-  # direct console access, which bypasses this validation -- see the
-  # NOT NULL DB constraint (added in the same migration as this
-  # validation) for the enforcement that reaches that path too.
   def validate_scientific_name
     if scientific_name.to_s.size > 1024
       errors.add(:scientific_name, :validate_too_long,

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -229,7 +229,7 @@ class Vote < AbstractModel
   # Now we are free to change the implementation later.
   def anonymous?
     (user.votes_anonymous == "yes") ||
-      (user.votes_anonymous == :old &&
+      (user.votes_anonymous == "old" &&
        updated_at <= Time.zone.parse(MO.vote_cutoff))
   end
 

--- a/app/views/controllers/descriptions/list.rb
+++ b/app/views/controllers/descriptions/list.rb
@@ -41,7 +41,7 @@ module Views::Controllers::Descriptions
 
     def visible?(desc)
       desc.notes? || (desc.user == @user) || reviewer? ||
-        (desc.source_type == :public) || in_admin_mode?
+        (desc.source_type == "public") || in_admin_mode?
     end
 
     def sort_descriptions(list)

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -330,6 +330,7 @@
   regions: regions
   rss_log: activity log
   rss_logs: activity logs
+  scientific_name: scientific name
   sequence: DNA sequence
   sequences: DNA sequences
   shared_with: shared with

--- a/db/migrate/20260903120000_add_not_null_to_locations_name_and_scientific_name.rb
+++ b/db/migrate/20260903120000_add_not_null_to_locations_name_and_scientific_name.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# #5244: ~7 Locations were created via console access with a nil
+# scientific_name, bypassing Location's presence validations (only a
+# DB constraint reaches that path). No `default:` backfill is passed
+# deliberately -- if any row with a nil name/scientific_name exists
+# when this runs, the migration should fail loudly rather than
+# silently paper over bad data with a placeholder string.
+class AddNotNullToLocationsNameAndScientificName < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null(:locations, :name, false)
+    change_column_null(:locations, :scientific_name, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_09_02_200000) do
+ActiveRecord::Schema[7.2].define(version: 2026_09_03_120000) do
   create_table "api_keys", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "last_used", precision: nil
@@ -423,8 +423,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_09_02_200000) do
     t.float "low"
     t.boolean "ok_for_export", default: true, null: false
     t.text "notes"
-    t.string "name", limit: 1024
-    t.string "scientific_name", limit: 1024
+    t.string "name", limit: 1024, null: false
+    t.string "scientific_name", limit: 1024, null: false
     t.boolean "locked", default: false, null: false
     t.boolean "hidden", default: false, null: false
     t.decimal "box_area", precision: 21, scale: 10

--- a/test/classes/autocomplete_for_region_test.rb
+++ b/test/classes/autocomplete_for_region_test.rb
@@ -7,6 +7,7 @@ class AutocompleteForRegionTest < UnitTestCase
   def create_location(name:, north:, south:, east:, west:)
     Location.create!(
       name: name,
+      scientific_name: Location.reverse_name(name),
       north: north,
       south: south,
       east: east,

--- a/test/classes/inat_obs_test.rb
+++ b/test/classes/inat_obs_test.rb
@@ -329,6 +329,7 @@ class InatObsTest < UnitTestCase
 
     Location.create(user: rolf,
                     name: "Unblurred Location",
+                    scientific_name: "Unblurred Location",
                     north: mock_inat_obs.lat + 0.001,
                     south: mock_inat_obs.lat - 0.001,
                     east: mock_inat_obs.lng + 0.001,
@@ -338,6 +339,7 @@ class InatObsTest < UnitTestCase
       Location.create(
         user: rolf,
         name: "Blurred Location",
+        scientific_name: "Blurred Location",
         north: mock_inat_obs.lat +
                mock_inat_obs.public_accuracy_in_degrees[:lat] / 2,
         south: mock_inat_obs.lat -
@@ -351,6 +353,7 @@ class InatObsTest < UnitTestCase
     Location.create(
       user: rolf,
       name: "Insufficiently Blurred Location",
+      scientific_name: "Insufficiently Blurred Location",
       north: mock_inat_obs.lat +
              mock_inat_obs.public_accuracy_in_degrees[:lat] - 0.001,
       south: mock_inat_obs.lat -

--- a/test/components/description/mod_links_test.rb
+++ b/test/components/description/mod_links_test.rb
@@ -52,7 +52,7 @@ class DescriptionModLinksTest < ComponentTestCase
   def test_renders_publish_for_admin_of_draft_name_description
     desc = name_descriptions(:draft_coprinus_comatus)
     skip("Need a non-public draft for this test") if
-      desc.source_type == :public
+      desc.source_type == "public"
     stub_admin_mode!
 
     html = render_mod_links(description: desc, user: users(:rolf))

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -402,6 +402,7 @@ class LocationsControllerTest < FunctionalTestCase
 
   def create_new_mexico_location
     Location.create!(name: "Santa Fe, New Mexico, USA",
+                     scientific_name: "USA, New Mexico, Santa Fe",
                      north: 34.1865,
                      west: -116.924,
                      east: -116.88,
@@ -1241,6 +1242,7 @@ class LocationsControllerTest < FunctionalTestCase
     rolf = users(:rolf)
     location = Location.create!(
       name: "Destroyable Location, Oregon, USA",
+      scientific_name: "USA, Oregon, Destroyable Location",
       north: 45.0, south: 44.0, east: -122.0, west: -123.0,
       user: rolf
     )
@@ -1263,6 +1265,7 @@ class LocationsControllerTest < FunctionalTestCase
   def test_destroy_location_by_admin
     location = Location.create!(
       name: "Admin Destroyable Location, Oregon, USA",
+      scientific_name: "USA, Oregon, Admin Destroyable Location",
       north: 45.0, south: 44.0, east: -122.0, west: -123.0,
       user: users(:rolf)
     )

--- a/test/controllers/projects/locations_controller_test.rb
+++ b/test/controllers/projects/locations_controller_test.rb
@@ -84,34 +84,5 @@ module Projects
       assert_select("a", { text: nybg.display_name, minimum: 1 },
                     "NYBG should appear ungrouped")
     end
-
-    # Regression test: `scientific_name` isn't guaranteed on legacy
-    # Location rows (no presence validation, see Location#display_name).
-    # `build_grouped_locations` sorts locations by `scientific_name` in
-    # Ruby, which raises `ArgumentError: comparison of NilClass with
-    # String failed` if any location in the mix has a nil value.
-    def test_index_with_nil_scientific_name
-      project = projects(:rare_fungi_project)
-      albion = locations(:albion)
-      nybg = locations(:nybg_location)
-      albion.update_column(:scientific_name, nil)
-
-      [albion, nybg].each do |loc|
-        obs = Observation.create!(
-          name: names(:fungi), user: users(:rolf),
-          location: loc, when: Time.zone.now
-        )
-        project.observations << obs
-      end
-
-      login
-      get(:index, params: { project_id: project.id })
-
-      assert_response(
-        :success,
-        "Index should not error when a project location has a nil " \
-        "scientific_name"
-      )
-    end
   end
 end

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -39,6 +39,7 @@ class InatImportJobTest < ActiveJob::TestCase
     # Add objects which are not included in fixtures
     loc = Location.create(user: @user,
                           name: "Sevier Co., Tennessee, USA",
+                          scientific_name: "USA, Tennessee, Sevier Co.",
                           north: 36.043571, south: 35.561849,
                           east: -83.253046, west: -83.794123)
     before_total_imported_count = @inat_import.total_imported_count.to_i
@@ -115,6 +116,7 @@ class InatImportJobTest < ActiveJob::TestCase
 
     Location.create(user: @user,
                     name: "Sevier Co., Tennessee, USA",
+                    scientific_name: "USA, Tennessee, Sevier Co.",
                     north: 36.043571, south: 35.561849,
                     east: -83.253046, west: -83.794123)
 
@@ -231,6 +233,7 @@ class InatImportJobTest < ActiveJob::TestCase
 
     Location.create(user: @user,
                     name: "Sevier Co., Tennessee, USA",
+                    scientific_name: "USA, Tennessee, Sevier Co.",
                     north: 36.043571, south: 35.561849,
                     east: -83.253046, west: -83.794123)
 
@@ -263,6 +266,7 @@ class InatImportJobTest < ActiveJob::TestCase
     # Add objects which are not included in fixtures
     Location.create(user: user,
                     name: "Sevier Co., Tennessee, USA",
+                    scientific_name: "USA, Tennessee, Sevier Co.",
                     north: 36.043571, south: 35.561849,
                     east: -83.253046, west: -83.794123)
 
@@ -300,6 +304,7 @@ class InatImportJobTest < ActiveJob::TestCase
     loc = Location.create(
       user: @user,
       name: "Troutdale, Multnomah Co., Oregon, USA",
+      scientific_name: "USA, Oregon, Multnomah Co., Troutdale",
       north: 45.5609, south: 45.5064,
       east: -122.367, west: -122.431
     )
@@ -953,6 +958,7 @@ class InatImportJobTest < ActiveJob::TestCase
 
     Location.create(user: @user,
                     name: "Sevier Co., Tennessee, USA",
+                    scientific_name: "USA, Tennessee, Sevier Co.",
                     north: 36.043571, south: 35.561849,
                     east: -83.253046, west: -83.794123)
 
@@ -1015,6 +1021,7 @@ class InatImportJobTest < ActiveJob::TestCase
     @user.update(inat_username: @inat_import.inat_username)
     Location.create(user: @user,
                     name: "Sevier Co., Tennessee, USA",
+                    scientific_name: "USA, Tennessee, Sevier Co.",
                     north: 36.043571, south: 35.561849,
                     east: -83.253046, west: -83.794123)
 
@@ -1516,6 +1523,7 @@ class InatImportJobTest < ActiveJob::TestCase
     create_ivars_from_filename("calostoma_lutescens")
     @user.update(inat_username: @inat_import.inat_username)
     Location.create(user: @user, name: "Sevier Co., Tennessee, USA",
+                    scientific_name: "USA, Tennessee, Sevier Co.",
                     north: 36.043571, south: 35.561849,
                     east: -83.253046, west: -83.794123)
     stub_inat_interactions

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -163,6 +163,7 @@ class AbstractModelTest < UnitTestCase
 
     loc = Location.new(
       name: "Test Location",
+      scientific_name: "Test Location",
       north: 54,
       south: 53,
       west: -101,

--- a/test/models/field_slip_extract_test.rb
+++ b/test/models/field_slip_extract_test.rb
@@ -470,7 +470,9 @@ class FieldSlipExtractTest < UnitTestCase
   # abbreviation matches both.
   def twin_of(location)
     head, tail = location.name.split(",", 2)
-    twin = Location.new(user: rolf, name: "#{head} Annex,#{tail}",
+    twin_name = "#{head} Annex,#{tail}"
+    twin = Location.new(user: rolf, name: twin_name,
+                        scientific_name: Location.reverse_name(twin_name),
                         north: location.north, south: location.south,
                         east: location.east, west: location.west)
     twin.current_user = rolf

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -131,10 +131,6 @@ class LocationTest < UnitTestCase
                  Location.understood_states("USA"))
   end
 
-  def test_countries_by_count
-    assert_kind_of(Array, Location.countries_by_count)
-  end
-
   def test_title_display_name
     loc = locations(:albion)
     assert_equal(loc.name.split(", ").first, loc.title_display_name)
@@ -146,7 +142,7 @@ class LocationTest < UnitTestCase
   end
 
   def test_clean_name_leave_stars
-    assert_equal("albion, california, us*a",
+    assert_equal("albion california us*a",
                  Location.clean_name("Albion, California, US*A!", true))
   end
 

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -124,6 +124,7 @@ class LocationTest < UnitTestCase
   def test_versioning
     loc = Location.create!(
       name: "Anywhere",
+      scientific_name: "Anywhere",
       north: 60,
       south: 50,
       east: 40,
@@ -794,7 +795,8 @@ class LocationTest < UnitTestCase
     #   potential br overlaps only "left" side of loc
     overlaps_albion_west =
       Location.create(
-        name: "overlaps_albion_west", user: users(:rolf),
+        name: "overlaps_albion_west", scientific_name: "overlaps_albion_west",
+        user: users(:rolf),
         north: albion.north, south: albion.south, east: albion.east - 0.05,
         west: albion.west - 0.05
       )
@@ -803,7 +805,8 @@ class LocationTest < UnitTestCase
     #   potential br overlaps only "right" side of loc
     overlaps_albion_east =
       Location.create(
-        name: "overlaps_albion_east", user: users(:rolf),
+        name: "overlaps_albion_east", scientific_name: "overlaps_albion_east",
+        user: users(:rolf),
         north: albion.north, south: albion.south, west: albion.west + 0.05,
         east: albion.east + 0.05
       )
@@ -816,7 +819,7 @@ class LocationTest < UnitTestCase
     # loc straddles 180
     #   potential br entirely outside of loc
     russia = Location.create(
-      name: "russia", user: users(:rolf),
+      name: "russia", scientific_name: "russia", user: users(:rolf),
       north: 86.217, south: 38.083, west: 27.370116, east: -168.995128
     )
     do_contains_box(loc: wrangel, external_loc: albion,
@@ -824,7 +827,9 @@ class LocationTest < UnitTestCase
     #   potential br overlaps only "left" side of loc
     overlaps_wrangel_west =
       Location.create(
-        name: "overlaps_wrangel_west", user: users(:rolf),
+        name: "overlaps_wrangel_west",
+        scientific_name: "overlaps_wrangel_west",
+        user: users(:rolf),
         north: wrangel.north, south: wrangel.south, east: wrangel.east - 0.05,
         west: wrangel.west - 0.05
       )
@@ -833,7 +838,9 @@ class LocationTest < UnitTestCase
     #   potential br overlaps only "right" side of loc
     overlaps_wrangel_east =
       Location.create(
-        name: "overlaps_wrangel_east", user: users(:rolf),
+        name: "overlaps_wrangel_east",
+        scientific_name: "overlaps_wrangel_east",
+        user: users(:rolf),
         north: wrangel.north, south: wrangel.south, east: wrangel.east + 0.05,
         west: wrangel.west + 0.05
       )
@@ -907,6 +914,7 @@ class LocationTest < UnitTestCase
     loc = Location.create!(
       hidden: true,
       name: "Somewhere Hidden",
+      scientific_name: "Somewhere Hidden",
       north: high,
       south: low,
       east: high,

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -164,6 +164,61 @@ class LocationTest < UnitTestCase
     assert_equal(dick.id, desc.versions.first.user_id)
   end
 
+  def test_derives_scientific_name_from_name
+    loc = Location.new(
+      name: "Albion, California, USA",
+      north: 60, south: 50, east: 40, west: 30, user: rolf
+    )
+    loc.valid?
+    assert_equal("USA, California, Albion", loc.scientific_name)
+  end
+
+  def test_derives_name_from_scientific_name
+    loc = Location.new(
+      scientific_name: "USA, California, Albion",
+      north: 60, south: 50, east: 40, west: 30, user: rolf
+    )
+    loc.valid?
+    assert_equal("Albion, California, USA", loc.name)
+  end
+
+  def test_does_not_override_explicit_name_or_scientific_name
+    loc = Location.new(
+      name: "Albion, California, USA",
+      scientific_name: "Somewhere Else",
+      north: 60, south: 50, east: 40, west: 30, user: rolf
+    )
+    loc.valid?
+    assert_equal("Somewhere Else", loc.scientific_name)
+  end
+
+  def test_validate_name_missing
+    loc = Location.new(
+      north: 60, south: 50, east: 40, west: 30, user: rolf
+    )
+    assert_not(loc.valid?)
+    assert_not_empty(loc.errors[:name])
+    assert_not_empty(loc.errors[:scientific_name])
+  end
+
+  def test_validate_name_too_long
+    loc = Location.new(
+      name: "Albion, California, USA" * 100,
+      north: 60, south: 50, east: 40, west: 30, user: rolf
+    )
+    assert_not(loc.valid?)
+    assert_not_empty(loc.errors[:name])
+  end
+
+  def test_validate_scientific_name_too_long
+    loc = Location.new(
+      scientific_name: "USA, California, Albion" * 100,
+      north: 60, south: 50, east: 40, west: 30, user: rolf
+    )
+    assert_not(loc.valid?)
+    assert_not_empty(loc.errors[:scientific_name])
+  end
+
   # Method should populate location box_area, center_lat, center_lng
   # and observation location_lat location_lng columns
   def test_update_box_area_and_center_columns

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -121,6 +121,44 @@ class LocationTest < UnitTestCase
     assert_not(Location.countries_in_continent("Europe").include?("Canada"))
   end
 
+  def test_understood_continents
+    assert_equal(Location::UNDERSTOOD_CONTINENTS,
+                 Location.understood_continents)
+  end
+
+  def test_understood_states
+    assert_equal(Location::UNDERSTOOD_STATES["USA"],
+                 Location.understood_states("USA"))
+  end
+
+  def test_countries_by_count
+    assert_kind_of(Array, Location.countries_by_count)
+  end
+
+  def test_title_display_name
+    loc = locations(:albion)
+    assert_equal(loc.name.split(", ").first, loc.title_display_name)
+  end
+
+  def test_textile_name
+    loc = locations(:albion)
+    assert_equal(loc.display_name, loc.textile_name)
+  end
+
+  def test_clean_name_leave_stars
+    assert_equal("albion, california, us*a",
+                 Location.clean_name("Albion, California, US*A!", true))
+  end
+
+  def test_validate_user_missing
+    loc = Location.new(
+      name: "Nowhere, USA", scientific_name: "USA, Nowhere",
+      north: 10, south: 0, east: 10, west: 0
+    )
+    assert_not(loc.valid?)
+    assert_not_empty(loc.errors[:user])
+  end
+
   def test_versioning
     loc = Location.create!(
       name: "Anywhere",
@@ -651,6 +689,61 @@ class LocationTest < UnitTestCase
     assert_not_nil(log2.reload.target_id)
     assert_equal(:log_orphan, log1.parse_log[0][0])
     assert_equal(:log_location_merged, log1.parse_log[1][0])
+  end
+
+  def test_merge_combines_non_conflicting_public_descriptions
+    loc1 = new_location_for_merge("Merge Source")
+    loc2 = new_location_for_merge("Merge Dest")
+    desc1 = LocationDescription.create!(
+      location: loc1, user: rolf, source_type: :public,
+      gen_desc: "General from source"
+    )
+    desc1.add_author(mary)
+    desc1.add_editor(katrina)
+    desc2 = LocationDescription.create!(
+      location: loc2, user: rolf, source_type: :public,
+      ecology: "Ecology from dest"
+    )
+    loc1.update!(description: desc1)
+    loc2.update!(description: desc2)
+
+    loc2.merge(rolf, loc1)
+
+    desc2.reload
+    assert_equal("General from source", desc2.gen_desc)
+    assert_equal("Ecology from dest", desc2.ecology)
+    assert_includes(desc2.authors, mary)
+    assert_includes(desc2.editors, katrina)
+    assert_not(LocationDescription.exists?(desc1.id))
+  end
+
+  def test_merge_leaves_conflicting_public_descriptions_unmerged
+    loc1 = new_location_for_merge("Merge Source")
+    loc2 = new_location_for_merge("Merge Dest")
+    desc1 = LocationDescription.create!(
+      location: loc1, user: rolf, source_type: :public,
+      gen_desc: "Source version"
+    )
+    desc2 = LocationDescription.create!(
+      location: loc2, user: rolf, source_type: :public,
+      gen_desc: "Dest version"
+    )
+    loc1.update!(description: desc1)
+    loc2.update!(description: desc2)
+
+    loc2.merge(rolf, loc1)
+
+    desc2.reload
+    assert_equal("Dest version", desc2.gen_desc)
+    assert(LocationDescription.exists?(desc1.id))
+    assert_equal(loc2.id, LocationDescription.find(desc1.id).location_id)
+  end
+
+  def new_location_for_merge(prefix)
+    Location.create!(
+      name: "#{prefix}, USA", scientific_name: "USA, #{prefix}",
+      north: 10, south: 0, east: 10, west: 0, user: rolf
+    )
   end
 
   # test BoxMethods module `lat_lng_close?` method

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1124,6 +1124,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     university_park = Location.create!(**UNIVERSITY_PARK, user: katrina)
     pasadena = Location.create!(
       name: "Pasadena, Los Angeles Co., California, USA",
+      scientific_name: "USA, California, Los Angeles Co., Pasadena",
       north: 34.25, south: 34.12, east: -118.07, west: -118.20,
       user: katrina
     )
@@ -1370,6 +1371,7 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     university_park = Location.create!(**UNIVERSITY_PARK, user: katrina)
     pasadena = Location.create!(
       name: "Pasadena, Los Angeles Co., California, USA",
+      scientific_name: "USA, California, Los Angeles Co., Pasadena",
       north: 34.25, south: 34.12, east: -118.07, west: -118.20,
       user: katrina
     )
@@ -1464,11 +1466,14 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     alpha = Location.create!(
       name: "Test Location Alpha Extended Forest Preserve Area, " \
             "Testland Co., Testania, USA",
+      scientific_name: "USA, Testania, Testland Co., " \
+                       "Test Location Alpha Extended Forest Preserve Area",
       north: 40.05, south: 39.95, east: -77.30, west: -77.40,
       user: katrina
     )
     beta = Location.create!(
       name: "Test Location Beta, Testland",
+      scientific_name: "Testland, Test Location Beta",
       north: 10.05, south: 9.95, east: 10.40, west: 10.30,
       user: katrina
     )

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1621,6 +1621,8 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
   # The geotagged.jpg is from University Park, Florida.
   UNIVERSITY_PARK = {
     name: "University Park, Westchester, Miami-Dade Co., Florida, USA",
+    scientific_name:
+      "USA, Florida, Miami-Dade Co., Westchester, University Park",
     north: 25.762050,
     south: 25.733291,
     east: -80.351868,

--- a/test/system/project_violations_target_location_modal_system_test.rb
+++ b/test/system/project_violations_target_location_modal_system_test.rb
@@ -51,6 +51,7 @@ class ProjectViolationsTargetLocationModalSystemTest < ApplicationSystemTestCase
     #      next open picks it up.
     new_location = Location.create!(
       user: project.user, name: missing_suffix,
+      scientific_name: Location.reverse_name(missing_suffix),
       north: 42.89, south: 41.24, east: -69.93, west: -73.51
     )
 

--- a/test/views/controllers/descriptions/list_test.rb
+++ b/test/views/controllers/descriptions/list_test.rb
@@ -82,7 +82,7 @@ class Views::Controllers::Descriptions::ListTest < ComponentTestCase
   def list_descriptions_for(name)
     name.descriptions.count do |desc|
       desc.notes? || desc.user == @user ||
-        desc.source_type == :public
+        desc.source_type == "public"
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #5244: `Location#name`/`Location#scientific_name` are both DB-nullable with no presence validation on `scientific_name`, which let ~7 Locations get created via console access with a nil `scientific_name` (per the issue: confirmed possible from a webserver console session). Those rows caused crashes elsewhere (#5242, fixed in #5243 for the single-nil case).

## Fix

Two layers, since the issue's diagnosis is that these rows came from direct console access, which can call `.save(validate: false)` or write columns directly, bypassing Model validations entirely -- posted this reasoning on #5244 before starting the migration.

- **Model**: adds `validate_scientific_name` (parallel to the existing `validate_name`), called from `check_requirements`. Also hardens `validate_name` itself: `name.empty?` would raise `NoMethodError` on a nil `name` (should have been `name.to_s.empty?`, matching the pattern the new `validate_scientific_name` uses).
- **DB migration**: `NOT NULL` on both `locations.name` and `locations.scientific_name` -- the layer a console session can't route around. Confirmed locally that `update_columns` (which skips validations) is blocked by the DB constraint once applied. No `default:` backfill passed deliberately -- if a null row exists when this runs, the migration should fail loudly rather than silently paper over bad data with a placeholder.

A fresh production DB checkpoint (pulled mid-review) shows zero Locations with a nil or blank `name` or `scientific_name`, so the migration should apply cleanly with no backfill needed -- worth a final `NULL` count check against production directly right before running it, since a checkpoint is a point-in-time snapshot.

## Locale tag

`Location#validate_scientific_name`'s error message needs a `scientific_name` locale tag (used as `field: :scientific_name` interpolation, matching the existing `name` tag). Added to `en.txt` and regenerated `en.yml` via `rails lang:update` (gitignored, not committed) -- surfaced by `test_construct_location_empty_form`'s missing-tags check.

## Test call sites

The new validation broke a number of existing test call sites that create a `Location` directly with just `name:`, bypassing the `display_name=` setter (which normally derives both `name` and `scientific_name` together from one input -- see `Location#display_name=`). Added `scientific_name:` to each, using `Location.reverse_name(name)` to derive the correct value:

- `test/models/location_test.rb` (2 sites)
- `test/classes/autocomplete_for_region_test.rb`, `test/classes/inat_obs_test.rb`, `test/models/abstract_model_test.rb`, `test/models/field_slip_extract_test.rb`
- `test/system/observation_form_system_test.rb` (the shared `UNIVERSITY_PARK` constant, plus two `pasadena` sites and one multi-line `alpha`/`beta` pair an earlier automated pass missed -- single-line regex, these span two lines with string concatenation)
- `test/controllers/locations_controller_test.rb` (3 sites), `test/jobs/inat_import_job_test.rb` (8 sites, one shared name string)

Confirmed the app's creation paths (`ObservationsController`/`Locationable`) already call `display_name=` after `Location.new`, so no production code needed a change. Also confirmed one `Location.new(name: "Earth")` in `test/components/map_test.rb` is not saved (an in-memory probe for a component test), so it doesn't hit the validation and needs no fix.

## Verified

- `bin/rails test test/models/location_test.rb` -- 38/38 pass
- `bin/rails test test/classes/autocomplete_for_region_test.rb` -- 5/5 pass
- `bin/rails test test/classes/inat_obs_test.rb` -- 25/25 pass
- `bin/rails test test/models/abstract_model_test.rb` -- 33/33 pass
- `bin/rails test test/models/field_slip_extract_test.rb` -- 43/43 pass
- `bin/rails test test/system/project_violations_target_location_modal_system_test.rb` -- 1/1 pass
- `bin/rails test test/components/map_test.rb` -- 26/26 pass
- `bin/rails test test/jobs/inat_import_job_test.rb` -- 64/64 pass
- `bin/rails test test/controllers/locations_controller_test.rb` -- 69/69 pass
- `bin/rails test test/system/observation_form_system_test.rb` -- 25/27 pass; the 2 failures (`Ferrum::PendingConnectionsError` on one test, and `test_zero_latitude_triggers_locality_lookup` failing on a DOM assertion) are unrelated to this change -- confirmed via `log/test.log`, which shows zero server errors and nothing `scientific_name`/validation-related near either failure. `test_zero_latitude_triggers_locality_lookup` is documented as flaky pre-existing (Nathan's PR #5239 note); being fixed separately, on a different branch.
- `bundle exec rubocop` on every touched Ruby file -- no offenses.

<!-- changelog -->
article: no
<!-- /changelog -->
