### PR TITLE
Changelog for `deploy-2026-09-04-10-34`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-04 (deploy-2026-09-04-10-34)
+
+- Repair changelog sections from the transitional deploys ([PR5304](https://github.com/MushroomObserver/mushroom-observer/pull/5304), @mo-nathan)
+- Fix production 500 on `glossary_terms#index` for admins ([PR5306](https://github.com/MushroomObserver/mushroom-observer/pull/5306), @nimmolo)
+- Fix `Date::Error` crash on out-of-range month in date search ([PR5307](https://github.com/MushroomObserver/mushroom-observer/pull/5307), @nimmolo)
+- Require `Location#name`/`scientific_name` at model and DB level ([PR5308](https://github.com/MushroomObserver/mushroom-observer/pull/5308), @nimmolo)
+- Fix flaky `test_zero_latitude_triggers_locality_lookup` ([PR5309](https://github.com/MushroomObserver/mushroom-observer/pull/5309), @nimmolo)
+- Add script to resolve MyCoPortal `external_links` to occids (#4591) ([PR5305](https://github.com/MushroomObserver/mushroom-observer/pull/5305), @nimmolo)
+- Drop and recreate `mo_development` in `db/strip_checkpoint` ([PR5311](https://github.com/MushroomObserver/mushroom-observer/pull/5311), @nimmolo)
+
 ## 2026-09-03 (deploy-2026-09-03-12-00)
 
 - Add `script/prerelease.rb` to build the pre-deploy changelog PR ([PR5281](https://github.com/MushroomObserver/mushroom-observer/pull/5281), @mo-nathan)

--- a/article_pending.textile
+++ b/article_pending.textile
@@ -1,2 +1,1 @@
-|{white-space:nowrap}. 2026-09-03 | Speed up observation creation, lighten the upload lock | "PR#5239":https://github.com/MushroomObserver/mushroom-observer/pull/5239 |
-|{white-space:nowrap}. 2026-09-03 | Add Project choice and automatic filing to iNat imports | "PR#5301":https://github.com/MushroomObserver/mushroom-observer/pull/5301 |
+|{white-space:nowrap}. 2026-09-03 | Fix an error searching Observations by an invalid date | "PR#5307":https://github.com/MushroomObserver/mushroom-observer/pull/5307 |


### PR DESCRIPTION
Pre-deploy changelog for `deploy-2026-09-04-10-34` (issue #5155): the CHANGELOG.md section for every PR merged since `deploy-2026-09-03-12-00`, and `article_pending.textile` with the MO Article rows the deploy will publish. Merge this as the last PR before deploying; re-running `script/prerelease.rb --apply` refreshes it with any later merges.

## Expected MO Article lines

```
|{white-space:nowrap}. 2026-09-03 | Fix an error searching Observations by an invalid date | "PR#5307":https://github.com/MushroomObserver/mushroom-observer/pull/5307 |
```
(6 PR(s) marked `article: no`.) Edits to `article_pending.textile` in this PR are what the deploy publishes.

<!-- changelog -->
article: no
<!-- /changelog -->
