### PR TITLE
Changelog for `deploy-2026-09-10-12-00`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-09-10 (deploy-2026-09-10-12-00)
+
+- Keep `prerelease.rb` article rows in date order ([PR5350](https://github.com/MushroomObserver/mushroom-observer/pull/5350), @mo-nathan)
+- Normalize `inat_username` to lowercase; match logged-in iNat user case-insensitively ([PR5353](https://github.com/MushroomObserver/mushroom-observer/pull/5353), @mo-nathan)
+- Enable Rails 7.2 framework defaults ([PR5337](https://github.com/MushroomObserver/mushroom-observer/pull/5337), @nimmolo)
+- API docs: generate OpenAPI 3.1 from `API2` metadata (all 20 resources) ([PR5334](https://github.com/MushroomObserver/mushroom-observer/pull/5334), @mo-nathan)
+- Emit the logged-out-accessible `/obs/` form for every Observation URL that leaves the site ([PR5359](https://github.com/MushroomObserver/mushroom-observer/pull/5359), @mo-nathan)
+
 ## 2026-09-09 (deploy-2026-09-09-12-00)
 
 - Standardize `_utilities.scss` for the BS4 cutover, converge theme color derivation ([PR5340](https://github.com/MushroomObserver/mushroom-observer/pull/5340), @nimmolo)

--- a/article_pending.textile
+++ b/article_pending.textile
@@ -1,3 +1,3 @@
-|{white-space:nowrap}. 2026-09-09 | Ask which Observation to edit for a non-primary member | "PR#5328":https://github.com/MushroomObserver/mushroom-observer/pull/5328 |
-|{white-space:nowrap}. 2026-09-09 | Show occurrence-primary and read-only status with icons on Observations | "PR#5331":https://github.com/MushroomObserver/mushroom-observer/pull/5331 |
-|{white-space:nowrap}. 2026-09-08 | Fix missing help icons on the search form | "PR#5343":https://github.com/MushroomObserver/mushroom-observer/pull/5343 |
+|{white-space:nowrap}. 2026-09-10 | Fix emailed and shared Observation links for logged-out visitors | "PR#5359":https://github.com/MushroomObserver/mushroom-observer/pull/5359 |
+|{white-space:nowrap}. 2026-09-09 | Add browsable documentation for the MO API | "PR#5334":https://github.com/MushroomObserver/mushroom-observer/pull/5334 |
+|{white-space:nowrap}. 2026-09-09 | Fix iNat import rejecting usernames typed with capitals | "PR#5353":https://github.com/MushroomObserver/mushroom-observer/pull/5353 |


### PR DESCRIPTION
Pre-deploy changelog for `deploy-2026-09-10-12-00` (issue #5155): the CHANGELOG.md section for every PR merged since `deploy-2026-09-09-12-00`, and `article_pending.textile` with the MO Article rows the deploy will publish. Merge this as the last PR before deploying; re-running `script/prerelease.rb --apply` refreshes it with any later merges.

## Expected MO Article lines

```
|{white-space:nowrap}. 2026-09-10 | Fix emailed and shared Observation links for logged-out visitors | "PR#5359":https://github.com/MushroomObserver/mushroom-observer/pull/5359 |
|{white-space:nowrap}. 2026-09-09 | Add browsable documentation for the MO API | "PR#5334":https://github.com/MushroomObserver/mushroom-observer/pull/5334 |
|{white-space:nowrap}. 2026-09-09 | Fix iNat import rejecting usernames typed with capitals | "PR#5353":https://github.com/MushroomObserver/mushroom-observer/pull/5353 |
```
(2 PR(s) marked `article: no`.) Edits to `article_pending.textile` in this PR are what the deploy publishes.

<!-- changelog -->
article: no
<!-- /changelog -->
