### PR TITLE
Ignore `user_locale` params on GET requests (#5314)

### DIFF
--- a/app/controllers/application_controller/internationalization.rb
+++ b/app/controllers/application_controller/internationalization.rb
@@ -73,6 +73,11 @@ module ApplicationController::Internationalization
   def params_locale
     locale = string_param(:user_locale)
     return unless locale
+    # Only the language picker's POST switches (LocalesController).
+    # Legacy GET links (`?user_locale=pl` on pre-2021 URLs) survive in
+    # crawler indexes and external pages, and honoring them switched
+    # unsuspecting visitors' sessions to another language (#5314).
+    return unless request.post?
 
     logger.debug("[I18n] loading locale: #{locale} from params")
     locale

--- a/app/controllers/application_controller/internationalization.rb
+++ b/app/controllers/application_controller/internationalization.rb
@@ -73,10 +73,13 @@ module ApplicationController::Internationalization
   def params_locale
     locale = string_param(:user_locale)
     return unless locale
-    # Only the language picker's POST switches (LocalesController).
-    # Legacy GET links (`?user_locale=pl` on pre-2021 URLs) survive in
+    # Honor the param on a POST only -- the language picker submits
+    # one (LocalesController#update). A GET carrying `?user_locale=pl`
+    # is ignored: legacy pre-2021 links of that shape survive in
     # crawler indexes and external pages, and honoring them switched
-    # unsuspecting visitors' sessions to another language (#5314).
+    # unsuspecting visitors' sessions to another language (#5314). A
+    # GET is the crawlable/linkable shape; a POST is not, so this is
+    # the property that matters, not the specific controller.
     return unless request.post?
 
     logger.debug("[I18n] loading locale: #{locale} from params")

--- a/test/controllers/application_controller_internationalization_test.rb
+++ b/test/controllers/application_controller_internationalization_test.rb
@@ -52,39 +52,40 @@ class ApplicationControllerInternationalizationAccountPersistenceTest <
       FunctionalTestCase
   tests ObservationsController
 
-  # Issue #5074: a bare `?user_locale=` param (bookmark, crawler,
-  # remembered URL) must switch the current request/session locale
-  # but never silently overwrite the account's stored preference --
-  # only the Preferences form does that.
-  def test_params_locale_switches_request_but_not_account_preference
+  # Issue #5314: a `?user_locale=` param on a GET (bookmark, crawler
+  # index, legacy external link) is ignored entirely -- honoring it
+  # switched unsuspecting visitors' sessions to another language. Only
+  # the language picker's POST switches (see LocalesControllerTest).
+  def test_get_user_locale_param_is_ignored
     user = users(:rolf)
     user.update(locale: "en")
     login(user.login)
 
     get(:index, params: { user_locale: "pt" })
 
-    assert_equal("pt", I18n.locale.to_s)
-    assert_equal("pt", session[:locale])
-    assert_equal("en", user.reload.locale,
-                 "A bare user_locale param must not change @user.locale")
+    assert_equal("en", I18n.locale.to_s,
+                 "A GET user_locale param must not switch the locale")
+    assert_nil(session[:locale],
+               "A GET user_locale param must not write the session")
+    assert_equal("en", user.reload.locale)
   end
 
   # Issue #5074, second bug found in review: an explicit switch must
   # outrank the account's stored preference for the rest of the
-  # session, or it reverts on the visitor's very next page load --
-  # exactly what happened when @user.locale stopped being silently
-  # overwritten (the whole point of the fix above) without also
-  # fixing specified_locale's priority order.
+  # session, or it reverts on the visitor's very next page load. The
+  # switch itself is the picker's POST (LocalesControllerTest); its
+  # session write is injected here since this controller has no POST
+  # locale action.
   def test_explicit_switch_sticks_on_next_request_for_logged_in_user
     user = users(:rolf)
     user.update(locale: "en")
     login(user.login)
 
-    get(:index, params: { user_locale: "pt" })
+    get(:index, session: { locale: "pt" })
     assert_equal("pt", I18n.locale.to_s)
 
-    # Follow-up request, no user_locale param -- simulates the
-    # redirect back after the switcher POST.
+    # Follow-up request -- simulates the next page load after the
+    # switcher POST's redirect back.
     get(:index)
 
     assert_equal("pt", I18n.locale.to_s,

--- a/test/controllers/locales_controller_test.rb
+++ b/test/controllers/locales_controller_test.rb
@@ -9,6 +9,8 @@ class LocalesControllerTest < FunctionalTestCase
     post(:update, params: { user_locale: "pt" })
 
     assert_equal("pt", I18n.locale.to_s)
+    assert_equal("pt", session[:locale],
+                 "The POST switch persists for the rest of the session")
     assert_redirected_to("http://test.host/observations/1")
   end
 


### PR DESCRIPTION
Fixes #5314 (diagnosis in the issue comment): legacy GET URLs like `/observer/show_observation/N?user_locale=pl` survive in crawler indexes and old external links, and `set_locale` honored the param on any request and persisted it to `session[:locale]` — one click switched a visitor to another language for their whole session. The 2026-09-03/04 production logs show 570 such requests and 16+ distinct logged-in users switched to Polish this way.

## Change

`params_locale` now returns nothing unless the request is a POST — so only the language picker's POST to `/locale` (`LocalesController#update`, the #5074 mechanism) switches and persists the locale. A `user_locale` param on any GET is ignored outright: no switch for the request, no session write. Everything downstream (`session_locale` > `prefs_locale` > `browser_locale` priority, no account-preference writes) is unchanged.

## Tests

- `test_get_user_locale_param_is_ignored` (rewritten from the #5074-era test that asserted the old GET behavior): a GET with `user_locale=pt` leaves the locale, the session, and the account preference untouched.
- The switch-sticks-across-requests test now injects the session write the POST performs (this controller has no POST locale action); the POST path itself is covered in `LocalesControllerTest`, which now also asserts the session write.
- Ran the full locale surface: locales controller, internationalization priority tests, scalar-param injection, preferences controller, language switch button, sidebar languages, translators note, and the account Capybara integration test — all green. RuboCop clean.

Not in this PR: resetting affected accounts' stored `locale` preferences (370 accounts have `pl`, a mix of chosen and accidental — needs a human call per the issue).

<!-- changelog -->
article: yes
Stop old links from switching your language
<!-- /changelog -->
