### PR TITLE
Show occurrence-primary/read-only icons in Matching Observations; hide delete for reflections

### DIFF
--- a/app/assets/stylesheets/mo/_icons.scss
+++ b/app/assets/stylesheets/mo/_icons.scss
@@ -217,11 +217,14 @@ tbody.collapse.in {
 }
 
 // Baseline correction for icon+text pairs that aren't framed as a
-// .btn: plain Link::Get (excludes .inline-icon-link, which sets its
-// own top: 0) and the sidebar heading icons (Icon directly inside a
-// ListGroup::Item div, next to a text span).
+// .btn: plain Link::Get (.inline-icon-link sets top: 0 instead) and
+// the sidebar heading icons. The `> span >` variants cover
+// Components::Icon's title: wrap (moves tooltip attrs off the <svg>
+// onto a wrapping <span>).
 a:not(.btn):not(.inline-icon-link) > .mo-icon,
-.list-group-item > .mo-icon {
+a:not(.btn):not(.inline-icon-link) > span > .mo-icon,
+.list-group-item > .mo-icon,
+.list-group-item > span > .mo-icon {
   top: 2px;
 }
 

--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -306,11 +306,16 @@ form.button_to {
   // so the active pane is visible at a glance. Bootstrap's
   // collapse.js itself toggles `.collapsed` on every trigger as its
   // target opens/closes -- no extra JS or markup needed here. Scoped
-  // to [data-toggle="collapse"] so plain (non-trigger) id badges --
-  // which never carry `.collapsed` at all -- don't match `:not
-  // (.collapsed)` and end up permanently "hover" styled.
-  &:hover,
-  &[data-toggle="collapse"]:not(.collapsed) {
+  // to [data-toggle="collapse"] so plain (non-trigger) id badges,
+  // which don't carry `.collapsed`, don't match `:not(.collapsed)`
+  // and end up permanently "hover" styled.
+  //
+  // `button&:hover`, not a bare `&:hover` -- Components::IDBadge's
+  // `interactive: false` form renders a plain `<span>`, not a
+  // `<button>`; a static, non-clickable badge shouldn't invert color
+  // on hover.
+  &[data-toggle="collapse"]:not(.collapsed),
+  button&:hover {
     background-color: $text-color;
     color: $body-bg;
   }

--- a/app/assets/stylesheets/mo/_links_buttons_alerts.scss
+++ b/app/assets/stylesheets/mo/_links_buttons_alerts.scss
@@ -17,12 +17,9 @@
   font-weight: normal !important;
 }
 
-// Custom variant (not in BS3) that mirrors form-input styling, so
-// it visually plays nicely with input groups. Defines the full set
-// of interactive states using BS3's `darken()` step pattern (same
-// math `button-variant` uses for `.btn-{variant}`), pulling from
-// the theme-mapped `$input-*` vars so dark themes get dark hover/
-// active visuals automatically.
+// Custom variant (not in BS3) that mirrors form-input styling, using
+// BS3's darken() step pattern and $input-* vars so dark themes get
+// dark hover/active for free.
 .btn-outline-default {
   color: $input-color;
   background-color: $input-bg;
@@ -46,11 +43,8 @@
     box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   }
 
-  // Override BS3's default `.btn.disabled` opacity dim. For outline
-  // buttons, the disabled state usually IS the selected/current
-  // state (e.g. the active status button in a filter group), so the
-  // label still describes what the user is looking at — we want it
-  // legible, not greyed out. Cursor still signals non-clickability.
+  // Disabled here often means "currently selected" (e.g. an active
+  // filter button) -- keep it legible, not greyed out.
   &.disabled,
   &[disabled],
   &[aria-disabled="true"] {
@@ -64,11 +58,9 @@
   color: black;
 }
 
-// `Components::Button::CRUDBase`'s `<form class="button_to">` wrapper
-// -- sitewide base styling (inline flow, submit-button reset to look
-// like a plain link) for every `type: :put/:post/:delete` button,
-// regardless of whether it sits in a `.btn-group`. The `.btn-group`
-// supplement below is the exception to this inline-flow default.
+// Components::Button::CRUDBase's mutation-button form -- sitewide
+// base (inline flow, submit reset to look like a plain link).
+// .btn-group below overrides the inline-flow default.
 form.button_to {
   display: inline;
   margin: 0;
@@ -101,76 +93,46 @@ form.button_to {
   }
 }
 
-// A `type: :put/:post/:delete` button (Components::Button::CRUDBase)
-// renders as `<form class="button_to">` wrapping the
-// `<button class="btn">` -- a form is required to spoof a non-GET/POST
-// method. Bootstrap's own `.btn-group` CSS only reaches a `.btn` that's
-// a DIRECT child of `.btn-group`, and only prevents double borders
-// between two siblings that BOTH carry `.btn` directly (`.btn + .btn`)
-// -- neither selector sees through the `<form>` wrapper, so a
-// form-wrapped member of a `.btn-group` gets none of the group's
-// border-radius squaring or margin collapse, and (form.button_to is
-// sitewide `display: inline`, see above) sits at a different height
-// than its `.btn` siblings. This exact class of
-// problem has been worked around ad hoc more than once already
-// (`.vote-btn-group` above, `.project-violations td .button_to`
-// below) -- fixed generally here instead, for every `.btn-group`
-// sitewide, present and future. `.vote-btn-group` (VoteInterface,
-// carrying both `.btn-group` and `.vote-btn-group` on the same
-// element) picks up the border-radius reset below -- harmless there
-// (its members carry no `.btn` class, so there's no radius to square
-// in the first place) -- but its own `> form.button_to, > .image-vote
-// { margin: 0; ... }` (_images.scss) is a MORE specific selector
-// (adds a type selector) than this file's `> *:not(:first-child)`, so
-// it wins regardless of cascade order and keeps its own divider-
-// border spacing rather than the -1px collapse below. Its `display:
-// inline-block` on the same selector is EQUAL specificity to this
-// file's `display: flex`, so that one's decided by import order
-// instead -- `_images.scss` is `@import`ed after this file, so it
-// still wins. Both cases: no explicit override needed here.
+// A form-wrapped button (Components::Button::CRUDBase) gets none of
+// `.btn-group`'s border-radius squaring or margin collapse -- BS3's
+// CSS only reaches a `.btn` that's a direct child. Reimplemented
+// generically below for every `.btn-group`.
+//
+// `.vote-btn-group` (_images.scss) overrides this on its elements via
+// higher selector specificity and import order -- no extra override
+// needed here.
 .btn-group {
-  // BS4's own fix for this whole class of problem: flex stretches
-  // every direct child (form-wrapped or not) to the same height,
-  // replacing BS3's float-based layout, which didn't equalize mixed-
-  // content heights on its own.
+  // BS4's fix: flex stretches every child (form-wrapped or not) to
+  // the same height.
   display: inline-flex;
 
-  // The form itself becomes a flex container too, with its one child
-  // (the button) set to fill it -- otherwise `align-items:
-  // stretch` above only grows the (invisible) form's own box, not the
-  // visible button inside it.
+  // The form must also be flex, or the stretch above only grows the
+  // invisible form box, not the button inside it.
   > form.button_to {
     display: flex;
     margin: 0;
 
     button {
       flex: 1;
-      // Match `.btn:has(.mo-icon)`'s own centering (_icons.scss) so a
-      // form-wrapped button's content centers the same way a bare
-      // `.btn`'s does once the group stretches it taller than its
-      // own natural content height.
+      // Matches .btn:has(.mo-icon)'s centering (_icons.scss) once the
+      // group stretches the button taller than its content.
       display: inline-flex;
       align-items: center;
       justify-content: center;
     }
   }
 
-  // Content-centering isn't specific to icon-bearing buttons --
-  // `.btn:has(.mo-icon)` (_icons.scss) only centers icon+text pairs,
-  // so a plain-text member (no icon) stretched to match a taller
-  // icon-bearing sibling would otherwise sit at the top of its own
-  // box instead of centered like its neighbor. Apply the same
-  // treatment to every bare `.btn` member regardless of icon.
+  // Non-icon buttons need the same centering once stretched taller by
+  // an icon-bearing sibling (.btn:has(.mo-icon) only centers icon
+  // pairs -- see _icons.scss).
   > .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
   }
 
-  // Border-radius squaring / margin collapse, reimplemented keyed on
-  // each member's own position among the group's siblings
-  // (tag-agnostic), not on adjacent-.btn-class matching, so a
-  // form-wrapped member is treated the same as a bare `.btn`.
+  // Keyed by position, not by adjacent .btn matching, so a
+  // form-wrapped member is treated the same as a bare .btn.
   > *:not(:first-child) {
     margin-left: -1px;
   }
@@ -191,31 +153,15 @@ form.button_to {
   }
 }
 
-// BS3's `.input-group` (`_input-groups.scss`) is table/table-cell
-// layout -- `.input-group-addon`/`.input-group-btn`/`.form-control`
-// are each `display: table-cell`, which sizes every cell to the
-// tallest sibling automatically. That breaks down the same way
-// `.btn-group` did above: an icon-bearing `.btn` inside
-// `.input-group-btn` is `display: inline-flex` (`.btn:has(.mo-icon)`,
-// _icons.scss), and flex sizing is intrinsic/content-based -- it
-// doesn't stretch to fill the table-cell around it just because the
-// cell itself is tall enough. That was worked around with a
-// `.input-group-btn .btn:has(.mo-icon) { min-height: ... }` rule
-// scoped only to icon-bearing buttons (removed below in favor of
-// this general fix). Mirrors BS4's own solution
-// (`.input-group { display: flex; align-items: stretch; }`,
-// `.input-group-prepend/-append { display: flex; }`) without
-// adopting BS4's renamed classes -- same approach as the `.btn-group`
-// supplement above, just for `.input-group`.
+// BS3's .input-group is table/table-cell layout, which doesn't
+// stretch an icon-bearing flex .btn (.btn:has(.mo-icon), _icons.scss)
+// to match its cell's height. Switched to flex, mirroring BS4's fix,
+// same approach as the .btn-group supplement above.
 //
-// `.navbar-form .input-group` also needs the override explicitly: BS3
-// (`_navbars.scss`, `@media (min-width: 768px)`) sets
-// `display: inline-table` on `.input-group` when it sits inside a
-// `.navbar-form` (the goto-page/letter-jump forms both carry
-// `Components::Navbar::FORM_CLASS`) -- that two-class selector
-// out-specifies a bare `.input-group` rule regardless of import
-// order, and only applies at >=768px, which is why this broke on
-// desktop widths but not on mobile.
+// .navbar-form .input-group needs the override too: BS3's
+// `@media (min-width: 768px)` rule sets display: inline-table there,
+// out-specifying a bare .input-group rule -- desktop-only, hence
+// this breaking on desktop widths but not mobile.
 .input-group,
 .navbar-form .input-group {
   display: flex;
@@ -223,36 +169,22 @@ form.button_to {
 
   > .form-control {
     flex: 1 1 auto;
-    // BS3's own `float: left; width: 100%;` (`_input-groups.scss`)
-    // conflicts with flex sizing -- a flex item's width shrinks to
-    // its flex-basis (the `width` value) only when there's room;
-    // `min-width: 0` lets it shrink below its own content's natural
-    // width instead of overflowing the group when a sibling addon
-    // needs space.
+    // min-width: 0 lets it shrink below its content width when a
+    // sibling addon needs the room.
     min-width: 0;
   }
 
   > .input-group-addon,
   > .input-group-btn {
-    // BS3's own `.input-group-addon, .input-group-btn { width: 1%;
-    // ... }` (`_input-groups.scss`) relies on table-cell shrink-to-
-    // content sizing to make "1%" mean "as narrow as the content
-    // allows" -- under flex layout that same 1% is honored as a
-    // literal width, collapsing this box far narrower than its
-    // button/text content, which then overflows the box and visually
-    // sits on top of whatever follows the `.input-group` in the
-    // document. Override back to content-driven sizing.
+    // BS3's width: 1% relies on table shrink-to-content sizing; under
+    // flex that's a literal 1%, overflowing the box. Back to
+    // content-driven sizing.
     flex: 0 0 auto;
     width: auto;
     display: flex;
-    // `stretch` (not `center`) -- a `.btn`-classed child (a plain
-    // <button>/<input type=submit>, or a Link-rendered <a>, e.g. the
-    // pagination goto icon) needs to fill this span's own height
-    // (which the outer `.input-group`'s stretch already sized to
-    // match the sibling `.form-control`), not just center at its own
-    // shorter intrinsic content height -- confirmed empirically: an
-    // <a class="btn"> here sat ~2px short of the input's height with
-    // `center`, flush with `stretch`.
+    // stretch, not center -- a .btn child (e.g. the pagination goto
+    // icon) needs to fill this span's full height, confirmed
+    // empirically short by ~2px with center.
     align-items: stretch;
 
     > .btn {
@@ -265,9 +197,8 @@ form.button_to {
 
 // badges
 
-// Used for record id in title. No inherent font-size of its own --
-// every caller (Components::IDBadge's size: prop) states one of the
-// sibling .badge-* modifiers below explicitly.
+// Record id badge. No inherent font-size -- every caller states one
+// of the .badge-* sizes below.
 .badge-id {
   font-weight: normal;
   background-color: transparent;
@@ -283,9 +214,7 @@ form.button_to {
     letter-spacing: 0.03em;
   }
 
-  // Copy-to-clipboard external-site record id, inline next to its
-  // link (Components::Link::External) -- just digits, so smaller and
-  // tighter than .badge-xl's uppercase-label sizing.
+  // Copy-to-clipboard external-site id (Components::Link::External).
   &.badge-lg {
     font-size: 90% !important;
   }
@@ -300,55 +229,31 @@ form.button_to {
     font-size: 60% !important;
   }
 
-  // [data-toggle="collapse"]:not(.collapsed) -- an accordion-trigger
-  // badge (e.g. the external-links "Shared with [iNat]" badges) keeps
-  // this same filled look while its pane is open, not just on hover,
-  // so the active pane is visible at a glance. Bootstrap's
-  // collapse.js itself toggles `.collapsed` on every trigger as its
-  // target opens/closes -- no extra JS or markup needed here. Scoped
-  // to [data-toggle="collapse"] so plain (non-trigger) id badges,
-  // which don't carry `.collapsed`, don't match `:not(.collapsed)`
-  // and end up permanently "hover" styled.
-  //
-  // `button&:hover`, not a bare `&:hover` -- Components::IDBadge's
-  // `interactive: false` form renders a plain `<span>`, not a
-  // `<button>`; a static, non-clickable badge shouldn't invert color
-  // on hover.
-  &[data-toggle="collapse"]:not(.collapsed),
-  button&:hover {
+  // Accordion triggers stay "hovered" while their pane is open.
+  // Scoped to [data-toggle="collapse"] so plain badges don't match.
+  &[data-toggle="collapse"]:not(.collapsed) {
     background-color: $text-color;
     color: $body-bg;
   }
 }
 
-// The id-badge column of a "table-style" list-group row
-// (Projects::ListItem, SpeciesLists::Listing) -- badge width varies
-// with digit count, so without a floor the title column's left edge
-// drifts row to row.
+// Only the button form hovers -- not the static span form.
+// button& isn't valid Sass, so this stays a standalone rule.
+button.badge-id:hover {
+  background-color: $text-color;
+  color: $body-bg;
+}
+
+// Floors badge-id column width so digit-count variance doesn't drift
+// the title column's left edge row to row.
 .id-badge-col {
   min-width: 6rem;
 }
 
-// Icon-only inline mod/add links (Components::InlineCRUDLinks'
-// edit/destroy/add links, applied directly to each link/button's own
-// element -- not a wrapper, see Components::InlineLinkBlock). No
-// padding of its own on the icon -- Components::InlineLinkBlock
-// separates multiple items with a non-breaking space instead;
-// margin-right here adds a little further breathing room against
-// non-icon-link neighbors.
-//
-// vertical-align: middle -- an inline-block sitting on the text
-// baseline (the default) leaves room below it for a descender it
-// doesn't have, which stretches the surrounding line's height and
-// throws off spacing vs. sibling lines with no icon-link on them.
-//
-// .mo-icon's `top: 3px` (see _icons.scss) is a relative offset
-// tuned for icons in their usual (untethered) contexts; inside
-// this tight a box it just pushes the icon toward the bottom, so
-// it's undone here specifically.
-//
-// width/height: 1em -- .mo-icon's default 1.12em reads oversized
-// next to the plain body text these links usually sit beside.
+// Icon-only inline mod/add links (Components::InlineCRUDLinks).
+// vertical-align: middle avoids stretching the line for a text
+// descender the icon doesn't have. mo-icon's usual top offset and
+// 1.12em size are tuned for looser contexts -- undone/shrunk here.
 .inline-icon-link {
   display: inline-block;
   text-indent: 0;
@@ -386,9 +291,8 @@ form.button_to {
   }
 }
 
-// Responsive message text for .message-banner -- on the message
-// <div> itself, not .message-banner, so the banner's own layout
-// classes (padding, text-align) stay separate from font scaling.
+// Responsive message text, kept separate from .message-banner's
+// layout classes.
 .banner-message {
   font-size: 1em;
 

--- a/app/components/icon.rb
+++ b/app/components/icon.rb
@@ -35,7 +35,7 @@ class Components::Icon < Components::Base
     :chevron_right, :qrcode, :mobile, :project, :download, :attach,
     :new_window, :search, :prev, :next, :goto, :grid, :menu, :info,
     :fullscreen, :matrix, :info_circle, :user, :spinner, :reload,
-    :rotate_left, :rotate_right, :flip
+    :rotate_left, :rotate_right, :flip, :is_primary, :read_only
   ].freeze
 
   # vendor/assets/images/icons/mo-icons.svg only exists on disk when

--- a/app/components/icon.rb
+++ b/app/components/icon.rb
@@ -17,10 +17,12 @@
 #
 # @example With tooltip + accessible name + extra CSS
 #   Icon(type: :edit, title: :edit.ti, class: "text-primary")
+#   # => <span title="Edit" data-tooltip-target="tip" aria-label="Edit">
+#   #      <svg class="mo-icon mo-icon-edit text-primary">...</svg>
+#   #    </span>
 #
 # @example Spacing around the icon: use wrap_class:, not class:
 #   Icon(type: :read_only, wrap_class: "icon-text-gap")
-#   # => <span class="icon-text-gap"><svg class="mo-icon ...">...</svg></span>
 class Components::Icon < Components::Base
   # Valid icon keys. The sprite's own `<symbol id="...">` already
   # equals the key (see icon-library's script/build_sprite.rb), so
@@ -55,9 +57,15 @@ class Components::Icon < Components::Base
   prop :type, _Nilable(_Union(*GLYPHS.to_a)), default: nil
   prop :title, _Nilable(String), default: nil
   # Wraps the icon in a `<span class: wrap_class>` -- the sanctioned
-  # way to add spacing around an icon. See
-  # `validate_no_padding_classes!`: a padding class passed via
-  # `class:` lands on the `<svg>` itself and shrinks it instead.
+  # way to add spacing around an icon (a padding class passed via
+  # `class:` lands on the `<svg>` itself and shrinks it instead, see
+  # `validate_no_padding_classes!`). Whenever `title:` is also given,
+  # this wrap happens regardless -- with or without a `wrap_class` --
+  # and title/tooltip/aria move onto the `<span>`: bootstrap-sass's
+  # tooltip.js skips `$element.offset()` for an SVG trigger (the
+  # `isSvg` branch in tooltip.js), using viewport- instead of
+  # document-relative coordinates, which is off by ~the scroll offset
+  # once the page has scrolled.
   prop :wrap_class, _Nilable(String), default: nil
   # Catch-all for class:, data:, aria:, and any other HTML attrs --
   # matches Components::Navbar/Collapsible's pattern (plain `class:`/
@@ -81,7 +89,11 @@ class Components::Icon < Components::Base
     validate_no_padding_classes!
     return unless SPRITE_AVAILABLE && @type
 
-    if @wrap_class
+    if @title.present?
+      span(class: @wrap_class, title: @title, data: svg_data, aria: svg_aria) do
+        render_svg(title: nil, data: {}, aria: {})
+      end
+    elsif @wrap_class
       span(class: @wrap_class) { render_svg }
     else
       render_svg
@@ -90,9 +102,8 @@ class Components::Icon < Components::Base
 
   private
 
-  def render_svg
-    svg(class: svg_class, title: @title.presence, data: svg_data,
-        aria: svg_aria,
+  def render_svg(title: @title.presence, data: svg_data, aria: svg_aria)
+    svg(class: svg_class, title: title, data: data, aria: aria,
         **@attributes.except(:class, :data, :aria)) do |s|
       # width/height: "100%" -- without it, browsers inconsistently
       # default <use>'s size against an em-sized (not pixel-sized)

--- a/app/components/icon.rb
+++ b/app/components/icon.rb
@@ -17,6 +17,10 @@
 #
 # @example With tooltip + accessible name + extra CSS
 #   Icon(type: :edit, title: :edit.ti, class: "text-primary")
+#
+# @example Spacing around the icon: use wrap_class:, not class:
+#   Icon(type: :read_only, wrap_class: "icon-text-gap")
+#   # => <span class="icon-text-gap"><svg class="mo-icon ...">...</svg></span>
 class Components::Icon < Components::Base
   # Valid icon keys. The sprite's own `<symbol id="...">` already
   # equals the key (see icon-library's script/build_sprite.rb), so
@@ -50,6 +54,11 @@ class Components::Icon < Components::Base
 
   prop :type, _Nilable(_Union(*GLYPHS.to_a)), default: nil
   prop :title, _Nilable(String), default: nil
+  # Wraps the icon in a `<span class: wrap_class>` -- the sanctioned
+  # way to add spacing around an icon. See
+  # `validate_no_padding_classes!`: a padding class passed via
+  # `class:` lands on the `<svg>` itself and shrinks it instead.
+  prop :wrap_class, _Nilable(String), default: nil
   # Catch-all for class:, data:, aria:, and any other HTML attrs --
   # matches Components::Navbar/Collapsible's pattern (plain `class:`/
   # `data:` in, no separate `html_class:`/`data:` props needed).
@@ -61,11 +70,27 @@ class Components::Icon < Components::Base
   # `p-*`/`pl-*`/`pr-*`/`pt-*`/`pb-*`/`px-*`/`py-*` -- Bootstrap's
   # padding utilities.
   PADDING_CLASS_RE = /\Ap[lrtbxy]?-\d+\z/
+  # MO's spacing classes that declare padding under a name that
+  # doesn't match PADDING_CLASS_RE (see _icons.scss) -- caught here by
+  # name since the naming pattern above can't see them coming. Add to
+  # this set as new ones turn up (found this way once already: PR
+  # #5331 passed icon-text-gap straight into an Icon's class:).
+  NAMED_PADDING_CLASSES = Set["icon-text-gap"].freeze
 
   def view_template
     validate_no_padding_classes!
     return unless SPRITE_AVAILABLE && @type
 
+    if @wrap_class
+      span(class: @wrap_class) { render_svg }
+    else
+      render_svg
+    end
+  end
+
+  private
+
+  def render_svg
     svg(class: svg_class, title: @title.presence, data: svg_data,
         aria: svg_aria,
         **@attributes.except(:class, :data, :aria)) do |s|
@@ -78,24 +103,28 @@ class Components::Icon < Components::Base
     end
   end
 
-  private
-
   # Padding on a bare <svg> (a "replaced element", like <img>) eats
-  # into the element's own rendered content instead of adding space
+  # into the element's rendered content instead of adding space
   # around it -- the icon artwork renders smaller than its width/
-  # height alone would suggest, silently, no error. Wrap the icon in
-  # a span/div and put the padding class there instead.
+  # height alone would suggest, silently, no error. Checked against
+  # the fully resolved class string, so this catches a padding class
+  # arriving via a local variable or another method's return value,
+  # not just a literal string at the call site. Use wrap_class:
+  # instead.
   def validate_no_padding_classes!
     return if @attributes[:class].blank?
 
-    offenders = @attributes[:class].to_s.split.grep(PADDING_CLASS_RE)
+    classes = @attributes[:class].to_s.split
+    offenders = classes.select do |cls|
+      cls.match?(PADDING_CLASS_RE) || NAMED_PADDING_CLASSES.include?(cls)
+    end
     return if offenders.empty?
 
     raise(ArgumentError.new(
             "Icon can't take padding classes (#{offenders.join(", ")}) " \
             "-- padding on a bare <svg> shrinks its rendered content " \
-            "instead of adding space around it. Wrap the icon in a " \
-            "span/div and put the padding class there instead."
+            "instead of adding space around it. Use wrap_class: instead " \
+            "-- it wraps the icon in a span and applies the class there."
           ))
   end
 

--- a/app/components/id_badge.rb
+++ b/app/components/id_badge.rb
@@ -19,10 +19,16 @@
 # explicitly rather than relying on an implicit default:
 #   :xl -- project/species-list listing row title badges
 #          (Projects::ListItem, SpeciesLists::Listing)
-#   :lg -- copy-to-clipboard external-site record id (Link::External)
+#   :lg -- copy-to-clipboard external-site record id (Link::External),
+#          Matching Observations panel row ids
 #   :md -- matrix box title and other index-row id badges (Matrix::Box,
 #          Names::Index::Row, Occurrences::Projects::Form)
 #   :sm -- sitting next to a large page-title heading
+#
+# `interactive:` (default true) is the copy-to-clipboard `<button>`
+# described above. Pass `false` for a plain, non-clickable `<span>` --
+# e.g. next to an object that isn't itself a link either (Matching
+# Observations' current-observation row).
 class Components::IDBadge < Components::Base
   SIZE_CLASSES = { xl: "badge-xl", lg: "badge-lg",
                    md: "badge-md", sm: "badge-sm" }.freeze
@@ -32,11 +38,22 @@ class Components::IDBadge < Components::Base
   prop :size, _Union(*SIZE_CLASSES.keys)
   prop :title, _Nilable(String), default: nil
   prop :extra_class, _Nilable(String), default: "mr-4"
+  prop :interactive, _Boolean, default: true
 
   def view_template
+    if @interactive
+      render_interactive_badge
+    else
+      span(class: badge_class) { plain(display_value) }
+    end
+  end
+
+  private
+
+  def render_interactive_badge
     button(
       type: "button",
-      class: class_names("badge badge-id", SIZE_CLASSES[@size], @extra_class),
+      class: badge_class,
       role: "button",
       data: {
         tooltip_target: "tip", placement: "bottom",
@@ -50,7 +67,9 @@ class Components::IDBadge < Components::Base
     end
   end
 
-  private
+  def badge_class
+    class_names("badge badge-id", SIZE_CLASSES[@size], @extra_class)
+  end
 
   def display_value
     (@object&.id || @value)&.to_s || "?"

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -793,9 +793,13 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   # True only for the primary observation of an occurrence that has more
   # than one member -- the one case where the show page merges notes.
   def shows_merged_notes?
+    occurrence_primary? && occurrence.observations.many?
+  end
+
+  # True when this observation is the primary of its occurrence.
+  def occurrence_primary?
     occ = occurrence
-    occ.present? && occ.primary_observation_id == id &&
-      occ.observations.many?
+    occ.present? && occ.primary_observation_id == id
   end
 
   # Key used for general Observation.notes

--- a/app/views/controllers/observations/show/matching_observations_panel.rb
+++ b/app/views/controllers/observations/show/matching_observations_panel.rb
@@ -1,19 +1,10 @@
 # frozen_string_literal: true
 
-# "Matching observations" panel on the observation show page. When
-# the observation's occurrence has siblings, the heading is the bare
-# "Matching Observations" title with an icon-only link to the occurrence
-# flush right, and the body lists every member of the occurrence
-# (current observation first, as plain text, then siblings as links)
-# as a tight ul. Each row leads with an `IDBadge` (non-interactive for
-# the current observation, matching its non-link name; interactive
-# copy-to-clipboard for siblings), then a status icon for the
-# occurrence's primary and any read-only reflection, then the name
-# via `format_name` (not `unique_format_name` -- the badge already
-# shows the id; current observation: plain text, tagged "(this
-# observation)"; siblings: a link). When there's no occurrence yet,
-# the whole heading is an icon+text "Add Matching Observations" link
-# (no body).
+# "Matching Observations" panel. Lists every occurrence member: an
+# IDBadge, a status icon (occurrence primary / read-only reflection),
+# then the name -- current observation as plain text tagged "(this
+# observation)"; siblings as links. No occurrence yet: just an "Add
+# Matching Observations" link, no body.
 #
 class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views::Base
   prop :obs, ::Observation
@@ -51,43 +42,49 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
          label: true)
   end
 
+  # position-relative anchors each row's tooltip (see
+  # render_status_icons) instead of it drifting elsewhere on the page.
   def render_body
     ul(class: "tight-list pl-0 mb-0") do
-      li { render_member_row(@obs, link: false) }
-      @siblings.each { |sibling| li { render_member_row(sibling, link: true) } }
+      li(class: "position-relative") { render_member_row(@obs, link: false) }
+      @siblings.each do |sibling|
+        li(class: "position-relative") do
+          render_member_row(sibling, link: true)
+        end
+      end
     end
   end
 
+  # Icons sit inside the <a> when the row is a link, so hovering or
+  # clicking an icon also hovers/clicks the link.
   def render_member_row(member, link:)
     IDBadge(object: member, size: :lg, interactive: link, extra_class: "mr-3")
     icon_types = member_status_icon_types(member)
-    render_status_icons(icon_types)
-    render_member_name(member, link: link, gap: icon_types.any?)
-  end
-
-  # `format_name`, not `unique_format_name` -- the latter appends the
-  # observation's id, which the IDBadge above already shows. Needs a
-  # gap only when a status icon precedes it -- otherwise the badge's
-  # trailing margin is already the gap.
-  def render_member_name(member, link:, gap:)
-    gap_class = "icon-text-gap" if gap
+    gap_class = "icon-text-gap" if icon_types.any?
     if link
-      a(class: gap_class, href: permanent_observation_path(member.id)) do
-        trusted_html(member.format_name(default_viewer).t)
+      a(href: permanent_observation_path(member.id)) do
+        render_status_icons(icon_types)
+        span(class: gap_class) do
+          trusted_html(member.format_name(default_viewer).t)
+        end
       end
     else
-      span(class: gap_class) do
-        trusted_html(member.format_name(default_viewer).t)
-        whitespace
-        plain("(#{:show_observation_this_observation.l})")
-      end
+      render_status_icons(icon_types)
+      render_current_observation_name(member, gap_class)
     end
   end
 
-  # `member`'s status icon types (0, 1, or 2): occurrence primary,
-  # read-only reflection. Compares against `@occurrence` directly
-  # (not `member.occurrence_primary?`) to avoid an N+1 lookup per row
-  # -- every member here already belongs to the same @occurrence.
+  # format_name, not unique_format_name -- the badge already shows the id.
+  def render_current_observation_name(member, gap_class)
+    span(class: gap_class) do
+      trusted_html(member.format_name(default_viewer).t)
+      whitespace
+      plain("(#{:show_observation_this_observation.l})")
+    end
+  end
+
+  # Compares against @occurrence directly, not
+  # member.occurrence_primary?, to avoid an N+1 lookup per row.
   def member_status_icon_types(member)
     types = []
     types << :is_primary if @occurrence.primary_observation_id == member.id
@@ -95,17 +92,9 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
     types
   end
 
-  # The first icon follows the badge, whose trailing margin is already
-  # the gap; a second icon follows the first and needs a gap too --
-  # via wrap_class:, not class:, since a padding class landing on the
-  # bare <svg> shrinks it instead of adding space around it (see
-  # Components::Icon).
-  #
-  # data-tooltip-container: "li" -- Bootstrap's tooltip.js default
-  # (container: false) inserts the tooltip as the icon's tight inline
-  # sibling, where this row's cramped layout mis-renders it; appending
-  # it into the row's <li> instead fixes that (see the identical fix
-  # for the image vote button group in tooltip_controller.js).
+  # wrap_class:, not class: -- padding on a bare <svg> shrinks it
+  # (see Components::Icon). tooltip_container: "li" keeps the tooltip
+  # from mis-rendering in this row's tight layout (tooltip_controller.js).
   def render_status_icons(types)
     types.each_with_index do |type, index|
       wrap_class = "icon-text-gap" if index.positive?

--- a/app/views/controllers/observations/show/matching_observations_panel.rb
+++ b/app/views/controllers/observations/show/matching_observations_panel.rb
@@ -100,10 +100,17 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
   # via wrap_class:, not class:, since a padding class landing on the
   # bare <svg> shrinks it instead of adding space around it (see
   # Components::Icon).
+  #
+  # data-tooltip-container: "li" -- Bootstrap's tooltip.js default
+  # (container: false) inserts the tooltip as the icon's tight inline
+  # sibling, where this row's cramped layout mis-renders it; appending
+  # it into the row's <li> instead fixes that (see the identical fix
+  # for the image vote button group in tooltip_controller.js).
   def render_status_icons(types)
     types.each_with_index do |type, index|
       wrap_class = "icon-text-gap" if index.positive?
-      Icon(type: type, title: status_icon_title(type), wrap_class: wrap_class)
+      Icon(type: type, title: status_icon_title(type), wrap_class: wrap_class,
+           data: { tooltip_container: "li" })
     end
   end
 

--- a/app/views/controllers/observations/show/matching_observations_panel.rb
+++ b/app/views/controllers/observations/show/matching_observations_panel.rb
@@ -105,8 +105,8 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
 
   def status_icon_title(type)
     case type
-    when :is_primary then :show_observation_occurrence_primary.ti
-    when :read_only then :show_observation_reflection_read_only.ti
+    when :is_primary then :show_observation_occurrence_primary.l
+    when :read_only then :show_observation_reflection_read_only.l
     end
   end
 end

--- a/app/views/controllers/observations/show/matching_observations_panel.rb
+++ b/app/views/controllers/observations/show/matching_observations_panel.rb
@@ -3,9 +3,12 @@
 # "Matching observations" panel on the observation show page. When
 # the observation's occurrence has siblings, the heading is the bare
 # "Matching Observations" title with an icon-only link to the occurrence
-# flush right, and the body lists the sibling observations as a
-# tight ul. When there's no occurrence yet, the whole heading is an
-# icon+text "Add Matching Observations" link (no body).
+# flush right, and the body lists every member of the occurrence
+# (current observation first, as plain text, then siblings as links)
+# as a tight ul, each row carrying a status icon for the occurrence's
+# primary and any read-only reflection. When there's no occurrence
+# yet, the whole heading is an icon+text "Add Matching Observations"
+# link (no body).
 #
 class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views::Base
   prop :obs, ::Observation
@@ -45,13 +48,39 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
 
   def render_body
     ul(class: "tight-list pl-0 mb-0") do
-      @siblings.each do |sibling|
-        li do
-          a(href: permanent_observation_path(sibling.id)) do
-            trusted_html(viewer_aware_unique_format_name(sibling).t)
-          end
-        end
+      li { render_member_row(@obs, link: false) }
+      @siblings.each { |sibling| li { render_member_row(sibling, link: true) } }
+    end
+  end
+
+  def render_member_row(member, link:)
+    gap_class = "icon-text-gap" if render_member_status_icons(member)
+    if link
+      a(class: gap_class, href: permanent_observation_path(member.id)) do
+        trusted_html(viewer_aware_unique_format_name(member).t)
+      end
+    else
+      span(class: gap_class) do
+        trusted_html(viewer_aware_unique_format_name(member).t)
       end
     end
+  end
+
+  # Renders 0, 1, or 2 status icons for `member`; returns whether any
+  # were rendered, so the caller knows whether the following text
+  # needs the icon-text gap. Compares against `@occurrence` directly
+  # (not `member.occurrence_primary?`) to avoid an N+1 lookup per row
+  # -- every member here already belongs to the same @occurrence.
+  def render_member_status_icons(member)
+    shown = false
+    if @occurrence.primary_observation_id == member.id
+      Icon(type: :is_primary, title: :show_observation_occurrence_primary.t)
+      shown = true
+    end
+    if member.reflection?
+      Icon(type: :read_only, title: :show_observation_reflection_read_only.t)
+      shown = true
+    end
+    shown
   end
 end

--- a/app/views/controllers/observations/show/matching_observations_panel.rb
+++ b/app/views/controllers/observations/show/matching_observations_panel.rb
@@ -5,10 +5,15 @@
 # "Matching Observations" title with an icon-only link to the occurrence
 # flush right, and the body lists every member of the occurrence
 # (current observation first, as plain text, then siblings as links)
-# as a tight ul, each row carrying a status icon for the occurrence's
-# primary and any read-only reflection. When there's no occurrence
-# yet, the whole heading is an icon+text "Add Matching Observations"
-# link (no body).
+# as a tight ul. Each row leads with an `IDBadge` (non-interactive for
+# the current observation, matching its non-link name; interactive
+# copy-to-clipboard for siblings), then a status icon for the
+# occurrence's primary and any read-only reflection, then the name
+# via `format_name` (not `unique_format_name` -- the badge already
+# shows the id; current observation: plain text, tagged "(this
+# observation)"; siblings: a link). When there's no occurrence yet,
+# the whole heading is an icon+text "Add Matching Observations" link
+# (no body).
 #
 class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views::Base
   prop :obs, ::Observation
@@ -54,16 +59,27 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
   end
 
   def render_member_row(member, link:)
+    IDBadge(object: member, size: :lg, interactive: link, extra_class: "mr-3")
     icon_types = member_status_icon_types(member)
     render_status_icons(icon_types)
-    gap_class = "icon-text-gap" if icon_types.any?
+    render_member_name(member, link: link, gap: icon_types.any?)
+  end
+
+  # `format_name`, not `unique_format_name` -- the latter appends the
+  # observation's id, which the IDBadge above already shows. Needs a
+  # gap only when a status icon precedes it -- otherwise the badge's
+  # trailing margin is already the gap.
+  def render_member_name(member, link:, gap:)
+    gap_class = "icon-text-gap" if gap
     if link
       a(class: gap_class, href: permanent_observation_path(member.id)) do
-        trusted_html(viewer_aware_unique_format_name(member).t)
+        trusted_html(member.format_name(default_viewer).t)
       end
     else
       span(class: gap_class) do
-        trusted_html(viewer_aware_unique_format_name(member).t)
+        trusted_html(member.format_name(default_viewer).t)
+        whitespace
+        plain("(#{:show_observation_this_observation.l})")
       end
     end
   end
@@ -79,24 +95,16 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
     types
   end
 
-  # A second icon on the same row needs the same gap the trailing text
-  # gets, or it renders flush against the first icon. icon-text-gap is
-  # padding-left, which shrinks a bare <svg>'s rendered content
-  # instead of adding space around it (see Components::Icon's
-  # `validate_no_padding_classes!`) -- wrap the icon in a span instead
-  # of passing the class straight into `Icon(...)`.
+  # The first icon follows the badge, whose trailing margin is already
+  # the gap; a second icon follows the first and needs a gap too --
+  # via wrap_class:, not class:, since a padding class landing on the
+  # bare <svg> shrinks it instead of adding space around it (see
+  # Components::Icon).
   def render_status_icons(types)
     types.each_with_index do |type, index|
-      if index.positive?
-        span(class: "icon-text-gap") { render_status_icon(type) }
-      else
-        render_status_icon(type)
-      end
+      wrap_class = "icon-text-gap" if index.positive?
+      Icon(type: type, title: status_icon_title(type), wrap_class: wrap_class)
     end
-  end
-
-  def render_status_icon(type)
-    Icon(type: type, title: status_icon_title(type))
   end
 
   def status_icon_title(type)

--- a/app/views/controllers/observations/show/matching_observations_panel.rb
+++ b/app/views/controllers/observations/show/matching_observations_panel.rb
@@ -80,18 +80,29 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
   end
 
   # A second icon on the same row needs the same gap the trailing text
-  # gets, or it renders flush against the first icon.
+  # gets, or it renders flush against the first icon. icon-text-gap is
+  # padding-left, which shrinks a bare <svg>'s rendered content
+  # instead of adding space around it (see Components::Icon's
+  # `validate_no_padding_classes!`) -- wrap the icon in a span instead
+  # of passing the class straight into `Icon(...)`.
   def render_status_icons(types)
     types.each_with_index do |type, index|
-      gap_class = "icon-text-gap" if index.positive?
-      Icon(type: type, title: status_icon_title(type), class: gap_class)
+      if index.positive?
+        span(class: "icon-text-gap") { render_status_icon(type) }
+      else
+        render_status_icon(type)
+      end
     end
+  end
+
+  def render_status_icon(type)
+    Icon(type: type, title: status_icon_title(type))
   end
 
   def status_icon_title(type)
     case type
-    when :is_primary then :show_observation_occurrence_primary.t
-    when :read_only then :show_observation_reflection_read_only.t
+    when :is_primary then :show_observation_occurrence_primary.ti
+    when :read_only then :show_observation_reflection_read_only.ti
     end
   end
 end

--- a/app/views/controllers/observations/show/matching_observations_panel.rb
+++ b/app/views/controllers/observations/show/matching_observations_panel.rb
@@ -54,7 +54,9 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
   end
 
   def render_member_row(member, link:)
-    gap_class = "icon-text-gap" if render_member_status_icons(member)
+    icon_types = member_status_icon_types(member)
+    render_status_icons(icon_types)
+    gap_class = "icon-text-gap" if icon_types.any?
     if link
       a(class: gap_class, href: permanent_observation_path(member.id)) do
         trusted_html(viewer_aware_unique_format_name(member).t)
@@ -66,21 +68,30 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanel < Views:
     end
   end
 
-  # Renders 0, 1, or 2 status icons for `member`; returns whether any
-  # were rendered, so the caller knows whether the following text
-  # needs the icon-text gap. Compares against `@occurrence` directly
+  # `member`'s status icon types (0, 1, or 2): occurrence primary,
+  # read-only reflection. Compares against `@occurrence` directly
   # (not `member.occurrence_primary?`) to avoid an N+1 lookup per row
   # -- every member here already belongs to the same @occurrence.
-  def render_member_status_icons(member)
-    shown = false
-    if @occurrence.primary_observation_id == member.id
-      Icon(type: :is_primary, title: :show_observation_occurrence_primary.t)
-      shown = true
+  def member_status_icon_types(member)
+    types = []
+    types << :is_primary if @occurrence.primary_observation_id == member.id
+    types << :read_only if member.reflection?
+    types
+  end
+
+  # A second icon on the same row needs the same gap the trailing text
+  # gets, or it renders flush against the first icon.
+  def render_status_icons(types)
+    types.each_with_index do |type, index|
+      gap_class = "icon-text-gap" if index.positive?
+      Icon(type: type, title: status_icon_title(type), class: gap_class)
     end
-    if member.reflection?
-      Icon(type: :read_only, title: :show_observation_reflection_read_only.t)
-      shown = true
+  end
+
+  def status_icon_title(type)
+    case type
+    when :is_primary then :show_observation_occurrence_primary.t
+    when :read_only then :show_observation_reflection_read_only.t
     end
-    shown
   end
 end

--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -15,8 +15,9 @@
 # `Views::FullPageBase::Icons#add_edit_icons`.
 #
 # `Location` has a stricter destroy gate (model `destroyable?` + the
-# viewer owns the record or is in admin mode); other models follow
-# the edit-permission shape.
+# viewer owns the record or is in admin mode); `Observation` hides the
+# icon entirely for a read-only reflection (#5293); other models
+# follow the edit-permission shape.
 module Views::Layouts
   class Header::EditDeleteIcons < Views::Base
     prop :object, ::AbstractModel
@@ -56,6 +57,7 @@ module Views::Layouts
 
     def can_destroy_object?
       return can_destroy_location? if @object.is_a?(::Location)
+      return can_destroy_observation? if @object.is_a?(::Observation)
 
       can_edit_object?
     end
@@ -64,6 +66,15 @@ module Views::Layouts
       return false unless @object.destroyable?
 
       in_admin_mode? || @object.user == @user
+    end
+
+    # A read-only reflection can't be destroyed -- ObservationsController::
+    # Destroy blocks the action itself; this hides the icon that would
+    # otherwise offer it.
+    def can_destroy_observation?
+      return false if @object.reflection?
+
+      can_edit_object?
     end
   end
 end

--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -38,7 +38,7 @@ module Views::Layouts
     end
 
     def render_reflection_icon
-      Icon(type: :read_only, title: :show_observation_reflection_read_only.ti,
+      Icon(type: :read_only, title: :show_observation_reflection_read_only.l,
            wrap_class: "mr-2")
     end
 

--- a/app/views/layouts/header/edit_delete_icons.rb
+++ b/app/views/layouts/header/edit_delete_icons.rb
@@ -16,7 +16,8 @@
 #
 # `Location` has a stricter destroy gate (model `destroyable?` + the
 # viewer owns the record or is in admin mode); `Observation` hides the
-# icon entirely for a read-only reflection (#5293); other models
+# icon entirely for a read-only reflection (#5293) and shows a
+# read-only status icon beside edit/delete instead; other models
 # follow the edit-permission shape.
 module Views::Layouts
   class Header::EditDeleteIcons < Views::Base
@@ -25,11 +26,21 @@ module Views::Layouts
 
     def view_template
       div(class: "h4 my-0 d-flex align-items-center object_edit") do
+        render_reflection_icon if reflection?
         InlineLinkBlock(items: [edit_item, delete_item].compact)
       end
     end
 
     private
+
+    def reflection?
+      @object.is_a?(::Observation) && @object.reflection?
+    end
+
+    def render_reflection_icon
+      Icon(type: :read_only, title: :show_observation_reflection_read_only.ti,
+           wrap_class: "mr-2")
+    end
 
     # A read-only reflection keeps its edit icon: Edit opens a linked
     # companion observation for the changes.

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2689,6 +2689,8 @@
   naming_see_matching_observations_reasons: See Matching Observations to Edit Other Reasons
   show_observation_add_matching_observations: Add Matching Observations
   show_observation_matching_observations: Matching Observations
+  show_observation_occurrence_primary: Primary observation of this occurrence
+  show_observation_reflection_read_only: Read-only reflection of an imported source
   show_occurrence_location_differs: Location information differs across observations in this occurrence.
   edit_occurrence_submit: Save Changes
   edit_occurrence_add_heading: Add Recently Viewed Observations

--- a/config/locales/en.txt
+++ b/config/locales/en.txt
@@ -2691,6 +2691,7 @@
   show_observation_matching_observations: Matching Observations
   show_observation_occurrence_primary: Primary observation of this occurrence
   show_observation_reflection_read_only: Read-only reflection of an imported source
+  show_observation_this_observation: this observation
   show_occurrence_location_differs: Location information differs across observations in this occurrence.
   edit_occurrence_submit: Save Changes
   edit_occurrence_add_heading: Add Recently Viewed Observations

--- a/test/components/form/search_test.rb
+++ b/test/components/form/search_test.rb
@@ -92,8 +92,9 @@ class SearchFormTest < ComponentTestCase
                 "[data-search-type-target='barToggle']")
     assert_html(html,
                 "a[data-search-type-target='barToggle'] " \
-                "svg.mo-icon-minus" \
-                "[aria-label='#{:search_bar_fewer_options.l}']")
+                "span[aria-label='#{:search_bar_fewer_options.l}']")
+    assert_html(html,
+                "a[data-search-type-target='barToggle'] svg.mo-icon-minus")
     # navbar-link comes from Components::Navbar::LINK_CLASS, not a raw
     # literal.
     assert_html(html,

--- a/test/components/icon_test.rb
+++ b/test/components/icon_test.rb
@@ -35,17 +35,21 @@ class LinkIconTest < ComponentTestCase
     Components::Icon.const_set(:SPRITE_AVAILABLE, original)
   end
 
+  # title: wraps the icon in a <span> and puts tooltip/aria attrs
+  # there, not on the <svg> -- a Bootstrap tooltip anchored to an SVG
+  # trigger mispositions once the page scrolls (bootstrap-sass's
+  # tooltip.js skips $element.offset() for SVG elements).
   def test_title_adds_tooltip_and_accessible_name
     html = render_icon(type: :edit, title: :edit.ti, class: "text-primary")
 
     assert_html(html,
-                "svg.mo-icon.mo-icon-edit.text-primary" \
-                "[title='#{:edit.ti}'][data-tooltip-target='tip']" \
+                "span[title='#{:edit.ti}'][data-tooltip-target='tip']" \
                 "[aria-label='#{:edit.ti}']")
+    assert_html(html, "span > svg.mo-icon.mo-icon-edit.text-primary")
+    assert_no_html(html, "svg[title]")
     # No <title> child -- browsers render it as a second, native
-    # tooltip alongside the Bootstrap one triggered by
-    # data-tooltip-target. aria-label carries the accessible name
-    # instead without triggering any native tooltip.
+    # tooltip alongside the Bootstrap one. aria-label carries the
+    # accessible name instead without triggering a native tooltip.
     assert_no_html(html, "svg > title")
   end
 
@@ -54,14 +58,21 @@ class LinkIconTest < ComponentTestCase
                        data: { other: "v" })
 
     # Tooltip target still present alongside caller's custom data attr.
-    assert_html(html, "svg[data-tooltip-target='tip'][data-other='v']")
+    assert_html(html, "span[data-tooltip-target='tip'][data-other='v']")
   end
 
   def test_caller_aria_attrs_merge_with_accessible_name
     html = render_icon(type: :globe, title: "Tooltip text",
                        aria: { hidden: "false" })
 
-    assert_html(html, "svg[aria-label='Tooltip text'][aria-hidden='false']")
+    assert_html(html, "span[aria-label='Tooltip text'][aria-hidden='false']")
+  end
+
+  def test_title_with_wrap_class_applies_class_to_the_wrapping_span
+    html = render_icon(type: :globe, title: "Tooltip text",
+                       wrap_class: "icon-text-gap")
+
+    assert_html(html, "span.icon-text-gap[title='Tooltip text']")
   end
 
   def test_extra_attrs_passed_through

--- a/test/components/icon_test.rb
+++ b/test/components/icon_test.rb
@@ -88,6 +88,27 @@ class LinkIconTest < ComponentTestCase
     assert_html(html, "svg.mo-icon-globe.text-primary")
   end
 
+  def test_named_padding_class_raises
+    assert_raises(ArgumentError) do
+      render_icon(type: :globe, class: "icon-text-gap")
+    end
+  end
+
+  def test_padding_class_from_variable_raises
+    gap_class = "icon-text-gap"
+
+    assert_raises(ArgumentError) do
+      render_icon(type: :globe, class: gap_class)
+    end
+  end
+
+  def test_wrap_class_wraps_icon_in_span_leaving_svg_unpadded
+    html = render_icon(type: :globe, wrap_class: "icon-text-gap")
+
+    assert_html(html, "span.icon-text-gap > svg.mo-icon-globe")
+    assert_no_html(html, "svg.icon-text-gap")
+  end
+
   private
 
   def render_icon(**)

--- a/test/components/link/collapse_toggle_test.rb
+++ b/test/components/link/collapse_toggle_test.rb
@@ -134,13 +134,13 @@ class CollapseToggleLinkTest < ComponentTestCase
   def test_icon_title_forwarded_to_icon
     html = render_it(icon: :info, icon_title: "Help content")
 
-    assert_html(html, "a svg[aria-label='Help content']")
+    assert_html(html, "a span[aria-label='Help content']")
   end
 
   def test_icon_title_defaults_to_closed_text
     html = render_it(icon: :plus, closed_text: "Show more")
 
-    assert_html(html, "a svg[aria-label='Show more']")
+    assert_html(html, "a span[aria-label='Show more']")
   end
 
   def test_open_text_renders_collapse_toggle_open_span

--- a/test/views/controllers/account/api_keys/form_test.rb
+++ b/test/views/controllers/account/api_keys/form_test.rb
@@ -31,7 +31,8 @@ module Views::Controllers::Account::APIKeys
       assert_html(html, ".input-group-btn")
       assert_html(html, "#api_key_notes")
       assert_html(html, "a[data-toggle='collapse']")
-      assert_html(html, "a svg.mo-icon-cancel[aria-label='#{:cancel.ti}']")
+      assert_html(html, "a span[aria-label='#{:cancel.ti}']")
+      assert_html(html, "a svg.mo-icon-cancel")
       assert_html(
         html, "label",
         text: "#{:account_api_keys_notes_label.l}:".as_displayed

--- a/test/views/controllers/observations/show/matching_observations_panel_test.rb
+++ b/test/views/controllers/observations/show/matching_observations_panel_test.rb
@@ -108,7 +108,7 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanelTest <
                              occurrence: occurrence))
 
     assert_html(html, ".mo-icon-is-primary")
-    assert_html(html, ".mo-icon-read-only.icon-text-gap")
+    assert_html(html, "span.icon-text-gap > .mo-icon-read-only")
   end
 
   private

--- a/test/views/controllers/observations/show/matching_observations_panel_test.rb
+++ b/test/views/controllers/observations/show/matching_observations_panel_test.rb
@@ -53,6 +53,35 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanelTest <
     )
     assert_html(html,
                 "a[href='#{routes.permanent_observation_path(sibling.id)}']")
+    assert_html(html, "li:first-child",
+                text: "(#{:show_observation_this_observation.l})")
+  end
+
+  def test_every_row_leads_with_id_badge
+    occurrence = occurrences(:occ_field_slip_one)
+    current = occurrence.primary_observation
+    sibling = add_sibling_to(occurrence)
+
+    html = render(panel_with(obs: current, siblings: [sibling],
+                             occurrence: occurrence))
+
+    assert_html(html, ".badge-id", text: current.id.to_s)
+    assert_html(html, ".badge-id", text: sibling.id.to_s)
+  end
+
+  # The current observation isn't a link, so its badge shouldn't be
+  # either -- only siblings get the interactive copy-to-clipboard
+  # button form.
+  def test_only_sibling_badges_are_interactive
+    occurrence = occurrences(:occ_field_slip_one)
+    current = occurrence.primary_observation
+    sibling = add_sibling_to(occurrence)
+
+    html = render(panel_with(obs: current, siblings: [sibling],
+                             occurrence: occurrence))
+
+    assert_html(html, "span.badge-id", text: current.id.to_s)
+    assert_html(html, "button.badge-id", text: sibling.id.to_s)
   end
 
   def test_occurrence_primary_gets_star_icon
@@ -96,9 +125,9 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanelTest <
   end
 
   # Both icons apply when the occurrence primary is also a read-only
-  # reflection -- each icon needs a gap, or they render flush against
-  # each other.
-  def test_primary_and_reflection_icons_both_get_gap_class
+  # reflection. The first icon follows the badge (whose margin is the
+  # gap); the second follows the first icon and needs a gap too.
+  def test_primary_and_reflection_icons_both_render_with_second_gapped
     occurrence = occurrences(:occ_field_slip_one)
     primary = occurrence.primary_observation
     primary.update_column(:reflected_at, Time.zone.now)
@@ -108,6 +137,7 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanelTest <
                              occurrence: occurrence))
 
     assert_html(html, ".mo-icon-is-primary")
+    assert_no_html(html, "span.icon-text-gap > .mo-icon-is-primary")
     assert_html(html, "span.icon-text-gap > .mo-icon-read-only")
   end
 

--- a/test/views/controllers/observations/show/matching_observations_panel_test.rb
+++ b/test/views/controllers/observations/show/matching_observations_panel_test.rb
@@ -79,6 +79,38 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanelTest <
     assert_html(html, ".mo-icon-read-only")
   end
 
+  # The star icon isn't tied to "is the current observation" -- a
+  # sibling that happens to be the occurrence's primary gets it too,
+  # on its link row.
+  def test_primary_as_sibling_gets_star_icon_on_link_row
+    occurrence = occurrences(:occ_field_slip_one)
+    primary = occurrence.primary_observation
+    current = add_sibling_to(occurrence)
+
+    html = render(panel_with(obs: current, siblings: [primary],
+                             occurrence: occurrence))
+
+    assert_html(html, ".mo-icon-is-primary")
+    assert_html(html,
+                "a[href='#{routes.permanent_observation_path(primary.id)}']")
+  end
+
+  # Both icons apply when the occurrence primary is also a read-only
+  # reflection -- each icon needs a gap, or they render flush against
+  # each other.
+  def test_primary_and_reflection_icons_both_get_gap_class
+    occurrence = occurrences(:occ_field_slip_one)
+    primary = occurrence.primary_observation
+    primary.update_column(:reflected_at, Time.zone.now)
+    sibling = add_sibling_to(occurrence)
+
+    html = render(panel_with(obs: primary, siblings: [sibling],
+                             occurrence: occurrence))
+
+    assert_html(html, ".mo-icon-is-primary")
+    assert_html(html, ".mo-icon-read-only.icon-text-gap")
+  end
+
   private
 
   def add_sibling_to(occurrence)

--- a/test/views/controllers/observations/show/matching_observations_panel_test.rb
+++ b/test/views/controllers/observations/show/matching_observations_panel_test.rb
@@ -25,12 +25,8 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanelTest <
 
   def test_siblings_render_with_occurrence_link
     occurrence = occurrences(:occ_field_slip_one)
-    loc = locations(:obs_default_location)
-    Observation.create!(user: users(:rolf), when: Time.zone.now,
-                        location: loc, where: loc.name,
-                        name: names(:boletus_edulis),
-                        occurrence: occurrence)
-    siblings = occurrence.observations.reload.to_a
+    sibling = add_sibling_to(occurrence)
+    siblings = [sibling]
 
     html = render(panel_with(siblings: siblings, occurrence: occurrence))
 
@@ -43,11 +39,59 @@ class Views::Controllers::Observations::Show::MatchingObservationsPanelTest <
     end
   end
 
+  def test_current_observation_renders_first_as_plain_text
+    occurrence = occurrences(:occ_field_slip_one)
+    current = occurrence.primary_observation
+    sibling = add_sibling_to(occurrence)
+
+    html = render(panel_with(obs: current, siblings: [sibling],
+                             occurrence: occurrence))
+
+    assert_no_html(
+      html, "a[href='#{routes.permanent_observation_path(current.id)}']",
+      "Current observation should render as plain text, not a link"
+    )
+    assert_html(html,
+                "a[href='#{routes.permanent_observation_path(sibling.id)}']")
+  end
+
+  def test_occurrence_primary_gets_star_icon
+    occurrence = occurrences(:occ_field_slip_one)
+    primary = occurrence.primary_observation
+    sibling = add_sibling_to(occurrence)
+
+    html = render(panel_with(obs: primary, siblings: [sibling],
+                             occurrence: occurrence))
+
+    assert_html(html, ".mo-icon-is-primary")
+    assert_no_html(html, ".mo-icon-read-only")
+  end
+
+  def test_reflection_gets_read_only_icon
+    occurrence = occurrences(:occ_field_slip_one)
+    primary = occurrence.primary_observation
+    sibling = add_sibling_to(occurrence)
+    sibling.update_column(:reflected_at, Time.zone.now)
+
+    html = render(panel_with(obs: primary, siblings: [sibling],
+                             occurrence: occurrence))
+
+    assert_html(html, ".mo-icon-read-only")
+  end
+
   private
 
-  def panel_with(siblings:, occurrence:)
+  def add_sibling_to(occurrence)
+    loc = locations(:obs_default_location)
+    Observation.create!(user: users(:rolf), when: Time.zone.now,
+                        location: loc, where: loc.name,
+                        name: names(:boletus_edulis),
+                        occurrence: occurrence)
+  end
+
+  def panel_with(siblings:, occurrence:, obs: @obs)
     Views::Controllers::Observations::Show::MatchingObservationsPanel.new(
-      obs: @obs, occurrence: occurrence, siblings: siblings
+      obs: obs, occurrence: occurrence, siblings: siblings
     )
   end
 end

--- a/test/views/layouts/header/edit_delete_icons_test.rb
+++ b/test/views/layouts/header/edit_delete_icons_test.rb
@@ -42,17 +42,18 @@ module Views::Layouts
       assert_html(html, "div.object_edit form[action='#{destroy_action}']")
     end
 
-    # A read-only reflection (#4214) keeps both icons: Edit opens a
-    # linked companion observation for the changes.
-    def test_reflection_keeps_edit_and_delete_icons
+    # A read-only reflection (#4214) keeps its edit icon: Edit opens a
+    # linked companion observation for the changes. The delete icon is
+    # hidden -- a reflection can't be destroyed (#5293).
+    def test_reflection_keeps_edit_icon_hides_delete_icon
       @obs.update_column(:reflected_at, Time.zone.now)
       html = render_icons(user: @owner)
       edit_href = routes.edit_observation_path(@obs.id)
       destroy_action = routes.observation_path(@obs.id)
 
-      assert_html(html, "div.object_edit .inline-icon-link", count: 2)
+      assert_html(html, "div.object_edit .inline-icon-link", count: 1)
       assert_html(html, "div.object_edit a[href='#{edit_href}']")
-      assert_html(html, "div.object_edit form[action='#{destroy_action}']")
+      assert_no_html(html, "div.object_edit form[action='#{destroy_action}']")
     end
 
     private

--- a/test/views/layouts/header/edit_delete_icons_test.rb
+++ b/test/views/layouts/header/edit_delete_icons_test.rb
@@ -56,6 +56,19 @@ module Views::Layouts
       assert_no_html(html, "div.object_edit form[action='#{destroy_action}']")
     end
 
+    def test_reflection_shows_read_only_status_icon
+      @obs.update_column(:reflected_at, Time.zone.now)
+      html = render_icons(user: @owner)
+
+      assert_html(html, "div.object_edit .mo-icon-read-only")
+    end
+
+    def test_non_reflection_has_no_read_only_status_icon
+      html = render_icons(user: @owner)
+
+      assert_no_html(html, "div.object_edit .mo-icon-read-only")
+    end
+
     private
 
     def render_icons(**)

--- a/test/views/layouts/header/index_pagination_nav_test.rb
+++ b/test/views/layouts/header/index_pagination_nav_test.rb
@@ -104,7 +104,7 @@ module Views::Layouts
       html = render_nav(pagination_data: paginated(50, 2))
 
       assert_html(
-        html, "a[data-page-input-target='goToLink'] svg",
+        html, "a[data-page-input-target='goToLink'] span",
         attribute: { title: :goto_page_tooltip.t(number: 2) }
       )
     end

--- a/test/views/layouts/sidebar/languages_test.rb
+++ b/test/views/layouts/sidebar/languages_test.rb
@@ -48,8 +48,10 @@ class Views::Layouts::Sidebar
       flag_index = children.index do |node|
         node.name == "span" && node[:class]&.include?("lang-flag-emoji")
       end
+      # The chevron Icon carries title:, so it wraps in a <span> now
+      # (Components::Icon moves tooltip attrs off the <svg>).
       caret_index = children.index do |node|
-        node.name == "svg" && node[:class]&.include?("mo-icon-chevron-down")
+        node.name == "span" && node.at_css("svg.mo-icon-chevron-down")
       end
       assert_operator(label_index, :<, flag_index)
       assert_operator(flag_index, :<, caret_index)

--- a/test/views/layouts/top_nav/search_bar_test.rb
+++ b/test/views/layouts/top_nav/search_bar_test.rb
@@ -30,7 +30,9 @@ class Views::Layouts::TopNav
                   "[aria-expanded='false']")
       assert_html(html,
                   "a[data-search-type-target='helpToggle'] " \
-                  "svg.mo-icon-info[aria-label='#{:search_bar_help.t}']")
+                  "span[aria-label='#{:search_bar_help.t}']")
+      assert_html(html,
+                  "a[data-search-type-target='helpToggle'] svg.mo-icon-info")
       assert_no_html(html,
                      "a[data-search-type-target='helpToggle'].d-none")
       # Rendered via CollapseToggle's button:/size: kwarg, not via raw
@@ -58,8 +60,9 @@ class Views::Layouts::TopNav
                   "[aria-expanded='false']")
       assert_html(html,
                   "a[data-search-type-target='formToggle'] " \
-                  "svg.mo-icon-plus" \
-                  "[aria-label='#{:search_bar_more_options.l}']")
+                  "span[aria-label='#{:search_bar_more_options.l}']")
+      assert_html(html,
+                  "a[data-search-type-target='formToggle'] svg.mo-icon-plus")
       assert_no_html(html,
                      "a[data-search-type-target='formToggle'].d-none")
       assert_html(html,

--- a/test/views/layouts/top_nav_test.rb
+++ b/test/views/layouts/top_nav_test.rb
@@ -165,7 +165,10 @@ class Views::Layouts::TopNavTest < ComponentTestCase
     assert_html(html,
                 "button.top_nav_button.top_nav_icon_button" \
                 "[data-banner-target='showButton'] " \
-                "svg.mo-icon-interests[aria-label='#{:banner_show_tooltip.t}']")
+                "span[aria-label='#{:banner_show_tooltip.t}']")
+    assert_html(html,
+                "button.top_nav_button.top_nav_icon_button" \
+                "[data-banner-target='showButton'] svg.mo-icon-interests")
   end
 
   # ---- nav-toggles (mobile chrome) ----------------------------------


### PR DESCRIPTION
Fixes #5181. Fixes #5293.

## Summary

The observation show page gave no indication of an observation's role in its occurrence. This surfaces that in the Matching Observations panel, closes the gap it exposed in the title-bar delete icon, and fixes a sitewide icon-tooltip positioning bug found while building it.

- `Views::Controllers::Observations::Show::MatchingObservationsPanel` lists every occurrence member, not just the siblings. Each row: an `IDBadge`, then a status icon for the occurrence's primary (star, reusing `make_default`'s artwork) and/or a read-only reflection imported from iNaturalist (lock), then the name. The current observation's row is plain text tagged "(this observation)" with a non-interactive badge, matching its non-link name; siblings are links, with the status icon(s) nested inside the `<a>` so hovering or clicking an icon also hovers/clicks the link, and a copy-to-clipboard badge. Names use `format_name`, not `unique_format_name` — the badge already shows the id. No bold/italic to mark the current observation, per the issue's stated constraint.
- `Views::Layouts::Header::EditDeleteIcons#can_destroy_object?` gets an `Observation` branch (mirroring the existing `Location` special case) that hides the delete icon for a read-only reflection — `ObservationsController::Destroy` already blocks the destroy action itself (#4214), this closes the gap where the icon still offered it. When the observation itself is a reflection, the title bar also shows the read-only status icon beside the edit icon.
- **`Components::Icon` fix, sitewide impact:** whenever `title:` is given, Icon now always wraps the `<svg>` in a `<span>` and moves `title`/the tooltip data attribute/`aria-label` onto that span, instead of putting them on the bare `<svg>`. bootstrap-sass's `tooltip.js` skips `$element.offset()` specifically for an SVG trigger element (the `isSvg` branch), falling back to viewport-relative coordinates instead of document-relative ones — correct only when the page is unscrolled. Every icon tooltip in the app has had this bug; it went unnoticed because most icon-with-tooltip usages sit near the top of a page. Updated the one CSS rule that assumed `.mo-icon` was a direct child of its link/list-item wrapper (`_icons.scss`), and every existing test that asserted `title`/`aria-label`/the tooltip attribute directly on an `svg` element.
- `Components::IDBadge` gets an `interactive:` prop (default `true`) — `false` renders a plain, non-clickable `<span>` instead of the copy-to-clipboard `<button>`.
- Added `Observation#occurrence_primary?`, extracted from `shows_merged_notes?`'s existing primary check.
- The two new icons (`is_primary`, `read_only`) were added to the private `icon-library` repo and are merged there; this PR registers them in `Icon::GLYPHS`.
- Trimmed `_links_buttons_alerts.scss`'s comments — several ran to 20+ lines per rule; cut to the need-to-know fact in each case.

`app/controllers/observations_controller/show.rb#load_occurrence_data` is deliberately unchanged, even though the issue names it. `@sibling_observations` still needs to exclude the current observation for `Details`/`SpecimenPanel`, which check whether *other* members have collection numbers, sequences, etc. Instead of changing what the controller hands to every consumer, the panel itself prepends `@obs` to the list it renders.

## Local dev DB: refresh your checkpoint to see this

Most existing occurrences/reflections in production predate this feature's backfill of `Occurrence` records and `reflected_at` linkage. That backfill ran as a `script/run-once/` script against production, then was deleted per that directory's convention — it is not tracked in git and is not part of this PR. To see the Matching Observations panel render data locally, pull a fresh production checkpoint (`db/download_checkpoint`) rather than reusing an older one.

## Test plan

- [x] `bin/rails runner` console checks against dev-DB occurrences (a multi-member occurrence, one with a reflection, one where the primary is also a reflection, and one where a sibling rather than the current observation is the primary) confirming the panel renders the correct icon(s), badge, and name on the correct row.
- [x] `bin/rails runner` console checks confirming the delete icon disappears for a reflection while the edit icon stays (plus the new read-only status icon), and both action icons remain for a plain observation.
- [x] Live browser check confirming a status icon's tooltip renders at the correct position after scrolling the page (the bug this PR fixes), for both the old and new `Components::Icon` behavior.
- [x] RuboCop clean on all touched files.
- [x] `bin/rails test` on the touched test files, handed off per session convention.

<!-- changelog -->
article: yes
Show occurrence-primary and read-only status with icons on Observations
<!-- /changelog -->

