### PR TITLE
Enable Rails 7.2 framework defaults

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -13,11 +13,13 @@
 
 ###
 # Defer Active Job's `perform_later` enqueue until the enclosing Active
-# Record transaction commits, when the queue adapter supports it.
+# Record transaction commits, when the queue adapter supports it and a
+# `perform_later` call happens inside a transaction. A call outside any
+# transaction still enqueues immediately, same as before.
 #
 # Solid Queue's adapter always returns true for
 # `enqueue_after_transaction_commit?`, so :default defers every
-# `perform_later` call to after commit.
+# transaction-enclosed `perform_later` call to after commit.
 #
 # Only one call site in the app runs inside a transaction:
 # Image#strip_gps! enqueues TransferImagesJob inside a `with_lock` block.

--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Be sure to restart your server when you modify this file.
+#
+# This file eases your Rails 7.2 framework defaults upgrade.
+#
+# Uncomment each configuration one by one to switch to the new default.
+# Once your application is ready to run with all new defaults, you can remove
+# this file and set the `config.load_defaults` to `7.2`.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+# https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+###
+# Defer Active Job's `perform_later` enqueue until the enclosing Active
+# Record transaction commits, when the queue adapter supports it.
+#
+# Solid Queue's adapter always returns true for
+# `enqueue_after_transaction_commit?`, so :default defers every
+# `perform_later` call to after commit.
+#
+# Only one call site in the app runs inside a transaction:
+# Image#strip_gps! enqueues TransferImagesJob inside a `with_lock` block.
+# Deferring it there is a safety improvement, not a regression -- the job
+# will no longer be able to read the row before the lock-holding
+# transaction commits.
+#++
+Rails.application.config.active_job.enqueue_after_transaction_commit = :default
+
+###
+# Enable validation of migration timestamps. Only rejects a newly generated
+# migration whose timestamp is more than a day ahead of the current time --
+# does not affect existing migration files.
+#++
+Rails.application.config.active_record.validate_migration_timestamps = true
+
+###
+# Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements.
+#
+# Guarded by Rails itself (`if config.yjit && defined?(RubyVM::YJIT.enable)`),
+# so this is a no-op on a Ruby build without YJIT support. Production's
+# Dockerfile uses the official ruby:3.4.9-bookworm image, which ships YJIT.
+#++
+Rails.application.config.yjit = true


### PR DESCRIPTION
Follow-up to #5336 (Rails 7.0/7.1 defaults), scoped to Rails 7.2's default template.

## Summary

Adds `config/initializers/new_framework_defaults_7_2.rb`, read directly from the installed railties 7.2.3.2 gem's template. That template has 5 settings; 2 are N/A for MO and omitted rather than left commented out:

- `active_storage.web_image_content_types` — ActiveStorage isn't loaded.
- `active_record.postgresql_adapter_decode_dates` — MO uses `trilogy` (MySQL), not Postgres.

**Enabled**:

- `active_record.validate_migration_timestamps` — only rejects a newly generated migration whose timestamp is more than a day ahead of the current time; doesn't affect existing migration files.
- `yjit` — Rails guards the call (`if config.yjit && defined?(RubyVM::YJIT.enable)`), so this is a no-op on a Ruby build without YJIT support. Production's `Dockerfile` uses the official `ruby:3.4.9-bookworm` image, which ships YJIT.
- `active_job.enqueue_after_transaction_commit` (`:default`) — defers `perform_later` enqueuing until the enclosing transaction commits, when the queue adapter supports it. Solid Queue's adapter (`app_root/…/solid_queue/lib/active_job/queue_adapters/solid_queue_adapter.rb`) always returns `true` for `enqueue_after_transaction_commit?`, so this changes every `perform_later` call to defer until commit. Checked all 11 `perform_later` call sites in the app; only one runs inside a transaction — `Image#strip_gps!` enqueues `TransferImagesJob` inside a `with_lock` block. Deferring it there is a safety improvement: the job can no longer attempt to read the row before the lock-holding transaction commits.

## Test plan

- [x] `bin/rails runner` boot check — clean boot, no deprecation warnings.
- [x] Confirmed `ActiveJob::Base.enqueue_after_transaction_commit == :default` and `ActiveJob::Base.queue_adapter.enqueue_after_transaction_commit? == true` at runtime.
- [x] `bundle exec rubocop` on the new file — no offenses.
- [x] Full test suite.

<!-- changelog -->
article: no
<!-- /changelog -->
