### PR TITLE
Changelog for `deploy-2026-09-09-12-00`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-09 (deploy-2026-09-09-12-00)
+
+- Standardize `_utilities.scss` for the BS4 cutover, converge theme color derivation ([PR5340](https://github.com/MushroomObserver/mushroom-observer/pull/5340), @nimmolo)
+- Fix `Components::Form::Search` help icon/collapsible help -- missing `help_collapse: true` ([PR5343](https://github.com/MushroomObserver/mushroom-observer/pull/5343), @nimmolo)
+- Add a non-primary edit modal for occurrence members ([PR5328](https://github.com/MushroomObserver/mushroom-observer/pull/5328), @mo-nathan)
+- Refine the Professional Direct output style (drop "Let me" prefaces, a filler intensifier) ([PR5346](https://github.com/MushroomObserver/mushroom-observer/pull/5346), @mo-nathan)
+- Show occurrence-primary/read-only icons in Matching Observations; hide delete for reflections ([PR5331](https://github.com/MushroomObserver/mushroom-observer/pull/5331), @nimmolo)
+- Enable Rails 7.0/7.1 low-risk framework defaults ([PR5336](https://github.com/MushroomObserver/mushroom-observer/pull/5336), @nimmolo)
+- Fix `dev_setup` requiring sudo for `--icons-only` and on macOS ([PR5339](https://github.com/MushroomObserver/mushroom-observer/pull/5339), @nimmolo)
+
 ## 2026-09-08 (deploy-2026-09-08-12-00)
 
 - `external_id` becomes the identity for a resolved `ExternalLink`; drop `url` column ([PR5313](https://github.com/MushroomObserver/mushroom-observer/pull/5313), @nimmolo)

--- a/article_pending.textile
+++ b/article_pending.textile
@@ -1,3 +1,3 @@
 |{white-space:nowrap}. 2026-09-09 | Ask which Observation to edit for a non-primary member | "PR#5328":https://github.com/MushroomObserver/mushroom-observer/pull/5328 |
-|{white-space:nowrap}. 2026-09-08 | Fix missing help icons on the search form | "PR#5343":https://github.com/MushroomObserver/mushroom-observer/pull/5343 |
 |{white-space:nowrap}. 2026-09-09 | Show occurrence-primary and read-only status with icons on Observations | "PR#5331":https://github.com/MushroomObserver/mushroom-observer/pull/5331 |
+|{white-space:nowrap}. 2026-09-08 | Fix missing help icons on the search form | "PR#5343":https://github.com/MushroomObserver/mushroom-observer/pull/5343 |

--- a/article_pending.textile
+++ b/article_pending.textile
@@ -1,2 +1,3 @@
-|{white-space:nowrap}. 2026-09-08 | Show a read-only info panel for reflection photos on the Observation form | "PR#5326":https://github.com/MushroomObserver/mushroom-observer/pull/5326 |
-|{white-space:nowrap}. 2026-09-08 | Fix invisible carousel arrows on some images and themes | "PR#5332":https://github.com/MushroomObserver/mushroom-observer/pull/5332 |
+|{white-space:nowrap}. 2026-09-09 | Ask which Observation to edit for a non-primary member | "PR#5328":https://github.com/MushroomObserver/mushroom-observer/pull/5328 |
+|{white-space:nowrap}. 2026-09-08 | Fix missing help icons on the search form | "PR#5343":https://github.com/MushroomObserver/mushroom-observer/pull/5343 |
+|{white-space:nowrap}. 2026-09-09 | Show occurrence-primary and read-only status with icons on Observations | "PR#5331":https://github.com/MushroomObserver/mushroom-observer/pull/5331 |


### PR DESCRIPTION
Pre-deploy changelog for `deploy-2026-09-09-12-00` (issue #5155): the CHANGELOG.md section for every PR merged since `deploy-2026-09-08-12-00`, and `article_pending.textile` with the MO Article rows the deploy will publish. Merge this as the last PR before deploying; re-running `script/prerelease.rb --apply` refreshes it with any later merges.

## Expected MO Article lines

```
|{white-space:nowrap}. 2026-09-09 | Ask which Observation to edit for a non-primary member | "PR#5328":https://github.com/MushroomObserver/mushroom-observer/pull/5328 |
|{white-space:nowrap}. 2026-09-08 | Fix missing help icons on the search form | "PR#5343":https://github.com/MushroomObserver/mushroom-observer/pull/5343 |
|{white-space:nowrap}. 2026-09-09 | Show occurrence-primary and read-only status with icons on Observations | "PR#5331":https://github.com/MushroomObserver/mushroom-observer/pull/5331 |
```
(4 PR(s) marked `article: no`.) Edits to `article_pending.textile` in this PR are what the deploy publishes.

<!-- changelog -->
article: no
<!-- /changelog -->
