### PR TITLE
Keep `prerelease.rb` article rows in date order

### DIFF
--- a/script/prerelease.rb
+++ b/script/prerelease.rb
@@ -150,11 +150,26 @@ class Prerelease
   end
 
   def existing_rows_merged(existing_rows)
-    return @rows if existing_rows.nil?
+    return sort_rows_by_date(@rows) if existing_rows.nil?
 
     mentioned = pr_numbers(existing_rows.join("\n"))
     additions = @rows.reject { |row| mentioned.include?(pr_number(row)) }
-    existing_rows + additions
+    sort_rows_by_date(existing_rows + additions)
+  end
+
+  # Keep the article rows newest-first by their date cell (matching
+  # ArticleRows and the changelog convention) so appended PRs don't land
+  # out of order. Stable within a date, and rows with no parseable date
+  # sort to the end.
+  def sort_rows_by_date(rows)
+    rows.each_with_index.sort do |(row_a, idx_a), (row_b, idx_b)|
+      by_date = row_date(row_b) <=> row_date(row_a)
+      by_date.zero? ? (idx_a <=> idx_b) : by_date
+    end.map(&:first)
+  end
+
+  def row_date(row)
+    row[/\{white-space:nowrap\}\.\s*(\d{4}-\d{2}-\d{2})/, 1].to_s
   end
 
   # The changelog-pending branch's pending bullets and article rows, or


### PR DESCRIPTION
`script/prerelease.rb`'s `existing_rows_merged` appended the rows for newly merged PRs *after* the existing ones (to preserve reviewer edits) without re-sorting, so `article_pending.textile` drifted out of date order — e.g. a `2026-09-08` row sitting between two `2026-09-09` rows.

## Fix

Sort the merged article rows by their date cell (`|{white-space:nowrap}. YYYY-MM-DD |`), **newest first** — matching `ArticleRows` (which sorts by `mergedAt` descending) and the changelog convention documented in `.claude/rules/changelog.md`. The sort is stable within a date, so same-day rows keep their existing order, and any row with no parseable date sorts to the end.

Verified on the reported example (two `2026-09-09` rows + one `2026-09-08`): the two `09-09` rows come first in their original order, then `09-08`.

## Test plan

- [ ] `bin/rails runner script/prerelease.rb` (dry run) after a set of merges spanning multiple dates; confirm `article_pending.textile` rows come out newest-first with no date drift.

<!-- changelog -->
article: no
<!-- /changelog -->
