### PR TITLE
Adopt a non-obscured reflection location onto its native on import

### DIFF
--- a/app/classes/inat/project_slip_standardizer.rb
+++ b/app/classes/inat/project_slip_standardizer.rb
@@ -110,6 +110,34 @@ class Inat
       else
         observation.update!(occurrence: native.occurrence)
       end
+      adopt_reflection_location(native, observation)
+    end
+
+    # The native was usually created in the id room with a rough
+    # default location; the reflection just linked to it carries
+    # iNaturalist's resolved location. Adopt it onto the native when
+    # iNat did not obscure it and it differs (#5317 follow-up).
+    # update_columns: a location correction on an existing observation
+    # should not email its watchers or churn its RssLog during an
+    # import. gps_dubious is copied -- the native adopts the
+    # reflection's coords and location, so it inherits its status.
+    def adopt_reflection_location(native, reflection)
+      return if reflection.gps_hidden || reflection.lat.nil?
+      return if same_location?(native, reflection)
+
+      native.update_columns(
+        lat: reflection.lat, lng: reflection.lng, alt: reflection.alt,
+        location_id: reflection.location_id, where: reflection.where,
+        gps_hidden: false, gps_dubious: reflection.gps_dubious,
+        updated_at: Time.zone.now
+      )
+    end
+
+    def same_location?(native, reflection)
+      native.location_id == reflection.location_id &&
+        native.lat && reflection.lat &&
+        (native.lat - reflection.lat).abs <= 0.0001 &&
+        (native.lng.to_f - reflection.lng.to_f).abs <= 0.0001
     end
 
     # Case 2. Set the column directly: `FieldSlip#project=` gates on

--- a/app/classes/inat/project_slip_standardizer.rb
+++ b/app/classes/inat/project_slip_standardizer.rb
@@ -122,15 +122,24 @@ class Inat
     # import. gps_dubious is copied -- the native adopts the
     # reflection's coords and location, so it inherits its status.
     def adopt_reflection_location(native, reflection)
-      return if reflection.gps_hidden || reflection.lat.nil?
+      return if reflection.gps_hidden || reflection.lat.nil? ||
+                reflection.lng.nil?
       return if same_location?(native, reflection)
 
-      native.update_columns(
+      native.update_columns(adopted_location_attributes(reflection))
+    end
+
+    # update_columns bypasses check_hidden, which would force gps_hidden
+    # true for a hidden location; honor it here so a hidden adopted
+    # location can't leave gps_hidden false.
+    def adopted_location_attributes(reflection)
+      {
         lat: reflection.lat, lng: reflection.lng, alt: reflection.alt,
         location_id: reflection.location_id, where: reflection.where,
-        gps_hidden: false, gps_dubious: reflection.gps_dubious,
+        gps_hidden: reflection.location&.hidden || false,
+        gps_dubious: reflection.gps_dubious,
         updated_at: Time.zone.now
-      )
+      }
     end
 
     def same_location?(native, reflection)

--- a/test/classes/inat_project_slip_standardizer_test.rb
+++ b/test/classes/inat_project_slip_standardizer_test.rb
@@ -66,6 +66,43 @@ class InatProjectSlipStandardizerTest < UnitTestCase
     assert_includes(@project.observations.reload, obs)
   end
 
+  # #5317: the native, created in the id room with a rough default,
+  # adopts its reflection's non-obscured iNat location on import.
+  def test_adopts_reflection_location_onto_native
+    inat_id = "987654322"
+    native = native_with_slip(:coprinus_comatus_obs, code: "OPEN-9010",
+                                                     citing: inat_id)
+    native.update!(lat: 39.25, lng: -123.75, location: locations(:albion))
+    obs = import_obs(:detailed_unknown_obs)
+    obs.update!(lat: 38.538, lng: -123.318, alt: 30,
+                location: locations(:gualala), gps_hidden: false)
+
+    standardizer.standardize(obs, inat_id: inat_id)
+
+    native.reload
+    assert_equal(locations(:gualala).id, native.location_id,
+                 "native should adopt the reflection's location")
+    assert_in_delta(38.538, native.lat, 0.0001)
+    assert_in_delta(-123.318, native.lng, 0.0001)
+  end
+
+  # An obscured reflection carries blurred coords; do not overwrite the
+  # native with them.
+  def test_does_not_adopt_obscured_reflection_location
+    inat_id = "987654323"
+    native = native_with_slip(:coprinus_comatus_obs, code: "OPEN-9011",
+                                                     citing: inat_id)
+    native.update!(lat: 39.25, lng: -123.75, location: locations(:albion))
+    obs = import_obs(:detailed_unknown_obs)
+    obs.update!(lat: 38.538, lng: -123.318,
+                location: locations(:gualala), gps_hidden: true)
+
+    standardizer.standardize(obs, inat_id: inat_id)
+
+    assert_equal(locations(:albion).id, native.reload.location_id,
+                 "an obscured reflection must not overwrite the location")
+  end
+
   def test_merges_reused_slip_occurrence_into_native
     inat_id = "987650001"
     native = native_with_slip(:coprinus_comatus_obs, code: "OPEN-9005",

--- a/test/classes/inat_project_slip_standardizer_test.rb
+++ b/test/classes/inat_project_slip_standardizer_test.rb
@@ -103,6 +103,26 @@ class InatProjectSlipStandardizerTest < UnitTestCase
                  "an obscured reflection must not overwrite the location")
   end
 
+  # When the native already carries the reflection's location and
+  # coordinates, same_location? short-circuits and adoption is skipped
+  # (exercises the coordinate comparison, not just the location_id one).
+  def test_skips_adoption_when_location_already_matches
+    inat_id = "987654324"
+    native = native_with_slip(:coprinus_comatus_obs, code: "OPEN-9012",
+                                                     citing: inat_id)
+    native.update!(lat: 38.538, lng: -123.318, location: locations(:gualala))
+    obs = import_obs(:detailed_unknown_obs)
+    obs.update!(lat: 38.538, lng: -123.318,
+                location: locations(:gualala), gps_hidden: false)
+
+    standardizer.standardize(obs, inat_id: inat_id)
+
+    native.reload
+    assert_equal(locations(:gualala).id, native.location_id)
+    assert_in_delta(38.538, native.lat, 0.0001)
+    assert_in_delta(-123.318, native.lng, 0.0001)
+  end
+
   def test_merges_reused_slip_occurrence_into_native
     inat_id = "987650001"
     native = native_with_slip(:coprinus_comatus_obs, code: "OPEN-9005",


### PR DESCRIPTION
Follow-up to #5317. A native observation is often created in the id room with a rough default location (the fair building), while the iNat reflection later imported into its occurrence carries iNaturalist's precise, resolved location. This adopts the reflection's location onto the native at import time — the code half of the fix; a one-time backfill (gitignored `projects/` script) handles the existing rows.

## Change

`Inat::ProjectSlipStandardizer#link_to_native` (the #5259 native-partner join) now calls `adopt_reflection_location(native, reflection)` after linking: when the reflection's location is not obscured on iNat (`gps_hidden` false) and it has coordinates, and the native's location differs, the native adopts the reflection's `lat`/`lng`/`alt`/`location`/`where`. An obscured reflection carries blurred coordinates and is skipped, leaving the native as-is.

`update_columns` is used deliberately: a location correction during a bulk import must not email the native's watchers or churn its RssLog. The cached `gps_dubious` flag is copied from the reflection — the native adopts the reflection's coordinates and location, so it inherits its (iNat-resolved, non-dubious) status.

## Tests

- `test_adopts_reflection_location_onto_native` — a native with a stale id-room location adopts its reflection's location on standardize.
- `test_does_not_adopt_obscured_reflection_location` — an obscured reflection does not overwrite the native.
- Full standardizer suite green (13 tests). RuboCop clean.

## Related, not in this PR

- The one-time backfill for the ~629 existing native/reflection mismatches is a gitignored `projects/` script (run in production after deploy), not committed.
- The observation edit form should also show the read-only "Use this info" panel for a reflection (sibling) image and report iNat-obscured status — tracked as a separate UI PR.

<!-- changelog -->
article: yes
Fix imported Observation location on records first entered by hand
<!-- /changelog -->
