### PR TITLE
`backfill_mycoportal_export_links.rb`: update blank `ExternalLink` instead of duplicating

### DIFF
--- a/script/backfill_mycoportal_export_links.rb
+++ b/script/backfill_mycoportal_export_links.rb
@@ -21,6 +21,11 @@
 # Re-running this script doubles as a reconciliation check:
 # in a dry run, a nonzero "would create" count means MCP has
 # observations/images MO doesn't think it exported.
+#
+# A target that already has a pre-send marker link (external_id nil,
+# left by Report::Mycoportal / Report::MycoportalImageList's
+# #mark_exported!) gets that marker resolved to the discovered occid
+# in place, instead of a second row being created alongside it.
 
 # USAGE:
 #
@@ -53,6 +58,9 @@ require "optparse"
 require "fileutils"
 require "zip"
 
+# rubocop:disable Metrics/ClassLength -- Options/ReportWriter/Stopwatch
+# nest here to keep this one-off script self-contained in one file;
+# splitting them out for a line-count metric isn't worth it.
 class BackfillMycoportalExportLinks
   # CLI option parsing, in its own nested class to avoid method collisions
   # with scripts which define top-level `parse`
@@ -243,9 +251,11 @@ class BackfillMycoportalExportLinks
     return record_skipped_observation(row, existing) if
       existing.key?([row[:mo_id], row[:occid]])
 
-    create_export_link(target_type: "Observation", target_id: row[:mo_id],
-                       external_id: row[:occid],
-                       external_created_on: row[:date_entered])
+    resolve_or_create_export_link(
+      target_type: "Observation", target_id: row[:mo_id],
+      external_id: row[:occid], external_created_on: row[:date_entered],
+      existing: existing
+    )
   end
 
   def record_missing_observation(row)
@@ -307,9 +317,11 @@ class BackfillMycoportalExportLinks
     return record_skipped_image(row, existing) if
       existing.key?([row[:image_id], row[:occid]])
 
-    create_export_link(target_type: "Image", target_id: row[:image_id],
-                       external_id: row[:occid],
-                       external_created_on: row[:metadata_date])
+    resolve_or_create_export_link(
+      target_type: "Image", target_id: row[:image_id],
+      external_id: row[:occid], external_created_on: row[:metadata_date],
+      existing: existing
+    )
   end
 
   def record_missing_image(row)
@@ -328,12 +340,49 @@ class BackfillMycoportalExportLinks
   # Keyed by [target_id, external_id] (the MCP occid), not just target_id
   # -- the same target can legitimately have more than one export link
   # when it's attached to multiple distinct MCP occurrence records (an
-  # image can appear under two different occids; #4819 follow-up).
+  # image can appear under two different occids; #4819 follow-up). A
+  # [target_id, nil] key is a pre-send marker link (Report::Mycoportal
+  # / Report::MycoportalImageList's #mark_exported!, created before
+  # this site had assigned an id) still waiting to be resolved.
   def existing_links(target_type:, ids:)
     ExternalLink.where(target_type: target_type, target_id: ids,
                        external_site: @site, relationship: :export).
       pluck(:target_id, :external_id, :id).
       each_with_object({}) { |(tid, eid, id), h| h[[tid, eid]] = id }
+  end
+
+  # A target with a pre-send marker (external_id nil) gets that marker
+  # resolved in place, rather than leaving it a dead row while a
+  # second, id-bearing row is created alongside it. A target with no
+  # marker -- already resolved under a different occid, or reconciled
+  # directly without going through mark_exported! -- gets a new row,
+  # same as before.
+  def resolve_or_create_export_link(target_type:, target_id:, external_id:,
+                                    external_created_on:, existing:)
+    marker_id = existing[[target_id, nil]]
+    if marker_id
+      resolve_export_link_marker(marker_id, target_type, external_id,
+                                 external_created_on)
+    else
+      create_export_link(target_type: target_type, target_id: target_id,
+                         external_id: external_id,
+                         external_created_on: external_created_on)
+    end
+  end
+
+  def resolve_export_link_marker(marker_id, target_type, external_id,
+                                 external_created_on)
+    if @apply
+      begin
+        ExternalLink.find(marker_id).
+          update!(external_id: external_id,
+                  external_created_on: external_created_on)
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+        warn("  marker ##{marker_id}: #{e.message}")
+        return increment_stat(target_type, :invalid)
+      end
+    end
+    increment_stat(target_type, :marker_resolved)
   end
 
   def create_export_link(target_type:, target_id:, external_id: nil,
@@ -397,6 +446,7 @@ class BackfillMycoportalExportLinks
   def print_entity_summary(label, stats)
     puts("  #{label}:")
     puts("    created: #{stats[:created]}")
+    puts("    marker resolved: #{stats[:marker_resolved]}")
     puts("    already present (skipped): #{stats[:already_present]}")
     puts("    invalid (see warnings above): #{stats[:invalid]}")
     puts("    not found in MO: #{stats[:mo_missing]}")
@@ -462,6 +512,7 @@ class BackfillMycoportalExportLinks
     end
   end
 end
+# rubocop:enable Metrics/ClassLength
 
 if $PROGRAM_NAME == __FILE__
   BackfillMycoportalExportLinks.new(

--- a/script/backfill_mycoportal_export_links.rb
+++ b/script/backfill_mycoportal_export_links.rb
@@ -357,9 +357,13 @@ class BackfillMycoportalExportLinks
   # marker -- already resolved under a different occid, or reconciled
   # directly without going through mark_exported! -- gets a new row,
   # same as before.
+  # existing.delete, not a plain read -- a target with two occids in the
+  # same batch must not have both rows resolve the same marker. The
+  # first row to run claims it here; the second sees no marker left and
+  # creates a new row, not a duplicate resolve (#4819 multi-occid case).
   def resolve_or_create_export_link(target_type:, target_id:, external_id:,
                                     external_created_on:, existing:)
-    marker_id = existing[[target_id, nil]]
+    marker_id = existing.delete([target_id, nil])
     if marker_id
       resolve_export_link_marker(marker_id, target_type, external_id,
                                  external_created_on)

--- a/test/script/backfill_mycoportal_export_links_test.rb
+++ b/test/script/backfill_mycoportal_export_links_test.rb
@@ -128,6 +128,60 @@ class BackfillMycoportalExportLinksTest < UnitTestCase
            "linked record")
   end
 
+  # A pre-send marker (Report::MycoportalImageList#mark_exported!, no
+  # external_id yet) gets resolved in place -- not left behind while a
+  # second, id-bearing row is created alongside it.
+  def test_resolves_marker_link_for_image
+    image = images(:in_situ_image)
+    marker = make_link(image, external_id: nil)
+
+    subject = run_script([occurrence_row(1, "MUOB 1")],
+                         [multimedia_row(1, image_url(image.id))])
+
+    assert_equal("1", marker.reload.external_id)
+    assert_equal(
+      1, subject.instance_variable_get(:@stats)[:images][:marker_resolved]
+    )
+    assert_equal(
+      1,
+      ExternalLink.where(target: image, external_site: @site,
+                         relationship: :export).count,
+      "Resolving a marker should not leave a second row behind"
+    )
+  end
+
+  def test_dry_run_does_not_resolve_marker
+    image = images(:in_situ_image)
+    marker = make_link(image, external_id: nil)
+
+    run_script([occurrence_row(1, "MUOB 1")],
+               [multimedia_row(1, image_url(image.id))], apply: false)
+
+    assert_nil(marker.reload.external_id)
+  end
+
+  def test_marker_resolution_invalid_record_is_logged_and_skipped
+    image = images(:in_situ_image)
+    marker = make_link(image, external_id: nil)
+    stubbed_error = lambda do |*|
+      link = ExternalLink.new
+      link.errors.add(:base, :invalid)
+      raise(ActiveRecord::RecordInvalid.new(link))
+    end
+
+    subject = nil
+    marker.stub(:update!, stubbed_error) do
+      ExternalLink.stub(:find, marker) do
+        subject = run_script([occurrence_row(1, "MUOB 1")],
+                             [multimedia_row(1, image_url(image.id))])
+      end
+    end
+
+    assert_equal(
+      1, subject.instance_variable_get(:@stats)[:images][:invalid]
+    )
+  end
+
   # An MO image can legitimately be attached to more than one MCP
   # occurrence record (confirmed in real MCP data, #4819 follow-up) --
   # each occid it's seen under should get its own export link.
@@ -251,6 +305,27 @@ class BackfillMycoportalExportLinksTest < UnitTestCase
       ExternalLink.where(target: obs, external_site: @site,
                          relationship: :export).count,
       "Re-running should not create a duplicate export link"
+    )
+  end
+
+  def test_resolves_marker_link_for_observation
+    obs = observations(:coprinus_comatus_obs)
+    marker = ExternalLink.create!(user: User.admin, target: obs,
+                                  external_site: @site, relationship: :export,
+                                  external_id: nil)
+
+    subject = run_script([occurrence_row(500, "MUOB #{obs.id}")], [])
+
+    assert_equal("500", marker.reload.external_id)
+    assert_equal(
+      1,
+      subject.instance_variable_get(:@stats)[:observations][:marker_resolved]
+    )
+    assert_equal(
+      1,
+      ExternalLink.where(target: obs, external_site: @site,
+                         relationship: :export).count,
+      "Resolving a marker should not leave a second row behind"
     )
   end
 

--- a/test/script/backfill_mycoportal_export_links_test.rb
+++ b/test/script/backfill_mycoportal_export_links_test.rb
@@ -150,6 +150,31 @@ class BackfillMycoportalExportLinksTest < UnitTestCase
     )
   end
 
+  # A target with a marker and two distinct occids in the same batch:
+  # the first row must claim the marker, the second must create a new
+  # link rather than re-resolving the same marker a second time, which
+  # would silently drop one of the two correspondences.
+  def test_marker_and_second_occid_in_same_batch_both_resolve
+    image = images(:in_situ_image)
+    marker = make_link(image, external_id: nil)
+
+    subject = run_script([], [multimedia_row(101, image_url(image.id)),
+                              multimedia_row(102, image_url(image.id))])
+
+    assert_equal(
+      1, subject.instance_variable_get(:@stats)[:images][:marker_resolved]
+    )
+    assert_equal(
+      1, subject.instance_variable_get(:@stats)[:images][:created]
+    )
+    links = ExternalLink.where(target: image, external_site: @site,
+                               relationship: :export).order(:id)
+    assert_equal(%w[101 102], links.map(&:external_id))
+    assert_equal(marker.id, links.first.id,
+                 "The marker row should be the one resolved to the first " \
+                 "occid, not left behind")
+  end
+
   def test_dry_run_does_not_resolve_marker
     image = images(:in_situ_image)
     marker = make_link(image, external_id: nil)


### PR DESCRIPTION
`script/backfill_mycoportal_export_links.rb` was creating a second `ExternalLink` row when reconciling a MyCoPortal occid, instead of updating the blank `ExternalLink` that already existed for that target.

## The bug

`Report::MycoportalImageList#create_export_link` and `Report::Mycoportal#upsert_export_link` (#4926) both create an id-less `ExternalLink(relationship: :export)` marker before MyCoPortal has assigned an occid -- that's how MO tracks "already sent" ahead of the id being known.

This script's `existing_links` lookup is keyed on `[target_id, external_id]`. A marker's key is `[target_id, nil]`, which doesn't match `[target_id, occid]` once the id is discovered from a DwC-A dump -- so the script created a new row alongside the marker instead of resolving it, leaving the marker sitting with a nil id permanently. Every image or observation that goes through the export job followed by this backfill script ends up with two rows for the same correspondence. Not new to this branch -- the marker-creation pattern predates it.

## The fix

`resolve_or_create_export_link` checks for a `[target_id, nil]` marker first and updates it in place. A target with no marker -- already resolved under a different occid (the #4819 multi-occid case), or reconciled without going through the export job -- still gets a new row, unchanged.

## Test plan

- [x] New tests: marker resolved in place (image + observation), dry run doesn't touch the marker, invalid-record rescue path.
- [x] Verified in the console against fixture data: marker resolves in place (row count stays 1), no-marker path still creates, multi-occid path still adds a second row.
- [x] `bundle exec rubocop` -- no offenses (`Metrics/ClassLength` disabled for this class, pre-existing nested `Options`/`ReportWriter`/`Stopwatch` structure).

<!-- changelog -->
article: no
<!-- /changelog -->
