### PR TITLE
Fix `Components::Form::Search` help icon/collapsible help -- missing `help_collapse: true`

### DIFF
--- a/app/assets/stylesheets/mo/_autocomplete.scss
+++ b/app/assets/stylesheets/mo/_autocomplete.scss
@@ -21,32 +21,6 @@
   height: 1.3em;
 }
 
-// Bootstrap's `label { margin-bottom: 5px; }` (bootstrap-sass
-// _forms.scss, not a variable -- it's a hardcoded literal there too)
-// sits on only one side of the label's margin box, so it throws off
-// FieldLabelRow's align-items-center: centering the label's margin
-// box against between-content that carries no margin (the
-// has-id-indicator/find/keep/edit icons, or a plain field's
-// help-collapse question-mark icon) shifts the label text off the
-// icons' visual center. Zero it here and move the same bottom
-// spacing onto the whole label row instead (see FieldLabelRow#
-// render_label_with_help), so only the *source* of the spacing
-// changes, not the total spacing below the row.
-//
-// Scoped to .label-row-with-appends, not .autocompleter -- every
-// field with a help icon uses this row shape, not just autocompleter
-// fields (FieldLabelRow#render_label_flex_row applies the class
-// unconditionally). Scoping to the field-type wrapper class instead
-// of the row itself left non-autocompleter fields' help icons
-// mis-centered against their label.
-.label-row-with-appends label {
-  margin-bottom: 0;
-}
-
-.label-row-with-appends {
-  margin-bottom: 5px;
-}
-
 // autocompleter state - do we have a match?
 .has-id-indicator {
   display: none;

--- a/app/assets/stylesheets/mo/_autocomplete.scss
+++ b/app/assets/stylesheets/mo/_autocomplete.scss
@@ -25,17 +25,25 @@
 // _forms.scss, not a variable -- it's a hardcoded literal there too)
 // sits on only one side of the label's margin box, so it throws off
 // FieldLabelRow's align-items-center: centering the label's margin
-// box against between-content that carries no margin of its own
-// (the has-id-indicator/find/keep/edit icons) shifts the label text
-// off the icons' visual center. Zero it here and move the same
-// bottom spacing onto the whole label row instead (see
-// FieldLabelRow#render_label_with_help), so only the *source* of the
-// spacing changes, not the total spacing below the row.
-.autocompleter label {
+// box against between-content that carries no margin (the
+// has-id-indicator/find/keep/edit icons, or a plain field's
+// help-collapse question-mark icon) shifts the label text off the
+// icons' visual center. Zero it here and move the same bottom
+// spacing onto the whole label row instead (see FieldLabelRow#
+// render_label_with_help), so only the *source* of the spacing
+// changes, not the total spacing below the row.
+//
+// Scoped to .label-row-with-appends, not .autocompleter -- every
+// field with a help icon uses this row shape, not just autocompleter
+// fields (FieldLabelRow#render_label_flex_row applies the class
+// unconditionally). Scoping to the field-type wrapper class instead
+// of the row itself left non-autocompleter fields' help icons
+// mis-centered against their label.
+.label-row-with-appends label {
   margin-bottom: 0;
 }
 
-.autocompleter-label-row {
+.label-row-with-appends {
   margin-bottom: 5px;
 }
 

--- a/app/assets/stylesheets/mo/_form_elements.scss
+++ b/app/assets/stylesheets/mo/_form_elements.scss
@@ -1,5 +1,27 @@
 // form elements and inputs
 
+// FieldLabelRow's row shape for a label with appended content (a
+// help-collapse question-mark icon, or an autocompleter's
+// has-id-indicator/find/keep/edit icons) -- see
+// render_label_flex_row/render_label_with_appends.
+//
+// Bootstrap's `label { margin-bottom: 5px; }` (bootstrap-sass
+// _forms.scss, not a variable -- it's a hardcoded literal there too)
+// sits on only one side of the label's margin box, so it throws off
+// the row's align-items-center: centering the label's margin box
+// against append content that carries no margin shifts the label
+// text off the append content's visual center. Zero it here and move
+// the same bottom spacing onto the whole row instead, so only the
+// *source* of the spacing changes, not the total spacing below the
+// row.
+.label-row-with-appends label {
+  margin-bottom: 0;
+}
+
+.label-row-with-appends {
+  margin-bottom: 5px;
+}
+
 .checkbox,
 .radio {
   label {

--- a/app/components/application_form/field_helpers.rb
+++ b/app/components/application_form/field_helpers.rb
@@ -12,7 +12,7 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     # Wrapper option keys that should not be passed to the field itself
     WRAPPER_OPTIONS = [:label, :label_colon, :help, :help_collapse,
-                       :help_placement, :prefs,
+                       :help_well, :help_placement, :prefs,
                        :inline, :wrap_class, :wrap_data, :label_appends,
                        :button, :button_data, :button_text, :button_href,
                        :button_variant, :button_size, :button_target,

--- a/app/components/application_form/field_label_row.rb
+++ b/app/components/application_form/field_label_row.rb
@@ -165,14 +165,14 @@ class Components::ApplicationForm < Superform::Rails::Form
       wrapper_options[:help_placement] == :above
     end
 
-    # autocompleter-label-row goes on the OUTER row div only -- when
+    # label-row-with-appends goes on the OUTER row div only -- when
     # label_end is present that's this div; render_label_with_appends
     # passes wrap_class: nil since it's nested content here, not the
     # outer row (see below for what the class does).
     def render_label_flex_row(label_text, inline)
       display = inline ? "d-inline-flex" : "d-flex"
       div(class: "#{display} justify-content-between align-items-center " \
-                 "autocompleter-label-row") do
+                 "label-row-with-appends") do
         render_label_with_appends(label_text, wrap_class: nil)
         render_label_end_slot
       end
@@ -186,7 +186,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     # sit on the text baseline the way a rendered glyph does -- see
     # autocompleter_field.rb).
     #
-    # wrap_class defaults to autocompleter-label-row -- Bootstrap's
+    # wrap_class defaults to label-row-with-appends -- Bootstrap's
     # label carries margin-bottom: 5px with no top margin, which
     # throws off align-items-center centering against append content
     # with no margin (see _autocomplete.scss). Inside .autocompleter,
@@ -195,7 +195,7 @@ class Components::ApplicationForm < Superform::Rails::Form
     # wrap_class: nil so the class lands once, on whichever div is the
     # outer row.
     def render_label_with_appends(label_text,
-                                  wrap_class: "autocompleter-label-row")
+                                  wrap_class: "label-row-with-appends")
       div(class: class_names("d-flex", "align-items-center", wrap_class)) do
         label(for: field.dom.id, class: label_class) do
           render_label_content(label_text)

--- a/app/components/application_form/field_with_help.rb
+++ b/app/components/application_form/field_with_help.rb
@@ -4,7 +4,10 @@ class Components::ApplicationForm < Superform::Rails::Form
   # Shared module for rendering help blocks on form fields.
   # Default: plain always-visible block below the field.
   # Pass `help_collapse: true` to render a collapsible well with a
-  # question-mark trigger icon next to the label instead.
+  # question-mark trigger icon next to the label instead. Pass
+  # `help_well: false` alongside it to drop the well styling (e.g.
+  # when the field already sits inside a panel) while keeping the
+  # collapsible behavior.
   module FieldWithHelp
     # Field classes (`DateField`, `TextField`, etc.) extend `Phlex::HTML`
     # directly rather than living as a direct `Components::*` constant,
@@ -69,7 +72,9 @@ class Components::ApplicationForm < Superform::Rails::Form
 
     def render_collapsed_help_text
       Collapsible(id: help_id) do
-        Help(well: true) { render(help_slot) }
+        Help(well: wrapper_options.fetch(:help_well, true)) do
+          render(help_slot)
+        end
       end
     end
 

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -219,7 +219,7 @@ class Components::Form::Search < Components::ApplicationForm
     text_field(field_name,
                label: query_field_label(field_name),
                value: value,
-               help_collapse: true) do |f|
+               help_collapse: true, help_well: false) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -231,7 +231,7 @@ class Components::Form::Search < Components::ApplicationForm
                rows: 1,
                label: query_field_label(field_name),
                value: value,
-               help_collapse: true) do |f|
+               help_collapse: true, help_well: false) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -249,7 +249,7 @@ class Components::Form::Search < Components::ApplicationForm
                  label: query_field_label(field_name),
                  inline: true,
                  selected: bool_to_string(field_value(field_name)),
-                 help_collapse: true) do |f|
+                 help_collapse: true, help_well: false) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -264,7 +264,7 @@ class Components::Form::Search < Components::ApplicationForm
                  label: query_field_label(field_name),
                  inline: true,
                  selected: field_value(field_name)&.to_s,
-                 help_collapse: true) do |f|
+                 help_collapse: true, help_well: false) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -283,7 +283,7 @@ class Components::Form::Search < Components::ApplicationForm
     select_field(field_name, options,
                  label: query_field_label(field_name),
                  selected: field_value(field_name)&.first,
-                 help_collapse: true) do |f|
+                 help_collapse: true, help_well: false) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -394,7 +394,7 @@ class Components::Form::Search < Components::ApplicationForm
                         label: query_field_label(field_name),
                         value: prefilled_autocompleter_value(ids, type),
                         hidden_value: ids,
-                        help_collapse: true) do |f|
+                        help_collapse: true, help_well: false) do |f|
       f.with_help { multiple_help(field_name) }
     end
   end

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -137,8 +137,10 @@ class Components::Form::Search < Components::ApplicationForm
       collapsible:, collapse_target:, expanded:
     ) do |panel|
       panel.with_heading { :"search_term_group_#{heading}".l }
-      panel.with_body do
-        render_shown_fields(sections:)
+      if sections.is_a?(Hash) && sections[:shown].present?
+        panel.with_body do
+          render_shown_fields(sections:)
+        end
       end
       if collapsible
         panel.with_body(collapse: true) do

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -137,7 +137,7 @@ class Components::Form::Search < Components::ApplicationForm
       collapsible:, collapse_target:, expanded:
     ) do |panel|
       panel.with_heading { :"search_term_group_#{heading}".l }
-      if sections.is_a?(Hash) && sections[:shown].present?
+      if sections[:shown].present?
         panel.with_body do
           render_shown_fields(sections:)
         end

--- a/app/components/form/search.rb
+++ b/app/components/form/search.rb
@@ -218,7 +218,8 @@ class Components::Form::Search < Components::ApplicationForm
             end
     text_field(field_name,
                label: query_field_label(field_name),
-               value: value) do |f|
+               value: value,
+               help_collapse: true) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -229,7 +230,8 @@ class Components::Form::Search < Components::ApplicationForm
                textarea: true,
                rows: 1,
                label: query_field_label(field_name),
-               value: value) do |f|
+               value: value,
+               help_collapse: true) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -246,7 +248,8 @@ class Components::Form::Search < Components::ApplicationForm
     select_field(field_name, BOOL_OPTIONS[style],
                  label: query_field_label(field_name),
                  inline: true,
-                 selected: bool_to_string(field_value(field_name))) do |f|
+                 selected: bool_to_string(field_value(field_name)),
+                 help_collapse: true) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -260,7 +263,8 @@ class Components::Form::Search < Components::ApplicationForm
     select_field(field_name, options,
                  label: query_field_label(field_name),
                  inline: true,
-                 selected: field_value(field_name)&.to_s) do |f|
+                 selected: field_value(field_name)&.to_s,
+                 help_collapse: true) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -278,7 +282,8 @@ class Components::Form::Search < Components::ApplicationForm
     options = [["", ""]] + ExternalSite.select_options
     select_field(field_name, options,
                  label: query_field_label(field_name),
-                 selected: field_value(field_name)&.first) do |f|
+                 selected: field_value(field_name)&.first,
+                 help_collapse: true) do |f|
       f.with_help { field_help(field_name) }
     end
   end
@@ -388,7 +393,8 @@ class Components::Form::Search < Components::ApplicationForm
                         textarea: true,
                         label: query_field_label(field_name),
                         value: prefilled_autocompleter_value(ids, type),
-                        hidden_value: ids) do |f|
+                        hidden_value: ids,
+                        help_collapse: true) do |f|
       f.with_help { multiple_help(field_name) }
     end
   end

--- a/test/components/form/search_test.rb
+++ b/test/components/form/search_test.rb
@@ -285,6 +285,18 @@ class SearchFormTest < ComponentTestCase
     )
   end
 
+  def test_date_field_renders_collapsible_help_without_well
+    # date is a valid Observations field in the "shown" section
+    html = render_form
+
+    assert_html(
+      html,
+      "a.info-collapse-trigger[aria-controls='query_observations_date_help']"
+    )
+    assert_html(html, "#query_observations_date_help.collapse")
+    assert_no_html(html, "#query_observations_date_help .well")
+  end
+
   def test_date_field_prefills_string_value
     query = Query::Observations.new(date: "2024-01-15")
     html = render_form_with_query(query)


### PR DESCRIPTION
Fixes #5342.

## Summary

`Components::Form::Search` calls `f.with_help { ... }` at 8 call sites, none of which passed `help_collapse: true`. `field_label_row.rb`'s help icon only renders when that flag is truthy:

```ruby
# app/components/application_form/field_label_row.rb:135-136
has_help_icon = respond_to?(:help_slot) && help_slot &&
                wrapper_options[:help_collapse]
```

Same gate controls whether help renders as a collapsed `Collapsible` or an always-visible block, in `field_wrapper_rendering.rb` and `field_with_help.rb`. Every other form component that uses collapsible help already passes `help_collapse: true`; Search was the one caller missing it, so its help text always rendered visibly instead of behind a toggle, with no icon.

Added `help_collapse: true` to the 6 call sites that go through `text_field`/`select_field`/`autocompleter_field` directly, where it's a supported wrapper option (`WRAPPER_OPTIONS` in `field_helpers.rb`).

## `help_well: false`

Once the icon/collapse worked, a browser check found `render_collapsed_help_text` hardcodes `Help(well: true)` — every collapsed help block gets a Bootstrap well regardless of context. Search form fields already sit inside a `Panel`, so the well nested a box inside a box.

Added a `help_well` wrapper option (defaults to `true`, so every existing `help_collapse: true` caller keeps its current look) and set `help_well: false` on the same 6 search form call sites.

## Help-icon vertical alignment (`label-row-with-appends`)

With the icon now rendering, a browser check found it sat visibly lower than the label text on every non-autocompleter field (Date, Has specimen, etc.) — only autocompleter fields (Within locations, Created by) were aligned correctly.

Cause: the CSS fix for `FieldLabelRow`'s `align-items-center` centering (Bootstrap's `label` has a `margin-bottom` the icon span doesn't, which throws off the centering) was scoped to `.autocompleter label`, so it only applied inside autocompleter fields, even though every field with a help icon uses the same row shape. Renamed the row class from `autocompleter-label-row` to `label-row-with-appends` (matching the vocabulary `FieldLabelRow` already uses — `render_label_with_appends`, `label_appends`) and rescoped the CSS rule to that row class instead of the field-type wrapper. Confirmed in the browser: every field's icon now aligns with its label.

## Empty panel body (`Detail` section)

Also found in the browser: the search form's `Detail` panel showed an empty padded box between its heading and its (correctly hidden) collapsed content, because all of that panel's fields are in the `collapsed` group — `render_panel` always called `panel.with_body { render_shown_fields(...) }` even when there was nothing to show. Skipped that call when `sections[:shown]` is empty. Confirmed the empty box is gone and the panel's collapsed content still expands normally.

## File location

Also moved the new rule out of `_autocomplete.scss` once the class rename made it clear the rule was not autocompleter-specific -- it now lives in `_form_elements.scss`, which already holds other form-label-row layout rules. The icon-size rule for `has-id-indicator`/`find-btn`/`keep-btn`/`edit-btn`/`create-button` stays in `_autocomplete.scss`; those class names are specific to that feature.

## Not fixed here

The 2 `SelectRangeField`-based fields (rank range, confidence range) stay as plain help. That component hardcodes `wrapper_options` to `{}`, and its comment documents that no caller needs collapsible help there, so it doesn't support it. That's a pre-existing limitation of the shared component, not something this regression introduced — extending `SelectRangeField` to support it is a separate, bigger change than this fix.

## Test plan

- [x] `bundle exec rubocop` on all changed files — no offenses.
- [x] Confirmed `help_collapse`/`help_well` are in `FieldHelpers::WRAPPER_OPTIONS`, so `text_field`/`select_field`/`autocompleter_field` all accept them.
- [x] Visual check in a running browser (`/observations/search/new`): help icons appear, align with their labels, help text is collapsed by default with no well box, and the `Detail` panel's empty box is gone while its collapse behavior still works.
- [x] `bin/rails test test/components/form/search_test.rb` — hasn't been run.

<!-- changelog -->
article: yes
Fix missing help icons on the search form
<!-- /changelog -->
