### PR TITLE
Changelog for `deploy-2026-09-08-12-00`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-09-08 (deploy-2026-09-08-12-00)
+
+- `external_id` becomes the identity for a resolved `ExternalLink`; drop `url` column ([PR5313](https://github.com/MushroomObserver/mushroom-observer/pull/5313), @nimmolo)
+- `backfill_mycoportal_export_links.rb`: update blank `ExternalLink` instead of duplicating ([PR5329](https://github.com/MushroomObserver/mushroom-observer/pull/5329), @nimmolo)
+- Undefined Locations - add whitespace between the merge link icon and text ([PR5330](https://github.com/MushroomObserver/mushroom-observer/pull/5330), @nimmolo)
+- Read-only info panel for reflection images on the Observation edit form ([PR5326](https://github.com/MushroomObserver/mushroom-observer/pull/5326), @mo-nathan)
+- Fix invisible carousel arrows: `text-shadow` doesn't render on an SVG icon ([PR5332](https://github.com/MushroomObserver/mushroom-observer/pull/5332), @nimmolo)
+
 ## 2026-09-07 (deploy-2026-09-07-12-00)
 
 - Remove `script/resolve_mycoportal_links.rb` from the repo ([PR5316](https://github.com/MushroomObserver/mushroom-observer/pull/5316), @nimmolo)

--- a/article_pending.textile
+++ b/article_pending.textile
@@ -1,3 +1,2 @@
-|{white-space:nowrap}. 2026-09-06 | Show a thumbnail for Observations whose photos were added later | "PR#5319":https://github.com/MushroomObserver/mushroom-observer/pull/5319, "PR#5320":https://github.com/MushroomObserver/mushroom-observer/pull/5320 |
-|{white-space:nowrap}. 2026-09-06 | Stop old links from switching your language | "PR#5318":https://github.com/MushroomObserver/mushroom-observer/pull/5318 |
-|{white-space:nowrap}. 2026-09-07 | Fix imported Observation location on records first entered by hand | "PR#5325":https://github.com/MushroomObserver/mushroom-observer/pull/5325 |
+|{white-space:nowrap}. 2026-09-08 | Show a read-only info panel for reflection photos on the Observation form | "PR#5326":https://github.com/MushroomObserver/mushroom-observer/pull/5326 |
+|{white-space:nowrap}. 2026-09-08 | Fix invisible carousel arrows on some images and themes | "PR#5332":https://github.com/MushroomObserver/mushroom-observer/pull/5332 |


### PR DESCRIPTION
Pre-deploy changelog for `deploy-2026-09-08-12-00` (issue #5155): the CHANGELOG.md section for every PR merged since `deploy-2026-09-07-12-00`, and `article_pending.textile` with the MO Article rows the deploy will publish. Merge this as the last PR before deploying; re-running `script/prerelease.rb --apply` refreshes it with any later merges.

## Expected MO Article lines

```
|{white-space:nowrap}. 2026-09-08 | Show a read-only info panel for reflection photos on the Observation form | "PR#5326":https://github.com/MushroomObserver/mushroom-observer/pull/5326 |
|{white-space:nowrap}. 2026-09-08 | Fix invisible carousel arrows on some images and themes | "PR#5332":https://github.com/MushroomObserver/mushroom-observer/pull/5332 |
```
(3 PR(s) marked `article: no`.) Edits to `article_pending.textile` in this PR are what the deploy publishes.

<!-- changelog -->
article: no
<!-- /changelog -->
