### PR TITLE
Emit the logged-out-accessible `/obs/` form for every Observation URL that leaves the site

### DIFF
--- a/app/classes/inat/import_audit/row_builder.rb
+++ b/app/classes/inat/import_audit/row_builder.rb
@@ -29,7 +29,7 @@ module Inat::ImportAudit
     def base_columns(obs, snapshot, status, external_id)
       {
         mo_id: obs.id,
-        mo_url: "#{MO.http_domain}/#{obs.id}",
+        mo_url: obs.show_url,
         inat_id: external_id,
         inat_url: @site.observation_url(external_id),
         inat_status: status,

--- a/app/classes/inat/observation_importer.rb
+++ b/app/classes/inat/observation_importer.rb
@@ -235,7 +235,7 @@ class Inat
       update_inat_observation_field(
         observation_id: @inat_obs[:id],
         field_id: MO_URL_OBSERVATION_FIELD_ID,
-        value: "#{MO.http_domain}/#{@observation.id}"
+        value: @observation.show_url
       )
     end
 

--- a/app/classes/report/darwin/observations.rb
+++ b/app/classes/report/darwin/observations.rb
@@ -52,7 +52,7 @@ module Report
         ids.append(row.obs_id)
         [
           row.obs_id,
-          "#{MO.http_domain}/#{row.obs_id}",
+          row.obs_url,
           "HumanObservation",
           row.obs_updated_at,
           "MushroomObserver",

--- a/app/classes/tab/sequence/destroy.rb
+++ b/app/classes/tab/sequence/destroy.rb
@@ -18,7 +18,7 @@ class Tab::Sequence::Destroy < Tab::Base
 
   def html_options
     { button: :destroy,
-      back: observation_path(@sequence.observation) }
+      back: permanent_observation_path(@sequence.observation) }
   end
 
   def model

--- a/app/components/inline_crud_links.rb
+++ b/app/components/inline_crud_links.rb
@@ -325,11 +325,11 @@ class Components::InlineCRUDLinks < Components::Base
          @target.id, observation_id: @observation.id)
   end
 
-  # Sequence destroy keeps a `back: observation_path(obs)` query so
+  # Sequence destroy keeps a `back: permanent_observation_path(obs)` query so
   # the controller redirects to the obs after destroying.
   def path_sequence_with_back
     sequence_path(id: @target.id,
-                  back: observation_path(@target.observation))
+                  back: permanent_observation_path(@target.observation))
   end
 
   # Namings are nested under observations in routing; no top-level

--- a/app/components/map/popup.rb
+++ b/app/components/map/popup.rb
@@ -69,7 +69,7 @@ class Components::Map::Popup < Components::Base
   def render_thumbnail_media_left(obs)
     return unless obs.respond_to?(:thumb_image_id) && obs.thumb_image_id
 
-    url = observation_path(id: obs.id, params: query_path_params)
+    url = permanent_observation_path(id: obs.id, params: query_path_params)
     div(class: "media-left") do
       label = obs.text_name.presence || "Observation ##{obs.id}"
       Link(type: :get,
@@ -199,8 +199,8 @@ class Components::Map::Popup < Components::Base
   def render_observation_link(obs)
     Link(type: :get,
          name: obs.text_name.presence || "Observation ##{obs.id}",
-         target: observation_path(id: obs.id,
-                                  params: query_path_params),
+         target: permanent_observation_path(id: obs.id,
+                                            params: query_path_params),
          new_tab: true) { render_observation_label(obs) }
   end
 

--- a/app/controllers/collection_numbers_controller.rb
+++ b/app/controllers/collection_numbers_controller.rb
@@ -370,7 +370,7 @@ class CollectionNumbersController < ApplicationController
 
   def destroy_html_response
     if @observation
-      redirect_to(observation_path(@observation.id))
+      redirect_to(permanent_observation_path(@observation.id))
     else
       redirect_with_query(action: :index)
     end

--- a/app/controllers/field_slips_controller.rb
+++ b/app/controllers/field_slips_controller.rb
@@ -225,7 +225,7 @@ class FieldSlipsController < ApplicationController
         # isn't fully resolved until the user handles the project gaps.
         render_new_view_invalid
       elsif obs
-        redirect_to(observation_url(obs), notice: msg)
+        redirect_to(permanent_observation_url(obs), notice: msg)
       else
         redirect_to(field_slip_url(@field_slip), notice: msg)
       end

--- a/app/controllers/field_slips_controller/observation_handling.rb
+++ b/app/controllers/field_slips_controller/observation_handling.rb
@@ -21,7 +21,7 @@ module FieldSlipsController::ObservationHandling
       @field_slip.adopt_user_from(obs)
       check_for_species_list(obs, params[:species_list])
       name_flash_for_project(name, @field_slip.project)
-      redirect_to(observation_url(obs.id))
+      redirect_to(permanent_observation_url(obs.id))
     else
       redirect_to(new_observation_url(field_code: @field_slip.code,
                                       place_name:, date:, notes:))

--- a/app/controllers/field_slips_controller/show.rb
+++ b/app/controllers/field_slips_controller/show.rb
@@ -60,7 +60,7 @@ module FieldSlipsController::Show
   end
 
   def field_slip_redirect(obs_id)
-    redirect_to(observation_url(id: obs_id))
+    redirect_to(permanent_observation_url(id: obs_id))
   end
 
   # Context carried from a scanned slip into the observation form.

--- a/app/controllers/herbarium_records_controller.rb
+++ b/app/controllers/herbarium_records_controller.rb
@@ -367,7 +367,7 @@ class HerbariumRecordsController < ApplicationController
 
   def destroy_html_response
     if @observation
-      redirect_to(observation_path(@observation.id))
+      redirect_to(permanent_observation_path(@observation.id))
     else
       redirect_with_query(action: :index)
     end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -436,7 +436,7 @@ class LocationsController < ApplicationController
   # issuing no redirect at all for a stale or tampered set_* id.
   def return_to_caller
     if (observation = Observation.safe_find(@set_observation))
-      redirect_to(observation_path(observation))
+      redirect_to(permanent_observation_path(observation))
     elsif (species_list = SpeciesList.safe_find(@set_species_list))
       redirect_to(species_list_path(species_list))
     elsif (herbarium = Herbarium.safe_find(@set_herbarium))

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -240,6 +240,9 @@ class LookupsController < ApplicationController
         :runtime_suggest_one_alternate.t(match: id, type: model.type_tag)
       )
     end
+    # For observations this resolves to the logged-out-accessible /obs/
+    # form -- the obs/:id route is defined ahead of the resource route,
+    # so hash-form url_for picks it.
     redirect_to(controller: obj.show_controller,
                 action: obj.show_action,
                 id: obj.id)

--- a/app/controllers/observations/emails_controller.rb
+++ b/app/controllers/observations/emails_controller.rb
@@ -64,7 +64,7 @@ module Observations
     def show_flash_and_send_back(observation)
       respond_to do |format|
         format.html do
-          redirect_to(observation_path(observation.id)) and return
+          redirect_to(permanent_observation_path(observation.id)) and return
         end
         format.turbo_stream do
           render_modal_close_and_flash("observation_email") and return

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -284,6 +284,14 @@ class Observation < AbstractModel # rubocop:disable Metrics/ClassLength
   #
   # Swap the `thumb_image:` hash for the matrix_box_carousels
   # alternative below when the carousel feature lands.
+  # The /obs/ form is the shareable one: logged-out visitors get a 403
+  # on the /:id and /observations/:id forms (the spider block in
+  # ApplicationController::Indexes#check_for_spider_block allows only
+  # this form), so every URL that leaves the site must use it (#5357).
+  def self.show_url(id)
+    "#{MO.http_domain}/obs/#{id}"
+  end
+
   def self.matrix_box_includes
     [{ thumb_image: [:image_votes, :license, :projects, :user] },
      :collector_user,

--- a/app/views/controllers/collection_numbers/index.rb
+++ b/app/views/controllers/collection_numbers/index.rb
@@ -58,7 +58,7 @@ module Views::Controllers::CollectionNumbers
     def render_observation_links(collection_number)
       collection_number.observations.each_with_index do |obs, idx|
         plain(", ") if idx.positive?
-        a(href: observation_path(obs)) do
+        a(href: permanent_observation_path(obs)) do
           trusted_html(obs.unique_format_name.t)
         end
       end

--- a/app/views/controllers/herbarium_records/index.rb
+++ b/app/views/controllers/herbarium_records/index.rb
@@ -74,7 +74,7 @@ module Views::Controllers::HerbariumRecords
     def render_observation_links(rec)
       rec.observations.each_with_index do |obs, idx|
         plain(", ") if idx.positive?
-        a(href: observation_path(obs.id)) do
+        a(href: permanent_observation_path(obs.id)) do
           trusted_html(viewer_aware_unique_format_name(obs).t)
         end
       end

--- a/app/views/controllers/info/site_stats.rb
+++ b/app/views/controllers/info/site_stats.rb
@@ -30,7 +30,7 @@ module Views::Controllers::Info
           InteractiveImage(
             user: current_user,
             image: obs.thumb_image,
-            image_link: observation_path(obs.id),
+            image_link: permanent_observation_path(obs.id),
             votes: true
           )
           br

--- a/app/views/controllers/observations/show/specimen_panel/sequences_section.rb
+++ b/app/views/controllers/observations/show/specimen_panel/sequences_section.rb
@@ -6,7 +6,7 @@
 #
 # `Components::InlineCRUDLinks` handles the archive/edit/destroy
 # group — sequences are a real-DELETE target with a
-# `back: observation_path(obs)` query string so the controller
+# `back: permanent_observation_path(obs)` query string so the controller
 # redirects to the obs after destroy.
 class Views::Controllers::Observations::Show::SpecimenPanel
   class SequencesSection < Views::Base

--- a/app/views/controllers/projects/violations/form.rb
+++ b/app/views/controllers/projects/violations/form.rb
@@ -72,7 +72,7 @@ module Views::Controllers::Projects::Violations
     # obs's show page stays within this project's violations, rather
     # than falling back to session leftovers or an unscoped default.
     def render_obs_link(obs)
-      a(href: observation_path(id: obs.id, q: q_param),
+      a(href: permanent_observation_path(id: obs.id, q: q_param),
         class: "observation_link_#{obs.id}") do
         trusted_html(obs.text_name)
       end

--- a/app/views/controllers/species_lists/observation.rb
+++ b/app/views/controllers/species_lists/observation.rb
@@ -34,7 +34,7 @@ module Views::Controllers::SpeciesLists
         InteractiveImage(
           user: @user,
           image: @observation.thumb_image,
-          image_link: observation_path(id: @observation.id),
+          image_link: permanent_observation_path(id: @observation.id),
           votes: true
         )
       end
@@ -59,7 +59,7 @@ module Views::Controllers::SpeciesLists
       div(class: "font-weight-bold") do
         Link(type: :get,
              name: viewer_aware_unique_format_name(@observation).t,
-             target: observation_path(id: @observation.id))
+             target: permanent_observation_path(id: @observation.id))
       end
     end
 

--- a/app/views/layouts/header/show_prev_next_nav.rb
+++ b/app/views/layouts/header/show_prev_next_nav.rb
@@ -43,6 +43,9 @@ module Views::Layouts
 
     def adjacent_path(id)
       return activity_log_path(id: id) if type_tag == :rss_log
+      # Observation show links use the logged-out-accessible /obs/ form
+      # (see Observation.show_url).
+      return permanent_observation_path(id: id) if type_tag == :observation
 
       send(:"#{type_tag}_path", id: id)
     end

--- a/app/views/mailers/inat_import_digest_mailer.rb
+++ b/app/views/mailers/inat_import_digest_mailer.rb
@@ -87,7 +87,7 @@ class Views::Mailers::InatImportDigestMailer < Views::Mailers::Base
   # html_to_ascii would otherwise drop the href (matching how the shared
   # links section renders "label: url" in text).
   def emit_observation_row(obs, namings)
-    url = "#{MO.http_domain}/#{obs.id}"
+    url = obs.show_url
     if html?
       link_to("##{obs.id}", url)
       plain(": ")

--- a/app/views/mailers/naming_observer_mailer.rb
+++ b/app/views/mailers/naming_observer_mailer.rb
@@ -75,7 +75,7 @@ class Views::Mailers::NamingObserverMailer < Views::Mailers::Base
 
   def links
     [[:email_links_show_object.t(type: :observation),
-      "#{MO.http_domain}/#{observation.id}"],
+      observation.show_url],
      [:email_links_latest_changes.t, MO.http_domain]]
   end
 

--- a/app/views/mailers/naming_tracker_mailer.rb
+++ b/app/views/mailers/naming_tracker_mailer.rb
@@ -44,7 +44,7 @@ class Views::Mailers::NamingTrackerMailer < Views::Mailers::Base
 
   private
 
-  def observation_url = "#{MO.http_domain}/#{@observation.id}"
+  def observation_url = @observation.show_url
   def name_url = "#{MO.http_domain}/names/#{@naming.name_id}"
   def observer_url = "#{MO.http_domain}/users/#{@observation.user_id}"
   def identifier_url = "#{MO.http_domain}/users/#{@naming.user_id}"

--- a/app/views/mailers/observation_links.rb
+++ b/app/views/mailers/observation_links.rb
@@ -16,7 +16,7 @@ module Views::Mailers::ObservationLinks
   private
 
   def show_object_url
-    "#{MO.http_domain}/#{@observation.id}"
+    @observation.show_url
   end
 
   def post_comment_url

--- a/app/views/mailers/observer_question_mailer.rb
+++ b/app/views/mailers/observer_question_mailer.rb
@@ -32,7 +32,7 @@ class Views::Mailers::ObserverQuestionMailer < Views::Mailers::Base
 
   def links
     [[:email_links_show_object.t(type: :observation),
-      "#{MO.http_domain}/#{@observation.id}"],
+      @observation.show_url],
      [:email_links_stop_sending.t,
       "#{MO.http_domain}/account/no_email/#{@receiver.id}" \
       "?type=general_question"],

--- a/app/views/mailers/occurrence_change_mailer.rb
+++ b/app/views/mailers/occurrence_change_mailer.rb
@@ -38,7 +38,7 @@ class Views::Mailers::OccurrenceChangeMailer < Views::Mailers::Base
 
   def links
     [[:email_links_show_object.t(type: :observation),
-      "#{MO.http_domain}/#{@observation.id}"],
+      @observation.show_url],
      *occurrence_link,
      [:email_links_latest_changes.t, MO.http_domain]]
   end

--- a/test/classes/report_test.rb
+++ b/test/classes/report_test.rb
@@ -57,7 +57,7 @@ class ReportTest < UnitTestCase
     obs = observations(:detailed_unknown_obs)
     expect = [
       obs.id.to_s,
-      "#{MO.http_domain}/#{obs.id}",
+      "#{MO.http_domain}/obs/#{obs.id}",
       "HumanObservation",
       "#{obs.updated_at.api_time} UTC",
       "MushroomObserver",

--- a/test/classes/tab/sequence/tabs_test.rb
+++ b/test/classes/tab/sequence/tabs_test.rb
@@ -66,7 +66,7 @@ module Tab::Sequence
       assert_equal(@sequence, tab.path)
       assert_equal(:destroy, tab.html_options[:button])
       assert_equal(
-        routes.observation_path(@sequence.observation),
+        routes.permanent_observation_path(@sequence.observation),
         tab.html_options[:back]
       )
       assert_equal(@sequence, tab.model)

--- a/test/components/inline_crud_links_test.rb
+++ b/test/components/inline_crud_links_test.rb
@@ -60,9 +60,9 @@ class InlineCRUDLinksTest < ComponentTestCase
 
     assert_html(html,
                 "a[data-modal='modal_sequence_#{seq.id}']")
-    # `back: observation_path(obs)` is encoded as a query parameter
+    # `back: permanent_observation_path(obs)` is encoded as a query parameter
     expected_path = routes.sequence_path(
-      id: seq.id, back: routes.observation_path(obs)
+      id: seq.id, back: routes.permanent_observation_path(obs)
     )
     assert_html(html, "form[action='#{expected_path}']")
     assert_html(html, "button.destroy_sequence_link_#{seq.id}")

--- a/test/controllers/collection_numbers_controller_test.rb
+++ b/test/controllers/collection_numbers_controller_test.rb
@@ -639,7 +639,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
 
     # With back param set to observation ID, redirects to that observation.
     delete(:destroy, params: { id: nums[0].id, back: obs.id.to_s })
-    assert_redirected_to(observation_path(obs))
+    assert_redirected_to(permanent_observation_path(obs))
 
     # With back: "index", explicitly requests redirect to index.
     delete(:destroy, params: { id: nums[1].id, back: "index", q: })
@@ -684,7 +684,7 @@ class CollectionNumbersControllerTest < FunctionalTestCase
 
     # Should successfully destroy and redirect to the observation
     assert_equal(collection_number_count - 1, CollectionNumber.count)
-    assert_redirected_to(observation_path(obs))
+    assert_redirected_to(permanent_observation_path(obs))
   end
 
   # -------- Remove from observation (destroy with observation_id) ------------

--- a/test/controllers/field_slips_controller_test.rb
+++ b/test/controllers/field_slips_controller_test.rb
@@ -196,7 +196,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
 
     slip = FieldSlip.find_by(code: code)
     assert_equal(rolf.unique_text_name, slip.collector)
-    assert_redirected_to(observation_url(slip.observation))
+    assert_redirected_to(permanent_observation_url(slip.observation))
     assert_equal(slip.observation, ObservationView.last(@field_slip.user))
   end
 
@@ -223,7 +223,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     # rolf is not the owner, so his supplied collector is ignored and the
     # observation's existing collector is preserved.
     assert_equal("Original Collector", slip.collector)
-    assert_redirected_to(observation_url(slip.observation))
+    assert_redirected_to(permanent_observation_url(slip.observation))
     assert_equal(slip.observation, ObservationView.last(rolf.id))
   end
 
@@ -322,7 +322,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     fs = FieldSlip.find_by(code: code)
     assert(fs.user)
     obs = fs.observation
-    assert_redirected_to(observation_url(obs))
+    assert_redirected_to(permanent_observation_url(obs))
     assert(project.member?(user))
     assert(project.observations.member?(obs))
     assert(species_list.observations.member?(obs))
@@ -392,7 +392,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     obs = field_slip.observation
     assert_not_nil(obs, "Cannot find Observation for FieldSlip")
     assert_equal(date, obs.when)
-    assert_redirected_to(observation_url(obs.id))
+    assert_redirected_to(permanent_observation_url(obs.id))
   end
 
   def test_should_create_obs_with_link_to_inat
@@ -455,7 +455,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_not_nil(field_slip, "Cannot find FieldSlip for code #{code}")
     obs = field_slip.observation
     assert_not_nil(obs, "Cannot find Observation for FieldSlip")
-    assert_redirected_to(observation_url(obs.id))
+    assert_redirected_to(permanent_observation_url(obs.id))
     assert_equal("Fungi", obs.text_name)
   end
 
@@ -478,7 +478,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
     assert_not_nil(field_slip, "Cannot find FieldSlip for code #{code}")
     obs = field_slip.observation
     assert_not_nil(obs, "Cannot find Observation for FieldSlip")
-    assert_redirected_to(observation_url(obs.id))
+    assert_redirected_to(permanent_observation_url(obs.id))
   end
 
   def test_should_create_field_slip_in_project_from_code
@@ -532,7 +532,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
   def test_should_take_admin_to_edit
     login(@field_slip.user.login)
     get(:show, params: { id: @field_slip.code })
-    assert_redirected_to(observation_url(@field_slip.observation))
+    assert_redirected_to(permanent_observation_url(@field_slip.observation))
     # assert_redirected_to edit_field_slip_url(id: @field_slip.id)
   end
 
@@ -602,7 +602,7 @@ class FieldSlipsControllerTest < FunctionalTestCase
 
   def test_should_show_field_slip_by_code
     get(:show, params: { id: @field_slip.code })
-    assert_redirected_to(observation_url(@field_slip.observation))
+    assert_redirected_to(permanent_observation_url(@field_slip.observation))
   end
 
   # A code with no field slip goes straight to the observation form with

--- a/test/controllers/herbarium_records_controller_test.rb
+++ b/test/controllers/herbarium_records_controller_test.rb
@@ -708,7 +708,7 @@ class HerbariumRecordsControllerTest < FunctionalTestCase
 
     # Should successfully destroy and redirect to observation
     assert_equal(herbarium_record_count - 1, HerbariumRecord.count)
-    assert_redirected_to(observation_path(observation))
+    assert_redirected_to(permanent_observation_path(observation))
   end
 
   # Bug: Destroy button on show page uses turbo_stream format, causing error

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -758,7 +758,7 @@ class LocationsControllerTest < FunctionalTestCase
 
     post(:create, params: params)
 
-    assert_redirected_to(observation_path(obs))
+    assert_redirected_to(permanent_observation_path(obs))
   end
 
   def test_create_location_already_exists

--- a/test/controllers/observations/emails_controller_test.rb
+++ b/test/controllers/observations/emails_controller_test.rb
@@ -43,7 +43,7 @@ module Observations
       ) do
         post(:create, params: params)
       end
-      assert_redirected_to(observation_path(obs.id))
+      assert_redirected_to(permanent_observation_path(obs.id))
       assert_flash(:runtime_ask_observation_question_success)
     end
 

--- a/test/controllers/observations/maps_controller_test.rb
+++ b/test/controllers/observations/maps_controller_test.rb
@@ -84,7 +84,7 @@ module Observations
       assert_includes(json["html"], obs.name.text_name,
                       "popup html should render the observation's name")
       assert_includes(
-        json["html"], "/observations/#{obs.id}",
+        json["html"], "/obs/#{obs.id}",
         "popup html should link back to the observation show page"
       )
     end

--- a/test/controllers/observations_controller_show_test.rb
+++ b/test/controllers/observations_controller_show_test.rb
@@ -849,8 +849,8 @@ class ObservationsControllerShowTest < FunctionalTestCase
 
     # Test that prev/next links do not have :q, and index link does
     get(:show, params: { id: o_chron.third.id })
-    next_href = observation_path(o_chron.fourth.id)
-    prev_href = observation_path(o_chron.second.id)
+    next_href = permanent_observation_path(o_chron.fourth.id)
+    prev_href = permanent_observation_path(o_chron.second.id)
     index_href = observations_path(params: { id: o_chron.third.id, q: })
     assert_select("a.next_object_link[href='#{next_href}']")
     assert_select("a.prev_object_link[href='#{prev_href}']")

--- a/test/integration/capybara/lurker_integration_test.rb
+++ b/test/integration/capybara/lurker_integration_test.rb
@@ -147,7 +147,7 @@ class LurkerIntegrationTest < CapybaraIntegrationTestCase
       )
 
       # (Make sure observation is shown somewhere.)
-      assert(has_selector?("a[href^='#{observation_path(obs.id)}']"),
+      assert(has_selector?("a[href^='#{permanent_observation_path(obs.id)}']"),
              "Missing a link to Observation")
     end
     # back at Observation

--- a/test/mailers/consensus_change_mailer_test.rb
+++ b/test/mailers/consensus_change_mailer_test.rb
@@ -16,7 +16,7 @@ class ConsensusChangeMailerTest < MailerTestCase
     assert_includes(mail.to, mary.email)
     assert_html_mail(mail)
     body = mail.body.to_s
-    assert_includes(body, "https://mushroomobserver.org/#{observation.id}")
+    assert_includes(body, "https://mushroomobserver.org/obs/#{observation.id}")
     assert_includes(body, "type=observations_consensus")
   end
 

--- a/test/mailers/inat_import_digest_mailer_test.rb
+++ b/test/mailers/inat_import_digest_mailer_test.rb
@@ -14,7 +14,7 @@ class InatImportDigestMailerTest < MailerTestCase
     assert_html_mail(mail)
     body = mail.body.to_s
     # observation link and the interests-management link both present
-    assert_includes(body, "#{MO.http_domain}/#{naming.observation_id}")
+    assert_includes(body, "#{MO.http_domain}/obs/#{naming.observation_id}")
     assert_includes(body, "#{MO.http_domain}/interests")
   end
 
@@ -28,7 +28,7 @@ class InatImportDigestMailerTest < MailerTestCase
     assert_text_mail(mail)
     # the observation url survives into the text part (not just the anchor)
     assert_includes(mail.body.to_s,
-                    "#{MO.http_domain}/#{naming.observation_id}")
+                    "#{MO.http_domain}/obs/#{naming.observation_id}")
   end
 
   def test_build_defaults_total_observations_to_the_namings_given

--- a/test/mailers/naming_observer_mailer_test.rb
+++ b/test/mailers/naming_observer_mailer_test.rb
@@ -16,7 +16,7 @@ class NamingObserverMailerTest < MailerTestCase
     assert_html_mail(mail)
     body = mail.body.to_s
     assert_includes(body,
-                    "https://mushroomobserver.org/#{naming.observation_id}")
+                    "https://mushroomobserver.org/obs/#{naming.observation_id}")
   end
 
   def test_build_text

--- a/test/mailers/naming_tracker_mailer_test.rb
+++ b/test/mailers/naming_tracker_mailer_test.rb
@@ -13,7 +13,7 @@ class NamingTrackerMailerTest < MailerTestCase
     assert_html_mail(mail)
     body = mail.body.to_s
     assert_includes(
-      body, "https://mushroomobserver.org/#{naming.observation_id}"
+      body, "https://mushroomobserver.org/obs/#{naming.observation_id}"
     )
     assert_includes(
       body, "https://mushroomobserver.org/names/#{naming.name_id}"
@@ -28,7 +28,7 @@ class NamingTrackerMailerTest < MailerTestCase
 
     assert_text_mail(mail)
     assert_includes(mail.body.to_s,
-                    "https://mushroomobserver.org/#{naming.observation_id}")
+                    "https://mushroomobserver.org/obs/#{naming.observation_id}")
   end
 
   # Covers specimen_line's "available" branch (fixture's observation

--- a/test/models/abstract_model_test.rb
+++ b/test/models/abstract_model_test.rb
@@ -514,7 +514,8 @@ class AbstractModelTest < UnitTestCase
     assert_show_url(Location, "/locations")
     assert_show_url(Name, "/names")
     # assert_show_url(Naming, "/observations/show_naming") # there is no show
-    assert_show_url(Observation, "/observations")
+    # Observation overrides show_url to the logged-out-accessible form.
+    assert_show_url(Observation, "/obs")
     assert_show_url(Project, "/projects")
     assert_show_url(Sequence, "/sequences")
     assert_show_url(SpeciesList, "/species_lists")

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -22,6 +22,14 @@ class ObservationTest < UnitTestCase
   ##############################################################################
 
   # Add an observation to the database
+  def test_show_url_uses_permanent_obs_form
+    obs = observations(:minimal_unknown_obs)
+
+    assert_equal("#{MO.http_domain}/obs/#{obs.id}", obs.show_url,
+                 "Observation URLs that leave the site must use the " \
+                 "/obs/ form, the only one open to logged-out visitors")
+  end
+
   def test_create
     create_new_objects
     assert_kind_of(Observation, observations(:minimal_unknown_obs))

--- a/test/models/rss_log_test.rb
+++ b/test/models/rss_log_test.rb
@@ -12,7 +12,9 @@ class RssLogTest < UnitTestCase
       rss_log = create_rss_log(type)
       id = rss_log.target_id
 
-      assert(rss_log.url.include?("#{model(type).show_controller}/#{id}"),
+      # Observation.show_url uses the /obs/ form, not show_controller.
+      path = type == :observation ? "/obs" : model(type).show_controller
+      assert(rss_log.url.include?("#{path}/#{id}"),
              "rss_log.url incorrect for #{model(type)}")
     end
   end

--- a/test/views/controllers/species_lists/observation_test.rb
+++ b/test/views/controllers/species_lists/observation_test.rb
@@ -18,7 +18,7 @@ module Views::Controllers::SpeciesLists
       html = render_row
 
       assert_html(html, ".row")
-      obs_path = routes.observation_path(id: @observation.id)
+      obs_path = routes.permanent_observation_path(id: @observation.id)
       assert_html(html, "a[href='#{obs_path}']")
       # Always renders the who+when line.
       assert_html(html,

--- a/test/views/layouts/header/show_prev_next_nav_test.rb
+++ b/test/views/layouts/header/show_prev_next_nav_test.rb
@@ -87,7 +87,7 @@ module Views::Layouts
       html = render_nav(object: @middle_obs, query: @query)
 
       # Get the prev_id from the query
-      expected_href = "/observations/#{@query.prev_id}"
+      expected_href = "/obs/#{@query.prev_id}"
       assert_html(html, "a.prev_object_link",
                   attribute: { href: expected_href })
     end
@@ -98,7 +98,7 @@ module Views::Layouts
       html = render_nav(object: @middle_obs, query: @query)
 
       # Get the next_id from the query
-      expected_href = "/observations/#{@query.next_id}"
+      expected_href = "/obs/#{@query.next_id}"
       assert_html(html, "a.next_object_link",
                   attribute: { href: expected_href })
     end


### PR DESCRIPTION
## Summary

Logged-out visitors 403 on the `/:id` and `/observations/:id` observation-show forms (the spider block allows only `/obs/:id`), so every URL that leaves the site must use the `/obs/` form. This PR converts the emitters; the iNat field-value backfill is a separate run-once script (below). See the audit and revised plan on #5357.

## Changes

- **`Observation.show_url`** now returns `#{MO.http_domain}/obs/#{id}`. This one override fixes the RSS feed (`RssLog::Title#url` calls `target.show_url`) and the EOL export, and gives the mailers a shared helper.
- **Six mailers** stop hand-building bare-id URLs and call `show_url`: `observation_links.rb` (shared by several), `naming_tracker_mailer.rb`, `naming_observer_mailer.rb`, `observer_question_mailer.rb`, `occurrence_change_mailer.rb`, `inat_import_digest_mailer.rb`. This is the email-opened-logged-out-on-a-phone case from the issue.
- **iNat writeback** (`inat/observation_importer.rb`): the Mushroom Observer URL field value written on import is now the `/obs/` form. The id-extraction regex already accepted `/obs/`, so re-import dedup is unaffected.
- **DwCA/GBIF export** (`report/darwin/observations.rb`) uses `row.obs_url`, matching the Symbiota path which already emitted `/obs/`.
- **`lookup_observation`** (textile `_obs 123_` links) turned out to already redirect to `/obs/` — the `obs/:id` route is defined ahead of the resource route, so hash-form `url_for` picks it. Documented with a comment instead of changed.
- Internal audit tool (`inat/import_audit/row_builder.rb`) converted in passing.

Deliberately out of scope per #5357 discussion: any redirect of the old forms (the 403 is crawler defense), and the sitemap/SEO items (separate parked thread).

## Backfill script

`script/run-once/backfill_inat_mo_url_forms.rb` (run-once convention — developed locally, not committed) rewrites existing iNat field values to the `/obs/` form after this deploys: walks iNat observations carrying the field via `id_above` cursor pagination, inspects values from the search response (no per-observation GETs), PUTs only values needing rewrite at a throttled rate. Idempotent; skips `DEAD LINK:` values; reports unparseable ones; resumable via `--id-above` when the 24h JWT expires; refuses `--apply` outside production (a dev run would write localhost URLs). Dry-run smoke test against the live API confirmed pagination and value parsing — the oldest links use the legacy `/observer/show_observation/` form, which the shared regex handles.

## Test plan

- [ ] `bin/rails test test/mailers/ test/controllers/lookups_controller_test.rb test/classes/report_test.rb test/models/observation_test.rb test/classes/inat_observation_importer_test.rb test/jobs/inat_import_job_test.rb` (403 tests)
- [ ] After deploy: import an iNat observation and confirm the Mushroom Observer URL field on iNat reads `/obs/<id>`
- [ ] Open a notification email and confirm the observation link works logged out
- [ ] Backfill (Nathan runs, post-deploy): dry run with `--max-pages` sample, then `--apply` with a JWT

## Update: in-site links default to /obs/ too

A second commit makes `/obs/` the default form for in-site observation show links, not just external ones. Hash-form `url_for` call sites (most of the app, including the index pages) already resolved to `/obs/` via route priority; the stragglers were named-helper call sites: the show page's prev/next nav, a dozen view/component links (map popups, collection-number and herbarium-record indexes, species-list entries, site stats, project-violations form, sequence-destroy `back:` params), and seven controller redirects (locations, field slips, collection numbers, herbarium records, observation emails). All now use `permanent_observation_path`/`_url`. Full suite green (9,091 tests).

<!-- changelog -->
article: yes
Fix emailed and shared Observation links for logged-out visitors
<!-- /changelog -->
