### PR TITLE
Undefined Locations - add whitespace between the merge link icon and text

### DIFF
--- a/app/views/controllers/locations/index.rb
+++ b/app/views/controllers/locations/index.rb
@@ -100,7 +100,8 @@ module Views::Controllers::Locations
       location_name = obs[:where]
       list.item do
         Link(type: :location, where: location_name, count: count)
-        Link(type: :get,
+        whitespace
+        Link(type: :get, class: "icon-text-gap",
              name: :list_place_names_merge.l,
              target: matching_locations_for_observations_path(
                where: location_name


### PR DESCRIPTION
Adds whitespace between the merge-names link's icon and its text, in the observations/locations index rows.

## Test plan

- [x] Visual check: the merge-names link's icon and text no longer sit flush against each other.

<!-- changelog -->
article: no
<!-- /changelog -->
