### PR TITLE
Preserve reviewer edits on `prerelease.rb` re-run

### DIFF
--- a/script/prerelease.rb
+++ b/script/prerelease.rb
@@ -116,9 +116,98 @@ class Prerelease
       @pulls.empty?
     warn("Found #{@pulls.size} PR(s) merged since #{@prev}.\n\n")
 
-    @section = generator.pending_section(@tag, @pulls)
+    fresh_section = generator.pending_section(@tag, @pulls)
     @rows, @skipped, @blockless = ArticleRows.new.rows_for(@pulls)
+    @section = merge_developer_edits(fresh_section)
   end
+
+  # Preserve edits already made on the changelog-pending branch and add
+  # only lines for PRs mentioned nowhere there, so a re-run does not
+  # revert a reviewer's combined/reworded entries. A first run (no such
+  # branch) or one whose pending content was already deployed starts
+  # fresh. The heading is refreshed to the current @tag either way.
+  def merge_developer_edits(fresh_section)
+    existing = existing_pending_content
+    unless existing
+      @rows = existing_rows_merged(nil)
+      return fresh_section
+    end
+
+    @rows = existing_rows_merged(existing[:rows])
+    merge_section(fresh_section, existing[:bullets])
+  end
+
+  # [heading, "", *bullets] with the reviewer's bullets kept verbatim
+  # and a line appended for each PR whose number appears in none of
+  # them (matching PRNNNN and PR#NNNN).
+  def merge_section(fresh_section, kept_bullets)
+    heading = fresh_section.lines.first.chomp
+    mentioned = pr_numbers(kept_bullets.join("\n"))
+    additions = fresh_section.lines.map(&:chomp).
+                select { |line| line.start_with?("- ") }.
+                reject { |line| mentioned.include?(pr_number(line)) }
+    "#{([heading, ""] + kept_bullets + additions).join("\n")}\n"
+  end
+
+  def existing_rows_merged(existing_rows)
+    return @rows if existing_rows.nil?
+
+    mentioned = pr_numbers(existing_rows.join("\n"))
+    additions = @rows.reject { |row| mentioned.include?(pr_number(row)) }
+    existing_rows + additions
+  end
+
+  # The changelog-pending branch's pending bullets and article rows, or
+  # nil when there is no such branch or its top section was already
+  # deployed (stale -- start fresh).
+  def existing_pending_content
+    lines = pending_changelog_lines
+    return nil unless lines
+
+    { bullets: section_bullets(lines), rows: pending_article_rows }
+  end
+
+  # The changelog-pending CHANGELOG.md as lines, or nil when there is
+  # no such branch or its top section was already deployed (stale).
+  def pending_changelog_lines
+    changelog = show_branch_file(ChangelogGenerator::CHANGELOG)
+    return nil unless changelog
+
+    lines = changelog.lines.map(&:chomp)
+    heading = lines.find { |line| line.start_with?("## ") }
+    return nil unless heading
+
+    tag = heading[/\((deploy-[0-9-]+)\)/, 1]
+    tag && deployed_tag?(tag) ? nil : lines
+  end
+
+  def pending_article_rows
+    (show_branch_file(ARTICLE_FILE)&.lines&.map(&:chomp) || []).
+      reject(&:empty?)
+  end
+
+  # Bullet lines of the top section, up to the next heading or the end.
+  def section_bullets(lines)
+    start = lines.index { |line| line.start_with?("## ") }
+    rest = lines[(start + 1)..]
+    finish = rest.index { |line| line.start_with?("## ") }
+    (finish ? rest[0...finish] : rest).select { |l| l.start_with?("- ") }
+  end
+
+  def show_branch_file(path)
+    out, _err, status = Open3.capture3("git", "show",
+                                       "origin/#{BRANCH}:#{path}")
+    status.success? ? out : nil
+  end
+
+  def deployed_tag?(tag)
+    out, _err, status = Open3.capture3("git", "tag", "-l", tag)
+    status.success? && !out.strip.empty?
+  end
+
+  def pr_numbers(text) = text.scan(/PR#?(\d+)/).flatten
+
+  def pr_number(line) = line[/PR#?(\d+)/, 1]
 
   def preview
     puts("Pending deploy: #{@tag}")


### PR DESCRIPTION
Follow-up to #5321 (issue #5155). A `script/prerelease.rb --apply` re-run rebuilt the pending CHANGELOG section and article rows from scratch and force-pushed, reverting a reviewer who had combined or reworded entries on the `changelog-pending` branch (reported: combining the #5319 and #5320 lines was undone by the next `--apply`).

## Change

A re-run now reads the current `changelog-pending`, keeps its CHANGELOG bullets and `article_pending.textile` rows verbatim, and appends a line only for a PR whose number appears in none of them. The match is on `PRNNNN` and `PR#NNNN`, so a combined line that mentions both numbers keeps both PRs covered and neither is re-added. The section heading is refreshed to the run's target tag. A first run (no such branch) or one whose pending section was already deployed still starts fresh.

## Verification

- A simulated `changelog-pending` with a combined `[PR5319]`+`[PR5320]` bullet and a combined `PR#5319` / `PR#5320` article row, plus a later PR5321 mentioned nowhere: the combined entries survive and only the 5321 lines are appended, in both the CHANGELOG section and the article file.
- Live dry run runs end to end (reads `origin/changelog-pending`, produces the merged section). RuboCop clean.

<!-- changelog -->
article: no
<!-- /changelog -->
