### PR TITLE
Drop and recreate `mo_development` in `db/strip_checkpoint`

### DIFF
--- a/db/strip_checkpoint
+++ b/db/strip_checkpoint
@@ -7,6 +7,12 @@ database="mo_development"
 username="mo"
 password="mo"
 
+# Drop and recreate first -- a dump only emits DROP/CREATE for tables
+# present in the source, so a plain import onto an existing database
+# leaves any table absent from this snapshot (e.g. one dropped by a
+# migration since an older local run) sitting around indefinitely.
+mysql -u $username -p$password \
+  -e "DROP DATABASE IF EXISTS $database; CREATE DATABASE $database;"
 gunzip -c checkpoint.gz | mysql -u $username -p$password $database
 mysql -u $username -p$password $database < db/clean.sql
 # Uncomment this if there's a need to output a stripped checkpoint locally.

--- a/db/strip_checkpoint
+++ b/db/strip_checkpoint
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Installs a downloaded db snapshot which must be named `checkpoint.gz` and
 # located in the `/mushroom-observer` root directory, and calls `db/clean.sql`
@@ -11,9 +12,9 @@ password="mo"
 # present in the source, so a plain import onto an existing database
 # leaves any table absent from this snapshot (e.g. one dropped by a
 # migration since an older local run) sitting around indefinitely.
-mysql -u $username -p$password \
-  -e "DROP DATABASE IF EXISTS $database; CREATE DATABASE $database;"
-gunzip -c checkpoint.gz | mysql -u $username -p$password $database
-mysql -u $username -p$password $database < db/clean.sql
+mysql -u "$username" -p"$password" \
+  -e "DROP DATABASE IF EXISTS \`$database\`; CREATE DATABASE \`$database\`;"
+gunzip -c checkpoint.gz | mysql -u "$username" -p"$password" "$database"
+mysql -u "$username" -p"$password" "$database" < db/clean.sql
 # Uncomment this if there's a need to output a stripped checkpoint locally.
-# mysqldump -u $username -p$password $database | gzip > checkpoint_stripped.gz
+# mysqldump -u "$username" -p"$password" "$database" | gzip > checkpoint_stripped.gz


### PR DESCRIPTION
Fixes "phantom tables", long since dropped, that keep reappearing when changing to a new checkpoint.

## Summary

`db/strip_checkpoint` piped a downloaded checkpoint straight into the existing `mo_development` database (`gunzip -c checkpoint.gz | mysql ... mo_development`), with no `DROP DATABASE`/`CREATE DATABASE` step first.

## The bug

A `mysqldump`-style dump only emits `DROP TABLE IF EXISTS`/`CREATE TABLE` for tables present in the source database at dump time. It says nothing about a table that isn't in the source, so restoring it onto an existing database is non-destructive for anything the dump doesn't mention. Concretely: `inat_import_job_trackers` was dropped from production months ago (migration `20260630182155_drop_inat_import_job_trackers.rb`), so a fresh checkpoint correctly has no such table -- but a local `mo_development` that still had the table from an older run (predating that migration) kept it, since every later checkpoint restore just left it alone.

Traced directly on a local dev DB: `schema_migrations` correctly showed the drop migration as applied, but `ActiveRecord::Base.connection.table_exists?(:inat_import_job_trackers)` still returned `true`. This produced a recurring, unrelated `db/schema.rb` diff on unrelated branches every time a Rails command touched the schema.

## Fix

Drop and recreate `mo_development` before importing, so a restore matches its source database instead of accumulating stale tables across runs:

```bash
mysql -u $username -p$password \
  -e "DROP DATABASE IF EXISTS $database; CREATE DATABASE $database;"
gunzip -c checkpoint.gz | mysql -u $username -p$password $database
```

## Test plan

- [ ] Run `db/strip_checkpoint` against a checkpoint.gz and confirm the import succeeds end to end.

<!-- changelog -->
article: no
<!-- /changelog -->
