### PR TITLE
Remove exact-duplicate `external_links` before the unique-index migration

### DIFF
--- a/db/migrate/20260904020000_add_unique_index_and_drop_url_from_external_links.rb
+++ b/db/migrate/20260904020000_add_unique_index_and_drop_url_from_external_links.rb
@@ -11,16 +11,46 @@
 # first, so every resolvable link is resolved before the unique index
 # goes on.
 class AddUniqueIndexAndDropURLFromExternalLinks < ActiveRecord::Migration[7.2]
+  KEY_COLUMNS = [
+    :target_type, :target_id, :external_site_id, :external_id
+  ].freeze
+
   def change
     # Exact-duplicate backstop (#4592). Multiple links per (target, site)
     # stay allowed (#4565) as long as they carry different external_ids.
     # MySQL treats each NULL as distinct, so export-batch marker links
     # with no external_id yet do not collide with each other here.
+    #
+    # Remove any exact duplicates first so the index can't abort on
+    # pre-existing dupes regardless of whether the run-once prep scripts
+    # above have run. Idempotent (a no-op once they have). Keeps the
+    # oldest row in each group -- for a mixed-relationship duplicate that
+    # is the original import/provenance link.
+    reversible do |dir|
+      dir.up { remove_duplicate_external_links }
+    end
+
     add_index(:external_links,
               [:target_type, :target_id, :external_site_id, :external_id],
               unique: true,
               name: "index_external_links_on_target_and_site_and_extid")
 
     remove_column(:external_links, :url, :string, limit: 100)
+  end
+
+  private
+
+  def remove_duplicate_external_links
+    ExternalLink.group(*KEY_COLUMNS).having(Arel.star.count.gt(1)).count.
+      each_key { |values| dedupe_group(KEY_COLUMNS.zip(values).to_h) }
+  end
+
+  def dedupe_group(conditions)
+    ids = ExternalLink.where(conditions).order(:id).pluck(:id)
+    extra = ids.drop(1)
+    return if extra.empty?
+
+    say("Removing #{extra.size} duplicate external_link(s): #{extra.inspect}")
+    ExternalLink.where(id: extra).delete_all
   end
 end


### PR DESCRIPTION
## Problem

`db:migrate` aborts on the external-links unique-index migration when the database still has duplicate rows:

```
Trilogy::ProtocolError: 1062: Duplicate entry
'Observation-657131-1-https://www.inaturalist.org/observations/38'
for key 'index_external_links_on_target_and_site_and_extid'
```

The migration (`20260904020000`) adds a unique index on `(target_type, target_id, external_site_id, external_id)` and documents that it *requires* the run-once prep scripts (`resolve_mycoportal_links.rb`, `backfill_inaturalist_external_ids.rb`) to have de-duplicated first. On any DB where those have not run — including a fresh production checkpoint — it fails. With the release scheduled tomorrow, that's a risk if production still holds duplicates.

## What I found (on a current prod checkpoint)

- **3 exact-duplicate groups** — the only rows that break the index:
  - obs 593508 (iNaturalist): same `external_id` under `import` + `remote_manual`.
  - obs 657131, obs 664478: double-submits (identical rows seconds apart).
- **28 rows whose `external_id` is still a URL** (23 MyCoPortal, 5 iNaturalist) — a separate data-quality issue the prep scripts resolve. These are distinct strings, so **they do not break the index** and don't block the release.

## Fix

Delete exact duplicates before adding the index, keeping the **oldest** row in each group. For the mixed-relationship group that is the original `import` (provenance) link, so `import_link` is preserved. The step is:

- **idempotent** — a no-op once the prep scripts have run, so it's a safe backstop rather than a replacement for them;
- **ActiveRecord/Arel, no raw SQL** (per repo rule);
- **reversible** — wrapped in `reversible { dir.up }` so rollback stays clean.

This makes the migration self-sufficient: the release can't fail on pre-existing duplicates regardless of prep-script state.

## Verified locally

Ran `db:migrate` on the checkpoint that just failed — it removed the 3 duplicates, added the index, and dropped `url`. `db:rollback:primary` then `db:migrate` both succeed (rollback is clean).

## Not addressed here (still the prep scripts' job)

The 28 URL-valued `external_id`s. The index doesn't depend on them, but post-release the app derives URLs from `external_id`, so those rows would produce broken links until resolved. **Run `resolve_mycoportal_links.rb` + `backfill_inaturalist_external_ids.rb` against production before/with the release** (their MyCoPortal resolution is site-specific and can't be reconstructed from the URL alone). See the test-plan check below to size the problem in production first.

## Test plan

- [ ] `bin/rails db:migrate` succeeds on a DB with duplicates
- [ ] `bin/rails db:rollback:primary` then `bin/rails db:migrate` both succeed
- [ ] On production (read-only) before deploy, confirm scope:
  ```ruby
  bin/rails runner '
    dups = ExternalLink.group(:target_type, :target_id, :external_site_id,
                              :external_id).having(Arel.star.count.gt(1)).count
    puts "duplicate groups: #{dups.size}"
    puts "url-valued external_ids: #{ExternalLink.where("external_id LIKE ?", "http%").count}"
  '
  ```

<!-- changelog -->
article: no
<!-- /changelog -->
