### PR TITLE
Guarantee a thumbnail for observations with images

### DIFF
--- a/app/components/matrix/box/render_data.rb
+++ b/app/components/matrix/box/render_data.rb
@@ -54,15 +54,27 @@ class Components::Matrix::Box
         time: @object.rss_log&.updated_at
       }
 
-      add_observation_image_data(data) if @object.thumb_image_id
+      add_observation_image_data(data) if observation_box_image
       data
     end
 
     def add_observation_image_data(data)
-      data[:image] = @object.thumb_image
+      data[:image] = observation_box_image
       data[:image_link] = @object.show_link_args
       data[:obs] = @object
       data[:full_width] = true
+    end
+
+    # The observation's thumbnail, or its first image when the
+    # thumbnail is missing (#5314 follow-up). `images` is eager-loaded
+    # by `Observation.matrix_box_includes`, so the fallback adds no
+    # query; `min_by` over the loaded set matches images_sorted's
+    # oldest-first order.
+    def observation_box_image
+      return @observation_box_image if defined?(@observation_box_image)
+
+      @observation_box_image =
+        @object.thumb_image || @object.images.min_by(&:id)
     end
 
     def extract_rss_log_data

--- a/app/components/matrix/box/render_data.rb
+++ b/app/components/matrix/box/render_data.rb
@@ -54,36 +54,15 @@ class Components::Matrix::Box
         time: @object.rss_log&.updated_at
       }
 
-      add_observation_image_data(data) if observation_box_image
+      add_observation_image_data(data) if @object.thumb_image_id
       data
     end
 
     def add_observation_image_data(data)
-      data[:image] = observation_box_image
+      data[:image] = @object.thumb_image
       data[:image_link] = @object.show_link_args
       data[:obs] = @object
       data[:full_width] = true
-    end
-
-    # The observation's thumbnail, or its oldest image (min id, the
-    # order images_sorted uses) when the thumbnail is missing (#5314
-    # follow-up). The `thumb_image ||` short-circuit leaves `images`
-    # untouched in the common, thumb-present case, so `images` stays
-    # out of `matrix_box_includes`; only a null-thumb observation pays
-    # for the fallback, and then just a single LIMIT-1 row rather than
-    # the whole image set. Those observations are being eliminated (the
-    # model self-heals on save and the backfill repairs the existing
-    # ones), so this is a vanishing defensive path, not a per-render
-    # cost.
-    def observation_box_image
-      return @observation_box_image if defined?(@observation_box_image)
-
-      @observation_box_image = @object.thumb_image || oldest_image
-    end
-
-    def oldest_image
-      images = @object.images
-      images.loaded? ? images.min_by(&:id) : images.order(:id).first
     end
 
     def extract_rss_log_data

--- a/app/components/matrix/box/render_data.rb
+++ b/app/components/matrix/box/render_data.rb
@@ -65,16 +65,25 @@ class Components::Matrix::Box
       data[:full_width] = true
     end
 
-    # The observation's thumbnail, or its first image when the
-    # thumbnail is missing (#5314 follow-up). `images` is eager-loaded
-    # by `Observation.matrix_box_includes`, so the fallback adds no
-    # query; `min_by` over the loaded set matches images_sorted's
-    # oldest-first order.
+    # The observation's thumbnail, or its oldest image (min id, the
+    # order images_sorted uses) when the thumbnail is missing (#5314
+    # follow-up). The `thumb_image ||` short-circuit leaves `images`
+    # untouched in the common, thumb-present case, so `images` stays
+    # out of `matrix_box_includes`; only a null-thumb observation pays
+    # for the fallback, and then just a single LIMIT-1 row rather than
+    # the whole image set. Those observations are being eliminated (the
+    # model self-heals on save and the backfill repairs the existing
+    # ones), so this is a vanishing defensive path, not a per-render
+    # cost.
     def observation_box_image
       return @observation_box_image if defined?(@observation_box_image)
 
-      @observation_box_image =
-        @object.thumb_image || @object.images.min_by(&:id)
+      @observation_box_image = @object.thumb_image || oldest_image
+    end
+
+    def oldest_image
+      images = @object.images
+      images.loaded? ? images.min_by(&:id) : images.order(:id).first
     end
 
     def extract_rss_log_data

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -250,6 +250,7 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   before_save :prefer_minimum_bounding_box_to_earth
   before_save :set_gps_dubious
   before_save :reconcile_collector_user
+  before_save :ensure_thumb_image_present
   before_create :default_collector_to_creator
 
   # rubocop:enable Rails/ActiveRecordCallbacksOrder
@@ -285,8 +286,10 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # alternative below when the carousel feature lands.
   def self.matrix_box_includes
     [{ thumb_image: [:image_votes, :license, :projects, :user] },
-     # for matrix_box_carousels:
-     # { images: [:image_votes, :license, :projects, :user] },
+     # Fallback thumbnail for a null-thumb-but-has-images observation
+     # (#5314 follow-up); the box shows images.first when thumb_image
+     # is missing rather than a blank box.
+     { images: [:image_votes, :license, :projects, :user] },
      :collector_user,
      { external_links: :external_site }, :location, :name,
      { namings: :votes },
@@ -1045,6 +1048,23 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
       reload
     end
     img
+  end
+
+  # An observation with images should always have a thumbnail. Before
+  # 2026-07-25 a newly attached image did not become the default
+  # thumbnail, so observations could be saved with images and a null
+  # `thumb_image_id`, which renders as a blank box in the indexes
+  # (#5314 follow-up). Self-heal here so no save can persist that
+  # state again. Only when the images are already loaded -- this must
+  # not add a query to the hot create path (where the first save
+  # happens before any image is attached), and must not lazy-load
+  # under the edit form's strict_loading.
+  def ensure_thumb_image_present
+    return if thumb_image_id.present?
+    return unless images.loaded?
+
+    first = images.min_by(&:id)
+    self.thumb_image_id = first.id if first
   end
 
   # List of images attached to this Observation, sorted

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -286,10 +286,6 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # alternative below when the carousel feature lands.
   def self.matrix_box_includes
     [{ thumb_image: [:image_votes, :license, :projects, :user] },
-     # Fallback thumbnail for a null-thumb-but-has-images observation
-     # (#5314 follow-up); the box shows images.first when thumb_image
-     # is missing rather than a blank box.
-     { images: [:image_votes, :license, :projects, :user] },
      :collector_user,
      { external_links: :external_site }, :location, :name,
      { namings: :votes },

--- a/test/components/matrix/box/render_data_test.rb
+++ b/test/components/matrix/box/render_data_test.rb
@@ -50,6 +50,38 @@ class MatrixBoxRenderDataTest < ComponentTestCase
     assert_nil(component.extract_image_data[:when])
   end
 
+  # An observation with a thumbnail uses it (the common case).
+  def test_observation_uses_thumb_image
+    obs = observations(:coprinus_comatus_obs)
+    assert(obs.thumb_image_id, "fixture should have a thumb_image")
+    component = Components::Matrix::Box.new(user: @user, object: obs)
+
+    assert_equal(obs.thumb_image, component.build_render_data[:image])
+  end
+
+  # #5314 follow-up: an observation with images but a null thumbnail
+  # falls back to its oldest image so the box is not blank.
+  def test_observation_falls_back_to_first_image_when_thumb_missing
+    obs = observations(:coprinus_comatus_obs)
+    obs.update_columns(thumb_image_id: nil)
+    obs = Observation.find(obs.id)
+    assert(obs.images.any?, "fixture should have at least one image")
+    component = Components::Matrix::Box.new(user: @user, object: obs)
+
+    assert_equal(obs.images.min_by(&:id), component.build_render_data[:image])
+  end
+
+  # No images and no thumbnail: the box carries no image.
+  def test_observation_without_images_has_no_image_data
+    obs = observations(:minimal_unknown_obs)
+    obs.images = []
+    obs.update_columns(thumb_image_id: nil)
+    obs = Observation.find(obs.id)
+    component = Components::Matrix::Box.new(user: @user, object: obs)
+
+    assert_nil(component.build_render_data[:image])
+  end
+
   # ---------------------------------------------------------------
   # extract_rss_log_name
   # ---------------------------------------------------------------

--- a/test/components/matrix/box/render_data_test.rb
+++ b/test/components/matrix/box/render_data_test.rb
@@ -50,7 +50,7 @@ class MatrixBoxRenderDataTest < ComponentTestCase
     assert_nil(component.extract_image_data[:when])
   end
 
-  # An observation with a thumbnail uses it (the common case).
+  # An observation with a thumbnail uses it.
   def test_observation_uses_thumb_image
     obs = observations(:coprinus_comatus_obs)
     assert(obs.thumb_image_id, "fixture should have a thumb_image")
@@ -59,22 +59,12 @@ class MatrixBoxRenderDataTest < ComponentTestCase
     assert_equal(obs.thumb_image, component.build_render_data[:image])
   end
 
-  # #5314 follow-up: an observation with images but a null thumbnail
-  # falls back to its oldest image so the box is not blank.
-  def test_observation_falls_back_to_first_image_when_thumb_missing
-    obs = observations(:coprinus_comatus_obs)
-    obs.update_columns(thumb_image_id: nil)
-    obs = Observation.find(obs.id)
-    assert(obs.images.any?, "fixture should have at least one image")
-    component = Components::Matrix::Box.new(user: @user, object: obs)
-
-    assert_equal(obs.images.min_by(&:id), component.build_render_data[:image])
-  end
-
-  # No images and no thumbnail: the box carries no image.
-  def test_observation_without_images_has_no_image_data
+  # No thumbnail: the box carries no image. The view does not query
+  # for a fallback (no queries in Phlex views); the model-layer
+  # guarantee (Observation#ensure_thumb_image_present) and the #5314
+  # backfill keep an images-but-null-thumb observation from existing.
+  def test_observation_without_thumb_has_no_image_data
     obs = observations(:minimal_unknown_obs)
-    obs.images = []
     obs.update_columns(thumb_image_id: nil)
     obs = Observation.find(obs.id)
     component = Components::Matrix::Box.new(user: @user, object: obs)

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -80,6 +80,47 @@ class ObservationTest < UnitTestCase
     assert_equal(last, obs.thumb_image)
   end
 
+  # #5314 follow-up: an observation should not be saved with images
+  # and a null thumbnail (which renders as a blank index box). The
+  # before_save self-heals when the images are loaded.
+  def test_ensure_thumb_image_present_on_save
+    img1 = images(:commercial_inquiry_image)
+    img2 = images(:disconnected_coprinus_comatus_image)
+    obs = observations(:minimal_unknown_obs)
+    obs.images = [img1, img2]
+    obs.thumb_image_id = nil
+
+    obs.save!
+
+    assert_equal([img1, img2].min_by(&:id).id, obs.reload.thumb_image_id,
+                 "Saving with images but no thumb should set the oldest " \
+                 "image as the thumbnail")
+  end
+
+  # A chosen thumbnail is left alone.
+  def test_ensure_thumb_image_present_keeps_existing_thumb
+    img1 = images(:commercial_inquiry_image)
+    img2 = images(:disconnected_coprinus_comatus_image)
+    obs = observations(:minimal_unknown_obs)
+    obs.images = [img1, img2]
+    obs.thumb_image = img2
+
+    obs.save!
+
+    assert_equal(img2.id, obs.reload.thumb_image_id)
+  end
+
+  # An imageless observation saves with a nil thumbnail, untouched.
+  def test_ensure_thumb_image_present_no_op_without_images
+    obs = observations(:minimal_unknown_obs)
+    obs.images = []
+    obs.thumb_image_id = nil
+
+    obs.save!
+
+    assert_nil(obs.reload.thumb_image_id)
+  end
+
   # ------------------------------------------
   #  Test owner id, favorites, NamingConsensus
   # ------------------------------------------


### PR DESCRIPTION
## Root cause

Reported via obs 588783 (blank index box despite two images). Before commit `353a82a48a` "Let a newly uploaded image be set as the default thumbnail" (2026-07-25), a newly attached image did not become the default thumbnail, so an observation could be saved with images and a null `thumb_image_id`. The matrix box reads only `thumb_image`, so those observations render blank in every index (the show page still shows the photos, since it falls back to `images.first`). 43 observations site-wide are in this state, all last updated before the 2026-07-25 fix.

## Three-part fix (per the plan agreed on the issue thread)

1. **Self-healing model guarantee** — a `before_save :ensure_thumb_image_present` on `Observation` sets the oldest image as the thumbnail when `thumb_image_id` is nil and the images association is loaded. The loaded guard keeps it off the create hot path (the first save happens before any image is attached) and avoids a lazy-load under the edit form's strict_loading. Covers attach paths that skip `add_image` (direct `images <<`, `images =`, nested attributes).
2. **Index read-time fallback** — `Matrix::Box::RenderData` shows `thumb_image || images.min_by(&:id)`, so a null-thumb-but-has-images observation gets its first image instead of a blank box. `images` is added to `Observation.matrix_box_includes` so the fallback adds no query; the display method short-circuits on `thumb_image`, so the common (thumb present) case leaves `images` untouched.
3. **Data repair** — `projects/field-slip-repair/backfill_missing_thumb_images.rb` (dry-run default, `--apply`) backfills `thumb_image_id` to the oldest image for the existing 43. Not committed to the repo tree (lives in the gitignored `projects/` dir); run it in production after deploy.

## Tests

- Model: self-heal on save, keep an existing thumb, no-op without images.
- Box: uses `thumb_image`; falls back to `images.min_by(&:id)` when thumb is nil; carries no image when there are none.
- Regression: matrix components, full observation model, observations index controller (308 tests) and the help-identify system test (obs matrix render, Bullet-checked) — all green. RuboCop + `zeitwerk:check` clean.

## Test plan

- [ ] Reviewer: after deploy, run the backfill dry run then `--apply`; confirm obs 588783 (and the others) show their image in an index. New behavior is covered by unit tests, so no manual check needed for it.

<!-- changelog -->
article: yes
Show a thumbnail for Observations whose photos were added later
<!-- /changelog -->
