### PR TITLE
Fix invisible carousel arrows: `text-shadow` doesn't render on an SVG icon

### DIFF
--- a/app/assets/stylesheets/mo/_carousel.scss
+++ b/app/assets/stylesheets/mo/_carousel.scss
@@ -104,10 +104,6 @@
     &:hover,
     &:focus {
       color: inherit;
-      // text-shadow doesn't render on an SVG (Icon's chevron, not a
-      // glyphicon font character) -- filter: drop-shadow() is the
-      // SVG-compatible equivalent.
-      filter: drop-shadow(3px 3px 3px rgba($black, 0.5));
     }
   }
 
@@ -117,9 +113,9 @@
     opacity: 1;
   }
 
-  // Bootstrap's base .carousel-control text-shadow (bootstrap-sass)
-  // is likewise inert on the SVG chevron -- without this, the icon
-  // can disappear against a light or vertical image's background.
+  // text-shadow (bootstrap-sass's default) doesn't render on an SVG.
+  // Keep constant on hover -- a filter change here would move the
+  // absolutely-positioned chevron below (new containing block).
   .mo-icon {
     filter: drop-shadow($carousel-text-shadow);
   }

--- a/app/assets/stylesheets/mo/_carousel.scss
+++ b/app/assets/stylesheets/mo/_carousel.scss
@@ -104,7 +104,10 @@
     &:hover,
     &:focus {
       color: inherit;
-      text-shadow: 3px 3px 3px rgba($black, 0.5);
+      // text-shadow doesn't render on an SVG (Icon's chevron, not a
+      // glyphicon font character) -- filter: drop-shadow() is the
+      // SVG-compatible equivalent.
+      filter: drop-shadow(3px 3px 3px rgba($black, 0.5));
     }
   }
 
@@ -114,7 +117,14 @@
     opacity: 1;
   }
 
-  // Replaces Bootstrap's own .glyphicon-chevron-left/-right centering,
+  // Bootstrap's base .carousel-control text-shadow (bootstrap-sass)
+  // is likewise inert on the SVG chevron -- without this, the icon
+  // can disappear against a light or vertical image's background.
+  .mo-icon {
+    filter: drop-shadow($carousel-text-shadow);
+  }
+
+  // Replaces Bootstrap's .glyphicon-chevron-left/-right centering,
   // which no longer matches now that Icon renders <svg class="mo-icon
   // mo-icon-chevron-left">.
   .mo-icon-chevron-left,


### PR DESCRIPTION
Fixes #5148.

## Summary

Carousel arrow icons could be invisible against a light or portrait image, worst on the Black on White theme.

`.carousel-control`'s chevron icons used to be a Bootstrap glyphicon font character, and both bootstrap-sass's base styling and MO's hover/focus override gave that character a `text-shadow` for contrast against the image behind it. Since the carousel controls switched to `Components::Icon`'s `<svg>` output, `text-shadow` has been silently inert — it only applies to rendered text/font glyphs, not SVG shapes — so the shadow disappeared from the icon while the CSS declarations themselves stayed in place with no visible effect.

`filter: drop-shadow(...)` is the SVG-compatible equivalent, so this replaces both `text-shadow` declarations with it: the base state (reusing the existing `$carousel-text-shadow` value) and the `.btn:hover`/`:focus` state.

## Test plan

- [x] Live browser check on `/obs/657155` (multi-image carousel) confirming `getComputedStyle` reports the `drop-shadow` filter on the chevron `<svg>`, and the arrows are visibly shadowed against the image.
- [ ] Visual check against a portrait image and the Black on White theme specifically, handed off to the user.

<!-- changelog -->
article: yes
Fix invisible carousel arrows on some images and themes
<!-- /changelog -->
