### PR TITLE
Normalize `inat_username` to lowercase; match logged-in iNat user case-insensitively

### DIFF
--- a/app/controllers/inat_imports_controller/estimators.rb
+++ b/app/controllers/inat_imports_controller/estimators.rb
@@ -90,7 +90,10 @@ module InatImportsController::Estimators
     args = listing_url? ? url_query_args : {}
     args[:only_id] = true
     args[:id] = params[:inat_ids] if listing_ids?
-    args[:user_login] = params[:inat_username]&.strip unless import_others?
+    unless import_others?
+      args[:user_login] =
+        params[:inat_username]&.strip&.downcase
+    end
     args
   end
 
@@ -100,7 +103,10 @@ module InatImportsController::Estimators
     args[:only_id] = true
     args[:taxon_id] ||= IMPORTABLE_TAXON_IDS_ARG
     args[:id] = params[:inat_ids] if listing_ids?
-    args[:user_login] = params[:inat_username]&.strip unless import_others?
+    unless import_others?
+      args[:user_login] =
+        params[:inat_username]&.strip&.downcase
+    end
     args
   end
 
@@ -142,7 +148,7 @@ module InatImportsController::Estimators
     if import_others?
       LICENSED_FILTER
     else
-      { user_login: params[:inat_username]&.strip }
+      { user_login: params[:inat_username]&.strip&.downcase }
     end
   end
 

--- a/app/controllers/inat_imports_controller/estimators.rb
+++ b/app/controllers/inat_imports_controller/estimators.rb
@@ -90,10 +90,7 @@ module InatImportsController::Estimators
     args = listing_url? ? url_query_args : {}
     args[:only_id] = true
     args[:id] = params[:inat_ids] if listing_ids?
-    unless import_others?
-      args[:user_login] =
-        params[:inat_username]&.strip&.downcase
-    end
+    args[:user_login] = normalized_inat_username unless import_others?
     args
   end
 
@@ -103,11 +100,13 @@ module InatImportsController::Estimators
     args[:only_id] = true
     args[:taxon_id] ||= IMPORTABLE_TAXON_IDS_ARG
     args[:id] = params[:inat_ids] if listing_ids?
-    unless import_others?
-      args[:user_login] =
-        params[:inat_username]&.strip&.downcase
-    end
+    args[:user_login] = normalized_inat_username unless import_others?
     args
+  end
+
+  # iNat logins are lowercase; send iNat the form it stores.
+  def normalized_inat_username
+    params[:inat_username]&.strip&.downcase
   end
 
   # Obs that will actually be imported: taxon + without_field
@@ -148,7 +147,7 @@ module InatImportsController::Estimators
     if import_others?
       LICENSED_FILTER
     else
-      { user_login: params[:inat_username]&.strip&.downcase }
+      { user_login: normalized_inat_username }
     end
   end
 

--- a/app/controllers/inat_imports_controller/validators.rb
+++ b/app/controllers/inat_imports_controller/validators.rb
@@ -172,7 +172,9 @@ module InatImportsController::Validators
     # entered is their actual iNat username. However, iNat authentication
     # requires them to know the password for that iNat username.
     return true if @user.inat_username.nil? ||
-                   params[:inat_username] == @user.inat_username
+                   params[:inat_username].to_s.strip.casecmp?(
+                     @user.inat_username
+                   )
 
     flash_warning(:inat_importing_all_anothers.t)
     false

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -85,7 +85,7 @@ class InatImportJob < ApplicationJob
     log("inat_logged_in_user: #{inat_logged_in_user}")
     # casecmp: records saved before inat_username was normalized to
     # lowercase can still hold the login with different case.
-    return if inat_logged_in_user.casecmp?(inat_username.to_s)
+    return if inat_logged_in_user.to_s.casecmp?(inat_username.to_s)
 
     wrong_inat_user_error(inat_logged_in_user)
   end

--- a/app/jobs/inat_import_job.rb
+++ b/app/jobs/inat_import_job.rb
@@ -81,17 +81,11 @@ class InatImportJob < ApplicationJob
   def ensure_not_importing_others
     return log("Skipped own-obs check (SuperImporter)") if super_importer?
 
-    begin
-      # fetch the logged-in iNat user
-      # https://api.inaturalist.org/v1/docs/#!/Users/get_users_me
-      response = Inat::APIRequest.new(token).request(path: "users/me")
-    rescue RestClient::Unauthorized, RestClient::ExceptionWithResponse => e
-      raise("iNat API user request failed: #{e.message}")
-    end
-
-    inat_logged_in_user = JSON.parse(response.body)["results"].first["login"]
+    inat_logged_in_user = fetch_inat_logged_in_user
     log("inat_logged_in_user: #{inat_logged_in_user}")
-    return if inat_logged_in_user == inat_username
+    # casecmp: records saved before inat_username was normalized to
+    # lowercase can still hold the login with different case.
+    return if inat_logged_in_user.casecmp?(inat_username.to_s)
 
     wrong_inat_user_error(inat_logged_in_user)
   end
@@ -103,6 +97,14 @@ class InatImportJob < ApplicationJob
   def wrong_inat_user_error(inat_logged_in_user)
     raise(:inat_wrong_user.t(inat_username: inat_username,
                              inat_logged_in_user: inat_logged_in_user))
+  end
+
+  # https://api.inaturalist.org/v1/docs/#!/Users/get_users_me
+  def fetch_inat_logged_in_user
+    response = Inat::APIRequest.new(token).request(path: "users/me")
+    JSON.parse(response.body)["results"].first["login"]
+  rescue RestClient::Unauthorized, RestClient::ExceptionWithResponse => e
+    raise("iNat API user request failed: #{e.message}")
   end
 
   def import_requested_observations(id_above:, continuation:)

--- a/app/models/concerns/normalizes_inat_username.rb
+++ b/app/models/concerns/normalizes_inat_username.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# iNat logins are lowercase; normalize the stored value so comparisons
+# against values from iNat match however the user typed it.
+module NormalizesInatUsername
+  def inat_username=(val)
+    if val.is_a?(String)
+      super(val.strip.downcase)
+    else
+      super
+    end
+  end
+end

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -73,6 +73,12 @@ class InatImport < ApplicationRecord
   belongs_to :project, optional: true
   has_many :observations, dependent: :nullify
 
+  # iNat logins are canonically lowercase; normalize so comparisons
+  # against values from iNat match however the user typed it.
+  def inat_username=(val)
+    super(val.is_a?(String) ? val.strip.downcase : val)
+  end
+
   serialize :log, type: Array, coder: YAML
   serialize :date_missing_inat_ids, coder: JSON
   serialize :license_added_inat_ids, coder: JSON

--- a/app/models/inat_import.rb
+++ b/app/models/inat_import.rb
@@ -73,11 +73,7 @@ class InatImport < ApplicationRecord
   belongs_to :project, optional: true
   has_many :observations, dependent: :nullify
 
-  # iNat logins are canonically lowercase; normalize so comparisons
-  # against values from iNat match however the user typed it.
-  def inat_username=(val)
-    super(val.is_a?(String) ? val.strip.downcase : val)
-  end
+  include NormalizesInatUsername
 
   serialize :log, type: Array, coder: YAML
   serialize :date_missing_inat_ids, coder: JSON

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -287,11 +287,7 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   # go through +change_password+.)
   before_create :crypt_password
 
-  # iNat logins are canonically lowercase; normalize so comparisons
-  # against values from iNat match however the user typed it.
-  def inat_username=(val)
-    super(val.is_a?(String) ? val.strip.downcase : val)
-  end
+  include NormalizesInatUsername
 
   before_update :update_image_copyright_holder
   before_update :expire_caches_of_associated_observations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -287,6 +287,12 @@ class User < AbstractModel # rubocop:disable Metrics/ClassLength
   # go through +change_password+.)
   before_create :crypt_password
 
+  # iNat logins are canonically lowercase; normalize so comparisons
+  # against values from iNat match however the user typed it.
+  def inat_username=(val)
+    super(val.is_a?(String) ? val.strip.downcase : val)
+  end
+
   before_update :update_image_copyright_holder
   before_update :expire_caches_of_associated_observations
 

--- a/test/controllers/inat_imports_controller_test.rb
+++ b/test/controllers/inat_imports_controller_test.rb
@@ -617,8 +617,8 @@ class InatImportsControllerTest < FunctionalTestCase
     )
     assert_response(:redirect)
     assert_equal(
-      user.name, created_import(user).inat_username,
-      "It should strip leading/trailing whitespace from inat_username"
+      user.name.downcase, created_import(user).inat_username,
+      "It should strip whitespace and downcase inat_username"
     )
   end
 

--- a/test/jobs/inat_import_job_test.rb
+++ b/test/jobs/inat_import_job_test.rb
@@ -1057,8 +1057,9 @@ class InatImportJobTest < ActiveJob::TestCase
     InatImportJob.perform_now(@inat_import)
 
     assert_equal(
-      updated_inat_username, @user.reload.inat_username,
-      "Failed to update User's inat_username after successful import"
+      updated_inat_username.downcase, @user.reload.inat_username,
+      "Failed to update User's inat_username (normalized to lowercase) " \
+      "after successful import"
     )
   end
 
@@ -1241,6 +1242,31 @@ class InatImportJobTest < ActiveJob::TestCase
     assert_nil(@user.reload.inat_username,
                "A username that failed the own-obs verification " \
                "must not be persisted")
+  end
+
+  # A record saved before inat_username was normalized to lowercase can
+  # hold the login with different case; the logged-in-user check must
+  # not treat it as a different account (iNat logins are lowercase).
+  def test_import_mixed_case_username_matches_logged_in_user
+    create_ivars_from_filename("calostoma_lutescens")
+    lowercase_login = @inat_import.inat_username
+    @inat_import.update_columns(inat_username: lowercase_login.capitalize)
+
+    Location.create(user: @user,
+                    name: "Sevier Co., Tennessee, USA",
+                    scientific_name: "USA, Tennessee, Sevier Co.",
+                    north: 36.043571, south: 35.561849,
+                    east: -83.253046, west: -83.794123)
+    stub_inat_interactions(login: lowercase_login)
+
+    assert_difference(
+      "Observation.count", 1,
+      "The same iNat account differing only by case should import"
+    ) do
+      InatImportJob.perform_now(@inat_import)
+    end
+    assert_equal(lowercase_login, @user.reload.inat_username,
+                 "Persisted username should be normalized to lowercase")
   end
 
   def test_super_importer_anothers_observation

--- a/test/models/inat_import_test.rb
+++ b/test/models/inat_import_test.rb
@@ -3,6 +3,15 @@
 require "test_helper"
 
 class InatImportTest < ActiveSupport::TestCase
+  def test_inat_username_normalized_to_lowercase
+    import = inat_imports(:rolf_inat_import)
+    import.update(inat_username: " MixedCase ")
+
+    assert_equal("mixedcase", import.inat_username,
+                 "inat_username should be stripped and downcased " \
+                 "(iNat logins are lowercase)")
+  end
+
   def test_total_expected_time_tabula_rasa
     zero_out_prior_import_records
     import = inat_imports(:rolf_inat_import)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,6 +3,15 @@
 require("test_helper")
 
 class UserTest < UnitTestCase
+  def test_inat_username_normalized_to_lowercase
+    user = users(:rolf)
+    user.update(inat_username: " Lothlin ")
+
+    assert_equal("lothlin", user.inat_username,
+                 "inat_username should be stripped and downcased " \
+                 "(iNat logins are lowercase)")
+  end
+
   def test_auth
     assert_equal(rolf,
                  User.authenticate(login: "rolf", password: "testpassword"))


### PR DESCRIPTION
## Summary

A user who typed their iNat username as "Lothlin" got the wrong-user error — "lothlin is logged into iNat. To import iNat observations of Lothlin make sure that Lothlin is logged into iNat on your device" — even though it is the same account. iNat logins are lowercase-only (capitals are rejected at signup), so the entered value and the login iNat's `users/me` returns can differ only by case, and `InatImportJob#ensure_not_importing_others` compared them with `==`.

## Changes

- `User#inat_username=` and `InatImport#inat_username=` strip and downcase, so the stored value always matches iNat's lowercase form however the user typed it.
- `InatImportJob#ensure_not_importing_others` compares with `casecmp?` — records saved before normalization can still hold mixed case. (The comparison was also extracted to `fetch_inat_logged_in_user` for a metrics limit.)
- `Validators#not_importing_all_anothers?` (the super-importer warning) compares case-insensitively for the same reason.
- The estimator queries send the downcased login to iNat's search as `user_login`, the form iNat stores.

## Test plan

- [x] `bin/rails test test/jobs/inat_import_job_test.rb test/models/inat_import_test.rb test/models/user_test.rb test/controllers/inat_imports_controller_test.rb` (250 tests)
- [x] New job test: an `InatImport` row holding "Capitalized" imports successfully when iNat reports the lowercase login, and the username persisted onto the user is lowercase
- [x] Manual: enter your iNat username with a capital letter on the import form; the import should proceed instead of showing the wrong-user warning

<!-- changelog -->
article: yes
Fix iNat import rejecting usernames typed with capitals
<!-- /changelog -->
