### PR TITLE
Changelog for `deploy-2026-09-07-12-00`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-07 (deploy-2026-09-07-12-00)
+
+- Remove `script/resolve_mycoportal_links.rb` from the repo ([PR5316](https://github.com/MushroomObserver/mushroom-observer/pull/5316), @nimmolo)
+- Ignore `user_locale` params on GET requests (#5314) ([PR5318](https://github.com/MushroomObserver/mushroom-observer/pull/5318), @mo-nathan)
+- Guarantee a thumbnail for observations with images ([PR5319](https://github.com/MushroomObserver/mushroom-observer/pull/5319), @mo-nathan)
+- Show occurrence-sibling thumbnails in the Observation index (#5317) ([PR5320](https://github.com/MushroomObserver/mushroom-observer/pull/5320), @mo-nathan)
+- Let `prerelease.rb` target a deploy-tag time (default next noon UTC) ([PR5321](https://github.com/MushroomObserver/mushroom-observer/pull/5321), @mo-nathan)
+- Preserve reviewer edits on `prerelease.rb` re-run ([PR5323](https://github.com/MushroomObserver/mushroom-observer/pull/5323), @mo-nathan)
+- Adopt a non-obscured reflection location onto its native on import ([PR5325](https://github.com/MushroomObserver/mushroom-observer/pull/5325), @mo-nathan)
+
 ## 2026-09-04 (deploy-2026-09-04-10-34)
 
 - Repair changelog sections from the transitional deploys ([PR5304](https://github.com/MushroomObserver/mushroom-observer/pull/5304), @mo-nathan)

--- a/article_pending.textile
+++ b/article_pending.textile
@@ -1,1 +1,4 @@
-|{white-space:nowrap}. 2026-09-03 | Fix an error searching Observations by an invalid date | "PR#5307":https://github.com/MushroomObserver/mushroom-observer/pull/5307 |
+|{white-space:nowrap}. 2026-09-06 | Show a thumbnail for Observations grouped in an Occurrence | "PR#5320":https://github.com/MushroomObserver/mushroom-observer/pull/5320 |
+|{white-space:nowrap}. 2026-09-06 | Show a thumbnail for Observations whose photos were added later | "PR#5319":https://github.com/MushroomObserver/mushroom-observer/pull/5319, "PR#5320":https://github.com/MushroomObserver/mushroom-observer/pull/5320 |
+|{white-space:nowrap}. 2026-09-06 | Stop old links from switching your language | "PR#5318":https://github.com/MushroomObserver/mushroom-observer/pull/5318 |
+|{white-space:nowrap}. 2026-09-07 | Fix imported Observation location on records first entered by hand | "PR#5325":https://github.com/MushroomObserver/mushroom-observer/pull/5325 |

--- a/article_pending.textile
+++ b/article_pending.textile
@@ -1,4 +1,3 @@
-|{white-space:nowrap}. 2026-09-06 | Show a thumbnail for Observations grouped in an Occurrence | "PR#5320":https://github.com/MushroomObserver/mushroom-observer/pull/5320 |
 |{white-space:nowrap}. 2026-09-06 | Show a thumbnail for Observations whose photos were added later | "PR#5319":https://github.com/MushroomObserver/mushroom-observer/pull/5319, "PR#5320":https://github.com/MushroomObserver/mushroom-observer/pull/5320 |
 |{white-space:nowrap}. 2026-09-06 | Stop old links from switching your language | "PR#5318":https://github.com/MushroomObserver/mushroom-observer/pull/5318 |
 |{white-space:nowrap}. 2026-09-07 | Fix imported Observation location on records first entered by hand | "PR#5325":https://github.com/MushroomObserver/mushroom-observer/pull/5325 |


### PR DESCRIPTION
Pre-deploy changelog for `deploy-2026-09-07-12-00` (issue #5155): the CHANGELOG.md section for every PR merged since `deploy-2026-09-04-10-34`, and `article_pending.textile` with the MO Article rows the deploy will publish. Merge this as the last PR before deploying; re-running `script/prerelease.rb --apply` refreshes it with any later merges.

## Expected MO Article lines

```
|{white-space:nowrap}. 2026-09-06 | Show a thumbnail for Observations grouped in an Occurrence | "PR#5320":https://github.com/MushroomObserver/mushroom-observer/pull/5320 |
|{white-space:nowrap}. 2026-09-06 | Show a thumbnail for Observations whose photos were added later | "PR#5319":https://github.com/MushroomObserver/mushroom-observer/pull/5319, "PR#5320":https://github.com/MushroomObserver/mushroom-observer/pull/5320 |
|{white-space:nowrap}. 2026-09-06 | Stop old links from switching your language | "PR#5318":https://github.com/MushroomObserver/mushroom-observer/pull/5318 |
|{white-space:nowrap}. 2026-09-07 | Fix imported Observation location on records first entered by hand | "PR#5325":https://github.com/MushroomObserver/mushroom-observer/pull/5325 |
```
(3 PR(s) marked `article: no`.) Edits to `article_pending.textile` in this PR are what the deploy publishes.

<!-- changelog -->
article: no
<!-- /changelog -->
