### PR TITLE
Add a non-primary edit modal for occurrence members

### DIFF
--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -352,15 +352,6 @@ form.button_to {
   background-color: transparent;
   text-decoration: none;
   vertical-align: middle;
-  // Reset user-agent button chrome so a <button> carrying this class
-  // (e.g. the occurrence edit-modal toggle) matches the <a> icon links
-  // -- no border, padding, or shadow. No-ops on an <a>.
-  padding: 0;
-  border: 0;
-  box-shadow: none;
-  -webkit-appearance: none;
-  appearance: none;
-  color: inherit;
 
   &:hover {
     text-decoration: none;

--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -352,6 +352,15 @@ form.button_to {
   background-color: transparent;
   text-decoration: none;
   vertical-align: middle;
+  // Reset user-agent button chrome so a <button> carrying this class
+  // (e.g. the occurrence edit-modal toggle) matches the <a> icon links
+  // -- no border, padding, or shadow. No-ops on an <a>.
+  padding: 0;
+  border: 0;
+  box-shadow: none;
+  -webkit-appearance: none;
+  appearance: none;
+  color: inherit;
 
   &:hover {
     text-decoration: none;

--- a/app/controllers/observations_controller/edit_and_update.rb
+++ b/app/controllers/observations_controller/edit_and_update.rb
@@ -4,6 +4,7 @@
 module ObservationsController::EditAndUpdate
   include ObservationsController::SharedFormMethods
   include ObservationsController::SiblingEXIF
+  include ObservationsController::EditablePrimary
   include ObservationsController::Validators
   include ::Locationable
 
@@ -63,7 +64,11 @@ module ObservationsController::EditAndUpdate
       redirect_to(action: :show, id: @observation.id)
       return false
     end
-    return false if companion ? redirect_to_companion! : redirect_if_reflection!
+    if companion
+      return false if redirect_for_companion_or_primary!
+    elsif redirect_if_reflection!
+      return false
+    end
 
     true
   end

--- a/app/controllers/observations_controller/editable_primary.rb
+++ b/app/controllers/observations_controller/editable_primary.rb
@@ -44,12 +44,18 @@ module ObservationsController::EditablePrimary
 
   def editable_primary?(occ)
     primary = occ.primary_observation
-    primary && !primary.reflection? && primary.can_edit?(@user)
+    primary && !primary.reflection? && editable_member?(primary)
   end
 
   def oldest_editable_member(occ)
     occ.observations.reject(&:reflection?).
-      select { |obs| obs.can_edit?(@user) }.min_by(&:id)
+      select { |obs| editable_member?(obs) }.min_by(&:id)
+  end
+
+  # Admin mode grants edit rights the same way the controller's
+  # permission check does, so honor it here too (#5328 review).
+  def editable_member?(obs)
+    in_admin_mode? || obs.can_edit?(@user)
   end
 
   def promote_to_primary(occ, obs)

--- a/app/controllers/observations_controller/editable_primary.rb
+++ b/app/controllers/observations_controller/editable_primary.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Resolves the occurrence's editable primary observation for the edit
+# form's "Edit Primary Observation" / "Create Editable Primary
+# Observation" choice (target=primary, from the non-primary edit modal
+# -- #5317). The clicked observation may be a read-only reflection or an
+# editable non-primary member; this hands the editor the member it
+# should change: the existing editable primary, the oldest editable
+# sibling (promoted to primary), or a companion created from a
+# reflection.
+module ObservationsController::EditablePrimary
+  private
+
+  # target=primary routes here; otherwise a reflection opens its
+  # companion. Returns the redirect when it stops the request.
+  def redirect_for_companion_or_primary!
+    return redirect_to_editable_primary! if params[:target] == "primary"
+
+    redirect_to_companion!
+  end
+
+  def redirect_to_editable_primary!
+    target, notice = resolve_editable_primary
+    flash_notice(notice.t) if notice
+    redirect_to(edit_observation_path(target.id))
+  rescue ActiveRecord::RecordInvalid => e
+    flash_error(e.record.errors.full_messages.join("; "))
+    redirect_to(action: :show, id: @observation.id)
+  end
+
+  def resolve_editable_primary
+    return [@observation, nil] unless @observation.occurrence_id
+
+    # Fresh load: @observation's occurrence association is strict-loaded
+    # (edit_includes), so its members/primary can't be read lazily.
+    occ = Occurrence.find(@observation.occurrence_id)
+    return [occ.primary_observation, nil] if editable_primary?(occ)
+
+    promoted = oldest_editable_member(occ)
+    return promote_to_primary(occ, promoted) if promoted
+
+    [create_companion(occ), :edit_observation_companion_created]
+  end
+
+  def editable_primary?(occ)
+    primary = occ.primary_observation
+    primary && !primary.reflection? && primary.can_edit?(@user)
+  end
+
+  def oldest_editable_member(occ)
+    occ.observations.reject(&:reflection?).
+      select { |obs| obs.can_edit?(@user) }.min_by(&:id)
+  end
+
+  def promote_to_primary(occ, obs)
+    occ.update!(primary_observation: obs)
+    [obs, :edit_observation_promoted_primary]
+  end
+
+  # Source the reflection from the freshly-loaded occurrence, not the
+  # strict-loaded @observation, so Companion's occurrence writes aren't
+  # blocked by strict loading.
+  def create_companion(occ)
+    reflection = occ.observations.find(&:reflection?)
+    Observation::Companion.new(reflection, @user).create
+  end
+end

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -72,14 +72,15 @@ module Views::Controllers::Observations
     # The edit icon opens the choice modal for a non-primary occurrence
     # member (a read-only reflection, or an editable non-primary), so the
     # editor is steered to the primary rather than the wrong member.
-    # Only for an occurrence member: a reflection with no occurrence has
-    # no primary to steer toward, and the resolver can't promote/create
-    # anything, so it would just bounce back (#5328 review).
+    # A read-only reflection always qualifies -- even with no occurrence
+    # yet, "Create Editable Primary" creates the native and links an
+    # occurrence (Companion#join_occurrence). An editable observation
+    # only qualifies when it's a non-primary occurrence member.
     def show_edit_modal?
-      return false unless @user && @occurrence && can_edit_observation?
+      return false unless @user && can_edit_observation?
+      return true if @observation.reflection?
 
-      @observation.reflection? ||
-        @occurrence.primary_observation_id != @observation.id
+      @occurrence && @occurrence.primary_observation_id != @observation.id
     end
 
     def can_edit_observation?

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -47,6 +47,7 @@ module Views::Controllers::Observations
       render_main_row
       render_secondary_row
       render_footer if @user
+      render_edit_modal if show_edit_modal?
     end
 
     private
@@ -57,10 +58,34 @@ module Views::Controllers::Observations
       if @user
         add_pager_for(@observation)
         add_interest_icons(@user, @observation)
-        add_edit_icons(@observation, @user)
+        add_edit_icons(@observation, @user,
+                       edit_modal_target: edit_modal_target)
       end
       container_class(:double)
       column_classes(:eight_four)
+    end
+
+    def edit_modal_target
+      Show::EditModal::MODAL_ID if show_edit_modal?
+    end
+
+    # The edit icon opens the choice modal for a non-primary occurrence
+    # member (a read-only reflection, or an editable non-primary), so the
+    # editor is steered to the primary rather than the wrong member.
+    def show_edit_modal?
+      return false unless @user && can_edit_observation?
+      return true if @observation.reflection?
+
+      @occurrence && @occurrence.primary_observation_id != @observation.id
+    end
+
+    def can_edit_observation?
+      in_admin_mode? || @observation.can_edit?(@user)
+    end
+
+    def render_edit_modal
+      render(Show::EditModal.new(observation: @observation,
+                                 occurrence: @occurrence, user: @user))
     end
 
     # ---- main row: carousel | obs details / name / lists -----

--- a/app/views/controllers/observations/show.rb
+++ b/app/views/controllers/observations/show.rb
@@ -72,11 +72,14 @@ module Views::Controllers::Observations
     # The edit icon opens the choice modal for a non-primary occurrence
     # member (a read-only reflection, or an editable non-primary), so the
     # editor is steered to the primary rather than the wrong member.
+    # Only for an occurrence member: a reflection with no occurrence has
+    # no primary to steer toward, and the resolver can't promote/create
+    # anything, so it would just bounce back (#5328 review).
     def show_edit_modal?
-      return false unless @user && can_edit_observation?
-      return true if @observation.reflection?
+      return false unless @user && @occurrence && can_edit_observation?
 
-      @occurrence && @occurrence.primary_observation_id != @observation.id
+      @observation.reflection? ||
+        @occurrence.primary_observation_id != @observation.id
     end
 
     def can_edit_observation?

--- a/app/views/controllers/observations/show/edit_modal.rb
+++ b/app/views/controllers/observations/show/edit_modal.rb
@@ -26,15 +26,15 @@ module Views::Controllers::Observations
       end
     end
 
-    # The create case (a reflection with no editable sibling) is about
-    # making a matching observation; the others are about which existing
-    # one to edit.
+    # Title by case: create a match (reflection, no editable sibling);
+    # edit the one matching native (a reflection whose sibling is
+    # editable -- a single option); or, for an editable non-primary,
+    # choose which of two to edit.
     def modal_title
-      if create_target?
-        :edit_occurrence_create_title.l
-      else
-        :edit_occurrence_modal_title.l
-      end
+      return :edit_occurrence_create_title.l if create_target?
+      return :edit_occurrence_edit_match_title.l if @observation.reflection?
+
+      :edit_occurrence_modal_title.l
     end
 
     private

--- a/app/views/controllers/observations/show/edit_modal.rb
+++ b/app/views/controllers/observations/show/edit_modal.rb
@@ -20,10 +20,20 @@ module Views::Controllers::Observations
     prop :user, _Nilable(::User), default: nil
 
     def view_template
-      Modal(id: MODAL_ID, title: :edit_occurrence_modal_title.l,
-            user: @user) do |m|
+      Modal(id: MODAL_ID, title: modal_title, user: @user) do |m|
         m.with_body { render_explanation }
         m.with_footer { render_buttons }
+      end
+    end
+
+    # The create case (a reflection with no editable sibling) is about
+    # making a matching observation; the others are about which existing
+    # one to edit.
+    def modal_title
+      if create_target?
+        :edit_occurrence_create_title.l
+      else
+        :edit_occurrence_modal_title.l
       end
     end
 
@@ -65,11 +75,15 @@ module Views::Controllers::Observations
     end
 
     def primary_button_label
-      if @observation.reflection? && !editable_sibling?
+      if create_target?
         :edit_occurrence_create_primary.l
       else
         :edit_occurrence_edit_primary.l
       end
+    end
+
+    def create_target?
+      @observation.reflection? && !editable_sibling?
     end
 
     def editable_sibling?

--- a/app/views/controllers/observations/show/edit_modal.rb
+++ b/app/views/controllers/observations/show/edit_modal.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Choice modal shown when the edit icon is clicked on a non-primary
+# occurrence member (#5317). It explains that the observation is not the
+# occurrence's primary (and, if it is a read-only reflection, that it
+# can't be edited here), then offers the appropriate edit targets:
+#
+# - editable non-primary: Edit Primary / Edit This / Cancel
+# - reflection with an editable sibling: Edit Primary / Cancel
+# - reflection with no editable sibling: Create Editable Primary / Cancel
+#
+# "Edit Primary" and "Create Editable Primary" hit the same route
+# (target=primary); the controller resolves which member to edit.
+module Views::Controllers::Observations
+  class Show::EditModal < Views::Base
+    MODAL_ID = "edit_occurrence_modal"
+
+    prop :observation, ::Observation
+    prop :occurrence, _Nilable(::Occurrence), default: nil
+    prop :user, _Nilable(::User), default: nil
+
+    def view_template
+      Modal(id: MODAL_ID, title: :edit_occurrence_modal_title.l,
+            user: @user) do |m|
+        m.with_body { render_explanation }
+        m.with_footer { render_buttons }
+      end
+    end
+
+    private
+
+    def render_explanation
+      p { :edit_occurrence_not_primary.l }
+      p { :edit_occurrence_is_reflection.l } if @observation.reflection?
+    end
+
+    def render_buttons
+      Button(type: :get, name: primary_button_label,
+             target: edit_observation_path(@observation.id, target: :primary),
+             variant: :primary)
+      whitespace
+      render_edit_this
+      whitespace
+      cancel_button
+    end
+
+    # Editing this member directly is offered only for an editable
+    # non-primary; a reflection can't be edited here.
+    def render_edit_this
+      return if @observation.reflection?
+
+      Button(type: :get, name: :edit_occurrence_edit_this.l,
+             target: edit_observation_path(@observation.id))
+    end
+
+    def cancel_button
+      Button(name: :cancel.ti, data: { dismiss: "modal" })
+    end
+
+    def primary_button_label
+      if @observation.reflection? && !editable_sibling?
+        :edit_occurrence_create_primary.l
+      else
+        :edit_occurrence_edit_primary.l
+      end
+    end
+
+    def editable_sibling?
+      return false unless @occurrence
+
+      @occurrence.observations.any? do |obs|
+        !obs.reflection? && obs.can_edit?(@user)
+      end
+    end
+  end
+end

--- a/app/views/controllers/observations/show/edit_modal.rb
+++ b/app/views/controllers/observations/show/edit_modal.rb
@@ -30,15 +30,15 @@ module Views::Controllers::Observations
     private
 
     def render_explanation
-      # A lone reflection is its occurrence's current primary until an
-      # editable one is created, so the "not primary" line only applies
-      # when this observation is not the primary (#5328 review).
-      p { :edit_occurrence_not_primary.l } unless primary?
+      # "not primary" only for a non-primary occurrence member -- not for
+      # a lone reflection (its occurrence's primary, or with no
+      # occurrence yet), where only the read-only line applies (#5328).
+      p { :edit_occurrence_not_primary.l } if non_primary_member?
       p { :edit_occurrence_is_reflection.l } if @observation.reflection?
     end
 
-    def primary?
-      @occurrence && @occurrence.primary_observation_id == @observation.id
+    def non_primary_member?
+      @occurrence && @occurrence.primary_observation_id != @observation.id
     end
 
     def render_buttons

--- a/app/views/controllers/observations/show/edit_modal.rb
+++ b/app/views/controllers/observations/show/edit_modal.rb
@@ -30,8 +30,15 @@ module Views::Controllers::Observations
     private
 
     def render_explanation
-      p { :edit_occurrence_not_primary.l }
+      # A lone reflection is its occurrence's current primary until an
+      # editable one is created, so the "not primary" line only applies
+      # when this observation is not the primary (#5328 review).
+      p { :edit_occurrence_not_primary.l } unless primary?
       p { :edit_occurrence_is_reflection.l } if @observation.reflection?
+    end
+
+    def primary?
+      @occurrence && @occurrence.primary_observation_id == @observation.id
     end
 
     def render_buttons
@@ -69,7 +76,7 @@ module Views::Controllers::Observations
       return false unless @occurrence
 
       @occurrence.observations.any? do |obs|
-        !obs.reflection? && obs.can_edit?(@user)
+        !obs.reflection? && (in_admin_mode? || obs.can_edit?(@user))
       end
     end
   end

--- a/app/views/full_page_base/icons.rb
+++ b/app/views/full_page_base/icons.rb
@@ -8,11 +8,12 @@
 module Views::FullPageBase::Icons
   # Edit / delete icons for the show-page title bar. Permission gating
   # + button rendering live on `Views::Layouts::Header::EditDeleteIcons`.
-  def add_edit_icons(object, user)
+  def add_edit_icons(object, user, edit_modal_target: nil)
     content_for(:edit_icons) do
       capture do
         render(::Views::Layouts::Header::EditDeleteIcons.new(
-                 object: object, user: user
+                 object: object, user: user,
+                 edit_modal_target: edit_modal_target
                ))
       end
     end

--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -21,6 +21,11 @@ module Views::Layouts
   class Header::EditDeleteIcons < Views::Base
     prop :object, ::AbstractModel
     prop :user, _Nilable(::User), default: nil
+    # When set, the edit icon toggles this modal (by DOM id) instead of
+    # navigating -- used for a non-primary occurrence member, whose edit
+    # opens the choice modal (#5317). The edit route stays as the href,
+    # so it degrades to a plain edit link without JS.
+    prop :edit_modal_target, _Nilable(String), default: nil
 
     def view_template
       div(class: "h4 my-0 d-flex align-items-center object_edit") do
@@ -37,8 +42,15 @@ module Views::Layouts
 
       ::Components::Button::Edit.new(
         target: @object, variant: :strip,
-        class: ::Components::InlineLinkBlock.item_class
+        class: ::Components::InlineLinkBlock.item_class,
+        **edit_modal_data
       )
+    end
+
+    def edit_modal_data
+      return {} unless @edit_modal_target
+
+      { data: { toggle: "modal", target: "##{@edit_modal_target}" } }
     end
 
     def delete_item

--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -39,24 +39,25 @@ module Views::Layouts
     # companion observation for the changes.
     def edit_item
       return nil unless can_edit_object?
+      return edit_modal_toggle if @edit_modal_target
 
       ::Components::Button::Edit.new(
         target: @object, variant: :strip,
-        class: ::Components::InlineLinkBlock.item_class,
-        **edit_modal_data
+        class: ::Components::InlineLinkBlock.item_class
       )
     end
 
-    # `data-turbo="false"` keeps Turbo Drive from navigating the edit
-    # href in the background when the icon is a modal toggle (Bootstrap
-    # opens the modal and prevents the native click; without it Turbo
-    # would visit the edit page and swap it in under the open modal).
-    # The href stays a no-JS fallback.
-    def edit_modal_data
-      return {} unless @edit_modal_target
-
-      { data: { turbo: "false", toggle: "modal",
-                target: "##{@edit_modal_target}" } }
+    # A plain <button> (no href) that opens the static choice modal via
+    # Bootstrap data-toggle. Deliberately not a link: an edit href here
+    # was navigable/prefetchable, so Turbo Drive would visit the edit
+    # page in the background and swap it in under the open modal (#5317).
+    def edit_modal_toggle
+      ::Components::Button.new(
+        icon: :edit, variant: :strip,
+        icon_title: :edit_object.t(type: @object.type_tag),
+        class: ::Components::InlineLinkBlock.item_class,
+        data: { toggle: "modal", target: "##{@edit_modal_target}" }
+      )
     end
 
     def delete_item

--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -47,14 +47,16 @@ module Views::Layouts
       )
     end
 
-    # A plain <button> (no href) that opens the static choice modal via
-    # Bootstrap data-toggle. Deliberately not a link: an edit href here
-    # was navigable/prefetchable, so Turbo Drive would visit the edit
-    # page in the background and swap it in under the open modal (#5317).
+    # Opens the static choice modal via Bootstrap data-toggle. Uses an
+    # href of "#" rather than the edit route: a same-page hash is not a
+    # Turbo visit (or prefetch), so the edit page can't load in the
+    # background under the open modal (#5317), while the anchor still
+    # gets the icon-link styling and link color the delete icon's
+    # sibling <a> has.
     def edit_modal_toggle
-      ::Components::Button.new(
-        icon: :edit, variant: :strip,
-        icon_title: :edit_object.t(type: @object.type_tag),
+      ::Components::Button::Get.new(
+        name: :edit_object.t(type: @object.type_tag),
+        target: "#", icon: :edit, variant: :strip,
         class: ::Components::InlineLinkBlock.item_class,
         data: { toggle: "modal", target: "##{@edit_modal_target}" }
       )

--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -47,10 +47,16 @@ module Views::Layouts
       )
     end
 
+    # `data-turbo="false"` keeps Turbo Drive from navigating the edit
+    # href in the background when the icon is a modal toggle (Bootstrap
+    # opens the modal and prevents the native click; without it Turbo
+    # would visit the edit page and swap it in under the open modal).
+    # The href stays a no-JS fallback.
     def edit_modal_data
       return {} unless @edit_modal_target
 
-      { data: { toggle: "modal", target: "##{@edit_modal_target}" } }
+      { data: { turbo: "false", toggle: "modal",
+                target: "##{@edit_modal_target}" } }
     end
 
     def delete_item

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1500,6 +1500,7 @@
   edit_observation_promoted_primary: The oldest editable observation in this occurrence is now its primary observation, and you are editing it.
   edit_occurrence_modal_title: Edit which observation?
   edit_occurrence_create_title: Create Matching Observation?
+  edit_occurrence_edit_match_title: Edit Matching Observation?
   edit_occurrence_not_primary: This observation is not the primary observation of its occurrence.
   edit_occurrence_is_reflection: This is a read-only reflection imported from another source, so it can't be edited here.
   edit_occurrence_edit_primary: Edit Primary Observation

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1497,6 +1497,13 @@
   destroy_observation_is_reflection: This observation is a read-only reflection of its imported source and can't be deleted here. To remove it, delete it at the source and resync.
   edit_observation_companion_created: That observation is a read-only reflection of its imported source, so Mushroom Observer created this companion observation for your changes and linked the two as one occurrence. Edit the companion here; the reflection keeps the imported data.
   edit_observation_companion_existing: That observation is a read-only reflection of its imported source. You are editing its linked companion observation instead.
+  edit_observation_promoted_primary: The oldest editable observation in this occurrence is now its primary observation, and you are editing it.
+  edit_occurrence_modal_title: Edit which observation?
+  edit_occurrence_not_primary: This observation is not the primary observation of its occurrence.
+  edit_occurrence_is_reflection: It is a read-only reflection imported from another source, so it can't be edited here.
+  edit_occurrence_edit_primary: Edit Primary Observation
+  edit_occurrence_edit_this: Edit This Observation
+  edit_occurrence_create_primary: Create Editable Primary Observation
   create_observation_field_slip_invalid: 'Observation created, but the field slip code "[code]" was invalid and was not attached.'
   create_observation_field_slip_full: 'Observation created, but field slip "[code]" already has [max] observations, the maximum allowed, so it was not attached.'
   form_observations_specimen_available: Specimen Available

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -1499,11 +1499,12 @@
   edit_observation_companion_existing: That observation is a read-only reflection of its imported source. You are editing its linked companion observation instead.
   edit_observation_promoted_primary: The oldest editable observation in this occurrence is now its primary observation, and you are editing it.
   edit_occurrence_modal_title: Edit which observation?
+  edit_occurrence_create_title: Create Matching Observation?
   edit_occurrence_not_primary: This observation is not the primary observation of its occurrence.
-  edit_occurrence_is_reflection: It is a read-only reflection imported from another source, so it can't be edited here.
+  edit_occurrence_is_reflection: This is a read-only reflection imported from another source, so it can't be edited here.
   edit_occurrence_edit_primary: Edit Primary Observation
   edit_occurrence_edit_this: Edit This Observation
-  edit_occurrence_create_primary: Create Editable Primary Observation
+  edit_occurrence_create_primary: Create Editable Match
   create_observation_field_slip_invalid: 'Observation created, but the field slip code "[code]" was invalid and was not attached.'
   create_observation_field_slip_full: 'Observation created, but field slip "[code]" already has [max] observations, the maximum allowed, so it was not attached.'
   form_observations_specimen_available: Specimen Available

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -33,13 +33,14 @@ class ObservationsControllerShowTest < FunctionalTestCase
 
     assert_response(:success)
     assert_select("#edit_occurrence_modal")
-    # The toggle is a <button> (no href), so Turbo Drive can't visit an
-    # edit page in the background under the open modal (#5317).
+    # The toggle's href is "#" (a same-page hash Turbo won't visit), so
+    # the edit page can't load in the background under the modal (#5317).
     assert_select(
-      "button[data-toggle='modal'][data-target='#edit_occurrence_modal']"
+      "a[href='#'][data-toggle='modal']" \
+      "[data-target='#edit_occurrence_modal']"
     )
     assert_select(
-      "a[data-target='#edit_occurrence_modal'][href]", count: 0
+      "[data-target='#edit_occurrence_modal'][href*='/edit']", count: 0
     )
   end
 

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -54,6 +54,22 @@ class ObservationsControllerShowTest < FunctionalTestCase
     assert_select("#edit_occurrence_modal", count: 0)
   end
 
+  # A reflection with no occurrence has no primary to steer toward, so
+  # no modal (#5328 review) -- it would just bounce back otherwise.
+  def test_show_no_edit_modal_for_reflection_without_occurrence
+    user = users(:rolf)
+    reflection = observations(:coprinus_comatus_obs)
+    reflection.update_columns(user_id: user.id, collector_user_id: user.id,
+                              occurrence_id: nil,
+                              reflected_at: Time.zone.now)
+    login(user.login)
+
+    get(:show, params: { id: reflection.id })
+
+    assert_response(:success)
+    assert_select("#edit_occurrence_modal", count: 0)
+  end
+
   def test_show_no_login_with_flow
     obs = observations(:deprecated_name_obs)
     get(:show, params: { id: obs.id, flow: "next" })

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -17,6 +17,40 @@ class ObservationsControllerShowTest < FunctionalTestCase
     assert_response(:success)
   end
 
+  # A non-primary occurrence member's edit icon opens the choice modal
+  # (#5317): the modal is rendered and the edit icon toggles it.
+  def test_show_edit_modal_for_non_primary_member
+    user = users(:rolf)
+    reflection = observations(:coprinus_comatus_obs)
+    reflection.update_columns(user_id: user.id, collector_user_id: user.id,
+                              occurrence_id: nil,
+                              reflected_at: Time.zone.now)
+    occ = Occurrence.create!(user: user, primary_observation: reflection)
+    reflection.update_column(:occurrence_id, occ.id)
+    login(user.login)
+
+    get(:show, params: { id: reflection.id })
+
+    assert_response(:success)
+    assert_select("#edit_occurrence_modal")
+    assert_select(
+      "[data-toggle='modal'][data-target='#edit_occurrence_modal']"
+    )
+  end
+
+  # A standalone observation (no occurrence) gets no modal; its edit
+  # icon is a plain edit link.
+  def test_show_no_edit_modal_for_standalone_observation
+    obs = observations(:minimal_unknown_obs)
+    obs.update_column(:occurrence_id, nil)
+    login(obs.user.login)
+
+    get(:show, params: { id: obs.id })
+
+    assert_response(:success)
+    assert_select("#edit_occurrence_modal", count: 0)
+  end
+
   def test_show_no_login_with_flow
     obs = observations(:deprecated_name_obs)
     get(:show, params: { id: obs.id, flow: "next" })

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -33,11 +33,13 @@ class ObservationsControllerShowTest < FunctionalTestCase
 
     assert_response(:success)
     assert_select("#edit_occurrence_modal")
-    # The toggle opts out of Turbo Drive so the edit href isn't visited
-    # in the background under the open modal (#5317).
+    # The toggle is a <button> (no href), so Turbo Drive can't visit an
+    # edit page in the background under the open modal (#5317).
     assert_select(
-      "[data-toggle='modal'][data-target='#edit_occurrence_modal']" \
-      "[data-turbo='false']"
+      "button[data-toggle='modal'][data-target='#edit_occurrence_modal']"
+    )
+    assert_select(
+      "a[data-target='#edit_occurrence_modal'][href]", count: 0
     )
   end
 

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -33,8 +33,11 @@ class ObservationsControllerShowTest < FunctionalTestCase
 
     assert_response(:success)
     assert_select("#edit_occurrence_modal")
+    # The toggle opts out of Turbo Drive so the edit href isn't visited
+    # in the background under the open modal (#5317).
     assert_select(
-      "[data-toggle='modal'][data-target='#edit_occurrence_modal']"
+      "[data-toggle='modal'][data-target='#edit_occurrence_modal']" \
+      "[data-turbo='false']"
     )
   end
 

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -59,7 +59,10 @@ class ObservationsControllerShowTest < FunctionalTestCase
 
   # A reflection with no occurrence has no primary to steer toward, so
   # no modal (#5328 review) -- it would just bounce back otherwise.
-  def test_show_no_edit_modal_for_reflection_without_occurrence
+  # A read-only reflection with no occurrence yet still gets the modal:
+  # "Create Editable Primary" creates the native and links an occurrence
+  # (#5317). It must not silently create a companion on icon click.
+  def test_show_edit_modal_for_reflection_without_occurrence
     user = users(:rolf)
     reflection = observations(:coprinus_comatus_obs)
     reflection.update_columns(user_id: user.id, collector_user_id: user.id,
@@ -70,7 +73,8 @@ class ObservationsControllerShowTest < FunctionalTestCase
     get(:show, params: { id: reflection.id })
 
     assert_response(:success)
-    assert_select("#edit_occurrence_modal", count: 0)
+    assert_select("#edit_occurrence_modal")
+    assert_select("a[href='#'][data-target='#edit_occurrence_modal']")
   end
 
   def test_show_no_login_with_flow

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -335,6 +335,27 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     assert_redirected_to(edit_observation_path(oldest.id))
   end
 
+  # In admin mode the resolver honors admin edit rights: it edits the
+  # existing (admin-editable) primary rather than creating a companion.
+  def test_edit_target_primary_honors_admin_editability
+    make_admin("rolf")
+    admin = users(:rolf)
+    primary = observations(:detailed_unknown_obs)
+    primary.update_columns(user_id: users(:mary).id, collector_user_id: nil,
+                           occurrence_id: nil)
+    assert_not(primary.can_edit?(admin), "premise: not editable sans admin")
+    reflection = observations(:coprinus_comatus_obs)
+    reflection.update_columns(occurrence_id: nil, reflected_at: Time.zone.now)
+    occ = Occurrence.create!(user: admin, primary_observation: primary)
+    [primary, reflection].each { |o| o.update_column(:occurrence_id, occ.id) }
+
+    assert_no_difference("Observation.count") do
+      get(:edit, params: { id: reflection.id, target: "primary" })
+    end
+
+    assert_redirected_to(edit_observation_path(primary.id))
+  end
+
   # A blank submitted for a sibling-held key is preserved (a deliberate
   # suppression of the inherited value); a blank for a key no sibling
   # holds is dropped as usual.

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -335,6 +335,19 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     assert_redirected_to(edit_observation_path(oldest.id))
   end
 
+  # target=primary on a reflection with no occurrence redirects to the
+  # reflection's edit, which then creates the companion (companion flow).
+  def test_edit_target_primary_on_occurrenceless_reflection
+    user = users(:rolf)
+    reflection = editable_member(:coprinus_comatus_obs, user)
+    reflection.update_column(:reflected_at, Time.zone.now)
+    login(user.login)
+
+    get(:edit, params: { id: reflection.id, target: "primary" })
+
+    assert_redirected_to(edit_observation_path(reflection.id))
+  end
+
   # In admin mode the resolver honors admin edit rights: it edits the
   # existing (admin-editable) primary rather than creating a companion.
   def test_edit_target_primary_honors_admin_editability

--- a/test/controllers/observations_controller_update_test.rb
+++ b/test/controllers/observations_controller_update_test.rb
@@ -253,6 +253,88 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     )
   end
 
+  # target=primary from an editable non-primary member edits the
+  # occurrence's existing editable primary.
+  def test_edit_target_primary_edits_existing_primary
+    user = users(:rolf)
+    primary = editable_member(:coprinus_comatus_obs, user)
+    other = editable_member(:detailed_unknown_obs, user)
+    occ = make_occurrence(user, primary, [primary, other])
+    login(user.login)
+
+    get(:edit, params: { id: other.id, target: "primary" })
+
+    assert_redirected_to(edit_observation_path(primary.id))
+    assert_equal(primary.id, occ.reload.primary_observation_id)
+  end
+
+  # target=primary from a reflection whose occurrence has no editable
+  # primary promotes the oldest editable sibling and edits it.
+  def test_edit_target_primary_promotes_editable_sibling
+    user = users(:rolf)
+    reflection = editable_member(:detailed_unknown_obs, user)
+    reflection.update_column(:reflected_at, Time.zone.now)
+    native = editable_member(:coprinus_comatus_obs, user)
+    occ = make_occurrence(user, reflection, [reflection, native])
+
+    login(user.login)
+    get(:edit, params: { id: reflection.id, target: "primary" })
+
+    assert_equal(native.id, occ.reload.primary_observation_id)
+    assert_redirected_to(edit_observation_path(native.id))
+  end
+
+  # target=primary from a lone read-only reflection creates a companion
+  # native, makes it primary, and edits it.
+  def test_edit_target_primary_creates_companion_for_lone_reflection
+    user = users(:rolf)
+    reflection = editable_member(:coprinus_comatus_obs, user)
+    reflection.update_column(:reflected_at, Time.zone.now)
+    occ = make_occurrence(user, reflection, [reflection])
+
+    login(user.login)
+    assert_difference("Observation.count", 1) do
+      get(:edit, params: { id: reflection.id, target: "primary" })
+    end
+
+    companion = occ.reload.primary_observation
+    assert_not(companion.reflection?, "companion is an editable native")
+    assert_redirected_to(edit_observation_path(companion.id))
+  end
+
+  # A companion that can't be created (here, invalid coordinates copied
+  # from the reflection) flashes an error and returns to the show page.
+  def test_edit_target_primary_flashes_when_companion_invalid
+    user = users(:rolf)
+    reflection = editable_member(:coprinus_comatus_obs, user)
+    reflection.update_columns(reflected_at: Time.zone.now,
+                              lat: 40.0, lng: nil)
+    make_occurrence(user, reflection, [reflection])
+    login(user.login)
+
+    get(:edit, params: { id: reflection.id, target: "primary" })
+
+    assert_flash_error
+    assert_redirected_to(action: :show, id: reflection.id)
+  end
+
+  # Guard: editable siblings but no primary set -- target=primary
+  # promotes the oldest editable member.
+  def test_edit_target_primary_promotes_oldest_when_no_primary
+    user = users(:rolf)
+    older = editable_member(:coprinus_comatus_obs, user)
+    newer = editable_member(:detailed_unknown_obs, user)
+    occ = make_occurrence(user, older, [older, newer])
+    occ.update_column(:primary_observation_id, nil)
+
+    login(user.login)
+    get(:edit, params: { id: newer.id, target: "primary" })
+
+    oldest = [older, newer].min_by(&:id)
+    assert_equal(oldest.id, occ.reload.primary_observation_id)
+    assert_redirected_to(edit_observation_path(oldest.id))
+  end
+
   # A blank submitted for a sibling-held key is preserved (a deliberate
   # suppression of the inherited value); a blank for a key no sibling
   # holds is dropped as usual.
@@ -1497,5 +1579,20 @@ class ObservationsControllerUpdateTest < FunctionalTestCase
     )
     args[:has_geolocation] = has_geolocation unless has_geolocation.nil?
     { id: obs.id, observation: args }
+  end
+
+  # A fixture observation detached from any occurrence and made editable
+  # by `user` (owner + collector), for the edit-primary resolver tests.
+  def editable_member(fixture, user)
+    obs = observations(fixture)
+    obs.update_columns(user_id: user.id, collector_user_id: user.id,
+                       occurrence_id: nil)
+    obs
+  end
+
+  def make_occurrence(user, primary, members)
+    occ = Occurrence.create!(user: user, primary_observation: primary)
+    members.each { |m| m.update_column(:occurrence_id, occ.id) }
+    occ
   end
 end

--- a/test/views/controllers/observations/show/edit_modal_test.rb
+++ b/test/views/controllers/observations/show/edit_modal_test.rb
@@ -18,6 +18,7 @@ class Views::Controllers::Observations::Show::EditModalTest <
 
     html = render_modal(other, occ)
 
+    assert_includes(html, :edit_occurrence_not_primary.l)
     assert_html(html, "a[href='#{edit_path(other, target: :primary)}']",
                 text: :edit_occurrence_edit_primary.l)
     assert_html(html, "a[href='#{edit_path(other)}']",
@@ -42,7 +43,9 @@ class Views::Controllers::Observations::Show::EditModalTest <
     assert_includes(html, :edit_occurrence_is_reflection.l)
   end
 
-  # Reflection with no editable sibling: Create Editable Primary.
+  # Reflection with no editable sibling: Create Editable Primary. It is
+  # its occurrence's current primary, so the "not primary" line is
+  # omitted; only the read-only-reflection line shows.
   def test_lone_reflection_offers_create
     reflection = make_editable(:coprinus_comatus_obs)
     reflection.update_column(:reflected_at, Time.zone.now)
@@ -53,6 +56,32 @@ class Views::Controllers::Observations::Show::EditModalTest <
     assert_html(html, "a[href='#{edit_path(reflection, target: :primary)}']",
                 text: :edit_occurrence_create_primary.l)
     assert_no_html(html, "a[href='#{edit_path(reflection)}']")
+    assert_includes(html, :edit_occurrence_is_reflection.l)
+    assert_not_includes(html, :edit_occurrence_not_primary.l)
+  end
+
+  # Admin mode grants edit rights, so a sibling the user can't edit
+  # still counts as an editable sibling -- the label is Edit Primary,
+  # not Create Editable Primary.
+  def test_admin_mode_counts_non_editable_sibling
+    reflection = make_editable(:coprinus_comatus_obs)
+    reflection.update_column(:reflected_at, Time.zone.now)
+    native = observations(:detailed_unknown_obs)
+    native.update_columns(user_id: users(:mary).id, collector_user_id: nil,
+                          occurrence_id: nil)
+    assert_not(native.can_edit?(@user), "premise: native not editable by user")
+    occ = occurrence_for(reflection, [reflection, native])
+
+    without_admin = render_modal(reflection, occ)
+    assert_html(without_admin,
+                "a[href='#{edit_path(reflection, target: :primary)}']",
+                text: :edit_occurrence_create_primary.l)
+
+    stub_admin_mode!
+    with_admin = render_modal(reflection, occ)
+    assert_html(with_admin,
+                "a[href='#{edit_path(reflection, target: :primary)}']",
+                text: :edit_occurrence_edit_primary.l)
   end
 
   private

--- a/test/views/controllers/observations/show/edit_modal_test.rb
+++ b/test/views/controllers/observations/show/edit_modal_test.rb
@@ -18,6 +18,7 @@ class Views::Controllers::Observations::Show::EditModalTest <
 
     html = render_modal(other, occ)
 
+    assert_includes(html, :edit_occurrence_modal_title.l)
     assert_includes(html, :edit_occurrence_not_primary.l)
     assert_html(html, "a[href='#{edit_path(other, target: :primary)}']",
                 text: :edit_occurrence_edit_primary.l)
@@ -53,6 +54,7 @@ class Views::Controllers::Observations::Show::EditModalTest <
 
     html = render_modal(reflection, occ)
 
+    assert_includes(html, :edit_occurrence_create_title.l)
     assert_html(html, "a[href='#{edit_path(reflection, target: :primary)}']",
                 text: :edit_occurrence_create_primary.l)
     assert_no_html(html, "a[href='#{edit_path(reflection)}']")

--- a/test/views/controllers/observations/show/edit_modal_test.rb
+++ b/test/views/controllers/observations/show/edit_modal_test.rb
@@ -60,6 +60,20 @@ class Views::Controllers::Observations::Show::EditModalTest <
     assert_not_includes(html, :edit_occurrence_not_primary.l)
   end
 
+  # A reflection with no occurrence yet still offers Create Editable
+  # Primary; only the read-only line shows (no "not primary").
+  def test_reflection_without_occurrence_offers_create
+    reflection = make_editable(:coprinus_comatus_obs)
+    reflection.update_column(:reflected_at, Time.zone.now)
+
+    html = render_modal(reflection, nil)
+
+    assert_html(html, "a[href='#{edit_path(reflection, target: :primary)}']",
+                text: :edit_occurrence_create_primary.l)
+    assert_includes(html, :edit_occurrence_is_reflection.l)
+    assert_not_includes(html, :edit_occurrence_not_primary.l)
+  end
+
   # Admin mode grants edit rights, so a sibling the user can't edit
   # still counts as an editable sibling -- the label is Edit Primary,
   # not Create Editable Primary.

--- a/test/views/controllers/observations/show/edit_modal_test.rb
+++ b/test/views/controllers/observations/show/edit_modal_test.rb
@@ -38,6 +38,7 @@ class Views::Controllers::Observations::Show::EditModalTest <
 
     html = render_modal(reflection, occ)
 
+    assert_includes(html, :edit_occurrence_edit_match_title.l)
     assert_html(html, "a[href='#{edit_path(reflection, target: :primary)}']",
                 text: :edit_occurrence_edit_primary.l)
     assert_no_html(html, "a[href='#{edit_path(reflection)}']")

--- a/test/views/controllers/observations/show/edit_modal_test.rb
+++ b/test/views/controllers/observations/show/edit_modal_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class Views::Controllers::Observations::Show::EditModalTest <
+  ComponentTestCase
+  def setup
+    super
+    @user = users(:rolf)
+  end
+
+  # Editable non-primary: Edit Primary + Edit This + Cancel, no
+  # reflection explanation.
+  def test_editable_non_primary_buttons
+    primary = make_editable(:coprinus_comatus_obs)
+    other = make_editable(:detailed_unknown_obs)
+    occ = occurrence_for(primary, [primary, other])
+
+    html = render_modal(other, occ)
+
+    assert_html(html, "a[href='#{edit_path(other, target: :primary)}']",
+                text: :edit_occurrence_edit_primary.l)
+    assert_html(html, "a[href='#{edit_path(other)}']",
+                text: :edit_occurrence_edit_this.l)
+    assert_html(html, "button[data-dismiss='modal']")
+    assert_not_includes(html, :edit_occurrence_is_reflection.l)
+  end
+
+  # Reflection with an editable sibling: Edit Primary + Cancel, no Edit
+  # This, plus the reflection explanation.
+  def test_reflection_with_editable_sibling_buttons
+    reflection = make_editable(:detailed_unknown_obs)
+    reflection.update_column(:reflected_at, Time.zone.now)
+    native = make_editable(:coprinus_comatus_obs)
+    occ = occurrence_for(native, [reflection, native])
+
+    html = render_modal(reflection, occ)
+
+    assert_html(html, "a[href='#{edit_path(reflection, target: :primary)}']",
+                text: :edit_occurrence_edit_primary.l)
+    assert_no_html(html, "a[href='#{edit_path(reflection)}']")
+    assert_includes(html, :edit_occurrence_is_reflection.l)
+  end
+
+  # Reflection with no editable sibling: Create Editable Primary.
+  def test_lone_reflection_offers_create
+    reflection = make_editable(:coprinus_comatus_obs)
+    reflection.update_column(:reflected_at, Time.zone.now)
+    occ = occurrence_for(reflection, [reflection])
+
+    html = render_modal(reflection, occ)
+
+    assert_html(html, "a[href='#{edit_path(reflection, target: :primary)}']",
+                text: :edit_occurrence_create_primary.l)
+    assert_no_html(html, "a[href='#{edit_path(reflection)}']")
+  end
+
+  private
+
+  def edit_path(obs, **)
+    Rails.application.routes.url_helpers.edit_observation_path(obs.id, **)
+  end
+
+  def make_editable(fixture)
+    obs = observations(fixture)
+    obs.update_columns(user_id: @user.id, collector_user_id: @user.id,
+                       occurrence_id: nil)
+    obs
+  end
+
+  def occurrence_for(primary, members)
+    occ = Occurrence.create!(user: @user, primary_observation: primary)
+    members.each { |m| m.update_column(:occurrence_id, occ.id) }
+    occ
+  end
+
+  def render_modal(obs, occ)
+    render(Views::Controllers::Observations::Show::EditModal.new(
+             observation: obs, occurrence: occ, user: @user
+           ))
+  end
+end


### PR DESCRIPTION
Part B of the #5326 rework (stacked on `njw-reflection-exif-panel`; retarget to main once #5326 merges). Adds the non-primary edit modal Nathan specified in the #5326 discussion.

## What it does

Clicking the edit icon on an observation that is a non-primary member of an occurrence — a read-only reflection, or an editable non-primary — now opens a choice modal instead of navigating straight to the form. The modal explains that the observation is not the occurrence's primary (and, for a reflection, that it can't be edited here), then offers the appropriate targets:

| Observation | Buttons |
|---|---|
| Editable non-primary | Edit Primary Observation · Edit This Observation · Cancel |
| Reflection with an editable sibling | Edit Primary Observation · Cancel |
| Reflection with no editable sibling | Create Editable Primary Observation · Cancel |

"Edit Primary Observation" and "Create Editable Primary Observation" hit the same route (`?target=primary`); the controller resolves which member to edit:

- the occurrence's existing editable primary, or
- the oldest editable sibling — **promoted to primary** if none is set (the guard for an occurrence that somehow lacks a primary), or
- a **companion** created from the reflection (which becomes the primary), reusing the existing `Observation::Companion` machinery.

## Mechanics

- The edit route stays the icon's `href`; the modal is opened by a Bootstrap `data-toggle="modal"` on the same element, so it degrades to a plain edit link when JS is off.
- The only entry point affected is the observation show-page title-bar edit icon (`Views::Layouts::Header::EditDeleteIcons`) — the one place observations expose an edit affordance. `EditDeleteIcons` gains an optional `edit_modal_target`; the show view passes it (and renders the modal) only for a non-primary member.
- The resolver lives in a new `ObservationsController::EditablePrimary` concern; it re-fetches the occurrence fresh so the strict-loaded show/edit associations don't block the promote/create writes.

## Related, not here

- Adopting the reflection's location onto the primary (the original #5317 goal) is issue #5327.
- Occurrence-role icons (primary / editable-sibling / reflection) are #5181.

## Test plan

- [ ] On the show page of a reflection that shares an occurrence with an editable native, the edit icon opens the modal; "Edit Primary Observation" lands on the native's edit form.
- [ ] On a lone reflection's show page, the modal offers "Create Editable Primary Observation," which creates the native and edits it.
- [ ] On an editable non-primary member, the modal offers both "Edit Primary" and "Edit This"; each lands on the right form.
- [ ] A standalone observation (no occurrence) shows no modal — its edit icon is a plain link.

<!-- changelog -->
article: yes
Ask which Observation to edit for a non-primary member
<!-- /changelog -->
