### PR TITLE
Show occurrence-sibling thumbnails in the Observation index (#5317)

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1057,10 +1057,29 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # under the edit form's strict_loading.
   def ensure_thumb_image_present
     return if thumb_image_id.present?
-    return unless images.loaded?
 
-    first = images.min_by(&:id)
-    self.thumb_image_id = first.id if first
+    self.thumb_image_id = replacement_thumb_image_id
+  end
+
+  # The image to adopt as thumbnail for an observation saved without
+  # one. An observation's images are preferred; a member holding no
+  # image takes a sibling's image (the cross-observation thumbnail the
+  # show page already pools -- #5317). Kept query-free on the hot
+  # paths: a loaded image set is read in memory, and an observation
+  # with no occurrence (a plain create or edit) issues no query. The
+  # occurrence branch uses ObservationImage directly rather than the
+  # `images` association, so it is safe under the edit form's
+  # strict_loading.
+  def replacement_thumb_image_id
+    first_id = images.min_by(&:id)&.id if images.loaded?
+    return first_id if first_id
+    return nil unless occurrence_id
+
+    ObservationImage.where(observation_id: id).minimum(:image_id) ||
+      ObservationImage.where(
+        observation_id: Observation.where(occurrence_id: occurrence_id).
+                        where.not(id: id).select(:id)
+      ).minimum(:image_id)
   end
 
   # List of images attached to this Observation, sorted

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1071,15 +1071,28 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # `images` association, so it is safe under the edit form's
   # strict_loading.
   def replacement_thumb_image_id
-    first_id = images.min_by(&:id)&.id if images.loaded?
-    return first_id if first_id
+    if images.loaded?
+      # In memory: an attached image if present (a loaded-empty set
+      # proves there are none, so no query), else a sibling's.
+      images.min_by(&:id)&.id || sibling_thumb_image_id
+    elsif occurrence_id
+      # Not loaded, but in an occurrence: attached image, then sibling.
+      ObservationImage.where(observation_id: id).minimum(:image_id) ||
+        sibling_thumb_image_id
+    end
+    # Not loaded and no occurrence (a plain create or edit): no query.
+  end
+
+  # The oldest image among this observation's occurrence siblings, by a
+  # direct ObservationImage query (strict_loading-safe), or nil when it
+  # has no occurrence.
+  def sibling_thumb_image_id
     return nil unless occurrence_id
 
-    ObservationImage.where(observation_id: id).minimum(:image_id) ||
-      ObservationImage.where(
-        observation_id: Observation.where(occurrence_id: occurrence_id).
-                        where.not(id: id).select(:id)
-      ).minimum(:image_id)
+    ObservationImage.where(
+      observation_id: Observation.where(occurrence_id: occurrence_id).
+                      where.not(id: id).select(:id)
+    ).minimum(:image_id)
   end
 
   # List of images attached to this Observation, sorted

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -121,6 +121,27 @@ class ObservationTest < UnitTestCase
     assert_nil(obs.reload.thumb_image_id)
   end
 
+  # #5317: an imageless observation in an occurrence takes a sibling's
+  # image as its thumbnail, so it is not blank in the index.
+  def test_ensure_thumb_image_present_uses_occurrence_sibling
+    sibling = observations(:coprinus_comatus_obs)
+    assert(sibling.images.any?, "fixture sibling should have images")
+    imageless = observations(:minimal_unknown_obs)
+    imageless.images = []
+    imageless.update_columns(thumb_image_id: nil)
+    occ = Occurrence.create!(user: sibling.user, primary_observation: sibling)
+    sibling.update!(occurrence: occ)
+    imageless.update!(occurrence: occ)
+
+    imageless.thumb_image_id = nil
+    imageless.save!
+
+    assert_equal(sibling.images.min_by(&:id).id,
+                 imageless.reload.thumb_image_id,
+                 "An imageless occurrence member should adopt a sibling's " \
+                 "oldest image as its thumbnail")
+  end
+
   # ------------------------------------------
   #  Test owner id, favorites, NamingConsensus
   # ------------------------------------------


### PR DESCRIPTION
Fixes #5317 (thumbnail absent in the Observation index for some Occurrences), the sibling of #5319. That PR handled observations with a null thumbnail that had images attached (Case A). #5317's cases are the other half: an observation with no attached image that sits in an occurrence whose sibling has images — the show page pools occurrence images and displays one, but the index reads only `thumb_image`, so the box is blank.

Site-wide the two cases are 43 (Case A, fixed by #5319) and 68 (Case B, this PR).

## Fix

`Observation#ensure_thumb_image_present` (the before_save self-heal from #5319) now falls back to an occurrence sibling's image when the observation has none attached. A sibling image is a valid thumbnail — the same cross-observation thumbnail the show page and API already lead with (#5160/#5170), and `valid_thumb_image_ids` already accepts it. So the fix is a data one: point `thumb_image_id` at the occurrence's image, and the existing `thumb_image` eager-load renders it in the index with no extra query.

Kept off the hot paths: an attached image (loaded) is read in memory; an observation with no occurrence issues no query; the occurrence lookup runs only for a member that lacks a thumbnail, and uses `ObservationImage` directly rather than the `images` association, so it is safe under the edit form's strict_loading.

## One-time repair

`projects/field-slip-repair/backfill_missing_thumb_images.rb` (gitignored `projects/` dir, dry-run default / `--apply`) is generalized to use `Observation#next_thumb_image`, which resolves an attached image first, then an occurrence sibling — so one `--apply` clears both Case A and Case B (111 rows). Run it in production after deploy.

## Tests

- Model: imageless occurrence member adopts a sibling's oldest image on save (plus the existing #5319 cases still pass — attached image wins, no-op without images).
- Regression: observation model, matrix box + render_data, and `no_queries_in_phlex_views_test` (the guard that shaped the #5319 approach) — 193 tests, all green. RuboCop clean.

## Test plan

- [ ] Reviewer: after deploy, run the backfill dry run then `--apply`; confirm #5317's example index now shows thumbnails for the occurrence rows. New behavior is unit-covered.

<!-- changelog -->
article: yes
Show a thumbnail for Observations grouped in an Occurrence
<!-- /changelog -->
