### PR TITLE
Changelog for `deploy-2026-09-12-12-00`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-09-12 (deploy-2026-09-12-12-00)
+
+- Fix `README_PRODUCTION_INSTALL`'s stale MySQL-on-app-box assumption ([PR5356](https://github.com/MushroomObserver/mushroom-observer/pull/5356), @nimmolo)
+- Enable Rails 7.0/7.1 defaults PR#3: Add session-cookie digest rotator ([PR5344](https://github.com/MushroomObserver/mushroom-observer/pull/5344), @nimmolo)
+- Skip `#index_bar` when no index filters are applied ([PR5362](https://github.com/MushroomObserver/mushroom-observer/pull/5362), @nimmolo)
+- Resync DNA sequences from iNat onto reflections (#4215) ([PR5361](https://github.com/MushroomObserver/mushroom-observer/pull/5361), @mo-nathan)
+- Deploy auto-refreshes the icon library when `Icon::GLYPHS` outruns the sprite (#5365) ([PR5366](https://github.com/MushroomObserver/mushroom-observer/pull/5366), @mo-nathan)
+
 ## 2026-09-10 (deploy-2026-09-10-12-00)
 
 - Keep `prerelease.rb` article rows in date order ([PR5350](https://github.com/MushroomObserver/mushroom-observer/pull/5350), @mo-nathan)

--- a/article_pending.textile
+++ b/article_pending.textile
@@ -1,3 +1,2 @@
-|{white-space:nowrap}. 2026-09-10 | Fix emailed and shared Observation links for logged-out visitors | "PR#5359":https://github.com/MushroomObserver/mushroom-observer/pull/5359 |
-|{white-space:nowrap}. 2026-09-09 | Add browsable documentation for the MO API | "PR#5334":https://github.com/MushroomObserver/mushroom-observer/pull/5334 |
-|{white-space:nowrap}. 2026-09-09 | Fix iNat import rejecting usernames typed with capitals | "PR#5353":https://github.com/MushroomObserver/mushroom-observer/pull/5353 |
+|{white-space:nowrap}. 2026-09-12 | Sync DNA sequences from iNaturalist onto imported Observations | "PR#5361":https://github.com/MushroomObserver/mushroom-observer/pull/5361 |
+|{white-space:nowrap}. 2026-09-11 | Hide the filter row on index pages when no filters are applied | "PR#5362":https://github.com/MushroomObserver/mushroom-observer/pull/5362 |


### PR DESCRIPTION
Pre-deploy changelog for `deploy-2026-09-12-12-00` (issue #5155): the CHANGELOG.md section for every PR merged since `deploy-2026-09-10-12-00`, and `article_pending.textile` with the MO Article rows the deploy will publish. Merge this as the last PR before deploying; re-running `script/prerelease.rb --apply` refreshes it with any later merges.

## Expected MO Article lines

```
|{white-space:nowrap}. 2026-09-12 | Sync DNA sequences from iNaturalist onto imported Observations | "PR#5361":https://github.com/MushroomObserver/mushroom-observer/pull/5361 |
|{white-space:nowrap}. 2026-09-11 | Hide the filter row on index pages when no filters are applied | "PR#5362":https://github.com/MushroomObserver/mushroom-observer/pull/5362 |
```
(3 PR(s) marked `article: no`.) Edits to `article_pending.textile` in this PR are what the deploy publishes.

<!-- changelog -->
article: no
<!-- /changelog -->
