### PR TITLE
Fix `dev_setup` requiring sudo for `--icons-only` and on macOS

### DIFF
--- a/script/dev_setup
+++ b/script/dev_setup
@@ -24,7 +24,15 @@ mo_ensure_repo
 case "$(uname -s)" in
     Darwin)
         # Homebrew refuses to run under root, and dev_setup_macos never
-        # needs elevated privileges -- no re-exec here.
+        # needs elevated privileges -- no re-exec here. If the caller
+        # invoked this via `sudo` themselves, fail fast with a clear
+        # message instead of letting it die deep inside `brew install`.
+        if [ "${EUID}" -eq 0 ]; then
+            echo "Don't run this as root/sudo on macOS -- Homebrew refuses" >&2
+            echo "to install under root, and this script doesn't need" >&2
+            echo "elevated privileges on macOS. Re-run without sudo." >&2
+            exit 1
+        fi
         exec script/dev_setup_components/dev_setup_macos "$@"
         ;;
     Linux)

--- a/script/dev_setup
+++ b/script/dev_setup
@@ -21,19 +21,25 @@ else
 fi
 mo_ensure_repo
 
-if [ "${EUID}" -ne 0 ]; then
-    if ! command -v sudo >/dev/null 2>&1; then
-        echo "This setup script must run as root, but sudo is not available." >&2
-        exit 1
-    fi
-    exec sudo script/dev_setup "$@"
-fi
-
 case "$(uname -s)" in
     Darwin)
+        # Homebrew refuses to run under root, and dev_setup_macos never
+        # needs elevated privileges -- no re-exec here.
         exec script/dev_setup_components/dev_setup_macos "$@"
         ;;
     Linux)
+        # --icons-only is a plain git sync plus a file copy -- never
+        # needs root, on either platform, and dev_setup_ubuntu already
+        # re-execs itself as `mo` once its own root-only provisioning
+        # step finishes. Only the fresh-box provisioning path needs
+        # this dispatcher to elevate first.
+        if [ "$1" != "--icons-only" ] && [ "${EUID}" -ne 0 ]; then
+            if ! command -v sudo >/dev/null 2>&1; then
+                echo "This setup script must run as root, but sudo is not available." >&2
+                exit 1
+            fi
+            exec sudo script/dev_setup_components/dev_setup_ubuntu "$@"
+        fi
         exec script/dev_setup_components/dev_setup_ubuntu "$@"
         ;;
     *)


### PR DESCRIPTION
Fixes the `script/dev_setup --icons-only` regression reported in chat: it started prompting for a sudo password, which it didn't before.

## Summary

`script/dev_setup` was lacking the elevation a fresh Ubuntu box needs: `dev_setup_ubuntu`'s root-only provisioning step (creating the `mo` user, `/var/web`, apt packages, chruby) has to run as root, and without the dispatcher elevating first, that path failed for a non-root user on a fresh box.

Commit 1548e0e49e ("Require root for dev setup dispatcher") fixed that, but at the dispatcher level, ahead of both the OS check and the `--icons-only` check — so it re-exec'd under sudo on every invocation, on both platforms, instead of just the Linux fresh-box case that needed it. Effects, beyond the extra prompt:

- `--icons-only` is a private-repo git sync plus a file copy (`mo_sync_icon_library`) with no package installs or system-level steps. It doesn't need root on either platform. Running it as root leaves the synced files in `vendor/assets/images/icons/` root-owned in the checkout.
- On Ubuntu, `dev_setup_ubuntu` already had its root/non-root split: run as root on a fresh box, it does the one-time provisioning then hands off to the `mo` user; run as `mo`, it does the rest, including the `--icons-only` short-circuit. The dispatcher-level re-exec means `--icons-only` run as `mo` on an already-provisioned box now re-enters as root and re-runs the entire provisioning pass before it reaches the icons sync.
- On macOS, `dev_setup_macos` was written assuming a normal user throughout — no `sudo` anywhere in it, and Homebrew refuses to run `brew install` as root. `--icons-only` happens to exit before hitting `brew install`, so it's not broken by this yet, but a full (non-`--icons-only`) macOS setup run through the new dispatcher would hit `brew install` running as root and fail.

## Fix

Moved the sudo re-exec inside the `Linux` branch of the platform `case`, and skip it when `$1 == "--icons-only"`. macOS no longer re-execs under root. The Linux fresh-box case Alan's commit was fixing stays covered — this just narrows where the elevation applies.

## Test plan

- [x] `bash -n script/dev_setup` — syntax check passes.
- [x] `shellcheck script/dev_setup` — same 2 pre-existing SC1090/SC1091 info/warning lines as before this change (unrelated `source` calls), no new findings.
- [x] Isolated the new conditional and checked all 4 cases (non-root/no-args, non-root/--icons-only, root/no-args, root/--icons-only) resolve to the expected sudo/no-sudo branch.
- [ ] Can't exercise the Ubuntu fresh-box or macOS Homebrew paths from this environment — worth a live run on a physical machine before merging.

<!-- changelog -->
article: no
<!-- /changelog -->
