### PR TITLE
Update RuboCop & dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -209,6 +209,12 @@ group :test, :development do
   gem("rubocop-thread_safety", require: false)
 end
 
+# Pin json below 3.0:
+# activesupport 7.2's JSON encoder passes
+# legacy `quirks_mode:` option to JSON.generate,
+# json 3.0 rejects that with ArgumentError (instead of ignoring).
+gem("json", "< 3.0")
+
 group :test do
   # Use capybara to simulate user-browser interaction
   gem("capybara")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (3.0.2)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.6)
@@ -656,6 +656,7 @@ DEPENDENCIES
   image_processing
   importmap-rails
   jbuilder
+  json (< 3.0)
   literal
   mimemagic
   mini_exiftool_vendored

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.21.2)
+    json (3.0.2)
     jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.6)
@@ -360,7 +360,7 @@ GEM
       version_gem (~> 1.1, >= 1.1.14)
     os (1.1.4)
     ostruct (0.6.3)
-    parallel (2.1.0)
+    parallel (2.2.0)
     parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
@@ -463,7 +463,7 @@ GEM
     rqrcode_core (2.1.0)
     rsync (1.0.9)
     rtf (0.3.3)
-    rubocop (1.90.0)
+    rubocop (1.91.0)
       json (>= 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)


### PR DESCRIPTION
## Summary

Updates RuboCop to 1.90.0
Pins json to < 3.0 to fix incompatibility with active_support 7.2.3.2

<!-- changelog -->
article: no

<!-- /changelog -->
