### PR TITLE
Fix flaky `test_zero_latitude_triggers_locality_lookup`

### DIFF
--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1280,13 +1280,28 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     university_park.destroy
   end
 
-  # Bug fix: a latitude or longitude of exactly 0 (equator or
-  # prime meridian) used to be treated as "no coordinate" by a falsy
-  # check and silently rejected. Under the old bug, a latitude of 0
-  # would keep the autocompleter in plain "location" mode; the fixed
-  # code swaps it into "location_containing" like any other valid
-  # point, and carries the exact (0-valued) params along.
+  # Bug fix: a latitude or longitude of 0 (equator or prime meridian)
+  # used to be treated as "no coordinate" by a falsy check and
+  # silently rejected. Under the old bug, a latitude of 0 would keep
+  # the autocompleter in plain "location" mode; the fixed code swaps
+  # it into "location_containing" like any other valid point, and
+  # carries the 0-valued params along.
+  #
+  # Needs a fixture-independent location containing (0, 0.5): the
+  # only fixture location whose box geographically contains that
+  # point is the global "Earth" catch-all (unknown_location), and
+  # Autocomplete::ForLocationContaining rejects overly-broad boxes as
+  # "vague" (Mappable::BoxMethods#vague?), so a whole-globe box does
+  # not match. Without a small, specific location here, the lookup
+  # finds nothing and falls back to "location_google" instead.
   def test_zero_latitude_triggers_locality_lookup
+    equator_location = Location.create!(
+      name: "Null Island Vicinity, Gulf of Guinea",
+      scientific_name: "Gulf of Guinea, Null Island Vicinity",
+      north: 0.7, south: -0.3, east: 1.0, west: 0.0,
+      user: katrina
+    )
+
     login!(katrina)
     visit(new_observation_path)
     assert_selector("body.observations__new")
@@ -1315,6 +1330,8 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     JS
     assert_equal(0, request_params["lat"])
     assert_in_delta(0.5, request_params["lng"])
+  ensure
+    equator_location&.destroy
   end
 
   # Bug fix: iNat exports coordinates as a single

--- a/test/system/observation_form_system_test.rb
+++ b/test/system/observation_form_system_test.rb
@@ -1280,12 +1280,9 @@ class ObservationFormSystemTest < ApplicationSystemTestCase
     university_park.destroy
   end
 
-  # Bug fix: a latitude or longitude of 0 (equator or prime meridian)
-  # used to be treated as "no coordinate" by a falsy check and
-  # silently rejected. Under the old bug, a latitude of 0 would keep
-  # the autocompleter in plain "location" mode; the fixed code swaps
-  # it into "location_containing" like any other valid point, and
-  # carries the 0-valued params along.
+  # A latitude or longitude of 0 (equator or prime meridian) is a
+  # valid coordinate: the autocompleter swaps into "location_containing"
+  # mode and carries the 0-valued params along, same as any other point.
   #
   # Needs a fixture-independent location containing (0, 0.5): the
   # only fixture location whose box geographically contains that


### PR DESCRIPTION
## Summary

Fixes the flaky `test_zero_latitude_triggers_locality_lookup` system test, previously noted as flaky in PR #5239.

## Root cause

The test dispatches synthetic `lat=0`/`lng=0.5` input events, expecting the autocompleter to swap into `location_containing` mode. The only fixture location whose bounding box geographically contains that point is `unknown_location` ("Earth"), a whole-globe box — and `Autocomplete::ForLocationContaining` deliberately rejects overly broad boxes as "vague" (`Mappable::BoxMethods#vague?`, `calculate_area > MO.obs_location_max_area` = 24,000 km²). With zero non-vague matches, the client falls back to `location_google`, and the test's `location_containing` assertion fails.

This is not the timing/race bug the earlier `wait_for_autocompleter_request_params` helper (PR #5239) was written for — that helper resolves `request_params` state correctly, confirmed via live browser debugging. The gap is that the server-side lookup finds nothing to match against, so the helper has nothing to wait for.

## Fix

Adds a purpose-built, appropriately sized `Location` fixture (`north: 0.7, south: -0.3, east: 1.0, west: 0.0`, 12,368 km², under the vague-area threshold) containing the test's target point, created at the start of the test and destroyed in an `ensure` block.

## Verified

- `bin/rails test test/system/observation_form_system_test.rb -n test_zero_latitude_triggers_locality_lookup` — passes, run twice to confirm stability (1 tests, 6 assertions, 0 failures, 0 errors, 0 skips both times).
- `bundle exec rubocop test/system/observation_form_system_test.rb` — no offenses.

<!-- changelog -->
article: no
<!-- /changelog -->
