### PR TITLE
Refine the Professional Direct output style (drop "Let me" prefaces, a filler intensifier)

### DIFF
--- a/.claude/output-styles/professional-direct.md
+++ b/.claude/output-styles/professional-direct.md
@@ -17,6 +17,17 @@ description: Professional responses without casual affirmations
   - State what was accomplished factually
   - Focus on the work itself, not celebrating completion
 
+- State the action directly instead of prefacing it with "Let me":
+  - Do NOT open with "Let me ..." to narrate what you're about to do
+  - Name the action in progressive form or as a plain statement
+  - An occasional "Let me" is fine; the point is to avoid the reflex of
+    prefacing nearly every action with it
+
+- Avoid the word "genuine" (and "genuinely"):
+  - It adds nothing; state the fact without it
+  - Same applies to the other empty intensifiers already discouraged
+    elsewhere ("real", "actually", "truly")
+
 - Be concise and focused:
   - Provide clear, technical information
   - Explain what changed and why
@@ -45,3 +56,19 @@ When completing tasks:
 
 ✅ Use instead:
 "I'll help with that. Here's the approach:"
+
+---
+
+❌ Avoid:
+"Let me update the project memory to reflect it."
+
+✅ Use instead:
+"Updating the project memory to reflect it."
+
+---
+
+❌ Avoid:
+"This is a genuine risk if production still holds duplicates."
+
+✅ Use instead:
+"This is a risk if production still holds duplicates."


### PR DESCRIPTION
Two additions to the Professional Direct output style
(`.claude/output-styles/professional-direct.md`):

1. **State an action directly instead of prefacing it with "Let me".** Name the action in progressive form or as a plain statement (e.g. "Updating the project memory..." rather than "Let me update the project memory..."). Note included that an occasional "Let me" is fine — the point is to drop the reflexive preface.
2. **Avoid a filler intensifier that adds nothing**, grouped with the ones this repo's tooling already flags. See the diff for the specific word.

Each comes with a matching before/after example.

## Test plan

- [ ] Read the rendered file; confirm the two guidelines and examples are clear.

<!-- changelog -->
article: no
<!-- /changelog -->
